### PR TITLE
Adds a navigation guard on channel opening

### DIFF
--- a/raiden-dapp/src/class-component-hooks.ts
+++ b/raiden-dapp/src/class-component-hooks.ts
@@ -1,0 +1,9 @@
+/* istanbul ignore file */
+import Component from 'vue-class-component';
+
+// Register the router hooks with their names
+Component.registerHooks([
+  'beforeRouteEnter',
+  'beforeRouteLeave',
+  'beforeRouteUpdate'
+]);

--- a/raiden-dapp/src/main.ts
+++ b/raiden-dapp/src/main.ts
@@ -7,6 +7,7 @@ import App from './App.vue';
 import router from './router';
 import store from './store';
 import './registerServiceWorker';
+import './class-component-hooks';
 import { RaidenPlugin } from '@/plugins/raiden';
 import { IdenticonPlugin } from '@/plugins/identicon-plugin';
 

--- a/raiden-dapp/src/views/Deposit.vue
+++ b/raiden-dapp/src/views/Deposit.vue
@@ -76,6 +76,7 @@ import ProgressOverlay from '@/components/ProgressOverlay.vue';
 import { Zero } from 'ethers/constants';
 import AddressUtils from '@/utils/address-utils';
 import NavigationMixin from '@/mixins/navigation-mixin';
+import { Route } from 'vue-router';
 
 @Component({
   components: { ProgressOverlay, AmountInput }
@@ -117,6 +118,22 @@ export default class Deposit extends Mixins(NavigationMixin) {
   };
   current = 0;
   done = false;
+
+  beforeRouteLeave(to: Route, from: Route, next: any) {
+    if (!this.loading) {
+      next();
+    } else {
+      if (
+        window.confirm(
+          'Channel opening is in progress, are you sure you want to leave?'
+        )
+      ) {
+        next();
+      } else {
+        next(false);
+      }
+    }
+  }
 
   async openChannel() {
     const token = this.token;


### PR DESCRIPTION
- User should be asked to confirm when they try to navigate out of the page while the opening channel is in progress.

Currently, the application doesn't protect against refresh, but I can think many ways you can accidentally navigate away but not one where you can accidentally refresh. 

If you think we still need a guard for that we could add it in a new PR. 

Depends on #156 
Closes #141 