### PR TITLE
Fix for settleChannel e2e tests timeout

### DIFF
--- a/raiden/tests/e2e/raiden.spec.ts
+++ b/raiden/tests/e2e/raiden.spec.ts
@@ -31,7 +31,7 @@ describe('Raiden', () => {
   let matrixServer = 'matrix.raiden.test';
 
   beforeAll(async () => {
-    jest.setTimeout(15e3);
+    jest.setTimeout(10e3);
 
     (fetch as jest.Mock).mockResolvedValue({
       ok: true,
@@ -326,7 +326,7 @@ describe('Raiden', () => {
       await expect(raiden.channels$.pipe(first()).toPromise()).resolves.toEqual({
         [token]: {},
       });
-    });
+    }, 60e3);
   });
 
   describe('events$', () => {


### PR DESCRIPTION
Quick fix for last update making `settleChannel` success test (which needs to mine/wait 500 blocks) taking longer than 15s. This sets overall e2e tests timeouts to 10s (down from 15) but sets this specific one to 60s.