### PR TITLE
Matrix room create, invite, be invited, leave, clean, send, receive messages

### DIFF
--- a/raiden/src/raiden.ts
+++ b/raiden/src/raiden.ts
@@ -64,6 +64,7 @@ import {
   matrixRequestMonitorPresence,
   MatrixPresenceUpdateAction,
   MatrixRequestMonitorPresenceActionFailed,
+  messageSend,
 } from './store';
 
 export class Raiden {
@@ -601,6 +602,13 @@ export class Raiden {
       .toPromise();
     this.store.dispatch(matrixRequestMonitorPresence(address));
     return promise;
+  }
+
+  /**
+   * Temporary interface to test MessageSendAction
+   */
+  public sendMessage(address: string, message: string): void {
+    this.store.dispatch(messageSend(address, message));
   }
 }
 

--- a/raiden/src/store/actions.ts
+++ b/raiden/src/store/actions.ts
@@ -25,6 +25,8 @@ export enum RaidenActionType {
   MATRIX_REQUEST_MONITOR_PRESENCE = 'matrixRequestMonitorPresence',
   MATRIX_PRESENCE_UPDATE = 'matrixPresenceUpdate',
   MATRIX_REQUEST_MONITOR_PRESENCE_FAILED = 'matrixRequestMonitorPresenceFailed',
+  MATRIX_ROOM = 'matrixRoom',
+  MESSAGE_SEND = 'messageSend',
 }
 
 export enum ShutdownReason {
@@ -191,6 +193,18 @@ export interface MatrixPresenceUpdateAction extends RaidenAction {
 export interface MatrixRequestMonitorPresenceActionFailed extends RaidenActionFailed {
   type: RaidenActionType.MATRIX_REQUEST_MONITOR_PRESENCE_FAILED;
   address: string;
+}
+
+export interface MatrixRoomAction extends RaidenAction {
+  type: RaidenActionType.MATRIX_ROOM;
+  address: string;
+  room: string;
+}
+
+export interface MessageSendAction extends RaidenAction {
+  type: RaidenActionType.MESSAGE_SEND;
+  address: string;
+  message: string;
 }
 
 // action factories:
@@ -422,6 +436,18 @@ export const matrixRequestMonitorPresenceFailed = (
   error,
 });
 
+export const matrixRoom = (address: string, room: string): MatrixRoomAction => ({
+  type: RaidenActionType.MATRIX_ROOM,
+  address,
+  room,
+});
+
+export const messageSend = (address: string, message: string): MessageSendAction => ({
+  type: RaidenActionType.MESSAGE_SEND,
+  address,
+  message,
+});
+
 export type RaidenActions =
   | RaidenInitAction
   | RaidenShutdownAction
@@ -444,7 +470,9 @@ export type RaidenActions =
   | MatrixSetupAction
   | MatrixRequestMonitorPresenceAction
   | MatrixPresenceUpdateAction
-  | MatrixRequestMonitorPresenceActionFailed;
+  | MatrixRequestMonitorPresenceActionFailed
+  | MatrixRoomAction
+  | MessageSendAction;
 
 export const RaidenEventType: (
   | RaidenActionType.SHUTDOWN

--- a/raiden/src/store/actions.ts
+++ b/raiden/src/store/actions.ts
@@ -28,6 +28,7 @@ export enum RaidenActionType {
   MATRIX_ROOM = 'matrixRoom',
   MATRIX_ROOM_LEAVE = 'matrixRoomLeave',
   MESSAGE_SEND = 'messageSend',
+  MESSAGE_RECEIVED = 'messageReceived',
 }
 
 export enum ShutdownReason {
@@ -212,6 +213,15 @@ export interface MessageSendAction extends RaidenAction {
   type: RaidenActionType.MESSAGE_SEND;
   address: string;
   message: string;
+}
+
+export interface MessageReceivedAction extends RaidenAction {
+  type: RaidenActionType.MESSAGE_RECEIVED;
+  address: string;
+  message: string;
+  ts: number;
+  userId?: string;
+  roomId?: string;
 }
 
 // action factories:
@@ -461,6 +471,21 @@ export const messageSend = (address: string, message: string): MessageSendAction
   message,
 });
 
+export const messageReceived = (
+  address: string,
+  message: string,
+  ts?: number,
+  userId?: string,
+  roomId?: string,
+): MessageReceivedAction => ({
+  type: RaidenActionType.MESSAGE_RECEIVED,
+  address,
+  message,
+  ts: ts || Date.now(),
+  userId,
+  roomId,
+});
+
 export type RaidenActions =
   | RaidenInitAction
   | RaidenShutdownAction
@@ -486,7 +511,8 @@ export type RaidenActions =
   | MatrixRequestMonitorPresenceActionFailed
   | MatrixRoomAction
   | MatrixRoomLeaveAction
-  | MessageSendAction;
+  | MessageSendAction
+  | MessageReceivedAction;
 
 export const RaidenEventType: (
   | RaidenActionType.SHUTDOWN

--- a/raiden/src/store/actions.ts
+++ b/raiden/src/store/actions.ts
@@ -26,6 +26,7 @@ export enum RaidenActionType {
   MATRIX_PRESENCE_UPDATE = 'matrixPresenceUpdate',
   MATRIX_REQUEST_MONITOR_PRESENCE_FAILED = 'matrixRequestMonitorPresenceFailed',
   MATRIX_ROOM = 'matrixRoom',
+  MATRIX_ROOM_LEAVE = 'matrixRoomLeave',
   MESSAGE_SEND = 'messageSend',
 }
 
@@ -198,7 +199,13 @@ export interface MatrixRequestMonitorPresenceActionFailed extends RaidenActionFa
 export interface MatrixRoomAction extends RaidenAction {
   type: RaidenActionType.MATRIX_ROOM;
   address: string;
-  room: string;
+  roomId: string;
+}
+
+export interface MatrixRoomLeaveAction extends RaidenAction {
+  type: RaidenActionType.MATRIX_ROOM_LEAVE;
+  address: string;
+  roomId: string;
 }
 
 export interface MessageSendAction extends RaidenAction {
@@ -436,10 +443,16 @@ export const matrixRequestMonitorPresenceFailed = (
   error,
 });
 
-export const matrixRoom = (address: string, room: string): MatrixRoomAction => ({
+export const matrixRoom = (address: string, roomId: string): MatrixRoomAction => ({
   type: RaidenActionType.MATRIX_ROOM,
   address,
-  room,
+  roomId,
+});
+
+export const matrixRoomLeave = (address: string, roomId: string): MatrixRoomLeaveAction => ({
+  type: RaidenActionType.MATRIX_ROOM_LEAVE,
+  address,
+  roomId,
 });
 
 export const messageSend = (address: string, message: string): MessageSendAction => ({
@@ -472,6 +485,7 @@ export type RaidenActions =
   | MatrixPresenceUpdateAction
   | MatrixRequestMonitorPresenceActionFailed
   | MatrixRoomAction
+  | MatrixRoomLeaveAction
   | MessageSendAction;
 
 export const RaidenEventType: (

--- a/raiden/src/store/epics/index.ts
+++ b/raiden/src/store/epics/index.ts
@@ -39,6 +39,8 @@ import {
   matrixLeaveUnknownRoomsEpic,
   matrixCleanLeftRoomsEpic,
   matrixMessageSendEpic,
+  matrixMessageReceivedEpic,
+  matrixMessageReceivedUpdateRoomEpic,
 } from './matrix';
 
 export const raidenEpics = (
@@ -80,6 +82,8 @@ export const raidenEpics = (
     matrixLeaveUnknownRoomsEpic,
     matrixCleanLeftRoomsEpic,
     matrixMessageSendEpic,
+    matrixMessageReceivedEpic,
+    matrixMessageReceivedUpdateRoomEpic,
   ]).pipe(
     mergeMap(epic => epic(limitedAction$, limitedState$, deps)),
     catchError(err => of(raidenShutdown(err))),

--- a/raiden/src/store/epics/index.ts
+++ b/raiden/src/store/epics/index.ts
@@ -27,7 +27,16 @@ import {
   channelCloseEpic,
   channelSettleEpic,
 } from './channel';
-import { matrixShutdownEpic, matrixMonitorPresenceEpic, matrixPresenceUpdateEpic } from './matrix';
+import {
+  matrixStartEpic,
+  matrixShutdownEpic,
+  matrixMonitorPresenceEpic,
+  matrixPresenceUpdateEpic,
+  matrixCreateRoomEpic,
+  matrixInviteEpic,
+  matrixHandleInvitesEpic,
+  matrixMessageSendEpic,
+} from './matrix';
 
 export const raidenEpics = (
   action$: Observable<RaidenActions>,
@@ -57,9 +66,14 @@ export const raidenEpics = (
     channelCloseEpic,
     channelSettleEpic,
     channelMatrixMonitorPresenceEpic,
+    matrixStartEpic,
     matrixShutdownEpic,
     matrixMonitorPresenceEpic,
     matrixPresenceUpdateEpic,
+    matrixCreateRoomEpic,
+    matrixInviteEpic,
+    matrixHandleInvitesEpic,
+    matrixMessageSendEpic,
   ]).pipe(
     mergeMap(epic => epic(limitedAction$, limitedState$, deps)),
     catchError(err => of(raidenShutdown(err))),

--- a/raiden/src/store/epics/index.ts
+++ b/raiden/src/store/epics/index.ts
@@ -35,6 +35,9 @@ import {
   matrixCreateRoomEpic,
   matrixInviteEpic,
   matrixHandleInvitesEpic,
+  matrixLeaveExcessRoomsEpic,
+  matrixLeaveUnknownRoomsEpic,
+  matrixCleanLeftRoomsEpic,
   matrixMessageSendEpic,
 } from './matrix';
 
@@ -73,6 +76,9 @@ export const raidenEpics = (
     matrixCreateRoomEpic,
     matrixInviteEpic,
     matrixHandleInvitesEpic,
+    matrixLeaveExcessRoomsEpic,
+    matrixLeaveUnknownRoomsEpic,
+    matrixCleanLeftRoomsEpic,
     matrixMessageSendEpic,
   ]).pipe(
     mergeMap(epic => epic(limitedAction$, limitedState$, deps)),

--- a/raiden/src/store/epics/init.ts
+++ b/raiden/src/store/epics/init.ts
@@ -267,10 +267,8 @@ export const initMatrixEpic = (
       }
     }),
     mergeMap(({ matrix, server, setup }) =>
-      // start client
-      from(matrix.startClient({ initialSyncLimit: 0 })).pipe(
-        // ensure displayName is set even on restarts
-        mergeMap(() => matrix.setDisplayName(setup.displayName)),
+      // ensure displayName is set even on restarts
+      from(matrix.setDisplayName(setup.displayName)).pipe(
         // ensure we joined discovery room
         mergeMap(() =>
           matrix.joinRoom(

--- a/raiden/src/store/epics/matrix.ts
+++ b/raiden/src/store/epics/matrix.ts
@@ -91,7 +91,7 @@ const getPresences$ = (
  */
 export const matrixStartEpic = (
   action$: Observable<RaidenActions>,
-  state$: Observable<RaidenState>,
+  {  }: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
 ): Observable<RaidenActions> =>
   action$.pipe(
@@ -107,7 +107,7 @@ export const matrixStartEpic = (
  */
 export const matrixShutdownEpic = (
   action$: Observable<RaidenActions>,
-  state$: Observable<RaidenState>,
+  {  }: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
 ): Observable<RaidenActions> =>
   matrix$.pipe(
@@ -125,7 +125,7 @@ export const matrixShutdownEpic = (
  */
 export const matrixMonitorPresenceEpic = (
   action$: Observable<RaidenActions>,
-  state$: Observable<RaidenState>,
+  {  }: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
 ): Observable<MatrixPresenceUpdateAction | MatrixRequestMonitorPresenceActionFailed> =>
   action$.pipe(
@@ -224,7 +224,7 @@ export const matrixMonitorPresenceEpic = (
  */
 export const matrixPresenceUpdateEpic = (
   action$: Observable<RaidenActions>,
-  state$: Observable<RaidenState>,
+  {  }: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
 ): Observable<MatrixPresenceUpdateAction> =>
   matrix$.pipe(
@@ -389,7 +389,7 @@ export const matrixInviteEpic = (
  */
 export const matrixHandleInvitesEpic = (
   action$: Observable<RaidenActions>,
-  state$: Observable<RaidenState>,
+  {  }: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
 ): Observable<MatrixRoomAction> =>
   matrix$.pipe(
@@ -455,7 +455,7 @@ export const matrixLeaveExcessRoomsEpic = (
     mergeMap(([{ action, matrix }, state]) => {
       const THRESHOLD = 3;
       const rooms = state.transport!.matrix!.address2rooms![action.address];
-      return from(rooms.filter((r, i) => i >= THRESHOLD)).pipe(
+      return from(rooms.filter(({}, i) => i >= THRESHOLD)).pipe(
         mergeMap(roomId => matrix.leave(roomId).then(() => roomId)),
         map(roomId => matrixRoomLeave(action.address, roomId)),
       );
@@ -467,7 +467,7 @@ export const matrixLeaveExcessRoomsEpic = (
  * interest
  */
 export const matrixLeaveUnknownRoomsEpic = (
-  action$: Observable<RaidenActions>,
+  {  }: Observable<RaidenActions>,
   state$: Observable<RaidenState>,
   { matrix$, network }: RaidenEpicDeps,
 ): Observable<RaidenActions> =>
@@ -506,7 +506,7 @@ export const matrixLeaveUnknownRoomsEpic = (
  * detected, and then no MatrixRoomLeaveAction is emitted for them by this epic.
  */
 export const matrixCleanLeftRoomsEpic = (
-  action$: Observable<RaidenActions>,
+  {  }: Observable<RaidenActions>,
   state$: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
 ): Observable<MatrixRoomLeaveAction> =>
@@ -598,7 +598,7 @@ export const matrixMessageSendEpic = (
                   return fromEvent<RoomMember>(
                     matrix,
                     'RoomMember.membership',
-                    (event: MatrixEvent, member: RoomMember) => member,
+                    ({  }: MatrixEvent, member: RoomMember) => member,
                   ).pipe(
                     // use up-to-date presences again, which may have been updated while
                     // waiting for member join event (e.g. user roamed and was re-invited)

--- a/raiden/src/store/reducers.ts
+++ b/raiden/src/store/reducers.ts
@@ -105,6 +105,13 @@ export function raidenReducer(
       set(state, ['transport', 'matrix', 'setup'], action.setup);
       return state;
 
+    case RaidenActionType.MATRIX_ROOM:
+      path = ['transport', 'matrix', 'address2rooms', action.address];
+      return set(cloneDeep(state), path, [
+        action.room,
+        ...(get(state, path, []) as string[]).filter(room => room !== action.room),
+      ]);
+
     default:
       return state;
   }

--- a/raiden/src/store/reducers.ts
+++ b/raiden/src/store/reducers.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, get, set, unset } from 'lodash';
+import { cloneDeep, get, isEmpty, set, unset } from 'lodash';
 import { Zero } from 'ethers/constants';
 
 import { RaidenState, initialState, ChannelState, Channel } from './state';
@@ -109,8 +109,17 @@ export function raidenReducer(
       path = ['transport', 'matrix', 'address2rooms', action.address];
       return set(cloneDeep(state), path, [
         action.room,
-        ...(get(state, path, []) as string[]).filter(room => room !== action.room),
+        ...(get(state, path, []) as string[]).filter(room => room !== action.roomId),
       ]);
+
+    case RaidenActionType.MATRIX_ROOM_LEAVE:
+      path = ['transport', 'matrix', 'address2rooms', action.address];
+      state = cloneDeep(state);
+      set(state, path, (get(state, path, []) as string[]).filter(r => r !== action.roomId));
+      if (isEmpty(get(state, path, []))) {
+        unset(state, path);
+      }
+      return state;
 
     default:
       return state;

--- a/raiden/src/store/reducers.ts
+++ b/raiden/src/store/reducers.ts
@@ -108,7 +108,7 @@ export function raidenReducer(
     case RaidenActionType.MATRIX_ROOM:
       path = ['transport', 'matrix', 'address2rooms', action.address];
       return set(cloneDeep(state), path, [
-        action.room,
+        action.roomId,
         ...(get(state, path, []) as string[]).filter(room => room !== action.roomId),
       ]);
 

--- a/raiden/src/store/state.ts
+++ b/raiden/src/store/state.ts
@@ -65,6 +65,7 @@ export const RaidenStateType = t.intersection([
         }),
         t.partial({
           setup: RaidenMatrixSetupType,
+          address2rooms: t.record(t.string, t.array(t.string)),
         }),
       ]),
     }),

--- a/raiden/src/types.ts
+++ b/raiden/src/types.ts
@@ -1,5 +1,5 @@
 /// <reference path="../typings/matrix-js-sdk/index.d.ts" />
-import { Subject, AsyncSubject } from 'rxjs';
+import { Subject, BehaviorSubject, AsyncSubject } from 'rxjs';
 import { Signer } from 'ethers';
 import { JsonRpcProvider } from 'ethers/providers';
 import { Network, BigNumber } from 'ethers/utils';
@@ -27,7 +27,7 @@ export interface RaidenContracts {
 }
 
 export interface RaidenEpicDeps {
-  stateOutput$: Subject<RaidenState>;
+  stateOutput$: BehaviorSubject<RaidenState>;
   actionOutput$: Subject<RaidenActions>;
   matrix$: AsyncSubject<MatrixClient>;
   provider: JsonRpcProvider;

--- a/raiden/typings/matrix-js-sdk/index.d.ts
+++ b/raiden/typings/matrix-js-sdk/index.d.ts
@@ -510,6 +510,7 @@ declare module 'matrix-js-sdk' {
     state_key?: string;
     redacts?: string;
     type: string;
+    origin_server_ts?: number;
   }
 
   interface MapStringString {

--- a/raiden/typings/matrix-js-sdk/index.d.ts
+++ b/raiden/typings/matrix-js-sdk/index.d.ts
@@ -596,6 +596,7 @@ declare module 'matrix-js-sdk' {
   /!* models/room.js *!/
   */
   export class Room {
+    public name: string;
     public roomId: string;
     public getMember(userId: string): RoomMember | null;
     public getJoinedMembers(): RoomMember[];

--- a/raiden/typings/matrix-js-sdk/index.d.ts
+++ b/raiden/typings/matrix-js-sdk/index.d.ts
@@ -114,6 +114,7 @@ declare module 'matrix-js-sdk' {
       opts?: { syncRoom?: boolean; inviteSignUrl?: string; viaServers?: string[] },
       callback?: requestCallback,
     ): Promise<Room>;
+    public leave(roomId: string, callback?: requestCallback): Promise<{}>;
 
     public setDisplayName(name: string, callback?: requestCallback): Promise<any>;
 
@@ -125,8 +126,17 @@ declare module 'matrix-js-sdk' {
       results: { user_id: string; display_name?: string; avatar_url?: string }[];
     }>;
 
+    public getUserId(): string | null;
     public getUser(userId: string): User | null;
     public getUsers(): User[];
+    public sendEvent(
+      roomId: string,
+      eventType: string,
+      content: any,
+      txnId: string,
+      callback?: requestCallback,
+    ): Promise<{ event_id: string }>;
+    public invite(roomId: string, userId: string, callback?: requestCallback): Promise<{}>;
 
     public acceptGroupInvite(groupId: string, opts: object): Promise<object> | MatrixError;
     public addPushRule(
@@ -190,7 +200,7 @@ declare module 'matrix-js-sdk' {
         topic?: string;
       },
       callback?: requestCallback,
-    ): Promise<{ room_id: string; room_alias?: string }> | MatrixError | void;
+    ): Promise<{ room_id: string; room_alias?: string }>;
     public deactivateAccount(auth?: object, callback?: requestCallback): Promise<object>;
     public deleteAlias(
       alias: string,
@@ -583,22 +593,29 @@ declare module 'matrix-js-sdk' {
   }
   /*
 
-      /!* models/room.js *!/
-      */
-  export interface Room {
+  /!* models/room.js *!/
+  */
+  export class Room {
+    public roomId: string;
+    public getMember(userId: string): RoomMember | null;
+    public getJoinedMembers(): RoomMember[];
+  }
+
+  /* models/room-member.js*/
+  export interface RoomMember {
     roomId: string;
+    userId: string;
+    name: string;
+    membership: string | null;
+    user: User | null;
+  }
+
+  /* models/room-state.js */
+  export interface RoomState {
+    roomId: string;
+    members: { [userId: string]: RoomMember };
   }
   /*
-
-      /!* models/room-member.js*!/
-      export class RoomMember {
-
-      }
-
-      /!* models/room-state.js *!/
-      export class RoomState {
-
-      }
 
       /!* models/user.js*!/
       export class User {

--- a/raiden/typings/matrix-js-sdk/index.d.ts
+++ b/raiden/typings/matrix-js-sdk/index.d.ts
@@ -226,7 +226,6 @@ declare module 'matrix-js-sdk' {
       callback?: requestCallback,
       userIds?: string[],
     ): Promise<any> | MatrixError | void; // TODO
-    public emit(event: string, listener: any): boolean;
     public exportRoomKeys(): Promise<any>;
     public forget(
       roomId: string,


### PR DESCRIPTION
- [x] `matrix.startClient` is called lazily, to give time for callback hooks to be in place
- [x] When sendMessage to an address we don't know how to talk, create a private room and invite them
- [x] Even if user is offline or roam of server, they can be re-invited to this room
- [x] If it happens they invite us instead, join and start talking on their room
- [x] If there's more than 3 rooms for a user, leave the >3 ones
- [x] Leave/cleanup rooms we don't know about (global/discovery, peers)
- [x] Clean a room if somehow we're kicked out of it
- [x] Send message: when required to send a message, wait for a valid user presence for address, a room to be created for them, they joining and being online, and only then send (once, for now)
- [x] On any relevant room (with users of interest, which we started monitoring), listen for messages and output actions for them
- [x] If we receive a message for an user on a room is not our first option, it means they want to talk on that room, so put it in front of the queue and start sending messages on it
- [ ] ~Wrap JSON messages and `message_id`s~ (on next PR)
- [ ] ~Retry JSON messages until some condition, e.g. `Delivered`~ (on next PR)
- [x] Tests

Fix #91 