### PR TITLE
Use typesafe-actions

### DIFF
--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -1,4 +1,4 @@
-import { Raiden, RaidenActionType, RaidenChannel } from 'raiden';
+import { Raiden, RaidenChannel } from 'raiden';
 import { Store } from 'vuex';
 import { RootState } from '@/types';
 import { Web3Provider } from '@/services/web3-provider';
@@ -66,11 +66,11 @@ export default class RaidenService {
         this.store.commit('balance', await this.getBalance());
 
         raiden.events$
-          .pipe(filter(value => value.type === RaidenActionType.SHUTDOWN))
+          .pipe(filter(value => value.type === 'raidenShutdown'))
           .subscribe(() => this.store.commit('reset'));
 
         raiden.events$
-          .pipe(filter(value => value.type === RaidenActionType.NEW_BLOCK))
+          .pipe(filter(value => value.type === 'newBlock'))
           .subscribe(async () => await this.updateTokenBalances());
 
         raiden.channels$.subscribe(value => {

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -12,7 +12,7 @@ import { Web3Provider } from '@/services/web3-provider';
 import Vuex, { Store } from 'vuex';
 import { RootState, Tokens } from '@/types';
 import flushPromises from 'flush-promises';
-import { Raiden, RaidenActionType } from 'raiden';
+import { Raiden } from 'raiden';
 import Vue from 'vue';
 import { BigNumber } from 'ethers/utils';
 import { BehaviorSubject, EMPTY } from 'rxjs';
@@ -567,7 +567,7 @@ describe('RaidenService', () => {
       factory.mockResolvedValue(raidenMock);
       await raidenService.connect();
       await flushPromises();
-      subject.next({ type: RaidenActionType.NEW_BLOCK });
+      subject.next({ type: 'newBlock' });
       await flushPromises();
 
       expect(store.commit).toHaveBeenLastCalledWith('updateTokens', anything());
@@ -594,7 +594,7 @@ describe('RaidenService', () => {
     factory.mockResolvedValue(raidenMock);
     await raidenService.connect();
     await flushPromises();
-    subject.next({ type: RaidenActionType.SHUTDOWN });
+    subject.next({ type: 'raidenShutdown' });
     await flushPromises();
 
     expect(store.commit).toHaveBeenCalledTimes(6);

--- a/raiden/package-lock.json
+++ b/raiden/package-lock.json
@@ -521,9 +521,9 @@
       }
     },
     "@types/prettier": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.16.1.tgz",
-      "integrity": "sha512-db6pZL5QY3JrlCHBhYQzYDci0xnoDuxfseUuguLRr3JNk+bnCfpkK6p8quiUDyO8A0vbpBKkk59Fw125etrNeA==",
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-MG7ExKBo7AQ5UrL1awyYLNinNM/kyXgE4iP4Ul9fB+T7n768Z5Xem8IZeP6Bna0xze8gkDly49Rgge2HOEw4xA==",
       "dev": true
     },
     "@types/redux-logger": {
@@ -6121,9 +6121,9 @@
       }
     },
     "typechain": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/typechain/-/typechain-0.3.14.tgz",
-      "integrity": "sha512-nOg7n7LngcA4Sx53q+4jjSpIEulEayZYnCMfyItnyxCX3nTCWVg8QXZppMDYNfITkJHex0v5dTgklOQzSbfUkw==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/typechain/-/typechain-0.3.17.tgz",
+      "integrity": "sha512-JydKdW/xdpsp3uLz8y8WlfGX6a8/3BLAKAAmVWI4NvsJED2/BgJ5Du36OjSvlMMZDahP1AdbU+B/NsCiUqLRZg==",
       "dev": true,
       "requires": {
         "command-line-args": "^4.0.7",
@@ -6142,6 +6142,11 @@
           }
         }
       }
+    },
+    "typesafe-actions": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/typesafe-actions/-/typesafe-actions-4.4.1.tgz",
+      "integrity": "sha512-uV74N8uDU2lVaNnYUGmg/Th/mPi9JQJJ5A8+YcHBE5GI+bdgFyl79zCZw4LLU331GCdHWDo6F2J7LVgBHRvaGQ=="
     },
     "typescript": {
       "version": "3.4.5",

--- a/raiden/package.json
+++ b/raiden/package.json
@@ -60,7 +60,7 @@
     "tiny-async-pool": "^1.0.4",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.1.0",
-    "typechain": "^0.3.14",
+    "typechain": "^0.3.17",
     "typescript": "^3.4.5"
   },
   "dependencies": {
@@ -72,7 +72,8 @@
     "redux": "^4.0.1",
     "redux-logger": "^3.0.6",
     "redux-observable": "^1.1.0",
-    "rxjs": "^6.5.2"
+    "rxjs": "^6.5.2",
+    "typesafe-actions": "^4.4.1"
   },
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",

--- a/raiden/src/constants.ts
+++ b/raiden/src/constants.ts
@@ -1,8 +1,14 @@
-import { arrayify } from 'ethers/utils';
+import { padZeros } from 'ethers/utils';
 
-export const SignatureZero = arrayify('0x' + '00'.repeat(65));
+export const SignatureZero = padZeros([], 65);
 
 export const MATRIX_KNOWN_SERVERS_URL: { [networkName: string]: string } = {
   default:
     'https://raw.githubusercontent.com/raiden-network/raiden-transport/master/known_servers.test.yaml',
 };
+
+export enum ShutdownReason {
+  STOP = 'raidenStopped',
+  ACCOUNT_CHANGED = 'providerAccountChanged',
+  NETWORK_CHANGED = 'providerNetworkChanged',
+}

--- a/raiden/src/index.ts
+++ b/raiden/src/index.ts
@@ -1,10 +1,5 @@
 /* istanbul ignore file */
-export {
-  RaidenState,
-  ChannelState,
-  RaidenEvents,
-  RaidenActionType,
-  ShutdownReason,
-} from './store';
+export { RaidenState, ChannelState, RaidenEvent } from './store';
+export { ShutdownReason } from './constants';
 export * from './types';
 export * from './raiden';

--- a/raiden/src/store/actions.ts
+++ b/raiden/src/store/actions.ts
@@ -1,526 +1,178 @@
-import { AnyAction } from 'redux';
 import { BigNumber } from 'ethers/utils';
+import { createStandardAction } from 'typesafe-actions';
+
 import { RaidenMatrixSetup } from './state';
+import { ChannelId } from './types';
+import { ShutdownReason } from '../constants';
 
-export enum RaidenActionType {
-  INIT = 'raidenInit',
-  SHUTDOWN = 'raidenShutdown',
-  NEW_BLOCK = 'newBlock',
-  TOKEN_MONITORED = 'tokenMonitored',
-  CHANNEL_OPEN = 'channelOpen',
-  CHANNEL_OPENED = 'channelOpened',
-  CHANNEL_OPEN_FAILED = 'channelOpenFailed',
-  CHANNEL_MONITORED = 'channelMonitored',
-  CHANNEL_DEPOSIT = 'channelDeposit',
-  CHANNEL_DEPOSITED = 'channelDeposited',
-  CHANNEL_DEPOSIT_FAILED = 'channelDepositFailed',
-  CHANNEL_CLOSE = 'channelClose',
-  CHANNEL_CLOSED = 'channelClosed',
-  CHANNEL_CLOSE_FAILED = 'channelCloseFailed',
-  CHANNEL_SETTLEABLE = 'channelSettleable',
-  CHANNEL_SETTLE = 'channelSettle',
-  CHANNEL_SETTLED = 'channelSettled',
-  CHANNEL_SETTLE_FAILED = 'channelSettleFailed',
-  MATRIX_SETUP = 'matrixSetup',
-  MATRIX_REQUEST_MONITOR_PRESENCE = 'matrixRequestMonitorPresence',
-  MATRIX_PRESENCE_UPDATE = 'matrixPresenceUpdate',
-  MATRIX_REQUEST_MONITOR_PRESENCE_FAILED = 'matrixRequestMonitorPresenceFailed',
-  MATRIX_ROOM = 'matrixRoom',
-  MATRIX_ROOM_LEAVE = 'matrixRoomLeave',
-  MESSAGE_SEND = 'messageSend',
-  MESSAGE_RECEIVED = 'messageReceived',
-}
-
-export enum ShutdownReason {
-  STOP = 'raidenStopped',
-  ACCOUNT_CHANGED = 'providerAccountChanged',
-  NETWORK_CHANGED = 'providerNetworkChanged',
-}
-
-// actions:
+// actions-creators
 // ========
 
-export interface RaidenAction extends AnyAction {
-  type: RaidenActionType;
-}
+export const raidenInit = createStandardAction('raidenInit')<undefined>();
 
-export interface RaidenActionFailed extends RaidenAction {
-  error: Error;
-}
-
-export interface RaidenInitAction extends RaidenAction {
-  type: RaidenActionType.INIT;
-}
-
-export interface RaidenShutdownAction extends RaidenAction {
-  type: RaidenActionType.SHUTDOWN;
+export const raidenShutdown = createStandardAction('raidenShutdown')<{
   reason: ShutdownReason | Error;
-}
+}>();
 
-export interface NewBlockAction extends RaidenAction {
-  type: RaidenActionType.NEW_BLOCK;
-  blockNumber: number;
-}
+export const newBlock = createStandardAction('newBlock')<{ blockNumber: number }>();
 
-export interface TokenMonitoredAction extends RaidenAction {
-  type: RaidenActionType.TOKEN_MONITORED;
-  token: string;
-  tokenNetwork: string;
-  first: boolean; // first time monitoring this token, i.e. just started monitoring
-}
+export const tokenMonitored = createStandardAction('tokenMonitored').map(
+  ({
+    token,
+    tokenNetwork,
+    first = false,
+  }: {
+    token: string;
+    tokenNetwork: string;
+    first?: boolean;
+  }) => ({
+    payload: { token, tokenNetwork, first },
+  }),
+);
 
-export interface ChannelOpenAction extends RaidenAction {
-  type: RaidenActionType.CHANNEL_OPEN;
-  tokenNetwork: string;
-  partner: string;
-  settleTimeout: number;
-}
+/**
+ * Channel actions receive ChannelId as 'meta' action property
+ * This way, 'meta' can be used equally for request, success and error actions
+ */
 
-export interface ChannelOpenedAction extends RaidenAction {
-  type: RaidenActionType.CHANNEL_OPENED;
-  tokenNetwork: string;
-  partner: string;
-  id: number;
-  settleTimeout: number;
-  openBlock: number;
-  txHash: string;
-}
+/* Request a channel to be opened with meta={ tokenNetwork, partner } and payload.settleTimeout */
+export const channelOpen = createStandardAction('channelOpen')<
+  { settleTimeout: number },
+  ChannelId
+>();
 
-export interface ChannelOpenActionFailed extends RaidenActionFailed {
-  type: RaidenActionType.CHANNEL_OPEN_FAILED;
-  tokenNetwork: string;
-  partner: string;
-}
+/* A channel is detected on-chain. Also works as 'success' for channelOpen action */
+export const channelOpened = createStandardAction('channelOpened')<
+  { id: number; settleTimeout: number; openBlock: number; txHash: string },
+  ChannelId
+>();
 
-export interface ChannelMonitoredAction extends RaidenAction {
-  type: RaidenActionType.CHANNEL_MONITORED;
-  tokenNetwork: string;
-  partner: string;
-  id: number;
-  fromBlock?: number;
-}
+/* A channelOpen request action (with meta: ChannelId) failed with payload=Error */
+export const channelOpenFailed = createStandardAction('channelOpenFailed').map(
+  (payload: Error, meta: ChannelId) => ({ payload, error: true, meta }),
+);
 
-export interface ChannelDepositAction extends RaidenAction {
-  type: RaidenActionType.CHANNEL_DEPOSIT;
-  tokenNetwork: string;
-  partner: string;
-  deposit: BigNumber;
-}
+/* Channel with meta:ChannelId + payload.id should be monitored */
+export const channelMonitored = createStandardAction('channelMonitored')<
+  { id: number; fromBlock?: number },
+  ChannelId
+>();
 
-export interface ChannelDepositedAction extends RaidenAction {
-  type: RaidenActionType.CHANNEL_DEPOSITED;
-  tokenNetwork: string;
-  partner: string;
-  id: number;
-  participant: string;
-  totalDeposit: BigNumber;
-  txHash: string;
-}
+/* Request a payload.deposit to be made to channel meta:ChannelId */
+export const channelDeposit = createStandardAction('channelDeposit')<
+  { deposit: BigNumber },
+  ChannelId
+>();
 
-export interface ChannelDepositActionFailed extends RaidenActionFailed {
-  type: RaidenActionType.CHANNEL_DEPOSIT_FAILED;
-  tokenNetwork: string;
-  partner: string;
-}
+/* A deposit is detected on-chain. Also works as 'success' for channelDeposit action */
+export const channelDeposited = createStandardAction('channelDeposited')<
+  { id: number; participant: string; totalDeposit: BigNumber; txHash: string },
+  ChannelId
+>();
 
-export interface ChannelCloseAction extends RaidenAction {
-  type: RaidenActionType.CHANNEL_CLOSE;
-  tokenNetwork: string;
-  partner: string;
-}
+/* A channelDeposit request action (with meta: ChannelId) failed with payload=Error */
+export const channelDepositFailed = createStandardAction('channelDepositFailed').map(
+  (payload: Error, meta: ChannelId) => ({ payload, error: true, meta }),
+);
 
-export interface ChannelClosedAction extends RaidenAction {
-  type: RaidenActionType.CHANNEL_CLOSED;
-  tokenNetwork: string;
-  partner: string;
-  id: number;
-  participant: string;
-  closeBlock: number;
-  txHash: string;
-}
+/* Request channel meta:ChannelId to be closed */
+export const channelClose = createStandardAction('channelClose')<undefined, ChannelId>();
 
-export interface ChannelCloseActionFailed extends RaidenActionFailed {
-  type: RaidenActionType.CHANNEL_CLOSE_FAILED;
-  tokenNetwork: string;
-  partner: string;
-}
+/* A close channel event is detected on-chain. Also works as 'success' for channelClose action */
+export const channelClosed = createStandardAction('channelClosed')<
+  { id: number; participant: string; closeBlock: number; txHash: string },
+  ChannelId
+>();
 
-export interface ChannelSettleableAction extends RaidenAction {
-  type: RaidenActionType.CHANNEL_SETTLEABLE;
-  tokenNetwork: string;
-  partner: string;
-  settleableBlock: number;
-}
+/* A channelClose request action (with meta: ChannelId) failed with payload=Error */
+export const channelCloseFailed = createStandardAction('channelCloseFailed').map(
+  (payload: Error, meta: ChannelId) => ({ payload, error: true, meta }),
+);
 
-export interface ChannelSettleAction extends RaidenAction {
-  type: RaidenActionType.CHANNEL_SETTLE;
-  tokenNetwork: string;
-  partner: string;
-}
+/* A channel meta:ChannelId becomes settleable, starting from payload.settleableBlock */
+export const channelSettleable = createStandardAction('channelSettleable')<
+  { settleableBlock: number },
+  ChannelId
+>();
 
-export interface ChannelSettledAction extends RaidenAction {
-  type: RaidenActionType.CHANNEL_SETTLED;
-  tokenNetwork: string;
-  partner: string;
-  id: number;
-  settleBlock: number;
-  txHash: string;
-}
+/* Request channel meta:ChannelId to be settled */
+export const channelSettle = createStandardAction('channelSettle')<undefined, ChannelId>();
 
-export interface ChannelSettleActionFailed extends RaidenActionFailed {
-  type: RaidenActionType.CHANNEL_SETTLE_FAILED;
-  tokenNetwork: string;
-  partner: string;
-}
+/* A settle channel event is detected on-chain. Also works as 'success' for channelSettle action */
+export const channelSettled = createStandardAction('channelSettled')<
+  { id: number; settleBlock: number; txHash: string },
+  ChannelId
+>();
 
-export interface MatrixSetupAction extends RaidenAction {
-  type: RaidenActionType.MATRIX_SETUP;
+/* A channelSettle request action (with meta: ChannelId) failed with payload=Error */
+export const channelSettleFailed = createStandardAction('channelSettleFailed').map(
+  (payload: Error, meta: ChannelId) => ({ payload, error: true, meta }),
+);
+
+/* MatrixClient instance is ready and logged in to payload.server with credentials payload.setup */
+export const matrixSetup = createStandardAction('matrixSetup')<{
   server: string;
   setup: RaidenMatrixSetup;
-}
+}>();
 
-export interface MatrixRequestMonitorPresenceAction extends RaidenAction {
-  type: RaidenActionType.MATRIX_REQUEST_MONITOR_PRESENCE;
-  address: string;
-}
+/* Request matrix to start monitoring presence updates for meta.address */
+export const matrixRequestMonitorPresence = createStandardAction('matrixRequestMonitorPresence')<
+  undefined,
+  { address: string }
+>();
 
-export interface MatrixPresenceUpdateAction extends RaidenAction {
-  type: RaidenActionType.MATRIX_PRESENCE_UPDATE;
-  address: string;
-  userId: string;
-  available: boolean;
-  ts: number;
-}
+// TODO: declare all { address: string } as { address: Address }
+/**
+ * Monitored user meta.address presence updated.
+ * First event for this address also works as 'success' for matrixRequestMonitorPresence
+ */
+export const matrixPresenceUpdate = createStandardAction('matrixPresenceUpdate').map(
+  (
+    { userId, available, ts }: { userId: string; available: boolean; ts?: number },
+    meta: { address: string },
+  ) => ({ payload: { userId, available, ts: ts || Date.now() }, meta }),
+);
 
-export interface MatrixRequestMonitorPresenceActionFailed extends RaidenActionFailed {
-  type: RaidenActionType.MATRIX_REQUEST_MONITOR_PRESENCE_FAILED;
-  address: string;
-}
+/* A matrixRequestMonitorPresence request action (with meta.address) failed with payload=Error */
+export const matrixRequestMonitorPresenceFailed = createStandardAction(
+  'matrixRequestMonitorPresenceFailed',
+).map((payload: Error, meta: { address: string }) => ({ payload, error: true, meta }));
 
-export interface MatrixRoomAction extends RaidenAction {
-  type: RaidenActionType.MATRIX_ROOM;
-  address: string;
-  roomId: string;
-}
+/* payload.roomId must go front on meta.address's room queue */
+export const matrixRoom = createStandardAction('matrixRoom')<
+  { roomId: string },
+  { address: string }
+>();
 
-export interface MatrixRoomLeaveAction extends RaidenAction {
-  type: RaidenActionType.MATRIX_ROOM_LEAVE;
-  address: string;
-  roomId: string;
-}
+/* payload.roomId must be excluded from meta.address room queue, if present */
+export const matrixRoomLeave = createStandardAction('matrixRoomLeave')<
+  { roomId: string },
+  { address: string }
+>();
 
-export interface MessageSendAction extends RaidenAction {
-  type: RaidenActionType.MESSAGE_SEND;
-  address: string;
-  message: string;
-}
+/* One-shot send payload.message to meta.address user in transport */
+export const messageSend = createStandardAction('messageSend')<
+  { message: string },
+  { address: string }
+>();
 
-export interface MessageReceivedAction extends RaidenAction {
-  type: RaidenActionType.MESSAGE_RECEIVED;
-  address: string;
-  message: string;
-  ts: number;
-  userId?: string;
-  roomId?: string;
-}
-
-// action factories:
-// =================
-
-export const raidenInit = (): RaidenInitAction => ({ type: RaidenActionType.INIT });
-
-export const raidenShutdown = (reason: ShutdownReason | Error): RaidenShutdownAction => ({
-  type: RaidenActionType.SHUTDOWN,
-  reason,
-});
-
-export const newBlock = (blockNumber: number): NewBlockAction => ({
-  type: RaidenActionType.NEW_BLOCK,
-  blockNumber,
-});
-
-export const tokenMonitored = (
-  token: string,
-  tokenNetwork: string,
-  first: boolean = false,
-): TokenMonitoredAction => ({
-  type: RaidenActionType.TOKEN_MONITORED,
-  token,
-  tokenNetwork,
-  first,
-});
-
-export const channelOpen = (
-  tokenNetwork: string,
-  partner: string,
-  settleTimeout: number,
-): ChannelOpenAction => ({
-  type: RaidenActionType.CHANNEL_OPEN,
-  tokenNetwork,
-  partner,
-  settleTimeout,
-});
-
-export const channelOpened = (
-  tokenNetwork: string,
-  partner: string,
-  id: number,
-  settleTimeout: number,
-  openBlock: number,
-  txHash: string,
-): ChannelOpenedAction => ({
-  type: RaidenActionType.CHANNEL_OPENED,
-  tokenNetwork,
-  partner,
-  id,
-  settleTimeout,
-  openBlock,
-  txHash,
-});
-
-export const channelOpenFailed = (
-  tokenNetwork: string,
-  partner: string,
-  error: Error,
-): ChannelOpenActionFailed => ({
-  type: RaidenActionType.CHANNEL_OPEN_FAILED,
-  tokenNetwork,
-  partner,
-  error,
-});
-
-export const channelMonitored = (
-  tokenNetwork: string,
-  partner: string,
-  id: number,
-  fromBlock?: number,
-): ChannelMonitoredAction => ({
-  type: RaidenActionType.CHANNEL_MONITORED,
-  tokenNetwork,
-  partner,
-  id,
-  fromBlock,
-});
-
-export const channelDeposit = (
-  tokenNetwork: string,
-  partner: string,
-  deposit: BigNumber,
-): ChannelDepositAction => ({
-  type: RaidenActionType.CHANNEL_DEPOSIT,
-  tokenNetwork,
-  partner,
-  deposit,
-});
-
-export const channelDeposited = (
-  tokenNetwork: string,
-  partner: string,
-  id: number,
-  participant: string,
-  totalDeposit: BigNumber,
-  txHash: string,
-): ChannelDepositedAction => ({
-  type: RaidenActionType.CHANNEL_DEPOSITED,
-  tokenNetwork,
-  partner,
-  id,
-  participant,
-  totalDeposit,
-  txHash,
-});
-
-export const channelDepositFailed = (
-  tokenNetwork: string,
-  partner: string,
-  error: Error,
-): ChannelDepositActionFailed => ({
-  type: RaidenActionType.CHANNEL_DEPOSIT_FAILED,
-  tokenNetwork,
-  partner,
-  error,
-});
-
-export const channelClose = (tokenNetwork: string, partner: string): ChannelCloseAction => ({
-  type: RaidenActionType.CHANNEL_CLOSE,
-  tokenNetwork,
-  partner,
-});
-
-export const channelClosed = (
-  tokenNetwork: string,
-  partner: string,
-  id: number,
-  participant: string,
-  closeBlock: number,
-  txHash: string,
-): ChannelClosedAction => ({
-  type: RaidenActionType.CHANNEL_CLOSED,
-  tokenNetwork,
-  partner,
-  id,
-  participant,
-  closeBlock,
-  txHash,
-});
-
-export const channelCloseFailed = (
-  tokenNetwork: string,
-  partner: string,
-  error: Error,
-): ChannelCloseActionFailed => ({
-  type: RaidenActionType.CHANNEL_CLOSE_FAILED,
-  tokenNetwork,
-  partner,
-  error,
-});
-
-export const channelSettleable = (
-  tokenNetwork: string,
-  partner: string,
-  settleableBlock: number,
-): ChannelSettleableAction => ({
-  type: RaidenActionType.CHANNEL_SETTLEABLE,
-  tokenNetwork,
-  partner,
-  settleableBlock,
-});
-
-export const channelSettle = (tokenNetwork: string, partner: string): ChannelSettleAction => ({
-  type: RaidenActionType.CHANNEL_SETTLE,
-  tokenNetwork,
-  partner,
-});
-
-export const channelSettled = (
-  tokenNetwork: string,
-  partner: string,
-  id: number,
-  settleBlock: number,
-  txHash: string,
-): ChannelSettledAction => ({
-  type: RaidenActionType.CHANNEL_SETTLED,
-  tokenNetwork,
-  partner,
-  id,
-  settleBlock,
-  txHash,
-});
-
-export const channelSettleFailed = (
-  tokenNetwork: string,
-  partner: string,
-  error: Error,
-): ChannelSettleActionFailed => ({
-  type: RaidenActionType.CHANNEL_SETTLE_FAILED,
-  tokenNetwork,
-  partner,
-  error,
-});
-
-export const matrixSetup = (server: string, setup: RaidenMatrixSetup): MatrixSetupAction => ({
-  type: RaidenActionType.MATRIX_SETUP,
-  server,
-  setup,
-});
-
-export const matrixRequestMonitorPresence = (
-  address: string,
-): MatrixRequestMonitorPresenceAction => ({
-  type: RaidenActionType.MATRIX_REQUEST_MONITOR_PRESENCE,
-  address,
-});
-
-export const matrixPresenceUpdate = (
-  address: string,
-  userId: string,
-  available: boolean,
-  ts?: number,
-): MatrixPresenceUpdateAction => ({
-  type: RaidenActionType.MATRIX_PRESENCE_UPDATE,
-  address,
-  userId,
-  available,
-  ts: ts || Date.now(),
-});
-
-export const matrixRequestMonitorPresenceFailed = (
-  address: string,
-  error: Error,
-): MatrixRequestMonitorPresenceActionFailed => ({
-  type: RaidenActionType.MATRIX_REQUEST_MONITOR_PRESENCE_FAILED,
-  address,
-  error,
-});
-
-export const matrixRoom = (address: string, roomId: string): MatrixRoomAction => ({
-  type: RaidenActionType.MATRIX_ROOM,
-  address,
-  roomId,
-});
-
-export const matrixRoomLeave = (address: string, roomId: string): MatrixRoomLeaveAction => ({
-  type: RaidenActionType.MATRIX_ROOM_LEAVE,
-  address,
-  roomId,
-});
-
-export const messageSend = (address: string, message: string): MessageSendAction => ({
-  type: RaidenActionType.MESSAGE_SEND,
-  address,
-  message,
-});
-
-export const messageReceived = (
-  address: string,
-  message: string,
-  ts?: number,
-  userId?: string,
-  roomId?: string,
-): MessageReceivedAction => ({
-  type: RaidenActionType.MESSAGE_RECEIVED,
-  address,
-  message,
-  ts: ts || Date.now(),
-  userId,
-  roomId,
-});
-
-export type RaidenActions =
-  | RaidenInitAction
-  | RaidenShutdownAction
-  | NewBlockAction
-  | TokenMonitoredAction
-  | ChannelOpenAction
-  | ChannelOpenedAction
-  | ChannelOpenActionFailed
-  | ChannelMonitoredAction
-  | ChannelDepositAction
-  | ChannelDepositedAction
-  | ChannelDepositActionFailed
-  | ChannelCloseAction
-  | ChannelClosedAction
-  | ChannelCloseActionFailed
-  | ChannelSettleableAction
-  | ChannelSettleAction
-  | ChannelSettledAction
-  | ChannelSettleActionFailed
-  | MatrixSetupAction
-  | MatrixRequestMonitorPresenceAction
-  | MatrixPresenceUpdateAction
-  | MatrixRequestMonitorPresenceActionFailed
-  | MatrixRoomAction
-  | MatrixRoomLeaveAction
-  | MessageSendAction
-  | MessageReceivedAction;
-
-export const RaidenEventType: (
-  | RaidenActionType.SHUTDOWN
-  | RaidenActionType.NEW_BLOCK
-  | RaidenActionType.MATRIX_PRESENCE_UPDATE)[] = [
-  RaidenActionType.SHUTDOWN,
-  RaidenActionType.NEW_BLOCK,
-  RaidenActionType.MATRIX_PRESENCE_UPDATE,
-];
-
-export type RaidenEvents = RaidenShutdownAction | NewBlockAction | MatrixPresenceUpdateAction;
+/**
+ * payload.message was received on payload.ts (timestamp) from meta.address
+ * payload.userId and payload.roomId are optional and specific to matrix transport, as sender info
+ */
+export const messageReceived = createStandardAction('messageReceived').map(
+  (
+    {
+      message,
+      ts,
+      userId,
+      roomId,
+    }: {
+      message: string;
+      ts?: number;
+      userId?: string;
+      roomId?: string;
+    },
+    meta: { address: string },
+  ) => ({ payload: { message, ts: ts || Date.now(), userId, roomId }, meta }),
+);

--- a/raiden/src/store/epics/matrix.ts
+++ b/raiden/src/store/epics/matrix.ts
@@ -1,4 +1,3 @@
-import { ofType } from 'redux-observable';
 import { Observable, combineLatest, from, of, EMPTY, fromEvent, timer, ReplaySubject } from 'rxjs';
 import {
   catchError,
@@ -20,34 +19,29 @@ import {
   tap,
   toArray,
 } from 'rxjs/operators';
+import { isActionOf, ActionType } from 'typesafe-actions';
 import { get, find, minBy } from 'lodash';
 
 import { getAddress, verifyMessage } from 'ethers/utils';
 import { MatrixClient, MatrixEvent, User, Room, RoomMember } from 'matrix-js-sdk';
 
 import { RaidenEpicDeps } from '../../types';
+import { RaidenAction } from '../';
 import { RaidenState } from '../state';
 import { getUserPresence } from '../../utils';
 import {
-  RaidenActionType,
-  RaidenActions,
-  MatrixSetupAction,
-  MatrixRequestMonitorPresenceAction,
-  MatrixRequestMonitorPresenceActionFailed,
-  MatrixPresenceUpdateAction,
   matrixPresenceUpdate,
   matrixRequestMonitorPresenceFailed,
-  MatrixRoomAction,
   matrixRoom,
-  MatrixRoomLeaveAction,
   matrixRoomLeave,
-  MessageSendAction,
-  MessageReceivedAction,
   messageReceived,
+  matrixSetup,
+  matrixRequestMonitorPresence,
+  messageSend,
 } from '../actions';
 
 interface Presences {
-  [address: string]: MatrixPresenceUpdateAction;
+  [address: string]: ActionType<typeof matrixPresenceUpdate>;
 }
 
 // unavailable just means the user didn't do anything over a certain amount of time, but they're
@@ -67,16 +61,16 @@ const userRe = /^@(0x[0-9a-f]{40})[.:]/i;
  * @returns Observable of aggregated Presences from subscription to now
  */
 const getPresences$ = (
-  action$: Observable<RaidenActions>,
+  action$: Observable<RaidenAction>,
   first: Presences = {},
 ): Observable<Presences> =>
   action$.pipe(
-    ofType<RaidenActions, MatrixPresenceUpdateAction>(RaidenActionType.MATRIX_PRESENCE_UPDATE),
+    filter(isActionOf(matrixPresenceUpdate)),
     scan(
       // scan all presence update actions and populate/output a per-address mapping
-      (presences: Presences, update: MatrixPresenceUpdateAction) => ({
+      (presences, update) => ({
         ...presences,
-        [update.address]: update,
+        [update.meta.address]: update,
       }),
       first,
     ),
@@ -90,12 +84,12 @@ const getPresences$ = (
  * losing one-shot events, like invitations.
  */
 export const matrixStartEpic = (
-  action$: Observable<RaidenActions>,
+  action$: Observable<RaidenAction>,
   {  }: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
-): Observable<RaidenActions> =>
+): Observable<RaidenAction> =>
   action$.pipe(
-    ofType<RaidenActions, MatrixSetupAction>(RaidenActionType.MATRIX_SETUP),
+    filter(isActionOf(matrixSetup)),
     switchMap(() => matrix$),
     tap(matrix => console.log('MATRIX client', matrix)),
     mergeMap(matrix => matrix.startClient({ initialSyncLimit: 0 })),
@@ -106,10 +100,10 @@ export const matrixStartEpic = (
  * Calls matrix.stopClient when raiden is shutting down, i.e. action$ completes
  */
 export const matrixShutdownEpic = (
-  action$: Observable<RaidenActions>,
+  action$: Observable<RaidenAction>,
   {  }: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
-): Observable<RaidenActions> =>
+): Observable<RaidenAction> =>
   matrix$.pipe(
     tap(matrix => action$.subscribe(undefined, undefined, () => matrix.stopClient())),
     ignoreElements(),
@@ -124,21 +118,21 @@ export const matrixShutdownEpic = (
  * updates may happen later without new requests (e.g. when the user goes offline)
  */
 export const matrixMonitorPresenceEpic = (
-  action$: Observable<RaidenActions>,
+  action$: Observable<RaidenAction>,
   {  }: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
-): Observable<MatrixPresenceUpdateAction | MatrixRequestMonitorPresenceActionFailed> =>
+): Observable<
+  ActionType<typeof matrixPresenceUpdate | typeof matrixRequestMonitorPresenceFailed>
+> =>
   action$.pipe(
-    ofType<RaidenActions, MatrixRequestMonitorPresenceAction>(
-      RaidenActionType.MATRIX_REQUEST_MONITOR_PRESENCE,
-    ),
+    filter(isActionOf(matrixRequestMonitorPresence)),
     // this mergeMap is like withLatestFrom, but waits until matrix$ emits its only value
     mergeMap(action => matrix$.pipe(map(matrix => ({ action, matrix })))),
     withLatestFrom(getPresences$(action$)),
     mergeMap(([{ action, matrix }, presences]) => {
-      if (action.address in presences)
+      if (action.meta.address in presences)
         // we already monitored/saw this user's presence
-        return of(presences[action.address]);
+        return of(presences[action.meta.address]);
 
       const validUsers: User[] = [];
       for (const user of matrix.getUsers()) {
@@ -147,9 +141,9 @@ export const matrixMonitorPresenceEpic = (
         let recovered: string;
         try {
           const match = userRe.exec(user.userId);
-          if (!match || getAddress(match[1]) !== action.address) continue;
+          if (!match || getAddress(match[1]) !== action.meta.address) continue;
           recovered = verifyMessage(user.userId, user.displayName);
-          if (!recovered || recovered !== action.address) continue;
+          if (!recovered || recovered !== action.meta.address) continue;
         } catch (err) {
           continue;
         }
@@ -161,14 +155,17 @@ export const matrixMonitorPresenceEpic = (
       if (validUsers.length > 0) {
         const user = minBy(validUsers, 'lastPresenceTs')!;
         return of(
-          matrixPresenceUpdate(action.address, user.userId, AVAILABLE.includes(user.presence!)),
+          matrixPresenceUpdate(
+            { userId: user.userId, available: AVAILABLE.includes(user.presence!) },
+            action.meta,
+          ),
         );
       }
 
       // if anything failed up to here, go the slow path: searchUserDirectory + getUserPresence
       return from(
         // search user directory for any user containing the address of interest in its userId
-        matrix.searchUserDirectory({ term: action.address.toLowerCase() }),
+        matrix.searchUserDirectory({ term: action.meta.address.toLowerCase() }),
       ).pipe(
         // for every result matches, verify displayName signature is address of interest
         map(({ results }) => {
@@ -177,9 +174,9 @@ export const matrixMonitorPresenceEpic = (
             if (!user.display_name) continue;
             try {
               const match = userRe.exec(user.user_id);
-              if (!match || getAddress(match[1]) !== action.address) continue;
+              if (!match || getAddress(match[1]) !== action.meta.address) continue;
               const recovered = verifyMessage(user.user_id, user.display_name);
-              if (!recovered || recovered !== action.address) continue;
+              if (!recovered || recovered !== action.meta.address) continue;
             } catch (err) {
               continue;
             }
@@ -189,7 +186,7 @@ export const matrixMonitorPresenceEpic = (
             // if no valid user could be found, throw an error to be handled below
             throw new Error(
               `Could not find any user with valid signature for ${
-                action.address
+                action.meta.address
               } in ${JSON.stringify(results)}`,
             );
           else return validUsers;
@@ -210,9 +207,15 @@ export const matrixMonitorPresenceEpic = (
         // seen user
         map(presences => minBy(presences, 'last_active_ago')!),
         map(({ presence, user_id: userId }) =>
-          matrixPresenceUpdate(action.address, userId, AVAILABLE.includes(presence)),
+          matrixPresenceUpdate(
+            {
+              userId,
+              available: AVAILABLE.includes(presence),
+            },
+            action.meta,
+          ),
         ),
-        catchError(err => of(matrixRequestMonitorPresenceFailed(action.address, err))),
+        catchError(err => of(matrixRequestMonitorPresenceFailed(err, action.meta))),
       );
     }),
   );
@@ -223,10 +226,10 @@ export const matrixMonitorPresenceEpic = (
  * and emit presence updates for any presence change happening to a user validating to this address
  */
 export const matrixPresenceUpdateEpic = (
-  action$: Observable<RaidenActions>,
+  action$: Observable<RaidenAction>,
   {  }: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
-): Observable<MatrixPresenceUpdateAction> =>
+): Observable<ActionType<typeof matrixPresenceUpdate>> =>
   matrix$.pipe(
     // when matrix finishes initialization, register to matrix presence events
     switchMap(matrix =>
@@ -249,14 +252,8 @@ export const matrixPresenceUpdateEpic = (
     withLatestFrom(
       // observable of all addresses whose presence monitoring was requested since init
       action$.pipe(
-        ofType<RaidenActions, MatrixRequestMonitorPresenceAction>(
-          RaidenActionType.MATRIX_REQUEST_MONITOR_PRESENCE,
-        ),
-        scan(
-          (toMonitor: Set<string>, request: MatrixRequestMonitorPresenceAction) =>
-            toMonitor.add(request.address),
-          new Set<string>(),
-        ),
+        filter(isActionOf(matrixRequestMonitorPresence)),
+        scan((toMonitor, request) => toMonitor.add(request.meta.address), new Set<string>()),
         startWith(new Set<string>()),
       ),
       // known presences as { address: <last seen MatrixPresenceUpdateAction> } mapping
@@ -274,8 +271,8 @@ export const matrixPresenceUpdateEpic = (
 
       if (
         address in presences &&
-        presences[address].userId === userId &&
-        presences[address].available === available
+        presences[address].payload.userId === userId &&
+        presences[address].payload.available === available
       )
         // even if signature verification passes, this wouldn't change presence, so return early
         return EMPTY;
@@ -300,7 +297,9 @@ export const matrixPresenceUpdateEpic = (
             );
           return recovered;
         }),
-        map(address => matrixPresenceUpdate(address, userId, available, user.lastPresenceTs)),
+        map(address =>
+          matrixPresenceUpdate({ userId, available, ts: user.lastPresenceTs }, { address }),
+        ),
       );
     }),
     catchError(err => (console.log('Error validating presence event, ignoring', err), EMPTY)),
@@ -311,17 +310,17 @@ export const matrixPresenceUpdateEpic = (
  * Requires address to have its presence monitored.
  */
 export const matrixCreateRoomEpic = (
-  action$: Observable<RaidenActions>,
+  action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
-): Observable<MatrixRoomAction> =>
+): Observable<ActionType<typeof matrixRoom>> =>
   combineLatest(getPresences$(action$), state$).pipe(
     // multicasting combined presences+state with a ReplaySubject makes it act as withLatestFrom
     // but working inside concatMap, which is called only at outer next and subscribe delayed
     multicast(new ReplaySubject<[Presences, RaidenState]>(1), presencesStateReplay$ =>
       // actual output observable, handles MessageSendAction serially and create room if needed
       action$.pipe(
-        ofType<RaidenActions, MessageSendAction>(RaidenActionType.MESSAGE_SEND),
+        filter(isActionOf(messageSend)),
         // this mergeMap is like withLatestFrom, but waits until matrix$ emits its only value
         mergeMap(action => matrix$.pipe(map(matrix => ({ action, matrix })))),
         // concatMap is used to prevent bursts of messages for a given address (eg. on startup)
@@ -330,22 +329,22 @@ export const matrixCreateRoomEpic = (
           // presencesStateReplay$+take(1) acts like withLatestFrom with cached result
           presencesStateReplay$.pipe(
             // wait for user to be monitored
-            filter(([presences]) => action.address in presences),
+            filter(([presences]) => action.meta.address in presences),
             take(1),
             // if there's already a room state for address and it's present in matrix, skip
             filter(
               ([, state]) =>
-                !get(state, ['transport', 'matrix', 'address2rooms', action.address, 0]),
+                !get(state, ['transport', 'matrix', 'address2rooms', action.meta.address, 0]),
             ),
             // else, create a room, invite known user and dispatch the respective MatrixRoomAction
             // to store it in state
             mergeMap(([presences]) =>
               matrix.createRoom({
                 visibility: 'private',
-                invite: [presences[action.address].userId],
+                invite: [presences[action.meta.address].payload.userId],
               }),
             ),
-            map(({ room_id: roomId }) => matrixRoom(action.address, roomId)),
+            map(({ room_id: roomId }) => matrixRoom({ roomId }, action.meta)),
           ),
         ),
       ),
@@ -356,13 +355,13 @@ export const matrixCreateRoomEpic = (
  * Invites users coming online to rooms we may have with them
  */
 export const matrixInviteEpic = (
-  action$: Observable<RaidenActions>,
+  action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
-): Observable<RaidenActions> =>
+): Observable<RaidenAction> =>
   action$.pipe(
-    ofType<RaidenActions, MatrixPresenceUpdateAction>(RaidenActionType.MATRIX_PRESENCE_UPDATE),
-    filter(action => action.available),
+    filter(isActionOf(matrixPresenceUpdate)),
+    filter(action => action.payload.available),
     // this mergeMap is like withLatestFrom, but waits until matrix$ emits its only value
     mergeMap(action => matrix$.pipe(map(matrix => ({ action, matrix })))),
     withLatestFrom(state$),
@@ -371,14 +370,14 @@ export const matrixInviteEpic = (
         'transport',
         'matrix',
         'address2rooms',
-        action.address,
+        action.meta.address,
         0,
       ]);
       if (roomId) {
         const room = matrix.getRoom(roomId);
         if (room) {
-          const member = room.getMember(action.userId);
-          if (!member) return from(matrix.invite(roomId, action.userId));
+          const member = room.getMember(action.payload.userId);
+          if (!member) return from(matrix.invite(roomId, action.payload.userId));
         }
       }
       return EMPTY;
@@ -390,10 +389,10 @@ export const matrixInviteEpic = (
  * Handle invites sent to us and accepts them iff sent by a monitored user
  */
 export const matrixHandleInvitesEpic = (
-  action$: Observable<RaidenActions>,
+  action$: Observable<RaidenAction>,
   {  }: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
-): Observable<MatrixRoomAction> =>
+): Observable<ActionType<typeof matrixRoom>> =>
   matrix$.pipe(
     // when matrix finishes initialization, register to matrix invite events
     switchMap(matrix =>
@@ -411,16 +410,14 @@ export const matrixHandleInvitesEpic = (
     withLatestFrom(getPresences$(action$)),
     mergeMap(([{ event, member, matrix }, presences]) => {
       const sender = event.getSender(),
-        cachedPresence = find(presences, p => p.userId === sender),
+        cachedPresence = find(presences, p => p.payload.userId === sender),
         senderPresence$ = cachedPresence
           ? of(cachedPresence)
           : action$.pipe(
               // as these membership events can come up quite early, we delay continue processing
               // them a while, to see if the sender is of interest to us (presence monitored)
-              ofType<RaidenActions, MatrixPresenceUpdateAction>(
-                RaidenActionType.MATRIX_PRESENCE_UPDATE,
-              ),
-              filter(a => a.userId === sender),
+              filter(isActionOf(matrixPresenceUpdate)),
+              filter(a => a.payload.userId === sender),
               take(1),
               // Don't wait more than some arbitrary time for this sender presence update to show
               // up; completes without emitting anything otherwise, ending this pipeline.
@@ -434,7 +431,7 @@ export const matrixHandleInvitesEpic = (
     mergeMap(({ matrix, member, senderPresence }) =>
       // join room and emit MatrixRoomAction to make it default/first option for sender address
       from(matrix.joinRoom(member.roomId, { syncRoom: true })).pipe(
-        map(() => matrixRoom(senderPresence.address, member.roomId)),
+        map(() => matrixRoom({ roomId: member.roomId }, { address: senderPresence.meta.address })),
       ),
     ),
   );
@@ -444,22 +441,22 @@ export const matrixHandleInvitesEpic = (
  * Excess rooms are the ones behind a given threshold (currently 3) in the address's rooms queue
  */
 export const matrixLeaveExcessRoomsEpic = (
-  action$: Observable<RaidenActions>,
+  action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
-): Observable<MatrixRoomLeaveAction> =>
+): Observable<ActionType<typeof matrixRoomLeave>> =>
   action$.pipe(
     // act whenever a new room is added to the address queue in state
-    ofType<RaidenActions, MatrixRoomAction>(RaidenActionType.MATRIX_ROOM),
+    filter(isActionOf(matrixRoom)),
     // this mergeMap is like withLatestFrom, but waits until matrix$ emits its only value
     mergeMap(action => matrix$.pipe(map(matrix => ({ action, matrix })))),
     withLatestFrom(state$),
     mergeMap(([{ action, matrix }, state]) => {
       const THRESHOLD = 3;
-      const rooms = state.transport!.matrix!.address2rooms![action.address];
+      const rooms = state.transport!.matrix!.address2rooms![action.meta.address];
       return from(rooms.filter(({}, i) => i >= THRESHOLD)).pipe(
         mergeMap(roomId => matrix.leave(roomId).then(() => roomId)),
-        map(roomId => matrixRoomLeave(action.address, roomId)),
+        map(roomId => matrixRoomLeave({ roomId }, action.meta)),
       );
     }),
   );
@@ -469,10 +466,10 @@ export const matrixLeaveExcessRoomsEpic = (
  * interest
  */
 export const matrixLeaveUnknownRoomsEpic = (
-  {  }: Observable<RaidenActions>,
+  {  }: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
   { matrix$, network }: RaidenEpicDeps,
-): Observable<RaidenActions> =>
+): Observable<RaidenAction> =>
   matrix$.pipe(
     // when matrix finishes initialization, register to matrix Room events
     switchMap(matrix =>
@@ -508,10 +505,10 @@ export const matrixLeaveUnknownRoomsEpic = (
  * detected, and then no MatrixRoomLeaveAction is emitted for them by this epic.
  */
 export const matrixCleanLeftRoomsEpic = (
-  {  }: Observable<RaidenActions>,
+  {  }: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
-): Observable<MatrixRoomLeaveAction> =>
+): Observable<ActionType<typeof matrixRoomLeave>> =>
   matrix$.pipe(
     // when matrix finishes initialization, register to matrix invite events
     switchMap(matrix =>
@@ -533,7 +530,7 @@ export const matrixCleanLeftRoomsEpic = (
       for (const address in address2rooms) {
         for (const roomId of address2rooms[address]) {
           if (roomId === room.roomId) {
-            yield matrixRoomLeave(address, roomId);
+            yield matrixRoomLeave({ roomId }, { address });
           }
         }
       }
@@ -544,20 +541,20 @@ export const matrixCleanLeftRoomsEpic = (
  * Handles a MessageSendAction and send its message to the first room on queue for address
  */
 export const matrixMessageSendEpic = (
-  action$: Observable<RaidenActions>,
+  action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
-): Observable<RaidenActions> =>
+): Observable<RaidenAction> =>
   combineLatest(getPresences$(action$), state$).pipe(
     // multicasting combined presences+state with a ReplaySubject makes it act as withLatestFrom
     // but working inside concatMap, called only at outer emit and subscription delayed
     multicast(new ReplaySubject<[Presences, RaidenState]>(1), presencesStateReplay$ =>
       // actual output observable, gets/wait for the user to be in a room, and then sendMessage
       action$.pipe(
-        ofType<RaidenActions, MessageSendAction>(RaidenActionType.MESSAGE_SEND),
+        filter(isActionOf(messageSend)),
         // this mergeMap is like withLatestFrom, but waits until matrix$ emits its only value
         mergeMap(action => matrix$.pipe(map(matrix => ({ action, matrix })))),
-        groupBy(({ action }) => action.address),
+        groupBy(({ action }) => action.meta.address),
         // merge all inner/grouped observables, so different user's "queues" can be parallel
         mergeMap(grouped$ =>
           // per-user "queue"
@@ -570,11 +567,13 @@ export const matrixMessageSendEpic = (
                 // ReplaySubject ensures it happens immediatelly if all conditions are satisfied
                 filter(
                   ([presences, state]) =>
-                    action.address in presences &&
-                    presences[action.address].available &&
-                    get(state, ['transport', 'matrix', 'address2rooms', action.address, 0]),
+                    action.meta.address in presences &&
+                    presences[action.meta.address].payload.available &&
+                    get(state, ['transport', 'matrix', 'address2rooms', action.meta.address, 0]),
                 ),
-                map(([, state]) => state.transport!.matrix!.address2rooms![action.address][0]),
+                map(
+                  ([, state]) => state.transport!.matrix!.address2rooms![action.meta.address][0],
+                ),
                 distinctUntilChanged(),
                 // get/wait room object for roomId
                 switchMap(roomId => {
@@ -592,7 +591,7 @@ export const matrixMessageSendEpic = (
                 // get room member for partner userId
                 mergeMap(([room, [presences]]) => {
                   // get latest known userId for address at this point in time
-                  const userId = presences[action.address].userId;
+                  const userId = presences[action.meta.address].payload.userId;
                   const member = room.getMember(userId);
                   // if it's already present in room, return its membership
                   if (member && member.membership === 'join') return of(member);
@@ -608,7 +607,7 @@ export const matrixMessageSendEpic = (
                     filter(
                       ([member, [presences]]) =>
                         member.roomId === room.roomId &&
-                        member.userId === presences[action.address].userId &&
+                        member.userId === presences[action.meta.address].payload.userId &&
                         member.membership === 'join',
                     ),
                     take(1),
@@ -621,7 +620,7 @@ export const matrixMessageSendEpic = (
                   matrix.sendEvent(
                     member.roomId,
                     'm.room.message',
-                    { body: action.message, msgtype: 'm.text' },
+                    { body: action.payload.message, msgtype: 'm.text' },
                     '',
                   ),
                 ),
@@ -639,10 +638,10 @@ export const matrixMessageSendEpic = (
  * an user of interest (one valid signature from an address we monitor) in a room we have for them
  */
 export const matrixMessageReceivedEpic = (
-  action$: Observable<RaidenActions>,
+  action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
   { matrix$ }: RaidenEpicDeps,
-): Observable<MessageReceivedAction> =>
+): Observable<ActionType<typeof messageReceived>> =>
   combineLatest(getPresences$(action$), state$).pipe(
     // multicasting combined presences+state with a ReplaySubject makes it act as withLatestFrom
     // but working inside concatMap, called only at outer emit and subscription delayed
@@ -671,7 +670,7 @@ export const matrixMessageReceivedEpic = (
               if (!presence) return false;
               const rooms: string[] = get(
                 state,
-                ['transport', 'matrix', 'address2rooms', presence.address],
+                ['transport', 'matrix', 'address2rooms', presence.meta.address],
                 [],
               );
               if (!rooms.includes(room.roomId)) return false;
@@ -684,11 +683,13 @@ export const matrixMessageReceivedEpic = (
             map(([presences]) => {
               const presence = find(presences, ['userId', event.getSender()])!;
               return messageReceived(
-                presence.address,
-                event.event.content.body,
-                event.event.origin_server_ts,
-                presence.userId,
-                room.roomId,
+                {
+                  message: event.event.content.body,
+                  ts: event.event.origin_server_ts,
+                  userId: presence.payload.userId,
+                  roomId: room.roomId,
+                },
+                presence.meta,
               );
             }),
           ),
@@ -702,19 +703,23 @@ export const matrixMessageReceivedEpic = (
  * update queue so this room goes to the front and will be used as send message room from now on
  */
 export const matrixMessageReceivedUpdateRoomEpic = (
-  action$: Observable<RaidenActions>,
+  action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-): Observable<MatrixRoomAction> =>
+): Observable<ActionType<typeof matrixRoom>> =>
   action$.pipe(
-    ofType<RaidenActions, MessageReceivedAction>(RaidenActionType.MESSAGE_RECEIVED),
+    filter(isActionOf(messageReceived)),
     withLatestFrom(state$),
     filter(([action, state]) => {
       const rooms: string[] = get(
         state,
-        ['transport', 'matrix', 'address2rooms', action.address],
+        ['transport', 'matrix', 'address2rooms', action.meta.address],
         [],
       );
-      return !!action.roomId && rooms.includes(action.roomId) && rooms[0] !== action.roomId;
+      return (
+        !!action.payload.roomId &&
+        rooms.includes(action.payload.roomId) &&
+        rooms[0] !== action.payload.roomId
+      );
     }),
-    map(([action]) => matrixRoom(action.address, action.roomId!)),
+    map(([action]) => matrixRoom({ roomId: action.payload.roomId! }, action.meta)),
   );

--- a/raiden/src/store/epics/matrix.ts
+++ b/raiden/src/store/epics/matrix.ts
@@ -666,7 +666,7 @@ export const matrixMessageReceivedEpic = (
         mergeMap(({ event, room }) =>
           presencesStateReplay$.pipe(
             filter(([presences, state]) => {
-              const presence = find(presences, ['userId', event.getSender()]);
+              const presence = find(presences, ['payload.userId', event.getSender()]);
               if (!presence) return false;
               const rooms: string[] = get(
                 state,
@@ -681,7 +681,7 @@ export const matrixMessageReceivedEpic = (
             // AND the room in which this message was sent to be in sender's address room queue
             takeUntil(timer(30e3)),
             map(([presences]) => {
-              const presence = find(presences, ['userId', event.getSender()])!;
+              const presence = find(presences, ['payload.userId', event.getSender()])!;
               return messageReceived(
                 {
                   message: event.event.content.body,

--- a/raiden/src/store/epics/output.ts
+++ b/raiden/src/store/epics/output.ts
@@ -1,23 +1,23 @@
 import { Observable, EMPTY } from 'rxjs';
 
 import { RaidenEpicDeps } from '../../types';
+import { RaidenAction } from '../';
 import { RaidenState } from '../state';
-import { RaidenActions } from '../actions';
 
 /**
  * This epic simply pipes all states to stateOutput$ subject injected as dependency
  */
 export const stateOutputEpic = (
-  action$: Observable<RaidenActions>,
+  {  }: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
   { stateOutput$ }: RaidenEpicDeps,
-): Observable<RaidenActions> => (state$.subscribe(stateOutput$), EMPTY);
+): Observable<RaidenAction> => (state$.subscribe(stateOutput$), EMPTY);
 
 /**
  * This epic simply pipes all actions to actionOutput$ subject injected as dependency
  */
 export const actionOutputEpic = (
-  action$: Observable<RaidenActions>,
-  state$: Observable<RaidenState>,
+  action$: Observable<RaidenAction>,
+  {  }: Observable<RaidenState>,
   { actionOutput$ }: RaidenEpicDeps,
-): Observable<RaidenActions> => (action$.subscribe(actionOutput$), EMPTY);
+): Observable<RaidenAction> => (action$.subscribe(actionOutput$), EMPTY);

--- a/raiden/src/store/index.ts
+++ b/raiden/src/store/index.ts
@@ -1,5 +1,20 @@
+import { pick } from 'lodash';
+import { ActionType, getType } from 'typesafe-actions';
+import * as RaidenActions from './actions';
+
 export * from './types';
 export * from './state';
-export * from './actions';
 export { raidenReducer } from './reducers';
 export { raidenEpics } from './epics';
+
+/* Tagged union of all action types from the action creators */
+export type RaidenAction = ActionType<typeof RaidenActions>;
+/* Mapping { [type: string]: Action } of a subset of RaidenActions exposed as events */
+export const RaidenEvents = pick(
+  RaidenActions,
+  [RaidenActions.raidenShutdown, RaidenActions.newBlock, RaidenActions.matrixPresenceUpdate].map(
+    getType,
+  ),
+);
+/* Tagged union of RaidenEvents actions */
+export type RaidenEvent = ActionType<typeof RaidenEvents>;

--- a/raiden/src/store/reducers.ts
+++ b/raiden/src/store/reducers.ts
@@ -1,27 +1,48 @@
+import { getType } from 'typesafe-actions';
 import { cloneDeep, get, isEmpty, set, unset } from 'lodash';
 import { Zero } from 'ethers/constants';
 
+import { RaidenAction } from './';
 import { RaidenState, initialState, ChannelState, Channel } from './state';
-import { RaidenActions, RaidenActionType } from './actions';
+import {
+  newBlock,
+  tokenMonitored,
+  channelOpen,
+  channelOpened,
+  channelOpenFailed,
+  channelDeposited,
+  channelClose,
+  channelClosed,
+  channelSettleable,
+  channelSettle,
+  channelSettled,
+  matrixSetup,
+  matrixRoom,
+  matrixRoomLeave,
+} from './actions';
 
 export function raidenReducer(
   state: RaidenState = initialState,
-  action: RaidenActions,
+  action: RaidenAction,
 ): RaidenState {
   let channel: Channel;
   let path: string[];
   switch (action.type) {
-    case RaidenActionType.NEW_BLOCK:
-      return { ...state, blockNumber: action.blockNumber };
+    case getType(newBlock):
+      return { ...state, blockNumber: action.payload.blockNumber };
 
-    case RaidenActionType.TOKEN_MONITORED:
+    case getType(tokenMonitored):
       // action.first should be true, but not required,
       // actual check is if token is in state.token2tokenNetwork
-      if (action.token in state.token2tokenNetwork) return state;
-      return set(cloneDeep(state), ['token2tokenNetwork', action.token], action.tokenNetwork);
+      if (action.payload.token in state.token2tokenNetwork) return state;
+      return set(
+        cloneDeep(state),
+        ['token2tokenNetwork', action.payload.token],
+        action.payload.tokenNetwork,
+      );
 
-    case RaidenActionType.CHANNEL_OPEN:
-      path = ['tokenNetworks', action.tokenNetwork, action.partner];
+    case getType(channelOpen):
+      path = ['tokenNetworks', action.meta.tokenNetwork, action.meta.partner];
       if (get(state, path)) return state; // there's already a channel with partner
       return set(cloneDeep(state), path, {
         state: ChannelState.opening,
@@ -29,66 +50,68 @@ export function raidenReducer(
         partnerDeposit: Zero,
       });
 
-    case RaidenActionType.CHANNEL_OPENED:
-      path = ['tokenNetworks', action.tokenNetwork, action.partner];
+    case getType(channelOpened):
+      path = ['tokenNetworks', action.meta.tokenNetwork, action.meta.partner];
       channel = {
         totalDeposit: Zero,
         partnerDeposit: Zero,
         state: ChannelState.open,
-        id: action.id,
-        settleTimeout: action.settleTimeout,
-        openBlock: action.openBlock,
+        id: action.payload.id,
+        settleTimeout: action.payload.settleTimeout,
+        openBlock: action.payload.openBlock,
         /* txHash: action.txHash, */ // not needed in state for now, but comes in action
       };
       return set(cloneDeep(state), path, channel);
 
-    case RaidenActionType.CHANNEL_OPEN_FAILED:
-      path = ['tokenNetworks', action.tokenNetwork, action.partner];
+    case getType(channelOpenFailed):
+      path = ['tokenNetworks', action.meta.tokenNetwork, action.meta.partner];
       if (get(state, [...path, 'state']) !== ChannelState.opening) return state;
       const newState = cloneDeep(state);
       unset(newState, path);
       return newState;
 
-    case RaidenActionType.CHANNEL_DEPOSITED:
-      path = ['tokenNetworks', action.tokenNetwork, action.partner];
+    case getType(channelDeposited):
+      path = ['tokenNetworks', action.meta.tokenNetwork, action.meta.partner];
       channel = cloneDeep(get(state, path));
-      if (!channel || channel.state !== ChannelState.open || channel.id !== action.id)
+      if (!channel || channel.state !== ChannelState.open || channel.id !== action.payload.id)
         return state;
-      if (action.participant === state.address) channel.totalDeposit = action.totalDeposit;
-      else if (action.participant === action.partner) channel.partnerDeposit = action.totalDeposit;
+      if (action.payload.participant === state.address)
+        channel.totalDeposit = action.payload.totalDeposit;
+      else if (action.payload.participant === action.meta.partner)
+        channel.partnerDeposit = action.payload.totalDeposit;
       else return state; // shouldn't happen, deposit from neither us or partner
       return set(cloneDeep(state), path, channel);
 
-    case RaidenActionType.CHANNEL_CLOSE:
-      path = ['tokenNetworks', action.tokenNetwork, action.partner, 'state'];
+    case getType(channelClose):
+      path = ['tokenNetworks', action.meta.tokenNetwork, action.meta.partner, 'state'];
       if (get(state, path) !== ChannelState.open) return state;
       return set(cloneDeep(state), path, ChannelState.closing);
 
-    case RaidenActionType.CHANNEL_CLOSED:
-      path = ['tokenNetworks', action.tokenNetwork, action.partner];
+    case getType(channelClosed):
+      path = ['tokenNetworks', action.meta.tokenNetwork, action.meta.partner];
       channel = cloneDeep(get(state, path));
       if (
         !channel ||
         !(channel.state === ChannelState.open || channel.state === ChannelState.closing) ||
-        channel.id !== action.id
+        channel.id !== action.payload.id
       )
         return state;
       channel.state = ChannelState.closed;
-      channel.closeBlock = action.closeBlock;
+      channel.closeBlock = action.payload.closeBlock;
       return set(cloneDeep(state), path, channel);
 
-    case RaidenActionType.CHANNEL_SETTLEABLE:
-      path = ['tokenNetworks', action.tokenNetwork, action.partner, 'state'];
+    case getType(channelSettleable):
+      path = ['tokenNetworks', action.meta.tokenNetwork, action.meta.partner, 'state'];
       if (get(state, path) !== ChannelState.closed) return state;
       return set(cloneDeep(state), path, ChannelState.settleable);
 
-    case RaidenActionType.CHANNEL_SETTLE:
-      path = ['tokenNetworks', action.tokenNetwork, action.partner, 'state'];
+    case getType(channelSettle):
+      path = ['tokenNetworks', action.meta.tokenNetwork, action.meta.partner, 'state'];
       if (get(state, path) !== ChannelState.settleable) return state;
       return set(cloneDeep(state), path, ChannelState.settling);
 
-    case RaidenActionType.CHANNEL_SETTLED:
-      path = ['tokenNetworks', action.tokenNetwork, action.partner, 'state'];
+    case getType(channelSettled):
+      path = ['tokenNetworks', action.meta.tokenNetwork, action.meta.partner, 'state'];
       if (
         ![ChannelState.closed, ChannelState.settleable, ChannelState.settling].includes(
           get(state, path),
@@ -96,26 +119,29 @@ export function raidenReducer(
       )
         return state;
       state = cloneDeep(state);
-      delete state.tokenNetworks[action.tokenNetwork][action.partner];
+      delete state.tokenNetworks[action.meta.tokenNetwork][action.meta.partner];
       return state;
 
-    case RaidenActionType.MATRIX_SETUP:
+    case getType(matrixSetup):
       state = cloneDeep(state);
-      set(state, ['transport', 'matrix', 'server'], action.server);
-      set(state, ['transport', 'matrix', 'setup'], action.setup);
+      set(state, ['transport', 'matrix', 'server'], action.payload.server);
+      set(state, ['transport', 'matrix', 'setup'], action.payload.setup);
       return state;
 
-    case RaidenActionType.MATRIX_ROOM:
-      path = ['transport', 'matrix', 'address2rooms', action.address];
+    case getType(matrixRoom):
+      path = ['transport', 'matrix', 'address2rooms', action.meta.address];
       return set(cloneDeep(state), path, [
-        action.roomId,
-        ...(get(state, path, []) as string[]).filter(room => room !== action.roomId),
+        action.payload.roomId,
+        ...(get(state, path, []) as string[]).filter(room => room !== action.payload.roomId),
       ]);
 
-    case RaidenActionType.MATRIX_ROOM_LEAVE:
-      path = ['transport', 'matrix', 'address2rooms', action.address];
-      state = cloneDeep(state);
-      set(state, path, (get(state, path, []) as string[]).filter(r => r !== action.roomId));
+    case getType(matrixRoomLeave):
+      path = ['transport', 'matrix', 'address2rooms', action.meta.address];
+      state = set(
+        cloneDeep(state),
+        path,
+        (get(state, path, []) as string[]).filter(r => r !== action.payload.roomId),
+      );
       if (isEmpty(get(state, path, []))) {
         unset(state, path);
       }

--- a/raiden/src/store/types.ts
+++ b/raiden/src/store/types.ts
@@ -38,3 +38,8 @@ export class EnumType<A> extends t.Type<A> {
 // simple helper function
 export const createEnumType = <T>(e: object, name?: string): EnumType<T> =>
   new EnumType<T>(e, name);
+
+export interface ChannelId {
+  tokenNetwork: string;
+  partner: string;
+}

--- a/raiden/src/types.ts
+++ b/raiden/src/types.ts
@@ -8,7 +8,7 @@ import { MatrixClient } from 'matrix-js-sdk';
 import { TokenNetworkRegistry } from '../contracts/TokenNetworkRegistry';
 import { TokenNetwork } from '../contracts/TokenNetwork';
 import { Token } from '../contracts/Token';
-import { RaidenState, RaidenActions, Channel } from './store';
+import { RaidenState, RaidenAction, Channel } from './store';
 export { ChannelState } from './store';
 
 interface Info {
@@ -28,7 +28,7 @@ export interface RaidenContracts {
 
 export interface RaidenEpicDeps {
   stateOutput$: BehaviorSubject<RaidenState>;
-  actionOutput$: Subject<RaidenActions>;
+  actionOutput$: Subject<RaidenAction>;
   matrix$: AsyncSubject<MatrixClient>;
   provider: JsonRpcProvider;
   network: Network;

--- a/raiden/tests/e2e/raiden.spec.ts
+++ b/raiden/tests/e2e/raiden.spec.ts
@@ -1,6 +1,7 @@
 import { first, filter } from 'rxjs/operators';
 import { Zero } from 'ethers/constants';
 import { parseEther, parseUnits, bigNumberify, BigNumber } from 'ethers/utils';
+import { getType } from 'typesafe-actions';
 import { get } from 'lodash';
 
 jest.mock('cross-fetch');
@@ -12,7 +13,9 @@ import { MockStorage, MockMatrixRequestFn } from './mocks';
 import { request } from 'matrix-js-sdk';
 
 import { Raiden } from 'raiden/raiden';
-import { initialState, RaidenActionType, ShutdownReason } from 'raiden/store';
+import { ShutdownReason } from 'raiden/constants';
+import { initialState } from 'raiden/store';
+import { raidenShutdown, newBlock } from 'raiden/store/actions';
 import { ContractsInfo, RaidenContracts, ChannelState, Storage } from 'raiden/types';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -334,8 +337,8 @@ describe('Raiden', () => {
       const promise = raiden.events$.toPromise();
       raiden.stop();
       await expect(promise).resolves.toMatchObject({
-        type: RaidenActionType.SHUTDOWN,
-        reason: ShutdownReason.STOP,
+        type: getType(raidenShutdown),
+        payload: { reason: ShutdownReason.STOP },
       });
     });
 
@@ -345,8 +348,8 @@ describe('Raiden', () => {
       const promise = raiden.events$.pipe(first()).toPromise();
       await provider.mine(10);
       await expect(promise).resolves.toMatchObject({
-        type: RaidenActionType.NEW_BLOCK,
-        blockNumber: expect.any(Number),
+        type: getType(newBlock),
+        payload: { blockNumber: expect.any(Number) },
       });
     });
   });

--- a/raiden/tests/unit/actions.spec.ts
+++ b/raiden/tests/unit/actions.spec.ts
@@ -1,10 +1,5 @@
 import { bigNumberify } from 'ethers/utils';
-import {
-  RaidenActionType,
-  channelDeposit,
-  channelDepositFailed,
-  channelMonitored,
-} from 'raiden/store';
+import { channelDeposit, channelDepositFailed, channelMonitored } from 'raiden/store/actions';
 
 describe('action factories not tested in reducers.spec.ts', () => {
   test('channelMonitor', () => {
@@ -12,12 +7,10 @@ describe('action factories not tested in reducers.spec.ts', () => {
       partner = '0xpartner',
       id = 12,
       fromBlock = 5123;
-    expect(channelMonitored(tokenNetwork, partner, id, fromBlock)).toEqual({
-      type: RaidenActionType.CHANNEL_MONITORED,
-      tokenNetwork,
-      partner,
-      id,
-      fromBlock,
+    expect(channelMonitored({ id, fromBlock }, { tokenNetwork, partner })).toEqual({
+      type: 'channelMonitored',
+      payload: { id, fromBlock },
+      meta: { tokenNetwork, partner },
     });
   });
 
@@ -25,11 +18,10 @@ describe('action factories not tested in reducers.spec.ts', () => {
     const tokenNetwork = '0xtokenNetwork',
       partner = '0xpartner',
       deposit = bigNumberify(999);
-    expect(channelDeposit(tokenNetwork, partner, deposit)).toEqual({
-      type: RaidenActionType.CHANNEL_DEPOSIT,
-      tokenNetwork,
-      partner,
-      deposit,
+    expect(channelDeposit({ deposit }, { tokenNetwork, partner })).toEqual({
+      type: 'channelDeposit',
+      payload: { deposit },
+      meta: { tokenNetwork, partner },
     });
   });
 
@@ -37,11 +29,11 @@ describe('action factories not tested in reducers.spec.ts', () => {
     const tokenNetwork = '0xtokenNetwork',
       partner = '0xpartner',
       error = new Error('not enough funds');
-    expect(channelDepositFailed(tokenNetwork, partner, error)).toEqual({
-      type: RaidenActionType.CHANNEL_DEPOSIT_FAILED,
-      tokenNetwork,
-      partner,
-      error,
+    expect(channelDepositFailed(error, { tokenNetwork, partner })).toEqual({
+      type: 'channelDepositFailed',
+      payload: error,
+      meta: { tokenNetwork, partner },
+      error: true,
     });
   });
 });

--- a/raiden/tests/unit/mocks.ts
+++ b/raiden/tests/unit/mocks.ts
@@ -56,8 +56,8 @@ import TokenNetworkAbi from 'raiden/abi/TokenNetwork.json';
 import TokenAbi from 'raiden/abi/Token.json';
 
 import { RaidenEpicDeps } from 'raiden/types';
+import { RaidenAction } from 'raiden/store';
 import { RaidenState, initialState } from 'raiden/store/state';
-import { RaidenActions } from 'raiden/store/actions';
 
 type MockedContract<T extends Contract> = jest.Mocked<T> & {
   functions: {
@@ -170,7 +170,7 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
 
   return {
     stateOutput$: new BehaviorSubject<RaidenState>(initialState),
-    actionOutput$: new Subject<RaidenActions>(),
+    actionOutput$: new Subject<RaidenAction>(),
     matrix$: new AsyncSubject<MatrixClient>(),
     address,
     network,


### PR DESCRIPTION
Replace hand-made actions with [typesafe-actions](https://github.com/piotrwitek/typesafe-actions), which are more explicit, have better typechecking capabilities, allow defining actions in a single declaration therefore easing splitting actions between domain driven modules as well as easing complying with [flux-standard-action](https://github.com/redux-utilities/flux-standard-action) pattern
- [x] implement `typesafe-actions`
- [x] adapt tests
- [x] adapt dApp events