### PR TITLE
Updates dapp dependency install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Then you need to install the wallet app dependencies.
 
 ```bash
 cd ../raiden-dapp
-npm install
+npm install --save raiden
 ```
 
 This will also create a symbolic link in `raiden-dapp/node_modules/raiden` to `raiden`.


### PR DESCRIPTION
If you do a simple `npm install` then the `npm run serve` fails with errors.