### PR TITLE
Lossless JSON

### DIFF
--- a/raiden-dapp/tsconfig.json
+++ b/raiden-dapp/tsconfig.json
@@ -31,7 +31,8 @@
       "dom",
       "dom.iterable",
       "scripthost"
-    ]
+    ],
+    "typeRoots": ["node_modules/@types", "../raiden/typings"]
   },
   "include": [
     "src/**/*.ts",

--- a/raiden/package-lock.json
+++ b/raiden/package-lock.json
@@ -4302,6 +4302,11 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lossless-json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-1.0.3.tgz",
+      "integrity": "sha512-r4w0WrhIHV1lOTVGbTg4Toqwso5x6C8pM7Q/Nto2vy4c7yUSdTYVYlj16uHVX3MT1StpSELDv8yrqGx41MBsDA=="
+    },
     "ltgt": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",

--- a/raiden/package.json
+++ b/raiden/package.json
@@ -68,6 +68,7 @@
     "ethers": "^4.0.31",
     "io-ts": "^1.10.2",
     "lodash": "^4.17.11",
+    "lossless-json": "^1.0.3",
     "matrix-js-sdk": "^1.2.0",
     "redux": "^4.0.1",
     "redux-logger": "^3.0.6",

--- a/raiden/src/index.ts
+++ b/raiden/src/index.ts
@@ -1,8 +1,8 @@
 /* istanbul ignore file */
+export * from './types';
 export { RaidenState } from './store';
 export { RaidenEvent } from './actions';
 export { ChannelState } from './channels';
 export { ShutdownReason } from './constants';
-export * from './types';
-export * from './raiden';
 export { Address } from './utils/types';
+export * from './raiden';

--- a/raiden/src/types.ts
+++ b/raiden/src/types.ts
@@ -1,5 +1,4 @@
 /// <reference path="../typings/matrix-js-sdk/index.d.ts" />
-
 import { Subject, BehaviorSubject, AsyncSubject } from 'rxjs';
 import { Signer } from 'ethers';
 import { JsonRpcProvider } from 'ethers/providers';

--- a/raiden/src/utils/matrix.ts
+++ b/raiden/src/utils/matrix.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/matrix-js-sdk/index.d.ts" />
-
 import fetch from 'cross-fetch';
 import { MatrixClient } from 'matrix-js-sdk';
 import { encodeUri } from 'matrix-js-sdk/lib/utils';

--- a/raiden/tests/unit/state.spec.ts
+++ b/raiden/tests/unit/state.spec.ts
@@ -36,8 +36,8 @@ describe('RaidenState codecs', () => {
         [tokenNetwork]: {
           [partner]: {
             state: 'open',
-            own: { deposit: '200' },
-            partner: { deposit: '210' },
+            own: { deposit: 200 },
+            partner: { deposit: 210 },
             id: 17,
             settleTimeout: 500,
             openBlock: 121,

--- a/raiden/tests/unit/utils.spec.ts
+++ b/raiden/tests/unit/utils.spec.ts
@@ -3,6 +3,7 @@ import { first, take, toArray } from 'rxjs/operators';
 
 import { Event } from 'ethers/contract';
 import { bigNumberify, BigNumber } from 'ethers/utils';
+import { LosslessNumber } from 'lossless-json';
 
 import { fromEthersEvent, getEventsStream } from 'raiden/utils/ethers';
 import {
@@ -159,7 +160,7 @@ describe('types', () => {
   test('BigNumberC', () => {
     const b = bigNumberify(16);
     expect(BigNumberC.is(b)).toBe(true);
-    expect(BigNumberC.encode(b)).toBe('16');
+    expect(BigNumberC.encode(b)).toEqual(new LosslessNumber('16'));
     const result = BigNumberC.decode(b);
     expect(result.isRight()).toBe(true);
     expect(result.value).toBeInstanceOf(BigNumber);

--- a/raiden/typings/lossless-json/index.d.ts
+++ b/raiden/typings/lossless-json/index.d.ts
@@ -1,0 +1,78 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare module 'lossless-json' {
+  /**
+   * Get and/or set configuration options
+   * @param {circularRefs} [options]
+   * @return New/current config
+   */
+  export function config({ circularRefs }?: { circularRefs?: boolean }): { circularRefs: boolean };
+  /**
+   * The LosslessJSON.parse() method parses a string as JSON, optionally transforming
+   * the value produced by parsing.
+   *
+   * @param text The string to parse as JSON. See the JSON object for a description of JSON syntax.
+   *
+   * @param reviver
+   * If a function, prescribes how the value originally produced by parsing is
+   * transformed, before being returned.
+   *
+   * @returns Returns the Object corresponding to the given JSON text.
+   *
+   * @throws Throws a SyntaxError exception if the string to parse is not valid JSON.
+   */
+  export function parse(text: string, reviver?: (key: string, value: any) => any): any;
+  /**
+   * The LosslessJSON.stringify() method converts a JavaScript value to a JSON string,
+   * optionally replacing values if a replacer function is specified, or
+   * optionally including only the specified properties if a replacer array is specified.
+   *
+   * @param value
+   * The value to convert to a JSON string.
+   *
+   * @param replacer
+   * A function that alters the behavior of the stringification process,
+   * or an array of String and Number objects that serve as a whitelist for
+   * selecting the properties of the value object to be included in the JSON string.
+   * If this value is null or not provided, all properties of the object are
+   * included in the resulting JSON string.
+   *
+   * @param space
+   * A String or Number object that's used to insert white space into the output
+   * JSON string for readability purposes. If this is a Number, it indicates the
+   * number of space characters to use as white space; this number is capped at 10
+   * if it's larger than that. Values less than 1 indicate that no space should be
+   * used. If this is a String, the string (or the first 10 characters of the string,
+   * if it's longer than that) is used as white space. If this parameter is not
+   * provided (or is null), no white space is used.
+   *
+   * @returns {string | undefined} Returns the string representation of the JSON object.
+   */
+  export function stringify(
+    value: any,
+    replacer?: ((key: string, value: any) => any) | (string | number)[],
+    space?: string | number,
+  ): string;
+
+  /**
+   * A lossless number. Stores it's value as string
+   * @param  value
+   */
+  export class LosslessNumber {
+    // value as string
+    public value: string;
+    public type: 'LosslessNumber';
+    public isLosslessNumber: true;
+    public constructor(value: string | number);
+    /**
+     * Get the value of the LosslessNumber as number.
+     * Will throw an error when this conversion would result in a truncation of the number.
+     * @return Number
+     */
+    public valueOf(): number;
+    /**
+     * Get the value of the LosslessNumber as string.
+     * @return string
+     */
+    public toString(): string;
+  }
+}


### PR DESCRIPTION
Implements Lossless JSON encoding/decoding.
For now, used only in RaidenState/persistency, but we need to keep consistency with messages encoding, to avoid needing multiple codecs for each type to support different serialization methods.
Based on top of #193 