### PR TITLE
Some adjustments to Address type and concurrency control for some events

### DIFF
--- a/raiden/src/utils/types.ts
+++ b/raiden/src/utils/types.ts
@@ -1,8 +1,8 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import * as t from 'io-ts';
 import { BigNumber, bigNumberify, getAddress } from 'ethers/utils';
 import { Two } from 'ethers/constants';
 import { LosslessNumber } from 'lossless-json';
-import { set } from 'lodash';
 
 /* A Subset of DOM's Storage/localStorage interface which supports async/await */
 export interface Storage {
@@ -62,8 +62,29 @@ export interface SizedB<S extends number> {
 }
 
 // map cache from size -> codecName -> codec
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const sizedCodecCache: { [s: number]: { [n: string]: t.BrandC<any, SizedB<number>> } } = {};
+
+/**
+ * Return or create a cached sized codec
+ * Given a size and a codec name, this function returns given codec name for size, or create and
+ * cache a new one through 'factory' on first call. Useful to ensure single codec instance across
+ * multiple calls, as well as enabling introspection through cache of size parameter.
+ * @param size The size of the Sized brand (for caching/introspection)
+ * @param name The name of the codec (for disambiguation of multiple codecs of the same size)
+ * @param factory To create and cache a sized codec, if on first call for given parameters
+ * @returns Cached codec for given size and name
+ */
+function makeSized<S extends number, C extends t.BrandC<any, SizedB<S>>>(
+  size: S,
+  name: string,
+  factory: () => C,
+): C {
+  if (!(size in sizedCodecCache)) sizedCodecCache[size] = {};
+  if (!(name in sizedCodecCache[size])) {
+    sizedCodecCache[size as number][name] = factory();
+  }
+  return sizedCodecCache[size][name] as C;
+}
 
 /**
  * Returns the size (in bytes) of a sized brand
@@ -73,9 +94,7 @@ const sizedCodecCache: { [s: number]: { [n: string]: t.BrandC<any, SizedB<number
  * @param codec Codec object of a SizedB branded type to query size of
  * @returns number representing size of the registered codec
  */
-export function sizeOf<S extends number, C extends t.Any = t.Any>(
-  codec: t.BrandC<C, SizedB<S>>,
-): S {
+export function sizeOf<S extends number>(codec: t.BrandC<any, SizedB<S>>): S {
   for (const siz in sizedCodecCache) {
     for (const c in sizedCodecCache[siz]) {
       if (sizedCodecCache[siz][c] === codec) return +siz as S;
@@ -97,16 +116,15 @@ export interface HexStringB<S extends number> extends SizedB<S> {
  */
 export function HexString<S extends number = number>(size?: S) {
   const name = 'HexString';
-  const siz: number = size === undefined ? 0 : size;
-  if (siz in sizedCodecCache && name in sizedCodecCache[siz])
-    return sizedCodecCache[siz][name] as t.BrandC<t.StringC, HexStringB<S>>;
-  const regex = size ? new RegExp(`^0x[0-9a-f]{${size * 2}}$`, 'i') : /^0x([0-9a-f]{2})*$/i;
-  if (!(siz in sizedCodecCache)) sizedCodecCache[siz] = {};
-  return (sizedCodecCache[siz][name] = t.brand(
-    t.string,
-    (n): n is t.Branded<string, HexStringB<S>> => typeof n === 'string' && !!n.match(regex),
-    name,
-  ));
+  const siz: S = size === undefined ? (0 as S) : size;
+  return makeSized(siz, name, () => {
+    const regex = siz ? new RegExp(`^0x[0-9a-f]{${siz * 2}}$`, 'i') : /^0x([0-9a-f]{2})*$/i;
+    return t.brand(
+      t.string,
+      (n): n is t.Branded<string, HexStringB<S>> => typeof n === 'string' && !!n.match(regex),
+      name,
+    );
+  });
 }
 
 // string brand: non size-constrained hex-string codec and its type
@@ -125,17 +143,15 @@ export interface UIntB<S extends number> extends SizedB<S> {
  */
 export function UInt<S extends number = number>(size?: S) {
   const name = 'UInt';
-  const siz: number = size === undefined ? 0 : size;
-  if (siz in sizedCodecCache && name in sizedCodecCache[siz])
-    return sizedCodecCache[siz][name] as t.BrandC<typeof BigNumberC, UIntB<S>>;
-  if (!(siz in sizedCodecCache)) sizedCodecCache[siz] = {};
-  const max = siz ? Two.pow(siz * 8) : undefined;
-  return (sizedCodecCache[siz][name] = t.brand(
-    BigNumberC,
-    (n): n is t.Branded<BigNumber, UIntB<S>> =>
-      BigNumberC.is(n) && n.gte(0) && (max === undefined || n.lt(max)),
-    name,
-  ));
+  return makeSized(size === undefined ? (0 as S) : size, name, () => {
+    const max = size ? Two.pow(size * 8) : undefined;
+    return t.brand(
+      BigNumberC,
+      (n): n is t.Branded<BigNumber, UIntB<S>> =>
+        BigNumberC.is(n) && n.gte(0) && (max === undefined || n.lt(max)),
+      name,
+    );
+  });
 }
 export type UInt<S extends number = number> = t.Branded<BigNumber, UIntB<S>>;
 
@@ -158,23 +174,21 @@ export const PrivateKey = HexString(32);
 export type PrivateKey = t.TypeOf<typeof PrivateKey>;
 
 // checksummed address brand interface
-export interface AddressB extends HexStringB<20> {
+export interface AddressB {
   readonly Address: unique symbol;
 }
 
 // string brand: checksummed address, 20 bytes
-export const Address = t.brand(
-  t.string,
-  (u): u is t.Branded<string, AddressB> => {
-    try {
-      return typeof u === 'string' && getAddress(u) === u;
-    } catch (e) {}
-    return false;
-  }, // type guard for branded values
-  'Address', // the name must match the readonly field in the brand
+export const Address = makeSized(20, 'Address', () =>
+  t.brand(
+    HexString(20),
+    (u): u is t.Branded<HexString<20>, AddressB> => {
+      try {
+        return typeof u === 'string' && getAddress(u) === u;
+      } catch (e) {}
+      return false;
+    }, // type guard for branded values
+    'Address', // the name must match the readonly field in the brand
+  ),
 );
 export type Address = t.TypeOf<typeof Address>;
-set(sizedCodecCache, ['20', 'Address'], Address); // register on sized cache, for sizeOf util
-
-export const Byte = UInt(1);
-export type Byte = t.TypeOf<typeof Byte>;


### PR DESCRIPTION
Simple change: Address now is a refinement of `HexString`, instead of its Brand inheriting from HexString's. The work is the same, but the type gets clearer: `string & Brand<HexStringB<20>> & Brand<AddressB>`, making it explicit an Address is also a HexString. Tests included.

Additionally, also removed long standing TODO in the code: we used `mergeMap` with `defer` and `listenerCount` checks to avoid concurrency on `tokenMonitoredEpic` and `channelMonitoredEpic` (each token network and each channel must be monitored by a single event listener). Now, this concurrency is much safer due to rxjs managing it through `exhaustMap`, which prevents multiple events registering naturally.