### PR TITLE
Send Processed for incoming transfers

### DIFF
--- a/raiden/src/channels/state.ts
+++ b/raiden/src/channels/state.ts
@@ -1,7 +1,7 @@
 import * as t from 'io-ts';
 
 import { EnumType, UInt } from '../utils/types';
-import { Signed, LockedTransfer, Unlock, LockExpired } from '../messages/types';
+import { Signed, LockedTransfer, Unlock, LockExpired, RefundTransfer } from '../messages/types';
 import { Lock, SignedBalanceProof } from './types';
 
 export enum ChannelState {
@@ -33,6 +33,7 @@ export const ChannelEnd = t.readonly(
           Signed(LockedTransfer),
           Signed(Unlock),
           Signed(LockExpired),
+          Signed(RefundTransfer),
         ]) /* sent by this end */,
       ),
     }),

--- a/raiden/src/transfers/actions.ts
+++ b/raiden/src/transfers/actions.ts
@@ -10,6 +10,7 @@ import {
   Unlock,
   Signed,
   LockExpired,
+  RefundTransfer,
 } from '../messages/types';
 
 // eslint-disable-next-line @typescript-eslint/prefer-interface
@@ -84,6 +85,12 @@ export const transferExpired = createStandardAction('transferExpired')<
 export const transferExpireFailed = createStandardAction('transferExpireFailed').map(
   (payload: Error, meta: TransferId) => ({ payload, error: true, meta }),
 );
+
+/** A transfer was refunded */
+export const transferRefunded = createStandardAction('transferRefunded')<
+  { message: Signed<RefundTransfer> },
+  TransferId
+>();
 
 /**
  * A transfer completed successfuly

--- a/raiden/src/transfers/state.ts
+++ b/raiden/src/transfers/state.ts
@@ -7,6 +7,7 @@ import {
   SecretReveal,
   Unlock,
   LockExpired,
+  RefundTransfer,
 } from '../messages/types';
 
 /**
@@ -40,7 +41,13 @@ export const SentTransfer = t.readonly(
        */
       lockExpired: Signed(LockExpired),
       // Processed for Unlock or LockExpired clear this transfer, so aren't persisted here
-      // TODO: check on how to handle RefundTransfer
+      /**
+       * <- incoming refund transfer (if so)
+       * If this is set, transfer failed and partner tried refunding the transfer to us. We don't
+       * handle receiving transfers, but just store it here to sign this transfer failed with a
+       * refund, until the lock expires normally
+       */
+      refund: Signed(RefundTransfer),
     }),
   ]),
 );


### PR DESCRIPTION
Handling incoming transfers depend on Monitoring Service and is planned for Milestone 0. For now, we must only send `Processed` messages for incoming transfers (`LockedTransfer`, `RefundTransfer`) and their respective `LockExpired` (when they happen, as we didn't proceed with requesting and revealing the secret), to avoid partner keeping retrying sending these messages to us which we aren't going to handle anyway.
Besides that, we also notify the user that a transfer failed when we receive the `RefundTransfer` message. Per protocol, partner only send a refund after they're sure transfer didn't succeed and target couldn't have requested the secret to us, or else they'd be in danger of losing money (e.g. if the target would reveal and unlock, and we as well their refunded transfer), therefore no additional checks are required even if the transfer is marked as failed with a refund.
This PR completes the protocol set for sending transfers and being a compliant actor for Red Eyes protocol.
Fixes #26 

- [x] Send Processed for refunds and incoming transfers to avoid retries
- [x] Notify user of `transferFailed` upon refund
- [x] Tests