### PR TITLE
Transfers history, public notifications

### DIFF
--- a/raiden/src/channels/state.ts
+++ b/raiden/src/channels/state.ts
@@ -1,7 +1,6 @@
 import * as t from 'io-ts';
 
 import { EnumType, UInt } from '../utils/types';
-import { Signed, LockedTransfer, Unlock, LockExpired, RefundTransfer } from '../messages/types';
 import { Lock, SignedBalanceProof } from './types';
 
 export enum ChannelState {
@@ -27,15 +26,6 @@ export const ChannelEnd = t.readonly(
     t.partial({
       locks: t.array(Lock),
       balanceProof: SignedBalanceProof,
-      history: t.record(
-        t.string /* timestamp */,
-        t.union([
-          Signed(LockedTransfer),
-          Signed(Unlock),
-          Signed(LockExpired),
-          Signed(RefundTransfer),
-        ]) /* sent by this end */,
-      ),
     }),
   ]),
 );

--- a/raiden/src/index.ts
+++ b/raiden/src/index.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
 export * from './types';
+export * from './transfers/types';
 export { RaidenState } from './state';
 export { RaidenEvent } from './actions';
 export { ChannelState } from './channels';

--- a/raiden/src/raiden.ts
+++ b/raiden/src/raiden.ts
@@ -675,21 +675,16 @@ export class Raiden {
    * queried with this id on this.transfers$ observable, which will just have emitted the 'pending'
    * transfer. Any following transfer state change will be notified through this observable.
    *
-   * Coverage ignored until we handle the full transfer lifecycle
-   * TODO: remove istanbul ignore when covered
-   *
    * @param token  Token address on currently configured token network registry
    * @param target  Target address (must be getAvailability before)
    * @param amount  Amount to try to transfer
-   * @param opts.paymentId  Optionally specify a paymentId to use for this transfer
-   * @param opts.secret  Optionally specify a secret to use on this transfer
-   *    (in which case, it'll be registered and revealed to target)
-   * @param opts.secrethash  Optionally specify a secrethash to use. If secret is provided,
-   *    secrethash must be the keccak256 hash of the secret. If no secret is provided, the target
-   *    must be informed of it by other means/externally.
+   * @param opts  Optional parameters for transfer:
+   *                - paymentId  payment identifier, a random one will be generated if missing
+   *                - secret  Secret to register, a random one will be generated if missing
+   *                - secrethash  Must match secret, if both provided, or else, secret must be
+   *                              informed to target by other means, and reveal can't be performed
    * @returns A promise to transfer's secrethash (unique id) when it's accepted
    */
-  /* istanbul ignore next */
   public async transfer(
     token: string,
     target: string,

--- a/raiden/src/raiden.ts
+++ b/raiden/src/raiden.ts
@@ -191,7 +191,12 @@ export class Raiden {
       /* this scan stores a reference to each [key,value] in 'acc', and emit as 'changed' iff it
        * changes from last time seen. It relies on value references changing only if needed */
       scan<[string, SentTransfer], { acc: SentTransfers; changed?: SentTransfer }>(
-        ({ acc }, [k, v]) => (acc[k] === v ? { acc } : { acc: { ...acc, [k]: v }, changed: v }),
+        ({ acc }, [secrethash, sent]) => {
+          // if ref didn't change, emit previous accumulator, without 'changed' value
+          if (acc[secrethash] === sent) return { acc };
+          // else, update ref in 'acc' and emit value in 'changed' prop
+          else return { acc: { ...acc, [secrethash]: sent }, changed: sent };
+        },
         { acc: {} },
       ),
       filter(({ changed }) => !!changed), // filter out if reference didn't change from last emit

--- a/raiden/src/transfers/actions.ts
+++ b/raiden/src/transfers/actions.ts
@@ -68,6 +68,12 @@ export const transferUnlocked = createStandardAction('transferUnlocked')<
   TransferId
 >();
 
+/** Partner acknowledge they received and processed our Unlock */
+export const transferUnlockProcessed = createStandardAction('transferUnlockProcessed')<
+  { message: Signed<Processed> },
+  TransferId
+>();
+
 /** A request to expire a given transfer */
 export const transferExpire = createStandardAction('transferExpire')<undefined, TransferId>();
 
@@ -85,6 +91,12 @@ export const transferExpired = createStandardAction('transferExpired')<
 export const transferExpireFailed = createStandardAction('transferExpireFailed').map(
   (payload: Error, meta: TransferId) => ({ payload, error: true, meta }),
 );
+
+/** Partner acknowledge they received and processed our LockExpired */
+export const transferExpireProcessed = createStandardAction('transferExpireProcessed')<
+  { message: Signed<Processed> },
+  TransferId
+>();
 
 /** A transfer was refunded */
 export const transferRefunded = createStandardAction('transferRefunded')<

--- a/raiden/src/transfers/epics.ts
+++ b/raiden/src/transfers/epics.ts
@@ -887,7 +887,7 @@ export const transferUnlockProcessedReceivedEpic = (
  * @param state$  Observable of RaidenStates
  * @returns  Observable of output actions for this epic
  */
-export const transferExpireProcessedClearsEpic = (
+export const transferExpireProcessedEpic = (
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
 ): Observable<ActionType<typeof transferExpireProcessed>> =>

--- a/raiden/src/transfers/epics.ts
+++ b/raiden/src/transfers/epics.ts
@@ -582,8 +582,8 @@ export const transferExpiredRetryMessageEpic = (
 /**
  * Process newBlocks, emits transferExpire (request to compose&sign LockExpired for a transfer)
  * if pending transfer's lock expired and transfer didn't unlock (succeed) in time
- * Also, emits transferFailed, to notify users that a transfer failed (rejecting potentially
- * pending Promises)
+ * Also, emits transferFailed, to notify users that a transfer has failed (although it'll only be
+ * considered as completed with fail once the transferExpireProcessed arrives).
  *
  * @param action$  Observable of newBlock|transferExpired|transferExpireFailed actions
  * @param state$  Observable of RaidenStates

--- a/raiden/src/transfers/reducer.ts
+++ b/raiden/src/transfers/reducer.ts
@@ -225,7 +225,6 @@ export function transfersReducer(
     state = set(['sent', secrethash], sentTransfer, state);
     return state;
   } else if (isActionOf(channelClosed, action)) {
-    // accumulator type is writable typeof state.sent
     return {
       ...state,
       sent: mapValues(

--- a/raiden/src/transfers/state.ts
+++ b/raiden/src/transfers/state.ts
@@ -9,6 +9,7 @@ import {
   LockExpired,
   RefundTransfer,
 } from '../messages/types';
+import { Timed, Hash } from '../utils/types';
 
 /**
  * This struct holds the relevant messages exchanged in a transfer
@@ -18,36 +19,53 @@ export const SentTransfer = t.readonly(
   t.intersection([
     t.type({
       /** -> outgoing locked transfer */
-      transfer: Signed(LockedTransfer),
+      transfer: Timed(Signed(LockedTransfer)),
     }),
     t.partial({
       /** <- incoming processed for locked transfer */
-      transferProcessed: Signed(Processed),
+      transferProcessed: Timed(Signed(Processed)),
       /**
        * -> outgoing secret reveal to target
        * If this is set, it means the secret was revealed (so transfer succeeded, even if it didn't
        * complete yet)
        */
-      secretReveal: Signed(SecretReveal),
+      secretReveal: Timed(Signed(SecretReveal)),
       /**
        * -> outgoing unlock to recipient
        * If this is set, it means the Unlock was sent (even if partner didn't acknowledge it yet)
        */
-      unlock: Signed(Unlock),
+      unlock: Timed(Signed(Unlock)),
+      /**
+       * <- incoming processed for Unlock message
+       * If this is set, the protocol completed by the transfer succeeding and partner
+       * acknowledging validity of our off-chain unlock
+       */
+      unlockProcessed: Timed(Signed(Processed)),
       /**
        * -> outgoing lock expired (if so)
        * If this is set, transfer failed, and we expired the lock (retrieving the locked amount).
        * Transfer failed may not have completed yet, e.g. waiting for LockExpired's Processed reply
        */
-      lockExpired: Signed(LockExpired),
-      // Processed for Unlock or LockExpired clear this transfer, so aren't persisted here
+      lockExpired: Timed(Signed(LockExpired)),
+      /**
+       * <- incoming processed for LockExpired message
+       * If this is set, the protocol completed by the transfer failing and partner acknowledging
+       * this transfer can't be claimed anymore
+       */
+      lockExpiredProcessed: Timed(Signed(Processed)),
       /**
        * <- incoming refund transfer (if so)
        * If this is set, transfer failed and partner tried refunding the transfer to us. We don't
-       * handle receiving transfers, but just store it here to sign this transfer failed with a
+       * handle receiving transfers, but just store it here to mark this transfer as failed with a
        * refund, until the lock expires normally
        */
-      refund: Signed(RefundTransfer),
+      refund: Timed(Signed(RefundTransfer)),
+      /**
+       * !! channel was closed !!
+       * In the case a channel is closed (possibly middle transfer), this will be the txHash of the
+       * CloseChannel transaction. No further actions are possible after it's set.
+       */
+      channelClosed: Timed(Hash),
     }),
   ]),
 );

--- a/raiden/src/transfers/state.ts
+++ b/raiden/src/transfers/state.ts
@@ -42,6 +42,13 @@ export const SentTransfer = t.readonly(
        */
       unlockProcessed: Timed(Signed(Processed)),
       /**
+       * <- incoming refund transfer (if so)
+       * If this is set, transfer failed and partner tried refunding the transfer to us. We don't
+       * handle receiving transfers, but just store it here to mark this transfer as failed with a
+       * refund, until the lock expires normally
+       */
+      refund: Timed(Signed(RefundTransfer)),
+      /**
        * -> outgoing lock expired (if so)
        * If this is set, transfer failed, and we expired the lock (retrieving the locked amount).
        * Transfer failed may not have completed yet, e.g. waiting for LockExpired's Processed reply
@@ -53,13 +60,6 @@ export const SentTransfer = t.readonly(
        * this transfer can't be claimed anymore
        */
       lockExpiredProcessed: Timed(Signed(Processed)),
-      /**
-       * <- incoming refund transfer (if so)
-       * If this is set, transfer failed and partner tried refunding the transfer to us. We don't
-       * handle receiving transfers, but just store it here to mark this transfer as failed with a
-       * refund, until the lock expires normally
-       */
-      refund: Timed(Signed(RefundTransfer)),
       /**
        * !! channel was closed !!
        * In the case a channel is closed (possibly middle transfer), this will be the txHash of the

--- a/raiden/src/transfers/types.ts
+++ b/raiden/src/transfers/types.ts
@@ -1,0 +1,31 @@
+import { BigNumber } from 'ethers/utils';
+import { Address, Hash } from '../utils/types';
+
+export enum RaidenSentTransferStatus {
+  pending = 'PENDING', // transfer was just sent
+  received = 'RECEIVED', // transfer acknowledged by partner
+  revealed = 'REVEALED', // secret asked and revealed to target
+  unlocked = 'UNLOCKED', // unlock sent to partner
+  refunded = 'REFUNDED', // partner informed that can't forward transfer
+  expired = 'EXPIRED', // lock expired sent to partner
+  succeeded = 'SUCCEEDED', // unlock acknowledged by partner (complete with success)
+  failed = 'FAILED', // lock expired acknowledged by partner (complete with failure)
+}
+
+export interface RaidenSentTransfer {
+  secrethash: Hash; // used as transfer identifier
+  status: RaidenSentTransferStatus;
+  initiator: Address; // us
+  recipient: Address; // receiver/partner/hub
+  target: Address; // final receiver of the transfer
+  paymentId: BigNumber;
+  chainId: number;
+  token: Address; // token address
+  tokenNetwork: Address; // token network address
+  channelId: BigNumber; // channel identifier in which the transfer went through
+  amount: BigNumber; // amount to transfer
+  fee: BigNumber; // not supported yet, so always Zero
+  startedAt: Date; // time of transfer start
+  changedAt: Date; // time of current/last state (if transfer completed, end timestamp)
+  success: boolean | undefined; // undefined=pending, true=success, false=failed
+}

--- a/raiden/src/transfers/types.ts
+++ b/raiden/src/transfers/types.ts
@@ -24,8 +24,18 @@ export interface RaidenSentTransfer {
   tokenNetwork: Address; // token network address
   channelId: BigNumber; // channel identifier in which the transfer went through
   amount: BigNumber; // amount to transfer
+  expirationBlock: number; // blockNumber in which this transfer expires (if doesn't succeed)
   fee: BigNumber; // not supported yet, so always Zero
   startedAt: Date; // time of transfer start
   changedAt: Date; // time of current/last state (if transfer completed, end timestamp)
-  success: boolean | undefined; // undefined=pending, true=success, false=failed
+  /**
+   * Set as soon as known if transfer did happen or fail (even if still there're pending actions)
+   * undefined=pending, true=success, false=failed
+   */
+  success: boolean | undefined;
+  /**
+   * True if transfer did complete, i.e. nothing else left to be done for it
+   * False if transfer still has pending actions (even if success status is already known)
+   */
+  completed: boolean;
 }

--- a/raiden/src/transfers/utils.ts
+++ b/raiden/src/transfers/utils.ts
@@ -99,11 +99,12 @@ export function raidenSentTransfer(sent: SentTransfer): RaidenSentTransfer {
         ? [RaidenSentTransferStatus.received, sent.transferProcessed[0]]
         : [RaidenSentTransferStatus.pending, sent.transfer[0]],
     success: boolean | undefined =
-      status === RaidenSentTransferStatus.succeeded
+      sent.secretReveal || sent.unlock
         ? true
-        : status === RaidenSentTransferStatus.failed
+        : sent.refund || sent.lockExpired || sent.channelClosed
         ? false
-        : undefined;
+        : undefined,
+    completed = !!(sent.unlockProcessed || sent.lockExpiredProcessed || sent.channelClosed);
   return {
     secrethash: sent.transfer[1].lock.secrethash,
     status,
@@ -116,9 +117,11 @@ export function raidenSentTransfer(sent: SentTransfer): RaidenSentTransfer {
     tokenNetwork: sent.transfer[1].token_network_address,
     channelId: sent.transfer[1].channel_identifier,
     amount: sent.transfer[1].lock.amount,
+    expirationBlock: sent.transfer[1].lock.expiration.toNumber(),
     fee: sent.transfer[1].fee,
     startedAt: new Date(sent.transfer[0]),
     changedAt: new Date(changedAt),
     success,
+    completed,
   };
 }

--- a/raiden/src/utils/types.ts
+++ b/raiden/src/utils/types.ts
@@ -145,3 +145,24 @@ export const Address = t.brand(
   'Address', // the name must match the readonly field in the brand
 );
 export type Address = string & t.Brand<HexStringB<20>> & t.Brand<AddressB>;
+
+/**
+ * Helper function to create codecs to validate [timestamp, value] tuples
+ *
+ * @param codec  Codec to compose with a timestamp in a tuple
+ * @returns  Codec of a tuple of timestamp and codec type
+ */
+export const Timed = memoize<<T extends t.Mixed>(codec: T) => t.TupleC<[t.NumberC, T]>>(
+  <T extends t.Mixed>(codec: T) => t.tuple([t.number, codec]),
+);
+export type Timed<T> = [number, T];
+
+/**
+ * Given a value of type T, returns a Timed<T> tuple with current time as first value
+ *
+ * @param v  Value to return with time
+ * @returns  Tuple of call timestamp as first elemtn and value passed as parameter as second
+ */
+export function timed<T>(v: T): Timed<T> {
+  return [Date.now(), v];
+}

--- a/raiden/tests/e2e/raiden.spec.ts
+++ b/raiden/tests/e2e/raiden.spec.ts
@@ -434,7 +434,7 @@ describe('Raiden', () => {
       raiden1.stop();
     });
 
-    test('secret and secrethash doesn\'t match', async () => {
+    test("secret and secrethash doesn't match", async () => {
       expect.assertions(1);
       const secret = makeSecret(),
         secrethash: Hash = keccak256('0xdeadbeef') as Hash;

--- a/raiden/tests/unit/utils.spec.ts
+++ b/raiden/tests/unit/utils.spec.ts
@@ -1,3 +1,4 @@
+import * as t from 'io-ts';
 import { fold, isRight } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 
@@ -9,7 +10,16 @@ import { BigNumber, bigNumberify, keccak256, hexDataLength } from 'ethers/utils'
 import { LosslessNumber } from 'lossless-json';
 
 import { fromEthersEvent, getEventsStream } from 'raiden/utils/ethers';
-import { Address, BigNumberC, HexString, UInt, Hash, Secret } from 'raiden/utils/types';
+import {
+  Address,
+  BigNumberC,
+  HexString,
+  UInt,
+  Hash,
+  Secret,
+  Timed,
+  timed,
+} from 'raiden/utils/types';
 import { LruCache } from 'raiden/utils/lru';
 import { encode, losslessParse, losslessStringify } from 'raiden/utils/data';
 import { splitCombined } from 'raiden/utils/rxjs';
@@ -220,6 +230,16 @@ describe('types', () => {
     }
     expect(foo(address)).toBe(address);
     expect(bar(address)).toBe(address);
+  });
+
+  test('Timed', () => {
+    const TimedAddress = Timed(Address);
+    type TimedAddress = t.TypeOf<typeof TimedAddress>;
+
+    const address = '0x000000000000000000000000000000000004000A' as Address,
+      data: TimedAddress = timed(address);
+    expect(TimedAddress.is(data)).toBe(true);
+    expect(TimedAddress.is(['invalid number', address])).toBe(false);
   });
 });
 


### PR DESCRIPTION
Fix #263 
channel state `history` property is gone. Now, success, failed, completed, channel-closed transfers are kept indefinitely in `state.sent` mapping (a clear history option will be added later). 
`Raiden.transfer` returned Promise resolves to `secrethash` as soon as the transfer is signed (or rejects if cancelled), and users may subscribe to `Raiden.transfers$` observable to get notified about update for this specific transfer, from the pending state until it's completed. History is kept, and at startup, all transfers history is emitted (as completed transfers), and may be stored to be presented to the user at any time, as well as pending transfers on restart, for example.

- [x] `RaidenState.sent` keeps history (isn't cleared upon transfer completion), timestamp of every message/event is saved as well, `ChannelEnd.history` gone as it was duplicating this info
- [x] `Raiden.transfers$` observable notifies about historic and current pending transfers
- [x] `Raiden.transfer` async method resolves to `secrethash` (transfer unique identifier) as soon as transfer is signed and persisted
- [x] Unit tests, and also first e2e tests for transfers!