### PR TITLE
Implements Withdraw handling

### DIFF
--- a/raiden-ts/src/channels/actions.ts
+++ b/raiden-ts/src/channels/actions.ts
@@ -1,7 +1,6 @@
-import { BigNumber } from 'ethers/utils';
 import { createStandardAction } from 'typesafe-actions';
 
-import { Address, Hash } from '../utils/types';
+import { Address, Hash, UInt } from '../utils/types';
 
 // interfaces need to be exported, and we need/want to support `import * as RaidenActions`
 // eslint-disable-next-line @typescript-eslint/prefer-interface
@@ -64,13 +63,13 @@ export const channelMonitored = createStandardAction('channelMonitored')<
 
 /* Request a payload.deposit to be made to channel meta:ChannelId */
 export const channelDeposit = createStandardAction('channelDeposit')<
-  { deposit: BigNumber },
+  { deposit: UInt<32> },
   ChannelId
 >();
 
 /* A deposit is detected on-chain. Also works as 'success' for channelDeposit action */
 export const channelDeposited = createStandardAction('channelDeposited')<
-  { id: number; participant: Address; totalDeposit: BigNumber; txHash: Hash },
+  { id: number; participant: Address; totalDeposit: UInt<32>; txHash: Hash },
   ChannelId
 >();
 
@@ -78,6 +77,12 @@ export const channelDeposited = createStandardAction('channelDeposited')<
 export const channelDepositFailed = createStandardAction('channelDepositFailed').map(
   (payload: Error, meta: ChannelId) => ({ payload, error: true, meta }),
 );
+
+/* A withdraw is detected on-chain */
+export const channelWithdrawn = createStandardAction('channelWithdrawn')<
+  { id: number; participant: Address; totalWithdraw: UInt<32>; txHash: Hash },
+  ChannelId
+>();
 
 /* Request channel meta:ChannelId to be closed */
 export const channelClose = createStandardAction('channelClose')<undefined, ChannelId>();

--- a/raiden-ts/src/channels/reducer.ts
+++ b/raiden-ts/src/channels/reducer.ts
@@ -18,6 +18,7 @@ import {
   channelSettled,
   newBlock,
   tokenMonitored,
+  channelWithdrawn,
 } from './actions';
 import { Channel, Channels, ChannelState } from './state';
 
@@ -68,8 +69,43 @@ function channels(state: Channels = initialState.channels, action: RaidenAction)
     if (!channel || channel.state !== ChannelState.open || channel.id !== action.payload.id)
       return state;
     if (action.payload.participant === action.meta.partner)
-      channel = set(['partner', 'deposit'], action.payload.totalDeposit, channel);
-    else channel = set(['own', 'deposit'], action.payload.totalDeposit, channel);
+      channel = {
+        ...channel,
+        partner: {
+          ...channel.partner,
+          deposit: action.payload.totalDeposit,
+        },
+      };
+    else
+      channel = {
+        ...channel,
+        own: {
+          ...channel.own,
+          deposit: action.payload.totalDeposit,
+        },
+      };
+    return set(path, channel, state);
+  } else if (isActionOf(channelWithdrawn, action)) {
+    const path = [action.meta.tokenNetwork, action.meta.partner];
+    let channel: Channel | undefined = get(path, state);
+    if (!channel || channel.state !== ChannelState.open || channel.id !== action.payload.id)
+      return state;
+    if (action.payload.participant === action.meta.partner)
+      channel = {
+        ...channel,
+        partner: {
+          ...channel.partner,
+          withdraw: action.payload.totalWithdraw,
+        },
+      };
+    else
+      channel = {
+        ...channel,
+        own: {
+          ...channel.own,
+          withdraw: action.payload.totalWithdraw,
+        },
+      };
     return set(path, channel, state);
   } else if (isActionOf(channelClose, action)) {
     const path = [action.meta.tokenNetwork, action.meta.partner];

--- a/raiden-ts/src/channels/state.ts
+++ b/raiden-ts/src/channels/state.ts
@@ -27,6 +27,7 @@ export const ChannelEnd = t.readonly(
     t.partial({
       locks: t.array(Lock),
       balanceProof: SignedBalanceProof,
+      withdraw: UInt(32),
     }),
   ]),
 );

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -545,7 +545,7 @@ export class Raiden {
     const tokenNetwork = state.tokens[token];
     if (!tokenNetwork) throw new Error('Unknown token network');
     deposit = bigNumberify(deposit);
-    if (!UInt(32).is(deposit)) throw new Error('invalid deposit');
+    if (!UInt(32).is(deposit)) throw new Error('invalid deposit: must be 0 < amount < 2^256');
     const promise = this.action$
       .pipe(
         filter(isActionOf([channelDeposited, channelDepositFailed])),

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -544,6 +544,8 @@ export class Raiden {
     const state = this.state;
     const tokenNetwork = state.tokens[token];
     if (!tokenNetwork) throw new Error('Unknown token network');
+    deposit = bigNumberify(deposit);
+    if (!UInt(32).is(deposit)) throw new Error('invalid deposit');
     const promise = this.action$
       .pipe(
         filter(isActionOf([channelDeposited, channelDepositFailed])),
@@ -557,9 +559,7 @@ export class Raiden {
         }),
       )
       .toPromise();
-    this.store.dispatch(
-      channelDeposit({ deposit: bigNumberify(deposit) }, { tokenNetwork, partner }),
-    );
+    this.store.dispatch(channelDeposit({ deposit }, { tokenNetwork, partner }));
     return promise;
   }
 

--- a/raiden-ts/src/transfers/actions.ts
+++ b/raiden-ts/src/transfers/actions.ts
@@ -11,6 +11,8 @@ import {
   Signed,
   LockExpired,
   RefundTransfer,
+  WithdrawRequest,
+  WithdrawConfirmation,
 } from '../messages/types';
 
 // eslint-disable-next-line @typescript-eslint/prefer-interface
@@ -135,3 +137,25 @@ export const transferFailed = createStandardAction('transferFailed').map(
 
 /** A pending transfer isn't needed anymore and should be cleared from state */
 export const transferClear = createStandardAction('transferClear')<undefined, TransferId>();
+
+// Withdraw actions
+
+// eslint-disable-next-line @typescript-eslint/prefer-interface
+type WithdrawId = {
+  tokenNetwork: Address;
+  partner: Address;
+  totalWithdraw: UInt<32>;
+  expiration: number;
+};
+
+/** A WithdrawRequest was received from partner */
+export const withdrawReceiveRequest = createStandardAction('withdrawReceiveRequest')<
+  { message: Signed<WithdrawRequest> },
+  WithdrawId
+>();
+
+/** A WithdrawConfirmation was signed and must be sent to partner */
+export const withdrawSendConfirmation = createStandardAction('withdrawSendConfirmation')<
+  { message: Signed<WithdrawConfirmation> },
+  WithdrawId
+>();

--- a/raiden-ts/tests/unit/actions.spec.ts
+++ b/raiden-ts/tests/unit/actions.spec.ts
@@ -5,7 +5,7 @@ import {
   channelDepositFailed,
   channelMonitored,
 } from 'raiden-ts/channels/actions';
-import { Address } from 'raiden-ts/utils/types';
+import { Address, UInt } from 'raiden-ts/utils/types';
 
 describe('action factories not tested in reducers.spec.ts', () => {
   const tokenNetwork = '0x0000000000000000000000000000000000020001' as Address,
@@ -21,7 +21,7 @@ describe('action factories not tested in reducers.spec.ts', () => {
   });
 
   test('channelDeposit', () => {
-    const deposit = bigNumberify(999);
+    const deposit = bigNumberify(999) as UInt<32>;
     expect(channelDeposit({ deposit }, { tokenNetwork, partner })).toEqual({
       type: 'channelDeposit',
       payload: { deposit },

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -162,7 +162,9 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
   const tokenContracts: { [address: string]: MockedContract<HumanStandardToken> } = {};
   const getTokenContract = (address: string): MockedContract<HumanStandardToken> => {
     if (!(address in tokenContracts)) {
-      const tokenContract = new Contract(address, HumanStandardTokenAbi, signer) as MockedContract<HumanStandardToken>;
+      const tokenContract = new Contract(address, HumanStandardTokenAbi, signer) as MockedContract<
+        HumanStandardToken
+      >;
       for (const func in tokenContract.functions) {
         jest.spyOn(tokenContract.functions, func as keyof HumanStandardToken['functions']);
       }

--- a/raiden-ts/tests/unit/reducers.spec.ts
+++ b/raiden-ts/tests/unit/reducers.spec.ts
@@ -263,7 +263,9 @@ describe('raidenReducer', () => {
     });
 
     test('channel not in open state', () => {
+      // put channel in 'closed' state
       state = set(['channels', tokenNetwork, partner, 'state'], ChannelState.closed, state);
+      // try to apply action/state change
       const newState = raidenReducer(
         state,
         channelWithdrawn(
@@ -276,7 +278,8 @@ describe('raidenReducer', () => {
           { tokenNetwork, partner },
         ),
       );
-      expect(newState).toEqual(state);
+      // if channel is not open, action is noop and new state must be the previous one
+      expect(newState).toBe(state);
     });
 
     test('own withdraw successful', () => {
@@ -943,9 +946,10 @@ describe('raidenReducer', () => {
     });
 
     test('transfer channel closed', () => {
-      let newState = [
-        transferSigned({ message: transfer }, { secrethash }),
-      ].reduce(raidenReducer, state);
+      let newState = [transferSigned({ message: transfer }, { secrethash })].reduce(
+        raidenReducer,
+        state,
+      );
 
       expect(get(newState, ['sent', secrethash, 'transfer', 1])).toBe(transfer);
       expect(get(newState, ['secrets', secrethash, 'channelClosed'])).toBeUndefined();


### PR DESCRIPTION
Implements withdraw request handling for requests and dummy `Processed` for `WithdrawExpired`.
Also, listen and store `ChannelWithdraw` events.
Fix #248 , solves the withdraw part of #291