### PR TITLE
Prevent users from paying/depositing when there's no open channel

### DIFF
--- a/raiden-dapp/src/components/Tokens.vue
+++ b/raiden-dapp/src/components/Tokens.vue
@@ -46,6 +46,7 @@
             >
               <v-layout justify-center>
                 <v-btn
+                  :disabled="token.open === 0"
                   :id="`pay-${index}`"
                   :to="`/payment/${token.address}`"
                   class="text-capitalize connected-tokens__tokens__token__button"


### PR DESCRIPTION
Prevents #297 from happening.

The **Pay** button in the **Connected Tokens** list should only be enabled if there're open channels for a token. 

Currently, the button is still enabled when e.g. all channels are closed, settling etc. Thus, allowing the user to attempt to make payments or deposits which is going to fail.