### PR TITLE
Get rid of EnumType, enum codecs and SignedMessageCodecs

### DIFF
--- a/raiden-ts/src/channels/state.ts
+++ b/raiden-ts/src/channels/state.ts
@@ -1,7 +1,7 @@
 import * as t from 'io-ts';
 import { BigNumber } from 'ethers/utils';
 
-import { EnumType, UInt, Address } from '../utils/types';
+import { UInt, Address } from '../utils/types';
 import { Lock, SignedBalanceProof } from './types';
 
 export enum ChannelState {
@@ -13,8 +13,6 @@ export enum ChannelState {
   settling = 'settling',
   settled = 'settled',
 }
-
-export const ChannelStateC = new EnumType<ChannelState>(ChannelState, 'ChannelState');
 
 /**
  * Contains info of each side of a channel

--- a/raiden-ts/src/messages/utils.ts
+++ b/raiden-ts/src/messages/utils.ts
@@ -10,7 +10,7 @@ import { HashZero } from 'ethers/constants';
 import { Address, Hash, HexString, Signature } from '../utils/types';
 import { encode, losslessParse, losslessStringify } from '../utils/data';
 import { SignedBalanceProof } from '../channels/types';
-import { EnvelopeMessage, Message, MessageType, SignedMessageCodecs, Signed } from './types';
+import { EnvelopeMessage, Message, MessageType, Signed } from './types';
 
 const CMDIDs: { readonly [T in MessageType]: number } = {
   [MessageType.DELIVERED]: 12,
@@ -226,9 +226,8 @@ export function getBalanceProofFromEnvelopeMessage(
  * @param message - Message object to be serialized
  * @returns JSON string
  */
-export function encodeJsonMessage<M extends Message>(message: Signed<M>): string {
-  const codec = SignedMessageCodecs[message.type];
-  return losslessStringify(codec.encode(message));
+export function encodeJsonMessage(message: Signed<Message>): string {
+  return losslessStringify(Signed(Message).encode(message));
 }
 
 /**
@@ -239,9 +238,8 @@ export function encodeJsonMessage<M extends Message>(message: Signed<M>): string
  * @returns Message object
  */
 export function decodeJsonMessage(text: string): Signed<Message> {
-  const parsed = losslessParse(text);
-  if (!Message.is(parsed)) throw new Error(`Could not find Message "type" in ${text}`);
-  const decoded = SignedMessageCodecs[parsed.type].decode(parsed);
+  const parsed = losslessParse(text),
+    decoded = Signed(Message).decode(parsed);
   if (isLeft(decoded)) throw ThrowReporter.report(decoded); // throws if decode failed
   return decoded.right;
 }

--- a/raiden-ts/src/utils/types.ts
+++ b/raiden-ts/src/utils/types.ts
@@ -37,23 +37,6 @@ export const BigNumberC = new t.Type<BigNumber, LosslessNumber>(
   a => new LosslessNumber(a.toString()),
 );
 
-/**
- * Creates a NEW codec for a specific [non-const] enum object
- */
-export class EnumType<A> extends t.Type<A> {
-  public readonly _tag: 'EnumType' = 'EnumType';
-  public enumObject!: object;
-  public constructor(e: object, name?: string) {
-    super(
-      name || 'enum',
-      (u): u is A => Object.values(this.enumObject).some(v => v === u),
-      (u, c) => (this.is(u) ? t.success(u) : t.failure(u, c)),
-      t.identity,
-    );
-    this.enumObject = e;
-  }
-}
-
 // sized brands interfaces must derive from this interface
 export interface SizedB<S extends number> {
   readonly size: S;

--- a/raiden-ts/tests/unit/messages.spec.ts
+++ b/raiden-ts/tests/unit/messages.spec.ts
@@ -300,7 +300,7 @@ describe('sign/verify, pack & encode/decode ', () => {
   });
 
   test('decodeJsonMessage invalid', () => {
-    expect(() => decodeJsonMessage('{"type":"Invalid"}')).toThrowError('Message "type"');
+    expect(() => decodeJsonMessage('{"type":"Invalid"}')).toThrowError('/type:');
     expect(() =>
       decodeJsonMessage('{"type":"Processed","message_identifier":123456}'),
     ).toThrowError('Invalid value undefined');


### PR DESCRIPTION
The first can be safely replaced by `t.union` of `t.literals`.
The later is now better/strictly described by `Message` being an actual
`t.union` of all message codecs, allowing to decode the [Signed] Messages
directly from the union.