### PR TITLE
Various fixes and improvements

### DIFF
--- a/raiden-ts/src/path/epics.ts
+++ b/raiden-ts/src/path/epics.ts
@@ -166,7 +166,7 @@ export const pfsCapacityUpdateEpic = (
     filter(([, , { pfsRoom }]) => !!pfsRoom), // ignore actions while/if config.pfsRoom isn't set
     mergeMap(([action, state, { revealTimeout, pfsRoom }]) => {
       const channel = state.channels[action.meta.tokenNetwork][action.meta.partner];
-      if (channel.state !== ChannelState.open) return EMPTY;
+      if (!channel || channel.state !== ChannelState.open) return EMPTY;
 
       const { ownCapacity, partnerCapacity } = channelAmounts(channel);
 

--- a/raiden-ts/src/path/epics.ts
+++ b/raiden-ts/src/path/epics.ts
@@ -10,6 +10,7 @@ import {
   map,
   withLatestFrom,
   timeout,
+  debounceTime,
 } from 'rxjs/operators';
 import { fromFetch } from 'rxjs/fetch';
 import { isActionOf, ActionType } from 'typesafe-actions';
@@ -162,6 +163,7 @@ export const pfsCapacityUpdateEpic = (
   action$.pipe(
     filter(isActionOf(channelDeposited)),
     filter(action => action.payload.participant === address),
+    debounceTime(10e3),
     withLatestFrom(state$, config$),
     filter(([, , { pfsRoom }]) => !!pfsRoom), // ignore actions while/if config.pfsRoom isn't set
     mergeMap(([action, state, { revealTimeout, pfsRoom }]) => {

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -79,6 +79,7 @@ import { transfer, transferFailed, transferSigned } from './transfers/actions';
 import { makeSecret, raidenSentTransfer, getSecrethash } from './transfers/utils';
 import { pathFind, pathFound, pathFindFailed } from './path/actions';
 import { patchSignSend } from './utils/ethers';
+import { losslessParse } from './utils/data';
 import { RaidenConfig, defaultConfig } from './config';
 import { Metadata } from './messages/types';
 
@@ -404,7 +405,7 @@ export class Raiden {
       const loaded = Object.assign(
         {},
         loadedState,
-        JSON.parse((await storageOrState.getItem(ns)) || 'null'),
+        losslessParse((await storageOrState.getItem(ns)) || 'null'),
       );
 
       loadedState = decodeRaidenState(loaded);

--- a/raiden-ts/src/transport/epics.ts
+++ b/raiden-ts/src/transport/epics.ts
@@ -675,7 +675,7 @@ export const matrixLeaveUnknownRoomsEpic = (
     switchMap(matrix =>
       fromEvent<Room>(matrix, 'Room').pipe(map(room => ({ matrix, roomId: room.roomId }))),
     ),
-    delay(30e3), // this room may become known later for some reason, so wait a little
+    delay(180e3), // this room may become known later for some reason, so wait a little
     withLatestFrom(state$, config$),
     // filter for leave events to us
     filter(([{ matrix, roomId }, state, config]) => {

--- a/raiden-ts/src/transport/epics.ts
+++ b/raiden-ts/src/transport/epics.ts
@@ -222,36 +222,14 @@ export const initMatrixEpic = (
             matrix$.next(matrix);
             matrix$.complete();
           }),
+          switchMap(() => matrix$),
+          delay(1e3), // wait 1s before starting matrix, so event listeners can be registered
+          mergeMap(matrix => matrix.startClient({ initialSyncLimit: 0 })),
           ignoreElements(),
         ),
         of(matrixSetup({ server, setup })),
       ),
     ),
-  );
-
-/**
- * Start MatrixClient sync polling when detecting MatrixSetupAction, **after** init time fromEvents
- * were already registered.
- * This is required to ensure init-time events registering are done before initial sync, to avoid
- * losing one-shot events, like invitations.
- *
- * @param action$ - Observable of matrixSetup actions
- * @param state$ - Observable of RaidenStates
- * @param matrix$ - RaidenEpicDeps members
- * @returns Empty observable (whole side-effect on matrix instance)
- */
-export const matrixStartEpic = (
-  action$: Observable<RaidenAction>,
-  {  }: Observable<RaidenState>,
-  { matrix$ }: RaidenEpicDeps,
-): Observable<RaidenAction> =>
-  action$.pipe(
-    filter(isActionOf(matrixSetup)),
-    switchMap(() => matrix$),
-    tap(matrix => console.log('MATRIX client', matrix)),
-    delay(1e3), // wait 1s before starting matrix, so event listeners can be registered
-    mergeMap(matrix => matrix.startClient({ initialSyncLimit: 0 })),
-    ignoreElements(),
   );
 
 /**

--- a/raiden-ts/tests/e2e/provider.ts
+++ b/raiden-ts/tests/e2e/provider.ts
@@ -72,7 +72,7 @@ export class TestProvider extends Web3Provider {
     ).deploy(
       secretRegistryContract.address,
       this.network.chainId,
-      500,
+      20,
       555428,
       10,
     )) as TokenNetworkRegistry;

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -425,7 +425,13 @@ describe('Raiden', () => {
       );
       expect(raiden1).toBeInstanceOf(Raiden);
 
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      // await raiden1 client matrix initialization
+      await raiden1.action$
+        .pipe(
+          filter(isActionOf(matrixSetup)),
+          first(),
+        )
+        .toPromise();
 
       await expect(raiden.getAvailability(accounts[2])).resolves.toMatchObject({
         userId: `@${accounts[2].toLowerCase()}:${matrixServer}`,
@@ -518,7 +524,15 @@ describe('Raiden', () => {
           info,
           config,
         );
-        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        // await raiden1 client matrix initialization
+        await raiden1.action$
+          .pipe(
+            filter(isActionOf(matrixSetup)),
+            first(),
+          )
+          .toPromise();
+
         await expect(raiden.getAvailability(partner)).resolves.toMatchObject({
           userId: `@${partner.toLowerCase()}:${matrixServer}`,
           available: true,
@@ -559,12 +573,16 @@ describe('Raiden', () => {
             { ...initialState, address: target, chainId, registry },
             info,
             config,
-          );
+          ),
+          matrix2Promise = raiden2.action$
+            .pipe(
+              filter(isActionOf(matrixSetup)),
+              first(),
+            )
+            .toPromise();
 
-        await new Promise(resolve => setTimeout(resolve, 1000));
-
-        await raiden1.openChannel(token, target);
-        await raiden1.depositChannel(token, target, 200);
+        // await raiden2 client matrix initialization
+        await matrix2Promise;
 
         await expect(raiden.getAvailability(target)).resolves.toMatchObject({
           userId: `@${target.toLowerCase()}:${matrixServer}`,
@@ -617,6 +635,8 @@ describe('Raiden', () => {
   describe('findRoutes', () => {
     const pfs = 'http://pfs';
     let raiden1: Raiden, raiden2: Raiden, target: string;
+
+    beforeAll(() => jest.setTimeout(60e3));
 
     beforeEach(async () => {
       target = accounts[2];

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -42,7 +42,6 @@ import {
   matrixMessageSendEpic,
   matrixMessageReceivedEpic,
   matrixMessageReceivedUpdateRoomEpic,
-  matrixStartEpic,
   deliveredEpic,
   matrixMessageGlobalSendEpic,
 } from 'raiden-ts/transport/epics';
@@ -85,35 +84,6 @@ describe('transport epic', () => {
       const promise = matrixMonitorChannelPresenceEpic(action$).toPromise();
       await expect(promise).resolves.toEqual(
         matrixRequestMonitorPresence(undefined, { address: partner }),
-      );
-    });
-  });
-
-  describe('matrixStartEpic', () => {
-    beforeEach(() => {
-      depsMock.matrix$ = new AsyncSubject();
-      depsMock.matrix$.next(matrix);
-      depsMock.matrix$.complete();
-    });
-
-    test('startClient called on MATRIX_SETUP', async () => {
-      expect.assertions(4);
-      expect(matrix.startClient).not.toHaveBeenCalled();
-      await expect(
-        matrixStartEpic(
-          of(
-            matrixSetup({
-              server: matrixServer,
-              setup: { userId, accessToken, deviceId, displayName },
-            }),
-          ),
-          EMPTY,
-          depsMock,
-        ).toPromise(),
-      ).resolves.toBeUndefined();
-      expect(matrix.startClient).toHaveBeenCalledTimes(1);
-      expect(matrix.startClient).toHaveBeenCalledWith(
-        expect.objectContaining({ initialSyncLimit: 0 }),
       );
     });
   });

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -689,7 +689,7 @@ describe('transport epic', () => {
         // we should wait a little before leaving rooms
         expect(matrix.leave).not.toHaveBeenCalled();
 
-        advance(60e3);
+        advance(200e3);
 
         expect(matrix.leave).toHaveBeenCalledTimes(1);
         expect(matrix.leave).toHaveBeenCalledWith(roomId);
@@ -725,7 +725,7 @@ describe('transport epic', () => {
         // we should wait a little before leaving rooms
         expect(matrix.leave).not.toHaveBeenCalled();
 
-        advance(60e3);
+        advance(200e3);
 
         // even after some time, discovery room isn't left
         expect(matrix.leave).not.toHaveBeenCalled();
@@ -751,7 +751,7 @@ describe('transport epic', () => {
         // we should wait a little before leaving rooms
         expect(matrix.leave).not.toHaveBeenCalled();
 
-        advance(60e3);
+        advance(200e3);
 
         // even after some time, partner's room isn't left
         expect(matrix.leave).not.toHaveBeenCalled();

--- a/raiden-ts/typings/matrix-js-sdk/index.d.ts
+++ b/raiden-ts/typings/matrix-js-sdk/index.d.ts
@@ -84,6 +84,7 @@ declare module 'matrix-js-sdk' {
 
     public _http: any;
 
+    public baseUrl: string;
     public deviceId: string | null;
     public credentials: { userId: string | null };
 


### PR DESCRIPTION
While working on #246, I came across some issues which were bitting us and it was not clear the reason:

- A last `JSON.parse` forgotten on the SDK, instead of the safer `losslessParse`, made the state be loaded possibly losing precision in several numbers inside it. This was most evident by some `payment_identifier` and other fields like this being reloaded (on restart) with a different values than previously, which then led to issues like `signature mismatch` on partner.
- matrix$ did complete possibly before `matrixSetup` went through the reducer, and some epics which waited directly on `matrix$` assumed the server was already set in the state, which was not the case. This led some unexpected exceptions being raised and the client going to the homescreen a couple of times, until matrixSetup won the race and everything loaded. Looks a little like #382, although the cause is different.
- If one loaded a clean state with already some states/events, like channelDeposit, previously it did trigger several capacity update message prompts to be asked and then send, while only the last one (most recent capacity) would be relevant. Added `debounceTime` to only care about the last.

Fixes #378, plus some other identified issues before they bite us