### PR TITLE
Persist config in state

### DIFF
--- a/raiden-ts/src/actions.ts
+++ b/raiden-ts/src/actions.ts
@@ -5,6 +5,7 @@ import { pick } from 'lodash';
 import { ActionType, createStandardAction, getType, Action } from 'typesafe-actions';
 import { ShutdownReason } from './constants';
 
+import { RaidenConfig } from './config';
 import * as ChannelsActions from './channels/actions';
 import * as TransportActions from './transport/actions';
 import * as MessagesActions from './messages/actions';
@@ -15,8 +16,13 @@ export const raidenShutdown = createStandardAction('raidenShutdown')<{
   reason: ShutdownReason | Error;
 }>();
 
+export const raidenConfigUpdate = createStandardAction('raidenConfigUpdate')<{
+  config: Partial<RaidenConfig>;
+}>();
+
 export const RaidenActions = {
   raidenShutdown,
+  raidenConfigUpdate,
   ...ChannelsActions,
   ...TransportActions,
   ...MessagesActions,

--- a/raiden-ts/src/channels/reducer.ts
+++ b/raiden-ts/src/channels/reducer.ts
@@ -20,7 +20,7 @@ import {
   tokenMonitored,
   channelWithdrawn,
 } from './actions';
-import { Channel, Channels, ChannelState } from './state';
+import { Channel, ChannelState } from './state';
 
 // state.blockNumber specific reducer, handles only newBlock action
 function blockNumber(state: number = initialState.blockNumber, action: RaidenAction) {
@@ -36,7 +36,7 @@ function tokens(state: RaidenState['tokens'] = initialState.tokens, action: Raid
 }
 
 // handles all channel actions and requests
-function channels(state: Channels = initialState.channels, action: RaidenAction) {
+function channels(state: RaidenState['channels'] = initialState.channels, action: RaidenAction) {
   if (isActionOf(channelOpen, action)) {
     const path = [action.meta.tokenNetwork, action.meta.partner];
     if (get(path, state)) return state; // there's already a channel with partner

--- a/raiden-ts/src/channels/state.ts
+++ b/raiden-ts/src/channels/state.ts
@@ -74,21 +74,6 @@ export const Channel = t.intersection([
 export type Channel = t.TypeOf<typeof Channel>;
 
 /**
- * Channels is a mapping from tokenNetwork -> partner -> Channel
- * As in: { [tokenNetwork: Address]: { [partner: Address]: Channel } }
- * It's used as codec and type for 'channels' key in RaidenState
- * We use t.string instead of the Address branded codecs because specialized types can't be used
- * as index mapping keys.
- */
-export const Channels = t.readonly(
-  t.record(
-    t.string /* tokenNetwork: Address */,
-    t.readonly(t.record(t.string /* partner: Address */, Channel)),
-  ),
-);
-export type Channels = t.TypeOf<typeof Channels>;
-
-/**
  * Public exposed channels interface (Raiden.channels$)
  *
  * This should be only used as a public view of the internal channel state

--- a/raiden-ts/src/epics.ts
+++ b/raiden-ts/src/epics.ts
@@ -1,5 +1,13 @@
 import { Observable, from, of } from 'rxjs';
-import { catchError, filter, mergeMap, takeWhile, takeUntil } from 'rxjs/operators';
+import {
+  catchError,
+  filter,
+  mergeMap,
+  takeWhile,
+  takeUntil,
+  pluck,
+  distinctUntilChanged,
+} from 'rxjs/operators';
 import { isActionOf } from 'typesafe-actions';
 import { negate } from 'lodash';
 
@@ -24,15 +32,28 @@ export const raidenRootEpic = (
   state$: Observable<RaidenState>,
   deps: RaidenEpicDeps,
 ): Observable<RaidenAction> => {
+  // observable which emits once when a raidenShutdown action goes through actions pipeline
   const shutdownNotification = action$.pipe(filter(isActionOf(raidenShutdown))),
+    // actions pipeline, but ends with (including) a raidenShutdown action
     limitedAction$ = action$.pipe(
       takeWhile<RaidenAction>(negate(isActionOf(raidenShutdown)), true),
     ),
+    // states pipeline, but ends when shutdownNotification emits
     limitedState$ = state$.pipe(takeUntil(shutdownNotification));
 
-  // wire state$ & action$ to output subjects, to expose them to Raiden public class
+  // wire state$ & action$ to output subjects, to expose them to Raiden public class,
+  // including complete notifications (these observables don't error, because error would end
+  // subscriptions at the returned observable instead of feed-backing them)
   limitedState$.subscribe(deps.stateOutput$);
   limitedAction$.subscribe(deps.actionOutput$);
+
+  // wire state.config to deps.config$ BehaviorSubject
+  limitedState$
+    .pipe(
+      pluck('config'),
+      distinctUntilChanged(),
+    )
+    .subscribe(deps.config$);
 
   // like combineEpics, but completes action$, state$ & output$ when a raidenShutdown goes through
   return from(Object.values(RaidenEpics)).pipe(

--- a/raiden-ts/src/reducer.ts
+++ b/raiden-ts/src/reducer.ts
@@ -1,11 +1,20 @@
+import { isActionOf } from 'typesafe-actions';
 import { channelsReducer } from './channels/reducer';
 import { transportReducer } from './transport/reducer';
 import { transfersReducer } from './transfers/reducer';
 
-import { RaidenAction } from './actions';
+import { RaidenAction, raidenConfigUpdate } from './actions';
 import { RaidenState, initialState } from './state';
 
+// update state.config on raidenConfigUpdate action
+const configReducer = (state: RaidenState = initialState, action: RaidenAction) => {
+  if (isActionOf(raidenConfigUpdate, action)) {
+    return { ...state, config: { ...state.config, ...action.payload.config } };
+  } else return state;
+};
+
 const raidenReducers = {
+  configReducer,
   channelsReducer,
   transportReducer,
   transfersReducer,

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -595,7 +595,7 @@ describe('Raiden', () => {
         await new Promise(resolve => setTimeout(resolve, 100));
 
         const pfs = 'http://pfs';
-        raiden.config({ pfs });
+        raiden.updateConfig({ pfs });
         const result = {
           result: [
             // first returned route is invalid and should be filtered
@@ -693,7 +693,7 @@ describe('Raiden', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      raiden.config({ pfs });
+      raiden.updateConfig({ pfs });
     });
 
     afterEach(() => {

--- a/raiden-ts/tests/unit/epics/raiden.spec.ts
+++ b/raiden-ts/tests/unit/epics/raiden.spec.ts
@@ -51,8 +51,8 @@ import { epicFixtures } from '../fixtures';
 import { raidenEpicDeps, makeLog, makeSignature } from '../mocks';
 
 describe('raiden epic', () => {
-  const depsMock = raidenEpicDeps();
-  const {
+  let depsMock = raidenEpicDeps();
+  let {
     token,
     tokenNetworkContract,
     tokenNetwork,
@@ -80,6 +80,29 @@ describe('raiden epic', () => {
       status: 200,
       text: jest.fn(async () => `- ${matrixServer}`),
     })),
+  });
+
+  beforeEach(() => {
+    depsMock = raidenEpicDeps();
+    ({
+      token,
+      tokenNetworkContract,
+      tokenNetwork,
+      channelId,
+      partner,
+      settleTimeout,
+      isFirstParticipant,
+      txHash,
+      state,
+      matrixServer,
+      userId,
+      accessToken,
+      deviceId,
+      displayName,
+      partnerRoomId,
+      partnerUserId,
+      matrix,
+    } = epicFixtures(depsMock));
   });
 
   afterEach(() => {

--- a/raiden-ts/tests/unit/fixtures.ts
+++ b/raiden-ts/tests/unit/fixtures.ts
@@ -10,7 +10,7 @@ import { bigNumberify } from 'ethers/utils';
 import { MatrixClient } from 'matrix-js-sdk';
 
 import { Address, Hash, UInt, Int } from 'raiden-ts/utils/types';
-import { initialState, RaidenState } from 'raiden-ts/state';
+import { RaidenState } from 'raiden-ts/state';
 import { HumanStandardToken } from 'raiden-ts/contracts/HumanStandardToken';
 import { TokenNetwork } from 'raiden-ts/contracts/TokenNetwork';
 import { Metadata, Processed, MessageType } from 'raiden-ts/messages/types';
@@ -99,11 +99,7 @@ export const epicFixtures = function(
     matrixServer,
     userId,
     txHash,
-    state: {
-      ...initialState,
-      address: depsMock.address,
-      blockNumber: 125,
-    },
+    state: depsMock.stateOutput$.value,
     partnerSigner: wallet,
     processed,
     paymentId,

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -24,12 +24,12 @@ import TokenNetworkAbi from 'raiden-ts/abi/TokenNetwork.json';
 import HumanStandardTokenAbi from 'raiden-ts/abi/HumanStandardToken.json';
 
 import 'raiden-ts/polyfills';
-import { RaidenEpicDeps } from 'raiden-ts/types';
+import { RaidenEpicDeps, ContractsInfo } from 'raiden-ts/types';
 import { RaidenAction } from 'raiden-ts/actions';
-import { RaidenState, initialState } from 'raiden-ts/state';
+import { RaidenState, makeInitialState } from 'raiden-ts/state';
 import { Address, Signature } from 'raiden-ts/utils/types';
 import { getServerName } from 'raiden-ts/utils/matrix';
-import { RaidenConfig, defaultConfig } from 'raiden-ts/config';
+import { RaidenConfig } from 'raiden-ts/config';
 
 export type MockedContract<T extends Contract> = jest.Mocked<T> & {
   functions: {
@@ -147,23 +147,22 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
     return tokenContracts[address];
   };
 
-  return {
-    stateOutput$: new BehaviorSubject<RaidenState>(initialState),
-    actionOutput$: new Subject<RaidenAction>(),
-    config$: new BehaviorSubject<RaidenConfig>({
-      ...defaultConfig.default,
-      discoveryRoom: `raiden_${network.name}_discovery`,
-      pfsRoom: `raiden_${network.name}_path_finding`,
-    }),
-    matrix$: new AsyncSubject<MatrixClient>(),
-    address,
-    network,
-    contractsInfo: {
+  const contractsInfo: ContractsInfo = {
       TokenNetworkRegistry: {
         address: registryContract.address as Address,
         block_number: 100, // eslint-disable-line
       },
     },
+    initialState = makeInitialState({ network, address, contractsInfo }, { blockNumber: 125 });
+
+  return {
+    stateOutput$: new BehaviorSubject<RaidenState>(initialState),
+    actionOutput$: new Subject<RaidenAction>(),
+    config$: new BehaviorSubject<RaidenConfig>(initialState.config),
+    matrix$: new AsyncSubject<MatrixClient>(),
+    address,
+    network,
+    contractsInfo,
     provider,
     signer,
     registryContract,

--- a/raiden-ts/tests/unit/reducers.spec.ts
+++ b/raiden-ts/tests/unit/reducers.spec.ts
@@ -1,11 +1,11 @@
-import { cloneDeep, get } from 'lodash';
+import { get } from 'lodash';
 import { set } from 'lodash/fp';
 
-import { Zero, One } from 'ethers/constants';
-import { bigNumberify, keccak256 } from 'ethers/utils';
+import { Zero, One, AddressZero } from 'ethers/constants';
+import { bigNumberify, keccak256, getNetwork } from 'ethers/utils';
 
 import { raidenReducer } from 'raiden-ts/reducer';
-import { RaidenState, initialState } from 'raiden-ts/state';
+import { RaidenState, makeInitialState } from 'raiden-ts/state';
 import { ShutdownReason } from 'raiden-ts/constants';
 import { raidenShutdown } from 'raiden-ts/actions';
 import {
@@ -75,7 +75,17 @@ describe('raidenReducer', () => {
     isFirstParticipant = true;
 
   beforeEach(() => {
-    state = cloneDeep({ ...initialState, address, blockNumber: 1337 });
+    state = makeInitialState(
+      {
+        network: getNetwork('unspecified'),
+        address,
+        contractsInfo: {
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          TokenNetworkRegistry: { address: AddressZero as Address, block_number: 0 },
+        },
+      },
+      { blockNumber: 1337 },
+    );
   });
 
   test('newBlock', () => {

--- a/raiden-ts/tests/unit/state.spec.ts
+++ b/raiden-ts/tests/unit/state.spec.ts
@@ -3,6 +3,7 @@ import { bigNumberify } from 'ethers/utils';
 import { ChannelState } from 'raiden-ts/channels';
 import { decodeRaidenState, encodeRaidenState, RaidenState } from 'raiden-ts/state';
 import { Address, UInt } from 'raiden-ts/utils/types';
+import { makeDefaultConfig } from 'raiden-ts/config';
 
 describe('RaidenState codecs', () => {
   const address = '0x1111111111111111111111111111111111111111' as Address,
@@ -18,6 +19,7 @@ describe('RaidenState codecs', () => {
       chainId,
       registry,
       blockNumber: 123,
+      config: makeDefaultConfig({ network: { name: 'testnet', chainId } }),
       channels: {
         [tokenNetwork]: {
           [partner]: {
@@ -41,6 +43,7 @@ describe('RaidenState codecs', () => {
       chainId,
       registry,
       blockNumber: 123,
+      config: expect.anything(),
       channels: {
         [tokenNetwork]: {
           [partner]: {
@@ -75,6 +78,7 @@ describe('RaidenState codecs', () => {
         chainId,
         registry,
         blockNumber: 123,
+        config: makeDefaultConfig({ network: { name: 'testnet', chainId } }),
         channels: {
           [tokenNetwork]: {
             [partner]: {
@@ -98,6 +102,7 @@ describe('RaidenState codecs', () => {
         chainId,
         registry,
         blockNumber: 123,
+        config: makeDefaultConfig({ network: { name: 'testnet', chainId } }),
         channels: {
           [tokenNetwork]: {
             [partner]: {
@@ -121,6 +126,7 @@ describe('RaidenState codecs', () => {
       chainId,
       registry,
       blockNumber: 123,
+      config: expect.anything(),
       channels: {
         [tokenNetwork]: {
           [partner]: {


### PR DESCRIPTION
Fix #399 
Config:
- It's stored & rehydrated from state    
- deps.config$ reflects state.config updates
- Raiden.config -> updateConfig commits an action to redux to update state instead of next'ing new config directly
- Raiden.config becomes getter for current config (from state)
- initial state & default config have their proper factories