### PR TITLE
Fetch PFS list from ServiceRegistry

### DIFF
--- a/raiden-ts/scripts/copyContracts.js
+++ b/raiden-ts/scripts/copyContracts.js
@@ -60,7 +60,6 @@ function postBuild() {
     if (!fs.existsSync(dir)) fs.mkdirSync(dir);
     const contractsDir = path.join(cwd, '../src/contracts');
     fs.readdirSync(contractsDir)
-      .filter(fileName => fileName.endsWith('.d.ts'))
       .forEach(fileName =>
         fs.copyFileSync(path.join(contractsDir, fileName), path.join(dir, fileName)),
       );

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -11,7 +11,6 @@ import { DeepPartial } from 'redux';
  * - revealTimeout - Timeout for secrets to be revealed
  * - settleTimeout - Timeout for channels to be settled
  * - httpTimeout - Used in http fetch requests
- * - pfs - Path Finding Service URL, set to null to disable
  * - discoveryRoom - Discovery Room to auto-join, use null to disable
  * - pfsRoom - PFS Room to auto-join and send PFSCapacityUpdate to, use null to disable
  * - pfsSafetyMargin - Safety margin to be added to fees received from PFS. Use `1.1` to add a 10% safety margin.
@@ -20,6 +19,7 @@ import { DeepPartial } from 'redux';
  * - matrixServer? - Specify a matrix server to use.
  * - logger? - String specifying the console log level of redux-logger. Use '' to disable.
  *             Defaults to 'debug' if undefined and process.env.NODE_ENV === 'development'
+ * - pfs - Path Finding Service URL, set to null to disable
  */
 export const RaidenConfig = t.readonly(
   t.intersection([
@@ -28,7 +28,6 @@ export const RaidenConfig = t.readonly(
       revealTimeout: t.number,
       settleTimeout: t.number,
       httpTimeout: t.number,
-      pfs: t.union([t.string, t.null]),
       discoveryRoom: t.union([t.string, t.null]),
       pfsRoom: t.union([t.string, t.null]),
       pfsSafetyMargin: t.number,
@@ -37,6 +36,7 @@ export const RaidenConfig = t.readonly(
     t.partial({
       matrixServer: t.string,
       logger: t.keyof({ ['']: null, debug: null, log: null, info: null, warn: null, error: null }),
+      pfs: t.union([t.string, t.null]),
     }),
   ]),
 );

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -56,19 +56,12 @@ export function makeDefaultConfig(
   { network }: { network: Network },
   overwrites: DeepPartial<RaidenConfig> = {},
 ): RaidenConfig {
-  const pfs: { [networkName: string]: string } = {
-    goerli: 'https://pfs-goerli.services-test.raiden.network',
-    ropsten: 'https://pfs-ropsten.services-test.raiden.network',
-    kovan: 'https://pfs-kovan.services-test.raiden.network',
-    rinkeby: 'https://pfs-rinkeby.services-test.raiden.network',
-  };
   return {
     matrixServerLookup:
       'https://raw.githubusercontent.com/raiden-network/raiden-transport/master/known_servers.test.yaml',
     settleTimeout: 500,
     revealTimeout: 50,
     httpTimeout: 30e3,
-    pfs: pfs[network.name] || null,
     discoveryRoom: `raiden_${
       network.name !== 'unknown' ? network.name : network.chainId
     }_discovery`,

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -1,6 +1,7 @@
 import * as t from 'io-ts';
 import { Network } from 'ethers/utils';
 import { DeepPartial } from 'redux';
+import { Address } from './utils/types';
 
 /**
  * A Raiden configuration object with required parameters and
@@ -19,7 +20,8 @@ import { DeepPartial } from 'redux';
  * - matrixServer? - Specify a matrix server to use.
  * - logger? - String specifying the console log level of redux-logger. Use '' to disable.
  *             Defaults to 'debug' if undefined and process.env.NODE_ENV === 'development'
- * - pfs - Path Finding Service URL, set to null to disable
+ * - pfs - Path Finding Service URL or Address. Set to null to disable, or leave undefined to
+ *             enable automatic fetching from ServiceRegistry.
  */
 export const RaidenConfig = t.readonly(
   t.intersection([
@@ -36,7 +38,7 @@ export const RaidenConfig = t.readonly(
     t.partial({
       matrixServer: t.string,
       logger: t.keyof({ ['']: null, debug: null, log: null, info: null, warn: null, error: null }),
-      pfs: t.union([t.string, t.null]),
+      pfs: t.union([Address, t.string, t.null]),
     }),
   ]),
 );

--- a/raiden-ts/src/index.ts
+++ b/raiden-ts/src/index.ts
@@ -4,7 +4,7 @@ export { RaidenEvent, RaidenAction } from './actions';
 export { ShutdownReason } from './constants';
 export { RaidenSentTransfer, RaidenSentTransferStatus } from './transfers/state';
 export { ChannelState, RaidenChannel, RaidenChannels } from './channels/state';
-export { RaidenPaths } from './path/types';
+export { RaidenPaths, RaidenPFS } from './path/types';
 export { Raiden } from './raiden';
 export { RaidenConfig } from './config';
 export * from './types';

--- a/raiden-ts/src/path/actions.ts
+++ b/raiden-ts/src/path/actions.ts
@@ -16,3 +16,5 @@ export const pathFound = createStandardAction('pathFound')<{ paths: Paths }, Pat
 export const pathFindFailed = createStandardAction('pathFindFailed').map(
   (payload: Error, meta: PathId) => ({ payload, error: true, meta }),
 );
+
+export const pfsListUpdated = createStandardAction('pfsListUpdated')<{ pfsList: Address[] }>();

--- a/raiden-ts/src/path/actions.ts
+++ b/raiden-ts/src/path/actions.ts
@@ -1,7 +1,7 @@
 import { createStandardAction } from 'typesafe-actions';
 
 import { Address, UInt } from '../utils/types';
-import { Paths } from './types';
+import { Paths, PFS } from './types';
 
 type PathId = {
   tokenNetwork: Address;
@@ -9,7 +9,7 @@ type PathId = {
   value: UInt<32>;
 };
 
-export const pathFind = createStandardAction('pathFind')<{ paths?: Paths }, PathId>();
+export const pathFind = createStandardAction('pathFind')<{ paths?: Paths; pfs?: PFS }, PathId>();
 
 export const pathFound = createStandardAction('pathFound')<{ paths: Paths }, PathId>();
 
@@ -17,4 +17,6 @@ export const pathFindFailed = createStandardAction('pathFindFailed').map(
   (payload: Error, meta: PathId) => ({ payload, error: true, meta }),
 );
 
-export const pfsListUpdated = createStandardAction('pfsListUpdated')<{ pfsList: Address[] }>();
+export const pfsListUpdated = createStandardAction('pfsListUpdated')<{
+  pfsList: readonly Address[];
+}>();

--- a/raiden-ts/src/path/epics.ts
+++ b/raiden-ts/src/path/epics.ts
@@ -74,7 +74,7 @@ export const pathFindServiceEpic = (
               )
                 return of([{ path: [state.address, target], fee: Zero as Int<32> }]);
               // else, request a route from PFS
-              else if (pfs !== null) {
+              else if (pfs !== null && pfs !== undefined) {
                 // from all channels
                 return fromFetch(`${pfs}/api/v1/${tokenNetwork}/paths`, {
                   method: 'POST',

--- a/raiden-ts/src/path/epics.ts
+++ b/raiden-ts/src/path/epics.ts
@@ -17,12 +17,15 @@ import {
   switchMap,
   mapTo,
   scan,
+  startWith,
+  tap,
 } from 'rxjs/operators';
 import { fromFetch } from 'rxjs/fetch';
 import { isActionOf, ActionType } from 'typesafe-actions';
 import { bigNumberify, BigNumber } from 'ethers/utils';
 import { Zero } from 'ethers/constants';
 import { Event } from 'ethers/contract';
+import { isNil } from 'lodash';
 
 import { RaidenAction } from '../actions';
 import { RaidenState } from '../state';
@@ -38,7 +41,7 @@ import { Address, UInt, Int, decode } from '../utils/types';
 import { losslessStringify, losslessParse } from '../utils/data';
 import { getEventsStream } from '../utils/ethers';
 import { pathFind, pathFound, pathFindFailed, pfsListUpdated } from './actions';
-import { channelCanRoute } from './utils';
+import { channelCanRoute, pfsInfo, pfsListInfo } from './utils';
 import { PathResults, Paths } from './types';
 
 /**
@@ -46,21 +49,31 @@ import { PathResults, Paths } from './types';
  *
  * @param action$ - Observable of pathFind actions
  * @param state$ - Observable of RaidenStates
+ * @param deps - RaidenEpicDeps object
  * @returns Observable of pathFound|pathFindFailed actions
  */
 export const pathFindServiceEpic = (
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-  { address, config$ }: RaidenEpicDeps,
+  deps: RaidenEpicDeps,
 ): Observable<ActionType<typeof pathFound | typeof pathFindFailed>> =>
-  combineLatest(state$, getPresences$(action$), config$).pipe(
-    publishReplay(1, undefined, statePresencesConfig$ => {
+  combineLatest(
+    state$,
+    getPresences$(action$),
+    deps.config$, // don't need to be cached, but here to avoid separate withLatestFrom
+    action$.pipe(
+      filter(isActionOf(pfsListUpdated)),
+      pluck('payload', 'pfsList'),
+      startWith([] as readonly Address[]),
+    ),
+  ).pipe(
+    publishReplay(1, undefined, cached$ => {
       return action$.pipe(
         filter(isActionOf(pathFind)),
         concatMap(action =>
-          statePresencesConfig$.pipe(
+          cached$.pipe(
             first(),
-            mergeMap(([state, presences, { pfs, httpTimeout, pfsSafetyMargin }]) => {
+            mergeMap(([state, presences, { pfs: configPfs, httpTimeout, pfsSafetyMargin }]) => {
               const { tokenNetwork, target } = action.meta;
               if (!(tokenNetwork in state.channels))
                 throw new Error(`PFS: unknown tokenNetwork ${tokenNetwork}`);
@@ -71,21 +84,46 @@ export const pathFindServiceEpic = (
               // else, if possible, use a direct transfer
               else if (
                 channelCanRoute(state, presences, tokenNetwork, target, action.meta.value) === true
-              )
+              ) {
                 return of([{ path: [state.address, target], fee: Zero as Int<32> }]);
-              // else, request a route from PFS
-              else if (pfs !== null && pfs !== undefined) {
-                // from all channels
-                return fromFetch(`${pfs}/api/v1/${tokenNetwork}/paths`, {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: losslessStringify({
-                    from: address,
-                    to: target,
-                    value: UInt(32).encode(action.meta.value),
-                    max_paths: 10,
-                  }),
-                }).pipe(
+              } else if (!action.payload.pfs && configPfs === null) {
+                // pfs not specified in action and disabled (null) in config
+                throw new Error(`PFS disabled and no direct route available`);
+              } else {
+                // else, request a route from PFS.
+                // pfs$ - Observable which emits one PFS info and then completes
+                const pfs$ = action.payload.pfs
+                  ? // first, honor action.payload.pfs
+                    of(action.payload.pfs)
+                  : !isNil(configPfs)
+                  ? // or if config.pfs isn't disabled nor auto (undefined), use it
+                    // configPfs is addr or url, so fetch pfsInfo from it
+                    pfsInfo(configPfs, deps)
+                  : // else (config.pfs undefined, auto mode)
+                    cached$.pipe(
+                      pluck(3), // get cached pfsList (4th combined value)
+                      // if needed, wait for list to be populated
+                      first(pfsList => pfsList.length > 0),
+                      // fetch pfsInfo from whole list & sort it
+                      mergeMap(pfsList => pfsListInfo(pfsList, deps)),
+                      tap(pfss => console.log('Auto-selecting best PFS from:', pfss)),
+                      // pop best ranked
+                      pluck(0),
+                    );
+                return pfs$.pipe(
+                  // TODO: use pfs.price to create & sign IOU
+                  mergeMap(pfs =>
+                    fromFetch(`${pfs.url}/api/v1/${tokenNetwork}/paths`, {
+                      method: 'POST',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: losslessStringify({
+                        from: deps.address,
+                        to: target,
+                        value: UInt(32).encode(action.meta.value),
+                        max_paths: 10,
+                      }),
+                    }),
+                  ),
                   timeout(httpTimeout),
                   mergeMap(async response => {
                     const text = await response.text();
@@ -106,11 +144,9 @@ export const pathFindServiceEpic = (
                       })),
                   ),
                 );
-              } else {
-                throw new Error(`PFS disabled and no direct route available`);
               }
             }),
-            withLatestFrom(statePresencesConfig$),
+            withLatestFrom(cached$),
             // validate/cleanup received routes/paths/results
             map(([paths, [state, presences]]) => {
               const filteredPaths: Paths = [],
@@ -217,7 +253,7 @@ export const pfsCapacityUpdateEpic = (
  * and aggregate list of valid service addresses
  *
  * Notice this epic only deals with the events & addresses, and don't fetch URLs, which need to be
- * fetched on-demand, as well as querying PFS's info endpoint.
+ * fetched on-demand through [[pfsInfo]] & [[pfsListInfo]].
  *
  * @param action$ - Observable of RaidenActions
  * @param state$ - Observable of RaidenStates
@@ -274,7 +310,7 @@ export const pfsServiceRegistryMonitorEpic = (
                       : valid && !acc.includes(service)
                       ? [...acc, service]
                       : acc,
-                  [] as Address[],
+                  [] as readonly Address[],
                 ),
                 distinctUntilChanged(),
                 debounceTime(1e3), // debounce burst of updates on initial fetch

--- a/raiden-ts/src/path/types.ts
+++ b/raiden-ts/src/path/types.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
 import { BigNumberish } from 'ethers/utils';
-import { Address, Int } from '../utils/types';
+import { Address, Int, UInt } from '../utils/types';
 
 /**
  * Codec for PFS API returned data
@@ -43,3 +43,21 @@ export type Paths = t.TypeOf<typeof Paths>;
  * Public Raiden interface for routes data
  */
 export type RaidenPaths = { readonly path: readonly string[]; readonly fee: BigNumberish }[];
+
+/**
+ * A PFS server/service instance info
+ */
+export const PFS = t.readonly(
+  t.type({
+    address: Address,
+    url: t.string,
+    rtt: t.number,
+    price: UInt(32),
+  }),
+);
+export interface PFS extends t.TypeOf<typeof PFS> {}
+
+/**
+ * Public Raiden interface for PFS info
+ */
+export type RaidenPFS = { address: string; url: string; rtt: number; price: BigNumberish };

--- a/raiden-ts/src/path/types.ts
+++ b/raiden-ts/src/path/types.ts
@@ -53,6 +53,7 @@ export const PFS = t.readonly(
     url: t.string,
     rtt: t.number,
     price: UInt(32),
+    token: Address,
   }),
 );
 export interface PFS extends t.TypeOf<typeof PFS> {}
@@ -60,4 +61,10 @@ export interface PFS extends t.TypeOf<typeof PFS> {}
 /**
  * Public Raiden interface for PFS info
  */
-export type RaidenPFS = { address: string; url: string; rtt: number; price: BigNumberish };
+export interface RaidenPFS {
+  address: string;
+  url: string;
+  rtt: number;
+  price: BigNumberish;
+  token: string;
+}

--- a/raiden-ts/src/path/utils.ts
+++ b/raiden-ts/src/path/utils.ts
@@ -8,6 +8,7 @@ import { memoize } from 'lodash';
 import { RaidenState } from '../state';
 import { RaidenEpicDeps } from '../types';
 import { Address, UInt, decode } from '../utils/types';
+import { losslessParse } from '../utils/data';
 import { Presences } from '../transport/types';
 import { ChannelState } from '../channels/state';
 import { channelAmounts } from '../channels/utils';
@@ -89,7 +90,7 @@ export function pfsInfo(
         mergeMap(
           async res =>
             [
-              decode(PathInfo, await res.json()),
+              decode(PathInfo, losslessParse(await res.text())),
               await serviceRegistryToken(serviceRegistryContract),
             ] as const,
         ),

--- a/raiden-ts/src/path/utils.ts
+++ b/raiden-ts/src/path/utils.ts
@@ -1,8 +1,16 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import * as t from 'io-ts';
+import { Observable, from, of, EMPTY } from 'rxjs';
+import { mergeMap, map, timeout, withLatestFrom, catchError, toArray } from 'rxjs/operators';
+import { fromFetch } from 'rxjs/fetch';
+
 import { RaidenState } from '../state';
-import { Address, UInt } from '../utils/types';
+import { RaidenEpicDeps } from '../types';
+import { Address, UInt, decode } from '../utils/types';
 import { Presences } from '../transport/types';
 import { ChannelState } from '../channels/state';
 import { channelAmounts } from '../channels/utils';
+import { PFS } from './types';
 
 /**
  * Either returns true if given channel can route a payment, or a reason as string if not
@@ -32,4 +40,97 @@ export function channelCanRoute(
   if (capacity.lt(value))
     return `path: channel with "${partner}" don't have enough capacity=${capacity.toString()}`;
   return true;
+}
+
+/**
+ * Returns a cold observable which fetch PFS info & validate for a given server address or URL
+ *
+ * @param pfsAddrOrUrl - PFS account/address or URL
+ * @param deps - RaidenEpicDeps needed for various parameters
+ * @returns Observable containing PFS server info
+ */
+export function pfsInfo(
+  pfsAddrOrUrl: Address | string,
+  { serviceRegistryContract, network, contractsInfo, config$ }: RaidenEpicDeps,
+): Observable<PFS> {
+  /**
+   * Codec for PFS /api/v1/info result schema
+   */
+  const PathInfo = t.type({
+    message: t.string,
+    network_info: t.type({
+      // literals will fail if trying to decode anything different from these constants
+      chain_id: t.literal(network.chainId),
+      registry_address: t.literal(contractsInfo.TokenNetworkRegistry.address),
+    }),
+    operator: t.string,
+    payment_address: Address,
+    price_info: UInt(32),
+    version: t.string,
+  });
+  // if it's an address, fetch url from ServiceRegistry, else it's already the URL
+  const url$ = Address.is(pfsAddrOrUrl)
+    ? from(serviceRegistryContract.functions.urls(pfsAddrOrUrl))
+    : of(pfsAddrOrUrl);
+  return url$.pipe(
+    withLatestFrom(config$),
+    mergeMap(([url, { httpTimeout }]) => {
+      if (!url || !url.includes('://')) throw new Error(`Invalid URL: ${url}`);
+      const start = Date.now();
+      return fromFetch(`${url}/api/v1/info`).pipe(
+        timeout(httpTimeout),
+        mergeMap(res => res.json()),
+        map(json => {
+          const info = decode(PathInfo, json);
+          return {
+            address: info.payment_address,
+            url,
+            rtt: Date.now() - start,
+            price: info.price_info,
+          };
+        }),
+      );
+    }),
+  );
+}
+
+/**
+ * Retrieve pfsInfo for these servers & return sorted PFS info
+ *
+ * Sort order is price then response time (rtt).
+ * Throws if no server can be validated, meaning either there's none in the current network or
+ * we're out-of-sync (outdated or ahead of PFS's deployment network version).
+ *
+ * @param pfsList - Array of PFS addresses, as notified by pfsListUpdated action
+ * @param deps - RaidenEpicDeps array
+ * @returns Observable of online, validated & sorted PFS info array
+ */
+export function pfsListInfo(pfsList: readonly Address[], deps: RaidenEpicDeps): Observable<PFS[]> {
+  return from(pfsList).pipe(
+    mergeMap(
+      addr =>
+        pfsInfo(addr, deps).pipe(
+          catchError(err => {
+            console.warn(`Error trying to fetch PFS info for "${addr}" - ignoring:`, err);
+            return EMPTY;
+          }),
+        ),
+      5, // maximum concurrency
+    ),
+    toArray(),
+    map(list => {
+      if (!list.length)
+        throw new Error(
+          'Could not validate any PFS info. Possibly out-of-sync with PFSs version.',
+        );
+      return list.sort((a, b) => {
+        const dif = a.price.sub(b.price);
+        // first, sort by price
+        if (dif.lt(0)) return -1;
+        else if (dif.gt(0)) return 1;
+        // if it's equal, tiebreak on rtt
+        else return a.rtt - b.rtt;
+      });
+    }),
+  );
 }

--- a/raiden-ts/src/state.ts
+++ b/raiden-ts/src/state.ts
@@ -125,6 +125,10 @@ export function makeInitialState(
 export const initialState = makeInitialState({
   network: getNetwork('unspecified'),
   address: AddressZero as Address,
-  // eslint-disable-next-line @typescript-eslint/camelcase
-  contractsInfo: { TokenNetworkRegistry: { address: AddressZero as Address, block_number: 0 } },
+  contractsInfo: {
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    TokenNetworkRegistry: { address: AddressZero as Address, block_number: 0 },
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    ServiceRegistry: { address: AddressZero as Address, block_number: 0 },
+  },
 });

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -6,6 +6,7 @@ import { Network } from 'ethers/utils';
 import { MatrixClient } from 'matrix-js-sdk';
 
 import { TokenNetworkRegistry } from './contracts/TokenNetworkRegistry';
+import { ServiceRegistry } from './contracts/ServiceRegistry';
 import { TokenNetwork } from './contracts/TokenNetwork';
 import { HumanStandardToken } from './contracts/HumanStandardToken';
 
@@ -21,6 +22,7 @@ interface Info {
 
 export interface ContractsInfo {
   TokenNetworkRegistry: Info;
+  ServiceRegistry: Info;
 }
 
 export interface RaidenEpicDeps {
@@ -36,4 +38,5 @@ export interface RaidenEpicDeps {
   registryContract: TokenNetworkRegistry;
   getTokenNetworkContract: (address: Address) => TokenNetwork;
   getTokenContract: (address: Address) => HumanStandardToken;
+  serviceRegistryContract: ServiceRegistry;
 }

--- a/raiden-ts/tests/e2e/provider.ts
+++ b/raiden-ts/tests/e2e/provider.ts
@@ -109,26 +109,14 @@ export class TestProvider extends Web3Provider {
     const serviceRegistryDeployBlock = serviceRegistryContract.deployTransaction.blockNumber;
 
     // mint CTK to deployer
-    console.warn(
-      '1',
-      await (await tokenContract.functions.mintFor(parseUnits('1000', 18), address)).wait(),
-    );
+    await (await tokenContract.functions.mintFor(parseUnits('1000', 18), address)).wait();
     // approve service registry transfering amount from deployer
-    console.warn(
-      '2',
-      await (await tokenContract.functions.approve(
-        serviceRegistryContract.address,
-        amount,
-      )).wait(),
-    );
+    await (await tokenContract.functions.approve(serviceRegistryContract.address, amount)).wait();
     await this.mine();
     // deposit amount tokens to service registry
-    console.warn('3', await (await serviceRegistryContract.functions.deposit(amount)).wait());
+    await (await serviceRegistryContract.functions.deposit(amount)).wait();
     // setURL for service registry
-    console.warn(
-      '4',
-      await (await serviceRegistryContract.functions.setURL('https://pfs.raiden.test')).wait(),
-    );
+    await (await serviceRegistryContract.functions.setURL('https://pfs.raiden.test')).wait();
 
     return {
       TokenNetworkRegistry: {

--- a/raiden-ts/tests/e2e/provider.ts
+++ b/raiden-ts/tests/e2e/provider.ts
@@ -5,13 +5,15 @@ import { range } from 'lodash';
 import asyncPool from 'tiny-async-pool';
 
 import { Web3Provider } from 'ethers/providers';
-import { MaxUint256 } from 'ethers/constants';
+import { MaxUint256, AddressZero } from 'ethers/constants';
 import { ContractFactory, Contract } from 'ethers/contract';
 import { parseUnits } from 'ethers/utils';
 
 import { ContractsInfo } from 'raiden-ts/types';
 import { Address } from 'raiden-ts/utils/types';
 import { TokenNetworkRegistry } from 'raiden-ts/contracts/TokenNetworkRegistry';
+import { CustomToken } from 'raiden-ts/contracts/CustomToken';
+import { ServiceRegistry } from 'raiden-ts/contracts/ServiceRegistry';
 import Contracts from '../../raiden-contracts/raiden_contracts/data/contracts.json';
 
 export class TestProvider extends Web3Provider {
@@ -56,7 +58,8 @@ export class TestProvider extends Web3Provider {
 
   public async deployRegistry(): Promise<ContractsInfo> {
     const accounts = await this.listAccounts();
-    const signer = this.getSigner(accounts[accounts.length - 1]);
+    const address = accounts[accounts.length - 1],
+      signer = this.getSigner(address);
 
     const secretRegistryContract = await new ContractFactory(
       Contracts.contracts.SecretRegistry.abi,
@@ -77,12 +80,64 @@ export class TestProvider extends Web3Provider {
       10,
     )) as TokenNetworkRegistry;
     await registryContract.deployed();
-    const registyDeployBlock = registryContract.deployTransaction.blockNumber;
+    const registryDeployBlock = registryContract.deployTransaction.blockNumber;
+
+    // controller token for service registry
+    const tokenContract = (await new ContractFactory(
+      Contracts.contracts.CustomToken.abi,
+      Contracts.contracts.CustomToken.bin,
+      signer,
+    ).deploy(parseUnits('1000000', 18), 18, `ControllerToken`, `CTK`)) as CustomToken;
+    await tokenContract.deployed();
+
+    const amount = 1e6;
+    const serviceRegistryContract = (await new ContractFactory(
+      Contracts.contracts.ServiceRegistry.abi,
+      Contracts.contracts.ServiceRegistry.bin,
+      signer,
+    ).deploy(
+      tokenContract.address, // token for registration
+      AddressZero, // controller
+      amount, // initial price, 1e-12 CTK
+      6, // price bump numerator
+      5, // price bump denominator
+      17280000, // decay constant
+      1000, // min price
+      17280000, // registration duration
+    )) as ServiceRegistry;
+    await serviceRegistryContract.deployed();
+    const serviceRegistryDeployBlock = serviceRegistryContract.deployTransaction.blockNumber;
+
+    // mint CTK to deployer
+    console.warn(
+      '1',
+      await (await tokenContract.functions.mintFor(parseUnits('1000', 18), address)).wait(),
+    );
+    // approve service registry transfering amount from deployer
+    console.warn(
+      '2',
+      await (await tokenContract.functions.approve(
+        serviceRegistryContract.address,
+        amount,
+      )).wait(),
+    );
+    await this.mine();
+    // deposit amount tokens to service registry
+    console.warn('3', await (await serviceRegistryContract.functions.deposit(amount)).wait());
+    // setURL for service registry
+    console.warn(
+      '4',
+      await (await serviceRegistryContract.functions.setURL('https://pfs.raiden.test')).wait(),
+    );
 
     return {
       TokenNetworkRegistry: {
         address: registryContract.address as Address,
-        block_number: registyDeployBlock!,
+        block_number: registryDeployBlock!,
+      },
+      ServiceRegistry: {
+        address: serviceRegistryContract.address as Address,
+        block_number: serviceRegistryDeployBlock!,
       },
     };
   }

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/camelcase */
 import { first, filter } from 'rxjs/operators';
 import { Zero } from 'ethers/constants';
 import { parseEther, parseUnits, bigNumberify, BigNumber, keccak256, Network } from 'ethers/utils';
@@ -23,8 +24,7 @@ import { RaidenSentTransfer, RaidenSentTransferStatus } from 'raiden-ts/transfer
 import { makeSecret, getSecrethash } from 'raiden-ts/transfers/utils';
 import { matrixSetup } from 'raiden-ts/transport/actions';
 import { losslessStringify } from 'raiden-ts/utils/data';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+import { ServiceRegistryFactory } from 'raiden-ts/contracts/ServiceRegistryFactory';
 
 describe('Raiden', () => {
   const provider = new TestProvider();
@@ -36,7 +36,11 @@ describe('Raiden', () => {
     token: string,
     tokenNetwork: string,
     partner: string,
-    network: Network;
+    network: Network,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    pfsInfoResponse: any,
+    pfsAddress: string,
+    pfsUrl: string;
   const config: Partial<RaidenConfig> = { settleTimeout: 20, revealTimeout: 5 };
 
   let httpBackend: MockMatrixRequestFn;
@@ -59,6 +63,31 @@ describe('Raiden', () => {
     accounts = await provider.listAccounts();
     partner = accounts[1];
     network = await provider.getNetwork();
+
+    const serviceRegistryContract = ServiceRegistryFactory.connect(
+        contractsInfo.ServiceRegistry.address,
+        provider,
+      ),
+      events = await provider.getLogs({
+        ...serviceRegistryContract.filters.RegisteredService(null, null, null, null),
+        fromBlock: 0,
+        toBlock: 'latest',
+      }),
+      parsed = serviceRegistryContract.interface.parseLog(events[0]);
+    pfsAddress = parsed.values[0] as string;
+    pfsUrl = await serviceRegistryContract.functions.urls(pfsAddress);
+
+    pfsInfoResponse = {
+      message: 'pfs message',
+      network_info: {
+        chain_id: network.chainId,
+        registry_address: contractsInfo.TokenNetworkRegistry.address,
+      },
+      operator: 'pfs operator',
+      payment_address: pfsAddress,
+      price_info: 2,
+      version: '0.4.1',
+    };
   });
 
   beforeEach(async () => {
@@ -164,14 +193,14 @@ describe('Raiden', () => {
   });
 
   test('config', async () => {
-    expect.assertions(2);
+    expect.assertions(3);
     expect(raiden.config).toMatchObject({
       discoveryRoom: 'raiden_1338_discovery',
       pfsRoom: 'raiden_1338_path_finding',
-      pfs: null,
       settleTimeout: 20,
       revealTimeout: 5,
     });
+    expect(raiden.config.pfs).toBeUndefined();
     raiden.updateConfig({ revealTimeout: 8 });
     expect(raiden.config).toMatchObject({
       revealTimeout: 8,
@@ -654,6 +683,14 @@ describe('Raiden', () => {
 
       afterEach(() => raiden1.stop());
 
+      test('fail: direct channel without enough capacity, pfs disabled', async () => {
+        expect.assertions(2);
+        raiden.updateConfig({ pfs: null });
+        await expect(raiden.transfer(token, partner, 201)).rejects.toThrowError(
+          /no direct route/i,
+        );
+      });
+
       test('success: direct route', async () => {
         expect.assertions(4);
 
@@ -667,14 +704,7 @@ describe('Raiden', () => {
         expect(transfers[secrethash].status).toBe(RaidenSentTransferStatus.pending);
       });
 
-      test('fail: direct channel without enough capacity, pfs disabled', async () => {
-        expect.assertions(2);
-        await expect(raiden.transfer(token, partner, 201)).rejects.toThrowError(
-          /no direct route/i,
-        );
-      });
-
-      test('success: pfs route', async () => {
+      test('success: auto pfs route', async () => {
         expect.assertions(7);
 
         const target = accounts[2],
@@ -702,8 +732,16 @@ describe('Raiden', () => {
         });
         await new Promise(resolve => setTimeout(resolve, 100));
 
-        const pfs = 'http://pfs';
-        raiden.updateConfig({ pfs });
+        // auto pfs mode
+        raiden.updateConfig({ pfs: undefined });
+
+        fetch.mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: jest.fn(async () => pfsInfoResponse),
+          text: jest.fn(async () => losslessStringify(pfsInfoResponse)),
+        });
+
         const result = {
           result: [
             // first returned route is invalid and should be filtered
@@ -737,7 +775,7 @@ describe('Raiden', () => {
         });
 
         expect(fetch).toHaveBeenCalledWith(
-          expect.stringMatching(new RegExp(`^${pfs}/.*/${tokenNetwork}/paths$`)),
+          expect.stringMatching(new RegExp(`^${pfsUrl}/.*/${tokenNetwork}/paths$`)),
           expect.objectContaining({ method: 'POST' }),
         );
 
@@ -746,8 +784,42 @@ describe('Raiden', () => {
     });
   });
 
+  describe('findPFS', () => {
+    test('fail config.pfs not in auto mode', async () => {
+      expect.assertions(2);
+
+      raiden.updateConfig({ pfs: null }); // disabled pfs
+      await expect(raiden.findPFS()).rejects.toThrowError("pfs isn't auto");
+
+      raiden.updateConfig({ pfs: pfsUrl }); // pfs set
+      await expect(raiden.findPFS()).rejects.toThrowError("pfs isn't auto");
+    });
+
+    test('success', async () => {
+      expect.assertions(1);
+
+      // pfsInfo
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn(async () => pfsInfoResponse),
+        text: jest.fn(async () => losslessStringify(pfsInfoResponse)),
+      });
+
+      raiden.updateConfig({ pfs: undefined });
+      await expect(raiden.findPFS()).resolves.toEqual([
+        {
+          address: pfsAddress,
+          url: pfsUrl,
+          rtt: expect.any(Number),
+          price: expect.any(BigNumber),
+          token: expect.any(String),
+        },
+      ]);
+    });
+  });
+
   describe('findRoutes', () => {
-    const pfs = 'http://pfs';
     let raiden1: Raiden, raiden2: Raiden, target: string;
 
     beforeAll(() => jest.setTimeout(90e3));
@@ -801,7 +873,14 @@ describe('Raiden', () => {
       });
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      raiden.updateConfig({ pfs });
+      raiden.updateConfig({ pfs: pfsUrl });
+
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn(async () => pfsInfoResponse),
+        text: jest.fn(async () => losslessStringify(pfsInfoResponse)),
+      });
     });
 
     afterEach(() => {
@@ -809,7 +888,7 @@ describe('Raiden', () => {
       raiden2.stop();
     });
 
-    test('success', async () => {
+    test('success with config.pfs', async () => {
       expect.assertions(4);
 
       const result = {
@@ -835,7 +914,57 @@ describe('Raiden', () => {
       ]);
 
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringMatching(new RegExp(`^${pfs}/.*/${tokenNetwork}/paths$`)),
+        expect.stringMatching(new RegExp(`^${pfsUrl}/.*/${tokenNetwork}/paths$`)),
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    test('success with findPFS', async () => {
+      expect.assertions(6);
+
+      // config.pfs in auto mode
+      raiden.updateConfig({ pfs: undefined });
+
+      const pfss = await raiden.findPFS();
+      expect(pfss).toEqual([
+        {
+          address: pfsAddress,
+          url: pfsUrl,
+          rtt: expect.any(Number),
+          price: expect.any(BigNumber),
+          token: expect.any(String),
+        },
+      ]);
+
+      const result = {
+        result: [
+          // first returned route is invalid and should be filtered
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          { path: [tokenNetwork, target], estimated_fee: 0 },
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          { path: [raiden.address, partner, target], estimated_fee: 0 },
+        ],
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        feedback_token: '0xfeedback',
+      };
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: jest.fn(async () => result),
+        text: jest.fn(async () => losslessStringify(result)),
+      });
+
+      await expect(raiden.findRoutes(token, target, 23, { pfs: pfss[0] })).resolves.toEqual([
+        { path: [partner, target], fee: bigNumberify(0) },
+      ]);
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(new RegExp(`^${pfsUrl}/.*/info`)),
+        expect.anything(),
+      );
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(new RegExp(`^${pfsUrl}/.*/${tokenNetwork}/paths$`)),
         expect.objectContaining({ method: 'POST' }),
       );
     });

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -52,7 +52,7 @@ describe('Raiden', () => {
   Object.assign(global, { fetch });
 
   beforeAll(async () => {
-    jest.setTimeout(20e3);
+    jest.setTimeout(40e3);
 
     contractsInfo = await provider.deployRegistry();
     ({ token, tokenNetwork } = await provider.deployTokenNetwork(contractsInfo));
@@ -117,6 +117,8 @@ describe('Raiden', () => {
               contractsInfo: {
                 // eslint-disable-next-line @typescript-eslint/camelcase
                 TokenNetworkRegistry: { address: token as Address, block_number: 0 },
+                // eslint-disable-next-line @typescript-eslint/camelcase
+                ServiceRegistry: { address: partner as Address, block_number: 1 },
               },
               address: accounts[1] as Address,
             },
@@ -469,7 +471,7 @@ describe('Raiden', () => {
       await expect(raiden.channels$.pipe(first()).toPromise()).resolves.toEqual({
         [token]: {},
       });
-    }, 60e3);
+    }, 90e3);
   });
 
   describe('events$', () => {
@@ -748,7 +750,7 @@ describe('Raiden', () => {
     const pfs = 'http://pfs';
     let raiden1: Raiden, raiden2: Raiden, target: string;
 
-    beforeAll(() => jest.setTimeout(60e3));
+    beforeAll(() => jest.setTimeout(90e3));
 
     beforeEach(async () => {
       target = accounts[2];

--- a/raiden-ts/tests/unit/fixtures.ts
+++ b/raiden-ts/tests/unit/fixtures.ts
@@ -7,48 +7,20 @@ patchEthersDefineReadOnly();
 import { Wallet } from 'ethers';
 import { AddressZero } from 'ethers/constants';
 import { bigNumberify } from 'ethers/utils';
-import { MatrixClient } from 'matrix-js-sdk';
 
-import { Address, Hash, UInt, Int } from 'raiden-ts/utils/types';
-import { RaidenState } from 'raiden-ts/state';
-import { HumanStandardToken } from 'raiden-ts/contracts/HumanStandardToken';
-import { TokenNetwork } from 'raiden-ts/contracts/TokenNetwork';
-import { Metadata, Processed, MessageType } from 'raiden-ts/messages/types';
+import { Address, Hash, Int } from 'raiden-ts/utils/types';
+import { Processed, MessageType } from 'raiden-ts/messages/types';
 import { makeMessageId, makePaymentId } from 'raiden-ts/transfers/utils';
-import { Paths } from 'raiden-ts/path/types';
 
-import { makeMatrix, MockRaidenEpicDeps, MockedContract } from './mocks';
+import { makeMatrix, MockRaidenEpicDeps } from './mocks';
 
-export const epicFixtures = function(
-  depsMock: MockRaidenEpicDeps,
-): {
-  token: Address;
-  tokenNetwork: Address;
-  partner: Address;
-  target: Address;
-  matrix: jest.Mocked<MatrixClient>;
-  channelId: number;
-  settleTimeout: number;
-  isFirstParticipant: boolean;
-  tokenContract: MockedContract<HumanStandardToken>;
-  tokenNetworkContract: MockedContract<TokenNetwork>;
-  accessToken: string;
-  deviceId: string;
-  displayName: string;
-  partnerRoomId: string;
-  partnerUserId: string;
-  targetUserId: string;
-  state: RaidenState;
-  partnerSigner: Wallet;
-  txHash: Hash;
-  matrixServer: string;
-  userId: string;
-  processed: Processed;
-  paymentId: UInt<8>;
-  fee: Int<32>;
-  paths: Paths;
-  metadata: Metadata;
-} {
+/**
+ * Composes several constants used across epics
+ *
+ * @param depsMock - RaidenEpicDeps mock object constructed through raidenEpicDeps
+ * @returns Diverse constant values and objects
+ */
+export function epicFixtures(depsMock: MockRaidenEpicDeps) {
   const wallet = new Wallet('0x3333333333333333333333333333333333333333333333333333333333333333'),
     token = '0x0000000000000000000000000000000000010001' as Address,
     tokenNetwork = '0x0000000000000000000000000000000000020001' as Address,
@@ -73,7 +45,20 @@ export const epicFixtures = function(
     paymentId = makePaymentId(),
     fee = bigNumberify(3) as Int<32>,
     paths = [{ path: [partner], fee }],
-    metadata = { routes: [{ route: [partner] }] };
+    metadata = { routes: [{ route: [partner] }] },
+    pfsAddress = '0x0900000000000000000000000000000000000009' as Address,
+    pfsTokenAddress = '0x0800000000000000000000000000000000000008' as Address,
+    pfsInfoResponse = {
+      message: 'pfs message',
+      network_info: {
+        chain_id: depsMock.network.chainId,
+        registry_address: depsMock.contractsInfo.TokenNetworkRegistry.address,
+      },
+      operator: 'pfs operator',
+      payment_address: pfsAddress,
+      price_info: 2,
+      version: '0.4.1',
+    };
 
   depsMock.registryContract.functions.token_to_token_networks.mockImplementation(async _token =>
     _token === token ? tokenNetwork : AddressZero,
@@ -106,5 +91,8 @@ export const epicFixtures = function(
     fee,
     paths,
     metadata,
+    pfsAddress,
+    pfsTokenAddress,
+    pfsInfoResponse,
   };
-};
+}

--- a/raiden-ts/tests/unit/reducers.spec.ts
+++ b/raiden-ts/tests/unit/reducers.spec.ts
@@ -82,6 +82,8 @@ describe('raidenReducer', () => {
         contractsInfo: {
           // eslint-disable-next-line @typescript-eslint/camelcase
           TokenNetworkRegistry: { address: AddressZero as Address, block_number: 0 },
+          // eslint-disable-next-line @typescript-eslint/camelcase
+          ServiceRegistry: { address: AddressZero as Address, block_number: 0 },
         },
       },
       { blockNumber: 1337 },


### PR DESCRIPTION
Fix #253 

- `config.pfs` can be 3 values:
  - undefined, currently the default, enables fetching pfs list from service registry
  - null, disable PFS if one isn't specified explicitly in `findRoutes` or `transfer` options
  - a string, which will be used as pfs URL to be used
- on the pfs list fetching, ServiceRegistry is monitored, and one can use `Raiden.findPFS` public API to fetch a list of available PFSs
  - in this case, the selected PFS can be passed to `findRoutes`, and this PFS will be used by findRoutes
  - if not specified, `findRoutes` will fetch, sort & select automatically a PFS from the registry

Notice that, currently, only the paid PFSs are registered on-chain, and we don't support paying PFS yet (#254), so findRoutes will fail when the PFS request fails due to the lack of an IOU. Workaround is to set the free PFS explicity with `raiden.updateConfig({ pfs: 'free-pfs' })`, if not set yet, on console.