### PR TITLE
Update dapp installation readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ You can find more detailed information on how to use the SDK in the [Raiden Ligh
 #### dApp Installation
 
 ```bash
-git clone https://github.com/raiden-network/light-client.git
+git clone --recurse-submodules https://github.com/raiden-network/light-client.git
 cd light-client/raiden-dapp
 ```
 


### PR DESCRIPTION
Currently the dapp installation instructions will fail because it doesn't pull in the `raiden-contract` sub module