### PR TITLE
Implement Raiden.start method

### DIFF
--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -5,7 +5,7 @@ import {
   RaidenPaths
 } from 'raiden-ts';
 import { Store } from 'vuex';
-import { RootState, Tokens } from '@/types';
+import { RootState } from '@/types';
 import { Web3Provider } from '@/services/web3-provider';
 import { BalanceUtils } from '@/utils/balance-utils';
 import {
@@ -118,22 +118,13 @@ export default class RaidenService {
           }
         });
 
-        const initialTokens = await raiden.getTokenList();
-        if (initialTokens.length) {
-          this.store.commit(
-            'updateTokens',
-            initialTokens.reduce(
-              (acc, token) => ({ ...acc, [token]: { address: token } }),
-              {} as Tokens
-            )
-          );
-        }
-
         raiden.channels$.subscribe(value => {
           this.store.commit('updateChannels', value);
         });
 
         this.store.commit('network', raiden.network);
+
+        raiden.start();
       }
     } catch (e) {
       console.error(e);

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -276,7 +276,8 @@ describe('RaidenService', () => {
       channels$: stub,
       getBalance: jest.fn().mockResolvedValue(Zero),
       events$: new BehaviorSubject({}),
-      stop: jest.fn().mockReturnValue(null),
+      stop: jest.fn(),
+      start: jest.fn(),
       getTokenList: jest.fn().mockResolvedValue([])
     };
 
@@ -289,6 +290,7 @@ describe('RaidenService', () => {
     expect(store.commit).toHaveBeenCalledTimes(5);
     raidenService.disconnect();
     expect(raidenMock.stop).toHaveBeenCalledTimes(1);
+    expect(raidenMock.start).toHaveBeenCalledTimes(1);
   });
 
   it('should resolve successfully on channel close', async function() {
@@ -502,7 +504,8 @@ describe('RaidenService', () => {
       factory.mockResolvedValue(
         mockRaiden({
           getTokenList,
-          getTokenInfo
+          getTokenInfo,
+          start: jest.fn()
         })
       );
     });
@@ -519,17 +522,9 @@ describe('RaidenService', () => {
 
       expect(store.commit).toHaveBeenNthCalledWith(1, 'account', '123');
       expect(store.commit).toHaveBeenNthCalledWith(2, 'balance', '0.0');
-      expect(store.commit).toHaveBeenNthCalledWith(
-        3,
-        'updateTokens',
-        expect.objectContaining({
-          [mockToken1]: { address: mockToken1 },
-          [mockToken2]: { address: mockToken2 }
-        })
-      );
-      expect(store.commit).toHaveBeenNthCalledWith(4, 'network', undefined);
-      expect(store.commit).toHaveBeenNthCalledWith(5, 'loadComplete');
-      expect(store.commit).toHaveBeenCalledTimes(5);
+      expect(store.commit).toHaveBeenNthCalledWith(3, 'network', undefined);
+      expect(store.commit).toHaveBeenNthCalledWith(4, 'loadComplete');
+      expect(store.commit).toHaveBeenCalledTimes(4);
     });
 
     test('fetch should fetch contracts that are not cached', async () => {
@@ -553,15 +548,15 @@ describe('RaidenService', () => {
       await raidenService.connect();
       await flushPromises();
 
-      expect(store.commit).toHaveBeenCalledTimes(5);
+      expect(store.commit).toHaveBeenCalledTimes(4);
 
       expect(store.commit).toHaveBeenNthCalledWith(1, 'account', '123');
       expect(store.commit).toHaveBeenNthCalledWith(2, 'balance', '0.0');
-      expect(store.commit).toHaveBeenNthCalledWith(5, 'loadComplete');
+      expect(store.commit).toHaveBeenNthCalledWith(4, 'loadComplete');
 
       await raidenService.fetchTokenData(['0xtoken1']);
 
-      expect(store.commit).toHaveBeenNthCalledWith(6, 'updateTokens', {
+      expect(store.commit).toHaveBeenNthCalledWith(5, 'updateTokens', {
         [mockToken1]: tokens[mockToken1]
       });
     });
@@ -650,7 +645,8 @@ describe('RaidenService', () => {
       getBalance: jest.fn().mockResolvedValue(Zero),
       events$: subject,
       getTokenList: jest.fn().mockResolvedValue([]),
-      stop: jest.fn().mockReturnValue(null)
+      start: jest.fn(),
+      stop: jest.fn()
     };
 
     factory.mockResolvedValue(raidenMock);

--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -77,16 +77,15 @@ export const initNewBlockEpic = (
  * @returns Observable of tokenMonitored actions
  */
 export const initMonitorRegistryEpic = (
-  action$: Observable<RaidenAction>,
+  {  }: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
   { registryContract, contractsInfo }: RaidenEpicDeps,
 ): Observable<ActionType<typeof tokenMonitored>> =>
   state$.pipe(
     publishReplay(1, undefined, state$ =>
-      action$.pipe(
-        first(isActionOf(newBlock)),
-        withLatestFrom(state$),
-        switchMap(([{ payload: { blockNumber } }, state]) =>
+      state$.pipe(
+        first(),
+        switchMap(state =>
           merge(
             // monitor old (in case of empty tokens) and new registered tokens
             // and starts monitoring every registered token
@@ -96,7 +95,7 @@ export const initMonitorRegistryEpic = (
               isEmpty(state.tokens)
                 ? of(contractsInfo.TokenNetworkRegistry.block_number)
                 : undefined,
-              isEmpty(state.tokens) ? of(blockNumber) : undefined,
+              isEmpty(state.tokens) ? state$.pipe(pluck('blockNumber')) : undefined,
             ).pipe(
               withLatestFrom(state$),
               map(([[token, tokenNetwork, event], state]) =>

--- a/raiden-ts/src/reducer.ts
+++ b/raiden-ts/src/reducer.ts
@@ -1,4 +1,6 @@
 import { isActionOf } from 'typesafe-actions';
+import { isEmpty } from 'lodash/fp';
+
 import { channelsReducer } from './channels/reducer';
 import { transportReducer } from './transport/reducer';
 import { transfersReducer } from './transfers/reducer';
@@ -9,8 +11,10 @@ import { RaidenState, initialState } from './state';
 // update state.config on raidenConfigUpdate action
 const configReducer = (state: RaidenState = initialState, action: RaidenAction) => {
   if (isActionOf(raidenConfigUpdate, action)) {
-    return { ...state, config: { ...state.config, ...action.payload.config } };
-  } else return state;
+    if (!isEmpty(action.payload.config))
+      return { ...state, config: { ...state.config, ...action.payload.config } };
+  }
+  return state;
 };
 
 const raidenReducers = {

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -71,6 +71,7 @@ describe('Raiden', () => {
     request(httpBackend.requestFn.bind(httpBackend));
 
     raiden = await Raiden.create(provider, 0, storage, contractsInfo, config);
+    raiden.start();
     // wait token register to be fetched
     await raiden.getTokenList();
   });
@@ -81,7 +82,7 @@ describe('Raiden', () => {
   });
 
   test('create from other params and RaidenState', async () => {
-    expect.assertions(5);
+    expect.assertions(8);
 
     // token address not found as an account in provider
     await expect(Raiden.create(provider, token, storage, contractsInfo, config)).rejects.toThrow(
@@ -135,7 +136,13 @@ describe('Raiden', () => {
       config,
     );
     expect(raiden1).toBeInstanceOf(Raiden);
+
+    // test Raiden.started, not yet started
+    expect(raiden1.started).toBeUndefined();
+    raiden1.start();
+    expect(raiden1.started).toBe(true);
     raiden1.stop();
+    expect(raiden1.started).toBe(false);
   });
 
   test('address', () => {
@@ -280,6 +287,7 @@ describe('Raiden', () => {
       await raiden.openChannel(token, partner);
       await raiden.depositChannel(token, partner, 200);
       raiden1 = await Raiden.create(provider, partner, undefined, contractsInfo, config);
+      raiden1.start();
     });
 
     afterEach(() => {
@@ -352,6 +360,7 @@ describe('Raiden', () => {
       raidenState = undefined;
       raiden = await Raiden.create(provider, 0, storage, contractsInfo, config);
       raiden.state$.subscribe(state => (raidenState = state));
+      raiden.start();
 
       // ensure after hot boot, state is rehydrated and contains (only) previous token
       expect(raidenState).toBeDefined();
@@ -521,6 +530,7 @@ describe('Raiden', () => {
         contractsInfo,
       );
       expect(raiden1).toBeInstanceOf(Raiden);
+      raiden1.start();
 
       // await raiden1 client matrix initialization
       await raiden1.action$
@@ -622,6 +632,7 @@ describe('Raiden', () => {
           makeInitialState({ network, contractsInfo, address: partner as Address }, { config }),
           contractsInfo,
         );
+        raiden1.start();
 
         // await raiden1 client matrix initialization
         await raiden1.action$
@@ -678,6 +689,7 @@ describe('Raiden', () => {
             )
             .toPromise();
 
+        raiden2.start();
         // await raiden2 client matrix initialization
         await matrix2Promise;
 
@@ -756,6 +768,8 @@ describe('Raiden', () => {
         makeInitialState({ network, contractsInfo, address: target as Address }, { config }),
         contractsInfo,
       );
+      raiden1.start();
+      raiden2.start();
 
       // await client's matrix initialization
       await Promise.all([

--- a/raiden-ts/tests/unit/epics/raiden.spec.ts
+++ b/raiden-ts/tests/unit/epics/raiden.spec.ts
@@ -166,11 +166,11 @@ describe('raiden epic', () => {
             ignoreElements(),
           );
         m.expect(merge(emitBlock$, raidenRootEpic(action$, state$, depsMock))).toBeObservable(
-          m.cold('bct-------B-|', {
+          m.cold('b(tc)-----B-|', {
             b: newBlock({ blockNumber: 633 }),
+            t: tokenMonitored({ token, tokenNetwork }),
             // ensure channelMonitored is emitted by init even for 'settling' channel
             c: channelMonitored({ id: channelId }, { tokenNetwork, partner }),
-            t: tokenMonitored({ token, tokenNetwork }),
             B: newBlock({ blockNumber: 635 }),
           }),
         );
@@ -186,7 +186,8 @@ describe('raiden epic', () => {
 
       action$.subscribe(action => state$.next(raidenReducer(state$.value, action)));
 
-      depsMock.provider.resetEventsBlock(126);
+      state$.next(raidenReducer(state$.value, newBlock({ blockNumber: 126 })));
+      depsMock.provider.resetEventsBlock(state$.value.blockNumber);
 
       depsMock.provider.getLogs.mockResolvedValueOnce([
         makeLog({
@@ -203,8 +204,6 @@ describe('raiden epic', () => {
           toArray(),
         )
         .toPromise();
-
-      action$.next(newBlock({ blockNumber: 126 }));
 
       depsMock.provider.resetEventsBlock(127);
       action$.next(newBlock({ blockNumber: 127 }));
@@ -230,6 +229,9 @@ describe('raiden epic', () => {
           toBlock: 126,
         }),
       );
+
+      action$.complete();
+      state$.complete();
     });
 
     test('ShutdownReason.ACCOUNT_CHANGED', async () => {


### PR DESCRIPTION
Also, improves reliability of fetching of old blockchain events, and also specifically test that events which happened while offline, even on edge blocks, are correctly picked.
Fix #356 