### PR TITLE
Updates dependabot configuration

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,16 +3,18 @@ version: 1
 update_configs:
   - package_manager: "javascript"
     directory: "/raiden-ts"
-    update_schedule: "weekly"
+    update_schedule: "live"
     default_labels:
       - "dependencies"
     commit_message:
       prefix: "dependencies"
+    version_requirement_updates: "increase_versions"
 
   - package_manager: "javascript"
     directory: "/raiden-dapp"
-    update_schedule: "weekly"
+    update_schedule: "live"
     default_labels:
       - "dependencies"
     commit_message:
       prefix: "dependencies"
+    version_requirement_updates: "increase_versions"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,6 +9,10 @@ update_configs:
     commit_message:
       prefix: "dependencies"
     version_requirement_updates: "increase_versions"
+    default_reviewers:
+      - "kelsos"
+      - "andrevmatos"
+      - "nephix"
 
   - package_manager: "javascript"
     directory: "/raiden-dapp"
@@ -18,3 +22,7 @@ update_configs:
     commit_message:
       prefix: "dependencies"
     version_requirement_updates: "increase_versions"
+    default_reviewers:
+      - "kelsos"
+      - "andrevmatos"
+      - "nephix"


### PR DESCRIPTION
Issue #345 

* Since it creates a new PR for each update, and it doesn't batch anything weekly schedule doesn't make much sense, especially since dependabot will rebase each PR on merge and run all the tests again.
* Added `version_requirement_updates` because without it might update `package-lock.json` without updated `package.json` from what I understood about the default behavior.