### PR TITLE
Fix/eslint no unused vars

### DIFF
--- a/raiden-dapp/.eslintrc.js
+++ b/raiden-dapp/.eslintrc.js
@@ -28,6 +28,12 @@ module.exports = {
     "vue/v-on-style": ["error", "shorthand"],
     'vue-i18n/no-raw-text': ['error', {
       "ignoreNodes": ['v-icon'],
+    }],
+    "@typescript-eslint/no-unused-vars": ["error", {
+      "vars": "all",
+      "args": "after-used",
+      "ignoreRestSiblings": false,
+      "argsIgnorePattern": "^_"
     }]
   },
   parserOptions: {

--- a/raiden-dapp/src/components/AddressInput.vue
+++ b/raiden-dapp/src/components/AddressInput.vue
@@ -109,9 +109,10 @@ export default class AddressInput extends Mixins(BlockieMixin) {
     }
   }
 
-  /* eslint-disable @typescript-eslint/no-unused-vars */
   @Emit()
-  public input(value?: string) {}
+  public input(value?: string) {
+    return value;
+  }
 
   isChecksumAddress(address: string): boolean {
     const tokenAddress = address;

--- a/raiden-dapp/src/components/AddressInput.vue
+++ b/raiden-dapp/src/components/AddressInput.vue
@@ -110,9 +110,7 @@ export default class AddressInput extends Mixins(BlockieMixin) {
   }
 
   @Emit()
-  public input(value?: string) {
-    return value;
-  }
+  public input(_value?: string) {}
 
   isChecksumAddress(address: string): boolean {
     const tokenAddress = address;

--- a/raiden-dapp/src/components/AddressInput.vue
+++ b/raiden-dapp/src/components/AddressInput.vue
@@ -109,11 +109,10 @@ export default class AddressInput extends Mixins(BlockieMixin) {
     }
   }
 
-  // noinspection JSUnusedLocalSymbols
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   @Emit()
   public input(value?: string) {}
 
-  // noinspection JSMethodCanBeStatic
   isChecksumAddress(address: string): boolean {
     const tokenAddress = address;
     return (

--- a/raiden-dapp/src/components/ChannelList.vue
+++ b/raiden-dapp/src/components/ChannelList.vue
@@ -133,13 +133,15 @@ export default class ChannelList extends Mixins(BlockieMixin) {
   token!: Token;
   selectedChannel: RaidenChannel | null = null;
 
-  // noinspection JSUnusedLocalSymbols
   @Emit()
-  message(message: string) {}
+  message(message: string) {
+    return message;
+  }
 
-  // noinspection JSUnusedLocalSymbols
   @Emit()
-  visibleChanged(element: string) {}
+  visibleChanged(element: string) {
+    return element;
+  }
 
   displayFormat = Filters.displayFormat;
   capitalizeFirst = Filters.capitalizeFirst;

--- a/raiden-dapp/src/components/ChannelList.vue
+++ b/raiden-dapp/src/components/ChannelList.vue
@@ -134,14 +134,10 @@ export default class ChannelList extends Mixins(BlockieMixin) {
   selectedChannel: RaidenChannel | null = null;
 
   @Emit()
-  message(message: string) {
-    return message;
-  }
+  message(_message: string) {}
 
   @Emit()
-  visibleChanged(element: string) {
-    return element;
-  }
+  visibleChanged(_element: string) {}
 
   displayFormat = Filters.displayFormat;
   capitalizeFirst = Filters.capitalizeFirst;

--- a/raiden-dapp/src/components/TokenOverlay.vue
+++ b/raiden-dapp/src/components/TokenOverlay.vue
@@ -104,7 +104,6 @@ import { mapGetters } from 'vuex';
 import BlockieMixin from '@/mixins/blockie-mixin';
 import NavigationMixin from '@/mixins/navigation-mixin';
 import { TokenModel, Token } from '../model/types';
-import { BalanceUtils } from '@/utils/balance-utils';
 import Filters from '@/filters';
 
 @Component({

--- a/raiden-dapp/src/plugins/identicon-plugin.ts
+++ b/raiden-dapp/src/plugins/identicon-plugin.ts
@@ -1,7 +1,7 @@
 import _Vue from 'vue';
 import { IdenticonCache } from '@/services/identicon-cache';
 
-export function IdenticonPlugin(Vue: typeof _Vue, options?: any): void {
+export function IdenticonPlugin(Vue: typeof _Vue, _options?: any): void {
   Vue.prototype.$identicon = new IdenticonCache();
 }
 

--- a/raiden-dapp/src/plugins/raiden.ts
+++ b/raiden-dapp/src/plugins/raiden.ts
@@ -2,7 +2,7 @@ import _Vue from 'vue';
 import RaidenService from '@/services/raiden-service';
 import store from '@/store';
 
-export function RaidenPlugin(Vue: typeof _Vue, options?: any): void {
+export function RaidenPlugin(Vue: typeof _Vue, _options?: any): void {
   Vue.prototype.$raiden = new RaidenService(store);
 }
 

--- a/raiden-dapp/src/router.ts
+++ b/raiden-dapp/src/router.ts
@@ -1,12 +1,9 @@
 /* istanbul ignore file */
 import Vue from 'vue';
-import Router, { Route } from 'vue-router';
-import { Dictionary } from 'vue-router/types/router';
+import Router from 'vue-router';
 
 import Home from './views/Home.vue';
 import { RouteNames } from '@/route-names';
-import store from './store';
-import { Tokens } from './types';
 
 Vue.use(Router);
 

--- a/raiden-dapp/src/shims-tsx.d.ts
+++ b/raiden-dapp/src/shims-tsx.d.ts
@@ -1,10 +1,10 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import Vue, { VNode } from 'vue';
 
 declare global {
   namespace JSX {
-    // tslint:disable no-empty-interface
     interface Element extends VNode {}
-    // tslint:disable no-empty-interface
+
     interface ElementClass extends Vue {}
     interface IntrinsicElements {
       [elem: string]: any;

--- a/raiden-dapp/tests/unit/components/token-overlay.spec.ts
+++ b/raiden-dapp/tests/unit/components/token-overlay.spec.ts
@@ -1,5 +1,4 @@
 import { createLocalVue, mount, Wrapper } from '@vue/test-utils';
-import flushPromises from 'flush-promises';
 import Vuex, { Store } from 'vuex';
 import Vuetify from 'vuetify';
 
@@ -12,13 +11,11 @@ describe('TokenOverlay.vue', () => {
   addElemWithDataAppToBody();
 
   let wrapper: Wrapper<TokenOverlay>;
-  let navigateToTokenSelect: jest.Mock<any, any>;
 
   beforeEach(() => {
     const localVue = createLocalVue();
     localVue.use(Vuex);
     localVue.use(Vuetify);
-    navigateToTokenSelect = jest.fn().mockResolvedValue(null);
     wrapper = mount(TokenOverlay, {
       localVue,
       store: new Store({


### PR DESCRIPTION
This pull requests adds eslinting for unused imports and parameters in the Dapp, to prevent them e.g. in #430 

For strict function signatures, we force the eslint rule ignore function parameters starting with a `_`, e.g. `function(a: string, _b: string)`

For `raiden-ts` this already works so no adjustments necessary