### PR TITLE
SDK fixes for events fetching

### DIFF
--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -370,41 +370,45 @@ export const channelMonitoredEpic = (
           ).pipe(
             mergeMap(function*(data) {
               if (isEvent<ChannelNewDepositEvent>(depositFilter, data)) {
+                const [id, participant, totalDeposit, event] = data;
                 yield channelDeposited(
                   {
-                    id: data[0].toNumber(),
-                    participant: data[1],
-                    totalDeposit: data[2],
-                    txHash: data[3].transactionHash! as Hash,
+                    id: id.toNumber(),
+                    participant,
+                    totalDeposit,
+                    txHash: event.transactionHash! as Hash,
                   },
                   action.meta,
                 );
               } else if (isEvent<ChannelWithdrawEvent>(withdrawFilter, data)) {
+                const [id, participant, totalWithdraw, event] = data;
                 yield channelWithdrawn(
                   {
-                    id: data[0].toNumber(),
-                    participant: data[1],
-                    totalWithdraw: data[2],
-                    txHash: data[3].transactionHash! as Hash,
+                    id: id.toNumber(),
+                    participant,
+                    totalWithdraw,
+                    txHash: event.transactionHash! as Hash,
                   },
                   action.meta,
                 );
               } else if (isEvent<ChannelClosedEvent>(closedFilter, data)) {
+                const [id, participant, , , event] = data;
                 yield channelClosed(
                   {
-                    id: data[0].toNumber(),
-                    participant: data[1],
-                    closeBlock: data[4].blockNumber!,
-                    txHash: data[4].transactionHash! as Hash,
+                    id: id.toNumber(),
+                    participant,
+                    closeBlock: event.blockNumber!,
+                    txHash: event.transactionHash! as Hash,
                   },
                   action.meta,
                 );
               } else if (isEvent<ChannelSettledEvent>(settledFilter, data)) {
+                const [id, , , , , event] = data;
                 yield channelSettled(
                   {
-                    id: data[0].toNumber(),
-                    settleBlock: data[5].blockNumber!,
-                    txHash: data[5].transactionHash! as Hash,
+                    id: id.toNumber(),
+                    settleBlock: event.blockNumber!,
+                    txHash: event.transactionHash! as Hash,
                   },
                   action.meta,
                 );

--- a/raiden-ts/src/channels/reducer.ts
+++ b/raiden-ts/src/channels/reducer.ts
@@ -141,9 +141,10 @@ function channels(state: RaidenState['channels'] = initialState.channels, action
     const channel: Channel | undefined = get(path, state);
     if (
       !channel ||
-      ![ChannelState.closed, ChannelState.settleable, ChannelState.settling].includes(
-        channel.state,
-      )
+      channel.state === ChannelState.opening ||
+      channel.state === ChannelState.open ||
+      channel.state === ChannelState.closing ||
+      channel.id !== action.payload.id
     )
       return state;
     return unset(path, state);

--- a/raiden-ts/src/messages/utils.ts
+++ b/raiden-ts/src/messages/utils.ts
@@ -322,6 +322,7 @@ export async function signMessage<M extends Message>(
   message: M,
 ): Promise<Signed<M>> {
   if (isSigned(message)) return message;
+  console.log(`Signing message "${message.type}"`, message);
   const signature = (await signer.signMessage(arrayify(packMessage(message)))) as Signature;
   return { ...message, signature };
 }

--- a/raiden-ts/src/path/epics.ts
+++ b/raiden-ts/src/path/epics.ts
@@ -25,7 +25,6 @@ import { isActionOf, ActionType } from 'typesafe-actions';
 import { bigNumberify, BigNumber } from 'ethers/utils';
 import { Zero, Two } from 'ethers/constants';
 import { Event } from 'ethers/contract';
-import { isNil } from 'lodash';
 
 import { RaidenAction } from '../actions';
 import { RaidenState } from '../state';
@@ -95,7 +94,7 @@ export const pathFindServiceEpic = (
                 const pfs$ = action.payload.pfs
                   ? // first, honor action.payload.pfs
                     of(action.payload.pfs)
-                  : !isNil(configPfs)
+                  : configPfs != null
                   ? // or if config.pfs isn't disabled nor auto (undefined), use it
                     // configPfs is addr or url, so fetch pfsInfo from it
                     pfsInfo(configPfs, deps)

--- a/raiden-ts/src/path/utils.ts
+++ b/raiden-ts/src/path/utils.ts
@@ -83,7 +83,12 @@ export function pfsInfo(
   return url$.pipe(
     withLatestFrom(config$),
     mergeMap(([url, { httpTimeout }]) => {
-      if (!url || !url.includes('://')) throw new Error(`Invalid URL: ${url}`);
+      if (!url) throw new Error(`Empty URL: ${url}`);
+      else if (url.includes('://') && !url.startsWith('https://'))
+        throw new Error(`Invalid URL schema: ${url}`);
+      // default to https for domain-only urls
+      else if (!url.includes('://')) url = `https://${url}`;
+
       const start = Date.now();
       return fromFetch(`${url}/api/v1/info`).pipe(
         timeout(httpTimeout),

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -152,6 +152,7 @@ export class Raiden {
    * @returns token info
    */
   public getTokenInfo: (
+    this: Raiden,
     token: string,
   ) => Promise<{
     totalSupply: BigNumber;
@@ -246,7 +247,7 @@ export class Raiden {
 
     this.events$ = action$.pipe(filter(isActionOf(Object.values(RaidenEvents))));
 
-    this.getTokenInfo = memoize(async (token: string) => {
+    this.getTokenInfo = memoize(async function(this: Raiden, token: string) {
       if (!Address.is(token)) throw new Error('Invalid address');
       if (!(token in this.state.tokens)) throw new Error(`token "${token}" not monitored`);
       const tokenContract = this.deps.getTokenContract(token);

--- a/raiden-ts/src/transport/epics.ts
+++ b/raiden-ts/src/transport/epics.ts
@@ -1030,6 +1030,7 @@ export const deliveredEpic = (
         type: MessageType.DELIVERED,
         delivered_message_identifier: msgId,
       };
+      console.log(`Signing "${delivered.type}" for "${message.type}" with id=${msgId.toString()}`);
       return from(signMessage(signer, delivered)).pipe(
         tap(signed => cache.put(key, signed)),
         map(signed => messageSend({ message: signed }, action.meta)),

--- a/raiden-ts/tests/unit/epics/channels.spec.ts
+++ b/raiden-ts/tests/unit/epics/channels.spec.ts
@@ -308,7 +308,7 @@ describe('channels epic', () => {
         .toPromise();
 
       depsMock.provider.emit(
-        tokenNetworkContract.filters.ChannelNewDeposit(channelId, null, null),
+        '*',
         makeLog({
           blockNumber: 125,
           filter: tokenNetworkContract.filters.ChannelNewDeposit(channelId, partner, null),
@@ -349,7 +349,7 @@ describe('channels epic', () => {
 
       // even though multiple channelMonitored events were fired, blockchain fires a single event
       depsMock.provider.emit(
-        tokenNetworkContract.filters.ChannelNewDeposit(channelId, null, null),
+        '*',
         makeLog({
           blockNumber: 125,
           filter: tokenNetworkContract.filters.ChannelNewDeposit(
@@ -369,7 +369,7 @@ describe('channels epic', () => {
         meta: { tokenNetwork, partner },
       });
 
-      expect(depsMock.provider.on).toHaveBeenCalledTimes(4); // one for each event
+      expect(depsMock.provider.on).toHaveBeenCalledTimes(1); // mergedFilter
     });
 
     test('new$ partner ChannelWithdraw event', async () => {
@@ -399,7 +399,7 @@ describe('channels epic', () => {
         .toPromise();
 
       depsMock.provider.emit(
-        tokenNetworkContract.filters.ChannelWithdraw(channelId, null, null),
+        '*',
         makeLog({
           blockNumber: closeBlock,
           transactionHash: txHash,
@@ -433,7 +433,7 @@ describe('channels epic', () => {
         .toPromise();
 
       depsMock.provider.emit(
-        tokenNetworkContract.filters.ChannelClosed(channelId, null, null, null),
+        '*',
         makeLog({
           blockNumber: closeBlock,
           transactionHash: txHash,
@@ -471,26 +471,10 @@ describe('channels epic', () => {
         .pipe(takeUntil(timer(100)))
         .toPromise();
 
-      expect(
-        tokenNetworkContract.listenerCount(
-          tokenNetworkContract.filters.ChannelNewDeposit(channelId, null, null),
-        ),
-      ).toBe(1);
-
-      expect(
-        tokenNetworkContract.listenerCount(
-          tokenNetworkContract.filters.ChannelClosed(channelId, null, null, null),
-        ),
-      ).toBe(1);
-
-      expect(
-        tokenNetworkContract.listenerCount(
-          tokenNetworkContract.filters.ChannelSettled(channelId, null, null, null, null),
-        ),
-      ).toBe(1);
+      expect(depsMock.provider.listenerCount()).toBe(1);
 
       depsMock.provider.emit(
-        tokenNetworkContract.filters.ChannelSettled(channelId, null, null, null, null),
+        '*',
         makeLog({
           blockNumber: settleBlock,
           transactionHash: txHash,
@@ -504,38 +488,8 @@ describe('channels epic', () => {
       );
 
       // ensure ChannelSettledAction completed channel monitoring and unsubscribed from events
-      expect(depsMock.provider.removeListener).toHaveBeenCalledWith(
-        tokenNetworkContract.filters.ChannelNewDeposit(channelId, null, null),
-        expect.anything(),
-      );
-
-      expect(depsMock.provider.removeListener).toHaveBeenCalledWith(
-        tokenNetworkContract.filters.ChannelClosed(channelId, null, null, null),
-        expect.anything(),
-      );
-
-      expect(depsMock.provider.removeListener).toHaveBeenCalledWith(
-        tokenNetworkContract.filters.ChannelSettled(channelId, null, null, null, null),
-        expect.anything(),
-      );
-
-      expect(
-        tokenNetworkContract.listenerCount(
-          tokenNetworkContract.filters.ChannelNewDeposit(channelId, null, null),
-        ),
-      ).toBe(0);
-
-      expect(
-        tokenNetworkContract.listenerCount(
-          tokenNetworkContract.filters.ChannelClosed(channelId, null, null, null),
-        ),
-      ).toBe(0);
-
-      expect(
-        tokenNetworkContract.listenerCount(
-          tokenNetworkContract.filters.ChannelSettled(channelId, null, null, null, null),
-        ),
-      ).toBe(0);
+      expect(depsMock.provider.removeListener).toHaveBeenCalledTimes(1);
+      expect(depsMock.provider.listenerCount()).toBe(0);
     });
   });
 

--- a/raiden-ts/tests/unit/epics/raiden.spec.ts
+++ b/raiden-ts/tests/unit/epics/raiden.spec.ts
@@ -208,15 +208,19 @@ describe('raiden epic', () => {
       depsMock.provider.resetEventsBlock(127);
       action$.next(newBlock({ blockNumber: 127 }));
 
-      depsMock.provider.emit(
-        depsMock.registryContract.filters.TokenNetworkCreated(null, null),
-        makeLog({
-          blockNumber: 127,
-          filter: depsMock.registryContract.filters.TokenNetworkCreated(
-            otherToken,
-            otherTokenNetwork,
+      setTimeout(
+        () =>
+          depsMock.provider.emit(
+            depsMock.registryContract.filters.TokenNetworkCreated(null, null),
+            makeLog({
+              blockNumber: 127,
+              filter: depsMock.registryContract.filters.TokenNetworkCreated(
+                otherToken,
+                otherTokenNetwork,
+              ),
+            }),
           ),
-        }),
+        10,
       );
 
       await expect(output).resolves.toEqual([

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -94,13 +94,21 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
     });
   };
 
+  let blockNumber = 125;
   Object.assign(provider, { network });
+  Object.defineProperty(provider, 'blockNumber', { get: () => blockNumber });
   jest.spyOn(provider, 'getNetwork').mockImplementation(async () => network);
   jest.spyOn(provider, 'resolveName').mockImplementation(async addressOrName => addressOrName);
   jest.spyOn(provider, 'getLogs').mockResolvedValue([]);
   jest.spyOn(provider, 'listAccounts').mockResolvedValue([]);
   // See: https://github.com/cartant/rxjs-marbles/issues/11
-  jest.spyOn(provider, 'getBlockNumber').mockReturnValue((of(120) as unknown) as Promise<number>);
+  jest
+    .spyOn(provider, 'getBlockNumber')
+    .mockImplementation(async () => (of(blockNumber) as unknown) as Promise<number>);
+  // use provider.resetEventsBlock used to set current block number for provider
+  jest
+    .spyOn(provider, 'resetEventsBlock')
+    .mockImplementation((number: number) => (blockNumber = number));
   mockEthersEventEmitter(provider);
 
   const signer = new Wallet(
@@ -169,7 +177,7 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
     },
     initialState = makeInitialState(
       { network, address, contractsInfo },
-      { blockNumber: 125, config: { pfsSafetyMargin: 1.1, pfs: 'https://pfs.raiden.test' } },
+      { blockNumber, config: { pfsSafetyMargin: 1.1, pfs: 'https://pfs.raiden.test' } },
     );
 
   const stateOutput$ = new BehaviorSubject<RaidenState>(initialState),

--- a/raiden-ts/tests/unit/utils.spec.ts
+++ b/raiden-ts/tests/unit/utils.spec.ts
@@ -84,19 +84,18 @@ describe('getEventsStream', () => {
       filter: registryContract.filters.TokenNetworkCreated(pastTokenAddr, pastTokenNetworkAddr),
     });
 
+    // ensure getEventsStream will need to wait for next block
+    provider.resetEventsBlock((undefined as unknown) as number);
     provider.getLogs.mockResolvedValueOnce([pastLog]);
 
-    const promise = getEventsStream<TokenNetworkCreatedEvent>(
-      registryContract,
-      [filter],
-      of(1),
-      of(1336),
-    )
+    const promise = getEventsStream<TokenNetworkCreatedEvent>(registryContract, [filter], of(1))
       .pipe(
         take(2),
         toArray(),
       )
       .toPromise();
+
+    provider.emit('block', 1336);
 
     const tokenAddr = '0x0000000000000000000000000000000000000001',
       tokenNetworkAddr = '0x0000000000000000000000000000000000000002';

--- a/raiden-ts/tests/unit/utils.spec.ts
+++ b/raiden-ts/tests/unit/utils.spec.ts
@@ -102,7 +102,7 @@ describe('getEventsStream', () => {
     const log = makeLog({
       filter: registryContract.filters.TokenNetworkCreated(tokenAddr, tokenNetworkAddr),
     });
-    provider.emit(filter, log);
+    setTimeout(() => provider.emit(filter, log), 10);
 
     const events = await promise;
 


### PR DESCRIPTION
- [x] Remove `toBlock$` from `getEventsStream`, ensure intervals don't interesect nor are disjunct, to avoid losing or getting duplicated events
- [x] Fix for long standing TODO to use a single event filter per channel, also fixes ordering of initial event fetching
- [x] Fix small issue with memoized `getTokenInfo` accessing wrong `this` and failing on some edge scenarios
- [x] Remove dependency of lodash's `isNil`, introduced in #405 , replace with `!= null`
- [x] Better validation of PFS's registered URL, accept domain-only (without schema, defaulting to `https://`), require `https://` otherwise.
- [x] Add some logs for message signature prompts.

This also ensures #400 doesn't happen anymore, as the most probable cause of it was some previous deposit event being missed.