### PR TITLE
Switching dependabot config back to weekly schedule

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,7 +3,7 @@ version: 1
 update_configs:
   - package_manager: "javascript"
     directory: "/raiden-ts"
-    update_schedule: "live"
+    update_schedule: "weekly"
     default_labels:
       - "dependencies"
     commit_message:
@@ -16,7 +16,7 @@ update_configs:
 
   - package_manager: "javascript"
     directory: "/raiden-dapp"
-    update_schedule: "live"
+    update_schedule: "weekly"
     default_labels:
       - "dependencies"
     commit_message:


### PR DESCRIPTION
Switching back to weekly schedule so that updates become less interrupting.
Current run time is set to Thursday 5am UTC in the Dependabot dashboard, as Wednesdays are usually our most stressful days
