### PR TITLE
Bumped eslint-plugin-vue to 6.0.0 and fixed resulting linter errors

### DIFF
--- a/raiden-dapp/.eslintrc.js
+++ b/raiden-dapp/.eslintrc.js
@@ -34,7 +34,15 @@ module.exports = {
       "args": "after-used",
       "ignoreRestSiblings": false,
       "argsIgnorePattern": "^_"
-    }]
+    }],
+    'vue/v-slot-style': [
+      'error',
+      {
+        atComponent: 'shorthand',
+        default: 'shorthand',
+        named: 'shorthand'
+      }
+    ]
   },
   parserOptions: {
     parser: '@typescript-eslint/parser',

--- a/raiden-dapp/package-lock.json
+++ b/raiden-dapp/package-lock.json
@@ -4183,6 +4183,12 @@
         "acorn-walk": "^6.0.1"
       }
     },
+    "acorn-jsx": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
+      "dev": true
+    },
     "acorn-walk": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
@@ -8927,51 +8933,12 @@
       }
     },
     "eslint-plugin-vue": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-5.2.3.tgz",
-      "integrity": "sha512-mGwMqbbJf0+VvpGR5Lllq0PMxvTdrZ/ZPjmhkacrCHbubJeJOt+T6E3HUzAifa2Mxi7RSdJfC9HFpOeSYVMMIw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-6.0.0.tgz",
+      "integrity": "sha512-+LxTJCd6nDt+AKQ1X+ySD48xJHft8OkeQmAhiq6UoAMxRFTiEKIDusiGgEUJLwKyiwGUGWbbqEbbWvupH5TSjg==",
       "dev": true,
       "requires": {
-        "vue-eslint-parser": "^5.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
-          "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
-          "dev": true
-        },
-        "acorn-jsx": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-          "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
-          "dev": true
-        },
-        "espree": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
-          "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
-          "dev": true,
-          "requires": {
-            "acorn": "^6.0.2",
-            "acorn-jsx": "^5.0.0",
-            "eslint-visitor-keys": "^1.0.0"
-          }
-        },
-        "vue-eslint-parser": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-5.0.0.tgz",
-          "integrity": "sha512-JlHVZwBBTNVvzmifwjpZYn0oPWH2SgWv5dojlZBsrhablDu95VFD+hriB1rQGwbD+bms6g+rAFhQHk6+NyiS6g==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.0",
-            "eslint-scope": "^4.0.0",
-            "eslint-visitor-keys": "^1.0.0",
-            "espree": "^4.1.0",
-            "esquery": "^1.0.1",
-            "lodash": "^4.17.11"
-          }
-        }
+        "vue-eslint-parser": "^6.0.4"
       }
     },
     "eslint-plugin-vue-i18n": {
@@ -9043,6 +9010,42 @@
       "requires": {
         "eslint-plugin-vue": "^5.2.2",
         "requireindex": "^1.2.0"
+      },
+      "dependencies": {
+        "eslint-plugin-vue": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-5.2.3.tgz",
+          "integrity": "sha512-mGwMqbbJf0+VvpGR5Lllq0PMxvTdrZ/ZPjmhkacrCHbubJeJOt+T6E3HUzAifa2Mxi7RSdJfC9HFpOeSYVMMIw==",
+          "dev": true,
+          "requires": {
+            "vue-eslint-parser": "^5.0.0"
+          }
+        },
+        "espree": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+          "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
+          "dev": true,
+          "requires": {
+            "acorn": "^6.0.2",
+            "acorn-jsx": "^5.0.0",
+            "eslint-visitor-keys": "^1.0.0"
+          }
+        },
+        "vue-eslint-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-5.0.0.tgz",
+          "integrity": "sha512-JlHVZwBBTNVvzmifwjpZYn0oPWH2SgWv5dojlZBsrhablDu95VFD+hriB1rQGwbD+bms6g+rAFhQHk6+NyiS6g==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "eslint-scope": "^4.0.0",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^4.1.0",
+            "esquery": "^1.0.1",
+            "lodash": "^4.17.11"
+          }
+        }
       }
     },
     "eslint-scope": {
@@ -9075,6 +9078,17 @@
       "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
       "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
       "dev": true
+    },
+    "espree": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.7",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "esprima": {
       "version": "4.0.1",
@@ -16071,7 +16085,7 @@
         "isomorphic-fetch": "^2.2.1",
         "lodash": "^4.17.15",
         "lossless-json": "^1.0.3",
-        "matrix-js-sdk": "^2.4.2",
+        "matrix-js-sdk": "^2.4.3",
         "redux": "^4.0.4",
         "redux-logger": "^3.0.6",
         "redux-observable": "^1.2.0",
@@ -19999,6 +20013,20 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
+      }
+    },
+    "vue-eslint-parser": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-6.0.4.tgz",
+      "integrity": "sha512-GYsDsDWwKaGtnkW4nGUxr01wqIO2FB9/QHQTW1Gl5SUr5OyQvpnR90/D+Gq2cIxURX7aJ7+VyD+37Yx9eFwTgw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "eslint-scope": "^4.0.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.0",
+        "esquery": "^1.0.1",
+        "lodash": "^4.17.11"
       }
     },
     "vue-hot-reload-api": {

--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -58,7 +58,7 @@
     "eslint": "^5.16.0",
     "eslint-plugin-jsdoc": "^17.1.0",
     "eslint-plugin-prettier": "^3.1.1",
-    "eslint-plugin-vue": "^5.2.3",
+    "eslint-plugin-vue": "^6.0.0",
     "eslint-plugin-vue-i18n": "^0.3.0",
     "eslint-plugin-vuetify": "^1.0.0-beta.5",
     "flush-promises": "^1.0.2",

--- a/raiden-dapp/src/App.vue
+++ b/raiden-dapp/src/App.vue
@@ -2,10 +2,10 @@
   <v-app dark>
     <splash-screen
       v-if="inaccessible"
-      @connect="connect()"
       :connecting="connecting"
+      @connect="connect()"
     ></splash-screen>
-    <div id="application-wrapper" v-else>
+    <div v-else id="application-wrapper">
       <div id="application-content">
         <app-header></app-header>
         <v-content>

--- a/raiden-dapp/src/components/ActionButton.vue
+++ b/raiden-dapp/src/components/ActionButton.vue
@@ -8,11 +8,11 @@
     <v-col cols="10" class="text-center">
       <v-btn
         :disabled="!enabled"
-        @click="click()"
         :loading="loading"
         class="text-capitalize action-button__button"
         depressed
         large
+        @click="click()"
       >
         {{ text }}
       </v-btn>

--- a/raiden-dapp/src/components/AddressInput.vue
+++ b/raiden-dapp/src/components/AddressInput.vue
@@ -13,15 +13,15 @@
         'address-input--untouched': !touched
       }"
       :placeholder="$t('address-input.input.placeholder')"
+      persistent-hint
       @blur="$emit('blur')"
       @focus="$emit('focus')"
       @input="updateValue"
       @change="updateValue"
-      persistent-hint
     >
       <template #append>
         <div class="address-input__status__paste-button">
-          <v-btn @click="paste()" text>
+          <v-btn text @click="paste()">
             <span
               class="address-input__status__paste-button__text text-capitalize"
             >

--- a/raiden-dapp/src/components/AmountInput.vue
+++ b/raiden-dapp/src/components/AmountInput.vue
@@ -10,11 +10,11 @@
       :disabled="disabled"
       :rules="rules"
       :value="amount"
+      :placeholder="placeholder"
+      autocomplete="off"
       @paste="onPaste($event)"
       @keypress="checkIfValid($event)"
       @input="onInput($event)"
-      :placeholder="placeholder"
-      autocomplete="off"
     >
       <div slot="append" class="amount-input__token-symbol">
         {{ token.symbol || 'TKN' }}

--- a/raiden-dapp/src/components/AppHeader.vue
+++ b/raiden-dapp/src/components/AppHeader.vue
@@ -6,11 +6,11 @@
           <div class="app-header__top__content__back">
             <v-btn
               v-if="canGoBack"
-              @click="onBackClicked()"
               height="40px"
               width="40px"
               text
               icon
+              @click="onBackClicked()"
             >
               <v-img
                 :src="require('../assets/back_arrow.svg')"
@@ -54,7 +54,7 @@
           </v-tooltip>
           <v-tooltip bottom dark close-delay="1500">
             <template #activator="{ on }">
-              <v-btn id="copyBtn" @click="copy()" v-on="on" text icon>
+              <v-btn id="copyBtn" text icon @click="copy()" v-on="on">
                 <v-img
                   :src="require('../assets/copy_icon.svg')"
                   class="app-header__bottom__address__copy"

--- a/raiden-dapp/src/components/ChannelActions.vue
+++ b/raiden-dapp/src/components/ChannelActions.vue
@@ -3,24 +3,24 @@
     <v-btn
       :id="`deposit-${index}`"
       :disabled="channel.state !== 'open'"
-      @click="$emit('deposit', channel)"
       class="channel-action__button text-capitalize channel-action__button__primary"
+      @click="$emit('deposit', channel)"
     >
       {{ $t('channel-actions.deposit') }}
     </v-btn>
     <v-btn
       :id="`close-${index}`"
       :disabled="channel.state !== 'open' && channel.state !== 'closing'"
-      @click="$emit('close', channel)"
       class="channel-action__button text-capitalize channel-action__button__secondary"
+      @click="$emit('close', channel)"
     >
       {{ $t('channel-actions.close') }}
     </v-btn>
     <v-btn
       :id="`settle-${index}`"
       :disabled="channel.state !== 'settleable' && channel.state !== 'settling'"
-      @click="$emit('settle', channel)"
       class="channel-action__button text-capitalize channel-action__button__secondary"
+      @click="$emit('settle', channel)"
     >
       {{ $t('channel-actions.settle') }}
     </v-btn>

--- a/raiden-dapp/src/components/ChannelDeposit.vue
+++ b/raiden-dapp/src/components/ChannelDeposit.vue
@@ -26,18 +26,18 @@
     >
       <v-btn
         :id="`cancel-${identifier}`"
-        @click="cancel()"
         light
         class="text-capitalize channel-deposit__buttons__cancel"
+        @click="cancel()"
       >
         {{ $t('general.buttons.cancel') }}
       </v-btn>
       <v-btn
         :id="`confirm-${identifier}`"
         :disabled="!valid"
-        @click="confirm()"
         light
         class="text-capitalize channel-deposit__buttons__confirm"
+        @click="confirm()"
       >
         {{ $t('channel-deposit.buttons.confirm') }}
       </v-btn>

--- a/raiden-dapp/src/components/Confirmation.vue
+++ b/raiden-dapp/src/components/Confirmation.vue
@@ -16,15 +16,15 @@
     >
       <v-btn
         :id="`cancel-${identifier}`"
-        @click="cancel()"
         class="text-capitalize confirmation__buttons__cancel"
+        @click="cancel()"
       >
         {{ $t('confirmation.buttons.cancel') }}
       </v-btn>
       <v-btn
         :id="`confirm-${identifier}`"
-        @click="confirm()"
         class="text-capitalize confirmation__buttons__confirm"
+        @click="confirm()"
       >
         {{ positiveAction }}
       </v-btn>

--- a/raiden-dapp/src/components/ConfirmationDialog.vue
+++ b/raiden-dapp/src/components/ConfirmationDialog.vue
@@ -14,13 +14,13 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn @click="cancel()" class="confirmation-dialog__button" text>
+          <v-btn class="confirmation-dialog__button" text @click="cancel()">
             {{ $t('confirmation-dialog.buttons.cancel') }}
           </v-btn>
           <v-btn
-            @click="confirm()"
             class="confirmation-dialog__button confirmation-dialog__button__primary"
             text
+            @click="confirm()"
           >
             {{ $t('confirmation-dialog.buttons.confirm') }}
           </v-btn>

--- a/raiden-dapp/src/components/ErrorScreen.vue
+++ b/raiden-dapp/src/components/ErrorScreen.vue
@@ -17,7 +17,7 @@
         </div>
         <div class="error-screen__content__message">{{ description }}</div>
         <div v-if="buttonLabel">
-          <v-btn @click="dismiss()" class="error-screen__content__button">
+          <v-btn class="error-screen__content__button" @click="dismiss()">
             {{ buttonLabel }}
           </v-btn>
         </div>

--- a/raiden-dapp/src/components/FindRoutes.vue
+++ b/raiden-dapp/src/components/FindRoutes.vue
@@ -38,7 +38,7 @@
             item-key="key"
             class="find-routes__table"
           >
-            <template v-slot:items="props">
+            <template #items="props">
               <tr
                 :active="props.selected"
                 @click="props.selected = !props.selected"

--- a/raiden-dapp/src/components/FindRoutes.vue
+++ b/raiden-dapp/src/components/FindRoutes.vue
@@ -63,17 +63,17 @@
           </p>
           <v-row align="end" justify="center" class="find-routes__buttons">
             <v-btn
-              @click="cancel()"
               light
               class="text-capitalize find-routes__buttons__cancel"
+              @click="cancel()"
             >
               {{ $t('general.buttons.cancel') }}
             </v-btn>
             <v-btn
               :disabled="selected.length === 0"
-              @click="confirm()"
               light
               class="text-capitalize find-routes__buttons__confirm"
+              @click="confirm()"
             >
               {{ $t('general.buttons.transfer') }}
             </v-btn>

--- a/raiden-dapp/src/components/PathfindingServices.vue
+++ b/raiden-dapp/src/components/PathfindingServices.vue
@@ -40,7 +40,6 @@
           v-model="selected"
           :headers="headers"
           :items="services"
-          @click:row="setSelected($event)"
           dense
           disable-pagination
           hide-default-footer
@@ -48,6 +47,7 @@
           sort-by="price"
           item-key="service"
           class="pathfinding-services__table"
+          @click:row="setSelected($event)"
         >
           <template #item.address="{ item }">
             <v-tooltip bottom>
@@ -107,17 +107,17 @@
           class="pathfinding-services__buttons"
         >
           <v-btn
-            @click="cancel()"
             light
             class="text-capitalize pathfinding-services__buttons__cancel"
+            @click="cancel()"
           >
             {{ $t('general.buttons.cancel') }}
           </v-btn>
           <v-btn
             :disabled="selected.length === 0"
-            @click="confirm()"
             light
             class="text-capitalize pathfinding-services__buttons__confirm"
+            @click="confirm()"
           >
             {{ $t('general.buttons.confirm') }}
           </v-btn>

--- a/raiden-dapp/src/components/SplashScreen.vue
+++ b/raiden-dapp/src/components/SplashScreen.vue
@@ -26,11 +26,11 @@
         </div>
         <div class="splash-screen__button">
           <action-button
-            :text="$t('splash-screen.connect-button')"
             v-if="injectedProvider"
-            @click="connect()"
+            :text="$t('splash-screen.connect-button')"
             :enabled="!connecting"
             :loading="connecting"
+            @click="connect()"
           ></action-button>
           <span v-else class="splash-screen__no-provider">
             {{ $t('splash-screen.no-provider') }}

--- a/raiden-dapp/src/components/TokenOverlay.vue
+++ b/raiden-dapp/src/components/TokenOverlay.vue
@@ -2,7 +2,7 @@
   <v-overlay :value="show" absolute opacity="1.0" class="token-network-overlay">
     <v-container class="container">
       <v-row no-gutters justify="end">
-        <v-btn @click="cancel" icon class="token-network-overlay__close-button">
+        <v-btn icon class="token-network-overlay__close-button" @click="cancel">
           <v-icon>mdi-close</v-icon>
         </v-btn>
       </v-row>

--- a/raiden-dapp/src/components/Tokens.vue
+++ b/raiden-dapp/src/components/Tokens.vue
@@ -48,8 +48,8 @@
               >
                 <v-row justify="center" align="center" no-gutters>
                   <v-btn
-                    :disabled="token.open === 0"
                     :id="`transfer-${index}`"
+                    :disabled="token.open === 0"
                     :to="`/transfer/${token.address}`"
                     class="text-capitalize connected-tokens__tokens__token__button"
                   >
@@ -57,8 +57,8 @@
                   </v-btn>
                   <v-btn
                     :id="`leave-${index}`"
-                    @click="leaveNetwork(token)"
                     class="text-capitalize connected-tokens__tokens__token__button leave"
+                    @click="leaveNetwork(token)"
                   >
                     {{ $t('tokens.connected.token.buttons.disconnect') }}
                   </v-btn>
@@ -76,10 +76,10 @@
       </v-row>
 
       <action-button
-        @click="navigateToTokenSelect()"
         :text="$t('tokens.connect-new')"
         class="connected-tokens__button"
         enabled
+        @click="navigateToTokenSelect()"
       ></action-button>
 
       <confirmation-dialog
@@ -104,7 +104,11 @@
           </span>
         </i18n>
       </confirmation-dialog>
-      <stepper :display="loading" :steps="steps" :doneStep="doneStep"></stepper>
+      <stepper
+        :display="loading"
+        :steps="steps"
+        :done-step="doneStep"
+      ></stepper>
     </v-col>
   </v-row>
 </template>

--- a/raiden-dapp/src/views/Channels.vue
+++ b/raiden-dapp/src/views/Channels.vue
@@ -4,8 +4,8 @@
       <Transition name="fade-transition" mode="out-in">
         <div
           v-show="visible"
-          @click="visible = ''"
           class="channels__overlay"
+          @click="visible = ''"
         ></div>
       </Transition>
     </v-row>
@@ -47,7 +47,7 @@
     ></channel-list>
     <v-snackbar v-model="snackbar" :multi-line="true" :timeout="3000" bottom>
       {{ message }}
-      <v-btn @click="snackbar = false" color="primary" text>
+      <v-btn color="primary" text @click="snackbar = false">
         {{ $t('channels.snackbar-close') }}
       </v-btn>
     </v-snackbar>

--- a/raiden-dapp/src/views/OpenChannel.vue
+++ b/raiden-dapp/src/views/OpenChannel.vue
@@ -28,8 +28,8 @@
 
     <action-button
       :enabled="valid"
-      @click="openChannel()"
       :text="$t('open-channel.open-button')"
+      @click="openChannel()"
     ></action-button>
 
     <stepper
@@ -42,9 +42,9 @@
 
     <error-screen
       :description="error"
-      @dismiss="error = ''"
       :title="$t('open-channel.error.title')"
       :button-label="$t('open-channel.error.button')"
+      @dismiss="error = ''"
     ></error-screen>
   </v-form>
 </template>

--- a/raiden-dapp/src/views/SelectHub.vue
+++ b/raiden-dapp/src/views/SelectHub.vue
@@ -14,8 +14,8 @@
 
     <action-button
       :enabled="valid"
-      @click="selectHub()"
       :text="$t('select-hub.select-button')"
+      @click="selectHub()"
     ></action-button>
   </v-form>
 </template>

--- a/raiden-dapp/src/views/SelectToken.vue
+++ b/raiden-dapp/src/views/SelectToken.vue
@@ -8,8 +8,8 @@
     <v-row no-gutters justify="center" class="select-token__tokens__wrapper">
       <v-col cols="12">
         <recycle-scroller
-          :items="allTokens"
           v-slot="{ item }"
+          :items="allTokens"
           :buffer="20"
           :item-size="105"
           key-field="address"
@@ -17,8 +17,8 @@
         >
           <v-list-item
             :key="item.address"
-            @click="navigateToSelectHub(item.address)"
             class="select-token__tokens__token"
+            @click="navigateToSelectHub(item.address)"
           >
             <v-list-item-avatar class="select-token__tokens__token__blockie">
               <img

--- a/raiden-dapp/src/views/SelectToken.vue
+++ b/raiden-dapp/src/views/SelectToken.vue
@@ -8,7 +8,7 @@
     <v-row no-gutters justify="center" class="select-token__tokens__wrapper">
       <v-col cols="12">
         <recycle-scroller
-          v-slot="{ item }"
+          #default="{ item }"
           :items="allTokens"
           :buffer="20"
           :item-size="105"

--- a/raiden-dapp/src/views/Transfer.vue
+++ b/raiden-dapp/src/views/Transfer.vue
@@ -9,9 +9,9 @@
       >
         <v-col cols="2" class="transfer__channels">
           <v-btn
-            @click="navigateToChannels(token.address)"
             text
             class="transfer__channel-button"
+            @click="navigateToChannels(token.address)"
           >
             {{ $t('transfer.channel-button') }}
           </v-btn>
@@ -26,8 +26,8 @@
             }}
           </div>
           <div
-            @click="showTokenNetworks = true"
             class="transfer__token-networks__dropdown"
+            @click="showTokenNetworks = true"
           >
             <span>{{ token.name }}</span>
             <span>
@@ -43,20 +43,20 @@
           <v-dialog v-model="depositing" max-width="625">
             <template #activator="{ on }">
               <v-btn
-                @click="depositing = true"
-                v-on="on"
                 text
                 class="transfer__deposit-button"
+                @click="depositing = true"
+                v-on="on"
               >
                 {{ $t('transfer.deposit-button') }}
               </v-btn>
             </template>
             <v-card class="transfer__deposit-dialog">
               <channel-deposit
-                @cancel="depositing = false"
-                @confirm="deposit($event)"
                 :token="token"
                 identifier="0"
+                @cancel="depositing = false"
+                @confirm="deposit($event)"
               ></channel-deposit>
             </v-card>
           </v-dialog>
@@ -89,9 +89,9 @@
 
       <action-button
         :enabled="valid"
-        @click="proceedWithPathfinding()"
         :text="$t('general.buttons.continue')"
         class="transfer__action-button"
+        @click="proceedWithPathfinding()"
       ></action-button>
 
       <v-dialog v-model="serviceSelection" max-width="625">
@@ -107,12 +107,12 @@
         <v-card class="transfer__route-dialog">
           <find-routes
             v-if="findingRoutes"
-            @cancel="findingRoutes = false"
-            @confirm="transfer($event)"
             :pfs="raidenPFS"
             :token="token"
             :amount="amount"
             :target="target"
+            @cancel="findingRoutes = false"
+            @confirm="transfer($event)"
           ></find-routes>
         </v-card>
       </v-dialog>
@@ -127,9 +127,9 @@
 
     <error-screen
       :description="error"
-      @dismiss="error = ''"
       :title="errorTitle"
       :button-label="$t('transfer.error.button')"
+      @dismiss="error = ''"
     ></error-screen>
   </v-form>
 </template>


### PR DESCRIPTION
#517 seems to have some new rules that cause [linting errors](https://circleci.com/gh/raiden-network/light-client/7882?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).

This PR bumps `eslint-plugin-vue` to 6.0.0 and contains the auto fixed linting errors from eslint