### PR TITLE
Spelling error in dialogue when closing a channel

### DIFF
--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -72,7 +72,7 @@
       },
       "closed": {
         "title": "Closed",
-        "description": "Please wait until your channel is settleable. \nhis may take up some time."
+        "description": "Please wait until your channel is settleable. \nthis may take some time."
       },
       "settleable": {
         "title": "Settleable",


### PR DESCRIPTION
Fixed the spelling error "his may take up some time" in this dialogue:

![Screenshot 2019-11-11 at 15 24 22](https://user-images.githubusercontent.com/43838780/68595471-c3d14280-0499-11ea-90c3-59af763104c3.png)
