### PR TITLE
Switch back and pin typedoc to 0.15.0

### DIFF
--- a/raiden-ts/package-lock.json
+++ b/raiden-ts/package-lock.json
@@ -12975,22 +12975,22 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.15.1.tgz",
-      "integrity": "sha512-zm/rWq2seVqaop9isXc5jMK5vqOjPHni3/t9OVWmuZYKNbYdlxbtM10CbpuaLdHn7ry2HLtMx7IP236B/F6Xwg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.15.0.tgz",
+      "integrity": "sha512-NOtfq5Tis4EFt+J2ozhVq9RCeUnfEYMFKoU6nCXCXUULJz1UQynOM+yH3TkfZCPLzigbqB0tQYGVlktUWweKlw==",
       "dev": true,
       "requires": {
         "@types/minimatch": "3.0.3",
         "fs-extra": "^8.1.0",
-        "handlebars": "^4.5.1",
-        "highlight.js": "^9.16.2",
+        "handlebars": "^4.1.2",
+        "highlight.js": "^9.15.8",
         "lodash": "^4.17.15",
         "marked": "^0.7.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.3",
-        "typedoc-default-themes": "^0.6.1",
-        "typescript": "3.7.x"
+        "typedoc-default-themes": "^0.6.0",
+        "typescript": "3.5.x"
       },
       "dependencies": {
         "fs-extra": {
@@ -13003,24 +13003,6 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
-        },
-        "handlebars": {
-          "version": "4.5.2",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
-          "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
-          "dev": true,
-          "requires": {
-            "neo-async": "^2.6.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.6.1",
-            "uglify-js": "^3.1.4"
-          }
-        },
-        "typescript": {
-          "version": "3.7.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
-          "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
-          "dev": true
         }
       }
     },

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -71,7 +71,7 @@
     "ts-node": "^8.4.1",
     "typechain": "^1.0.3",
     "typechain-target-ethers": "^1.0.1",
-    "typedoc": "^0.15.1",
+    "typedoc": "0.15.0",
     "typedoc-plugin-markdown": "^2.2.11",
     "typescript": "3.5.3",
     "vuepress": "^1.2.0"


### PR DESCRIPTION
`typedoc@0.15.1` uses TS3.7 and we aren't compatible with 3.7
Once we have bumped TS to 3.7 in #506 we should also bump `typedoc` to `0.15.1`