### PR TITLE
Fix stepper background color

### DIFF
--- a/raiden-dapp/src/views/TransferSteps.vue
+++ b/raiden-dapp/src/views/TransferSteps.vue
@@ -282,7 +282,7 @@ export default class TransferSteps extends Mixins(
 @import '../scss/colors';
 
 .transfer-steps {
-  background: transparent;
+  background: transparent !important;
   box-shadow: none;
   width: 100%;
   position: relative;


### PR DESCRIPTION
Currently on production there's a vuetify overruling on the stepper's background color:
![stepper-prod](https://user-images.githubusercontent.com/3169205/68853573-945d4880-06da-11ea-9205-ffc25c6e3a22.png)

Didn't occur when running `npm run serve`, probably due to the loading sequence of the generated CSS