### PR TITLE
Fix double fee on first IOU payment

### DIFF
--- a/raiden-ts/tests/unit/epics/path.spec.ts
+++ b/raiden-ts/tests/unit/epics/path.spec.ts
@@ -359,7 +359,7 @@ describe('PFS: pathFindServiceEpic', () => {
       iouPersist(
         {
           iou: expect.objectContaining({
-            amount: bigNumberify(4),
+            amount: bigNumberify(2),
           }),
         },
         { tokenNetwork, serviceAddress: iou.receiver },


### PR DESCRIPTION
On my review of #521, I didn't understand properly a change of @kelsos and made him make a change which caused the first `updateIOU` (increment) to happen on top of an already incremented initial IOU, instead of Zero, making the first payment be doubled.
This fix it, alongside some improvements to the reactivity of the IOU signing, although the algorithm continues to be the same.