### PR TITLE
Fix a timeout affecting signature instead of only fromFetch

### DIFF
--- a/raiden-ts/src/path/epics.ts
+++ b/raiden-ts/src/path/epics.ts
@@ -276,9 +276,11 @@ export const pathFindServiceEpic = (
                             }
                           : undefined,
                       }),
-                    }).pipe(map(response => ({ response, iou }))),
+                    }).pipe(
+                      timeout(httpTimeout),
+                      map(response => ({ response, iou })),
+                    ),
                   ),
-                  timeout(httpTimeout),
                   mergeMap(async ({ response, iou }) => ({
                     response,
                     text: await response.text(),

--- a/raiden-ts/tests/unit/epics/path.spec.ts
+++ b/raiden-ts/tests/unit/epics/path.spec.ts
@@ -359,7 +359,7 @@ describe('PFS: pathFindServiceEpic', () => {
       iouPersist(
         {
           iou: expect.objectContaining({
-            amount: bigNumberify(4),
+            amount: bigNumberify(2),
           }),
         },
         { tokenNetwork, serviceAddress: iou.receiver },


### PR DESCRIPTION
This goes on top of #573 to avoid merge conflict.
`timeout` should be contained in the `fromFetch`. If `fromFetch` is on the chain with some other async operation, it'll affect both, so needs to be scoped.