### PR TITLE
Matrix Alderaan transport updates

### DIFF
--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -97,7 +97,7 @@ import { makeSecret, raidenSentTransfer, getSecrethash, makePaymentId } from './
 import { pathFind, pathFound, pathFindFailed, pfsListUpdated } from './path/actions';
 import { Paths, RaidenPaths, PFS, RaidenPFS, IOU } from './path/types';
 import { pfsListInfo } from './path/utils';
-import { Address, PrivateKey, Secret, Storage, Hash, UInt, decode } from './utils/types';
+import { Address, PrivateKey, Secret, Storage, Hash, UInt, decode, isntNil } from './utils/types';
 import { patchSignSend } from './utils/ethers';
 import { losslessParse } from './utils/data';
 
@@ -247,8 +247,8 @@ export class Raiden {
               { acc: { ...acc, [secrethash]: sent }, changed: sent },
         { acc: {} },
       ),
-      filter(({ changed }) => !!changed), // filter out if reference didn't change from last emit
-      map(({ changed }) => changed!), // get the changed object only
+      pluck('changed'),
+      filter(isntNil), // filter out if reference didn't change from last emit
       // from here, we get SentTransfer objects which changed from previous state (all on first)
       map(raidenSentTransfer),
     );

--- a/raiden-ts/src/transport/epics.ts
+++ b/raiden-ts/src/transport/epics.ts
@@ -42,7 +42,7 @@ import { find, get, minBy, sortBy } from 'lodash';
 import { getAddress, verifyMessage } from 'ethers/utils';
 import { createClient, MatrixClient, MatrixEvent, User, Room, RoomMember } from 'matrix-js-sdk';
 
-import { Address, Signed } from '../utils/types';
+import { Address, Signed, isntNil } from '../utils/types';
 import { RaidenEpicDeps } from '../types';
 import { RaidenAction } from '../actions';
 import { channelMonitored } from '../channels/actions';
@@ -333,10 +333,10 @@ export const matrixMonitorPresenceEpic = (
             .then(presence => ({ ...presence, user_id: userId }))
             .catch(err => {
               console.log('Error fetching user presence, ignoring:', err);
-              return { presence: '', user_id: userId };
+              return undefined;
             }),
         ),
-        filter(presence => !!presence && !!presence.presence),
+        filter(isntNil),
         toArray(),
         // for all matched/verified users, get its presence through dedicated API
         // it's required because, as the user events could already have been handled and
@@ -435,7 +435,7 @@ export const matrixPresenceUpdateEpic = (
       const displayName$: Observable<string | undefined> = user.displayName
         ? of(user.displayName)
         : from(matrix.getProfileInfo(userId, 'displayname')).pipe(
-            map(profile => profile.displayname),
+            pluck('displayname'),
             catchError(() => of(undefined)),
           );
 

--- a/raiden-ts/src/transport/utils.ts
+++ b/raiden-ts/src/transport/utils.ts
@@ -6,6 +6,7 @@ import { MatrixClient, Room } from 'matrix-js-sdk';
 
 import { RaidenAction } from '../actions';
 import { RaidenConfig } from '../config';
+import { isntNil } from '../utils/types';
 import { Presences } from './types';
 import { matrixPresenceUpdate } from './actions';
 
@@ -41,7 +42,7 @@ export const getPresences$ = memoize(
  * @returns Array of room names
  */
 export function globalRoomNames(config: RaidenConfig) {
-  return [config.discoveryRoom, config.pfsRoom].filter((g): g is string => !!g);
+  return [config.discoveryRoom, config.pfsRoom].filter(isntNil);
 }
 
 /**

--- a/raiden-ts/src/utils/ethers.ts
+++ b/raiden-ts/src/utils/ethers.ts
@@ -7,6 +7,8 @@ import { flatten, sortBy } from 'lodash';
 import { Observable, fromEventPattern, merge, from, of, EMPTY, combineLatest, defer } from 'rxjs';
 import { filter, first, map, switchMap, mergeMap, share } from 'rxjs/operators';
 
+import { isntNil } from './types';
+
 /**
  * Like rxjs' fromEvent, but event can be an EventFilter
  *
@@ -93,7 +95,7 @@ export function getEventsStream<T extends any[]>(
       // emit log array elements as separate logs into stream (unwind)
       mergeMap(logs => from(sortBy(flatten(logs), ['blockNumber']))),
       map(logToEvent),
-      filter((event): event is T => !!event),
+      filter(isntNil),
     );
   }
 
@@ -104,7 +106,7 @@ export function getEventsStream<T extends any[]>(
     mergeMap(() => from(filters)),
     mergeMap(filter => fromEthersEvent<Log>(provider, filter)),
     map(logToEvent),
-    filter((event): event is T => !!event),
+    filter(isntNil),
   );
 
   return merge(pastEvents$, newEvents$);

--- a/raiden-ts/src/utils/types.ts
+++ b/raiden-ts/src/utils/types.ts
@@ -29,6 +29,17 @@ export function decode<C extends t.Mixed>(codec: C, data: C['_I']): C['_A'] {
   return decoded.right;
 }
 
+/**
+ * Test for value's non-nulliness
+ * Like lodash's negate(isNil), but also works as type guard (e.g. useful for filters)
+ *
+ * @param value - to be tested
+ * @returns true if value is not null nor undefined
+ */
+export function isntNil<T>(value: T): value is NonNullable<T> {
+  return value != null;
+}
+
 const isStringifiable = (u: unknown): u is { toString: () => string } =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   u !== null && u !== undefined && typeof (u as any)['toString'] === 'function';

--- a/raiden-ts/tests/e2e/mocks.ts
+++ b/raiden-ts/tests/e2e/mocks.ts
@@ -78,6 +78,8 @@ export class MockMatrixRequestFn {
     };
 
     this.endpoints['/join'] = ({}, callback) => this.respond(callback, 200, {});
+    this.endpoints['/createRoom'] = ({}, callback) =>
+      this.respond(callback, 200, { room_id: `!${Math.random()}:${server}` });
     this.endpoints['/versions'] = ({}, callback) => this.respond(callback, 200, {});
   }
 


### PR DESCRIPTION
- [x] better reactive handling of invites
- [x] retry invites until user joins (while online, supporting roaming)
- [x] always invite targets, partners & recipients of messages, instead of waiting for them to invite us
- [ ] ~~handle errors in matrix init~~ [#582]
- [x] adapt tests