### PR TITLE
Fix config.logger

### DIFF
--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -37,7 +37,14 @@ export const RaidenConfig = t.readonly(
     }),
     t.partial({
       matrixServer: t.string,
-      logger: t.keyof({ ['']: null, debug: null, log: null, info: null, warn: null, error: null }),
+      logger: t.keyof({
+        ['']: null,
+        trace: null,
+        debug: null,
+        info: null,
+        warn: null,
+        error: null,
+      }),
       pfs: t.union([Address, t.string, t.null]),
     }),
   ]),

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -280,12 +280,10 @@ export class Raiden {
 
     const middlewares: Middleware[] = [
       createLogger({
-        level: () =>
-          this.deps.config$.value.logger !== undefined
-            ? this.deps.config$.value.logger
-            : process.env.NODE_ENV === 'development'
-            ? 'debug'
-            : '',
+        predicate: () =>
+          this.deps.config$.value.logger !== '' &&
+          (this.deps.config$.value.logger !== undefined || process.env.NODE_ENV === 'development'),
+        level: () => this.deps.config$.value.logger || 'debug',
       }),
     ];
 

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -128,9 +128,12 @@ describe('transport epic', () => {
           ),
         );
 
-      await expect(initMatrixEpic(action$, state$, depsMock).toPromise()).resolves.toEqual({
-        type: getType(matrixSetup),
-        payload: {
+      await expect(
+        initMatrixEpic(action$, state$, depsMock)
+          .pipe(first())
+          .toPromise(),
+      ).resolves.toEqual(
+        matrixSetup({
           server: matrixServer,
           setup: {
             userId,
@@ -138,8 +141,8 @@ describe('transport epic', () => {
             deviceId: expect.any(String),
             displayName: expect.any(String),
           },
-        },
-      });
+        }),
+      );
       // ensure if stored setup works, servers list don't need to be fetched
       expect(fetch).not.toHaveBeenCalled();
     });
@@ -151,9 +154,12 @@ describe('transport epic', () => {
       // set config
       depsMock.config$.next({ ...state.config, matrixServer });
 
-      await expect(initMatrixEpic(action$, state$, depsMock).toPromise()).resolves.toEqual({
-        type: getType(matrixSetup),
-        payload: {
+      await expect(
+        initMatrixEpic(action$, state$, depsMock)
+          .pipe(first())
+          .toPromise(),
+      ).resolves.toEqual(
+        matrixSetup({
           server: matrixServer,
           setup: {
             userId,
@@ -161,8 +167,8 @@ describe('transport epic', () => {
             deviceId: expect.any(String),
             displayName: expect.any(String),
           },
-        },
-      });
+        }),
+      );
       expect(fetch).not.toHaveBeenCalled();
     });
 
@@ -186,9 +192,12 @@ describe('transport epic', () => {
       // set config
       depsMock.config$.next({ ...state.config, matrixServer });
 
-      await expect(initMatrixEpic(action$, state$, depsMock).toPromise()).resolves.toEqual({
-        type: getType(matrixSetup),
-        payload: {
+      await expect(
+        initMatrixEpic(action$, state$, depsMock)
+          .pipe(first())
+          .toPromise(),
+      ).resolves.toEqual(
+        matrixSetup({
           server: matrixServer,
           setup: {
             userId,
@@ -196,17 +205,20 @@ describe('transport epic', () => {
             deviceId: expect.any(String),
             displayName: expect.any(String),
           },
-        },
-      });
+        }),
+      );
       expect(fetch).not.toHaveBeenCalled();
     });
 
     test('matrix fetch servers list', async () => {
       const action$ = EMPTY as Observable<RaidenAction>,
         state$ = of(state);
-      await expect(initMatrixEpic(action$, state$, depsMock).toPromise()).resolves.toEqual({
-        type: getType(matrixSetup),
-        payload: {
+      await expect(
+        initMatrixEpic(action$, state$, depsMock)
+          .pipe(first())
+          .toPromise(),
+      ).resolves.toEqual(
+        matrixSetup({
           server: `https://${matrixServer}`,
           setup: {
             userId,
@@ -214,8 +226,8 @@ describe('transport epic', () => {
             deviceId: expect.any(String),
             displayName: expect.any(String),
           },
-        },
-      });
+        }),
+      );
       expect(fetch).toHaveBeenCalledTimes(2); // list + rtt
     });
 

--- a/raiden-ts/typings/matrix-js-sdk/index.d.ts
+++ b/raiden-ts/typings/matrix-js-sdk/index.d.ts
@@ -772,3 +772,8 @@ declare module 'matrix-js-sdk' {
 declare module 'matrix-js-sdk/lib/utils' {
   export function encodeUri(pathTemplate: string, variables: { [fragment: string]: any }): string;
 }
+
+declare module 'matrix-js-sdk/lib/logger' {
+  const logger: { setLevel: (level: string) => void; };
+  export = logger;
+}


### PR DESCRIPTION
It couldn't be fully disabled because even setting it to `''` still outputed the `console.group`, even if without content.

Now, setting `config.logger` to empty string or (if left as default of `undefined) `NODE_ENV` environment variable to something other than `develop`, `redux-logger` will be completely disabled.
One can also set it to some of the `console`'s logging level to enable and force it to a specific logging level.

Additionally, if the logs are disabled  on either way, also reflect this on matrix logging, which could polute the output (actually, set to filter only critical `error`s, but most of the normal logs are debug).

TODO for the future is replacing our internal direct usage of some `console`'s logging functions with a proper library like [loglevel](https://github.com/pimterry/loglevel), used by matrix.