### PR TITLE
Proper fees dialogs behavior if direct route available, single free PFS or single free route

### DIFF
--- a/raiden-dapp/src/components/PathfindingServices.vue
+++ b/raiden-dapp/src/components/PathfindingServices.vue
@@ -131,10 +131,10 @@ export default class PathfindingServices extends Vue {
   }: {
     item: RaidenPFS;
     value: boolean;
-  }): RaidenPFS | null {
+  }): [RaidenPFS, boolean] | null {
     // A PFS service got selected
     if (value) {
-      return item;
+      return [item, this.services.length === 1];
     }
 
     // A PFS service was unselected

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -198,6 +198,7 @@
         "title": "Request Route",
         "udc-description": "{token} Balance",
         "in-progress": "Sign the message to pay for the route request",
+        "searching-for-route": "Searching for route...",
         "done": "Route request payment complete"
       },
       "select-route": {

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -4,7 +4,7 @@ import { RootState } from '@/types';
 import { Web3Provider } from '@/services/web3-provider';
 import { BalanceUtils } from '@/utils/balance-utils';
 import { DeniedReason, Progress, Token, TokenModel } from '@/model/types';
-import { BigNumber } from 'ethers/utils';
+import { BigNumber, BigNumberish } from 'ethers/utils';
 import { Zero } from 'ethers/constants';
 import { exhaustMap, filter, first } from 'rxjs/operators';
 import asyncPool from 'tiny-async-pool';
@@ -293,6 +293,15 @@ export default class RaidenService {
 
   noPfsSelected(): boolean {
     return this.raiden.config.pfs === undefined;
+  }
+
+  /* istanbul ignore next */
+  async directRoute(
+    token: string,
+    target: string,
+    value: BigNumberish
+  ): Promise<RaidenPaths | undefined> {
+    return await this.raiden.directRoute(token, target, value);
   }
 
   /* istanbul ignore next */

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -291,10 +291,6 @@ export default class RaidenService {
     return raidenPFS;
   }
 
-  noPfsSelected(): boolean {
-    return this.raiden.config.pfs === undefined;
-  }
-
   /* istanbul ignore next */
   async directRoute(
     token: string,

--- a/raiden-dapp/src/views/TransferSteps.vue
+++ b/raiden-dapp/src/views/TransferSteps.vue
@@ -320,6 +320,27 @@ export default class TransferSteps extends Mixins(
 
     if (typeof this.token.decimals !== 'number') {
       this.navigateToHome();
+      return;
+    }
+
+    const directRoutes = await this.$raiden.directRoute(
+      address,
+      this.target,
+      BalanceUtils.parse(this.amount, this.token.decimals)
+    );
+
+    if (directRoutes) {
+      const [route] = directRoutes;
+
+      this.selectedRoute = {
+        key: 0,
+        fee: Zero,
+        displayFee: '0',
+        path: [...route.path],
+        hops: 0
+      };
+
+      this.transfer();
     }
   }
 

--- a/raiden-dapp/tests/unit/components/pathfinding-services.spec.ts
+++ b/raiden-dapp/tests/unit/components/pathfinding-services.spec.ts
@@ -82,7 +82,7 @@ describe('PathfindingService.vue', () => {
       .trigger('click');
     await wrapper.vm.$nextTick();
     expect(wrapper.emitted().select).toBeTruthy();
-    expect(wrapper.emitted().select[0][0]).toEqual(raidenPFS);
+    expect(wrapper.emitted().select[0][0]).toEqual([raidenPFS, false]);
   });
 
   test('the request fails with some error', async () => {

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -753,22 +753,4 @@ describe('RaidenService', () => {
       raidenService.findRoutes(AddressZero, AddressZero, One)
     ).resolves.toEqual([]);
   });
-
-  test('no pfs set', async () => {
-    providerMock.mockResolvedValue(mockProvider);
-    factory.mockResolvedValue(mockRaiden({ config: {} }));
-    await raidenService.connect();
-    await flushPromises();
-    expect(raidenService.noPfsSelected()).toBe(true);
-  });
-
-  test('pfs is set in config', async () => {
-    providerMock.mockResolvedValue(mockProvider);
-    factory.mockResolvedValue(
-      mockRaiden({ config: { pfs: 'https://pfs.service' } })
-    );
-    await raidenService.connect();
-    await flushPromises();
-    expect(raidenService.noPfsSelected()).toBe(false);
-  });
 });

--- a/raiden-ts/src/path/actions.ts
+++ b/raiden-ts/src/path/actions.ts
@@ -14,7 +14,10 @@ type ServiceId = {
   serviceAddress: Address;
 };
 
-export const pathFind = createStandardAction('pathFind')<{ paths?: Paths; pfs?: PFS }, PathId>();
+export const pathFind = createStandardAction('pathFind')<
+  { paths?: Paths; pfs?: PFS | null },
+  PathId
+>();
 
 export const pathFound = createStandardAction('pathFound')<{ paths: Paths }, PathId>();
 

--- a/raiden-ts/src/path/epics.ts
+++ b/raiden-ts/src/path/epics.ts
@@ -213,6 +213,7 @@ export const pathFindServiceEpic = (
                 throw new Error(`PFS: unknown tokenNetwork ${tokenNetwork}`);
               if (!(target in presences) || !presences[target].payload.available)
                 throw new Error(`PFS: target ${target} not online`);
+
               // if pathFind received a set of paths, pass it through to validation/cleanup
               if (action.payload.paths) return of({ paths: action.payload.paths, iou: undefined });
               // else, if possible, use a direct transfer
@@ -223,7 +224,10 @@ export const pathFindServiceEpic = (
                   paths: [{ path: [state.address, target], fee: Zero as Int<32> }],
                   iou: undefined,
                 });
-              } else if (!action.payload.pfs && configPfs === null) {
+              } else if (
+                action.payload.pfs === null || // explicitly disabled in action
+                (!action.payload.pfs && configPfs === null) // disabled in config and not provided
+              ) {
                 // pfs not specified in action and disabled (null) in config
                 throw new Error(`PFS disabled and no direct route available`);
               } else {

--- a/raiden-ts/src/path/utils.ts
+++ b/raiden-ts/src/path/utils.ts
@@ -118,17 +118,20 @@ export function pfsInfo(
  * Throws if no server can be validated, meaning either there's none in the current network or
  * we're out-of-sync (outdated or ahead of PFS's deployment network version).
  *
- * @param pfsList - Array of PFS addresses, as notified by pfsListUpdated action
+ * @param pfsList - Array of PFS addresses or URLs
  * @param deps - RaidenEpicDeps array
  * @returns Observable of online, validated & sorted PFS info array
  */
-export function pfsListInfo(pfsList: readonly Address[], deps: RaidenEpicDeps): Observable<PFS[]> {
+export function pfsListInfo(
+  pfsList: readonly (string | Address)[],
+  deps: RaidenEpicDeps,
+): Observable<PFS[]> {
   return from(pfsList).pipe(
     mergeMap(
-      addr =>
-        pfsInfo(addr, deps).pipe(
+      addrOrUrl =>
+        pfsInfo(addrOrUrl, deps).pipe(
           catchError(err => {
-            console.warn(`Error trying to fetch PFS info for "${addr}" - ignoring:`, err);
+            console.warn(`Error trying to fetch PFS info for "${addrOrUrl}" - ignoring:`, err);
             return EMPTY;
           }),
         ),


### PR DESCRIPTION
Fix #596 

- There's a new method available, `Raiden.directRoute`, similar to `findRoutes`, which can get earlier if a direct route is available
  - This can be used to skip PFS fee & mediation fee dialogs
  - It resolves to `undefined` if no direct route is found; rejects only if validation fails (e.g. token address), not on route not found like `findRoutes`
- `findPFS` will throw only if pfs is disabled in config (`config.pfs=null`), `directRoute` before can skip this error if direct transfer is possible; it uses set `config.pfs`, or fetches from `ServiceRegistry` only if `undefined` (default)
- Should skip PFS fee dialog if `findPFS` finds a single free (price=0) PFS
- Should skip mediation fee dialog if `findRoutes` finds a single free route

So, general dApp workflow should be like:
- call `Raiden.directRoute`
  - if there's a direct route: use it as `paths` for `transfer` in last point directly
  - else (resolves to undefined)
    - call `findPFS`
      - if throws, show error, means no direct route and PFS disabled
      - if returns a single free PFS, auto-confirm (skip) PFS fee dialog
      - else, show dialog and let the user select and confirm payment for a PFS
    - call `findRoutes` with selected `pfs` above
      - if there's a single free route, auto-confirm (skip) mediation fee dialog
      - else, show dialog and let user select and confirm a route and its fee
- call `transfer` with selected `paths`