### PR TITLE
Revert "dependencies: bump typedoc from 0.15.0 to 0.15.3 in /raiden-ts"

### DIFF
--- a/raiden-ts/package-lock.json
+++ b/raiden-ts/package-lock.json
@@ -13047,22 +13047,22 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.15.3.tgz",
-      "integrity": "sha512-RGX+dgnm9fyg5KHj81/ZhMiee0FfvJnjBXedhedhMWlrtM4YRv3pn8sYCWRt5TMi1Jli3/JG224pbFo3/3uaGw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.15.0.tgz",
+      "integrity": "sha512-NOtfq5Tis4EFt+J2ozhVq9RCeUnfEYMFKoU6nCXCXUULJz1UQynOM+yH3TkfZCPLzigbqB0tQYGVlktUWweKlw==",
       "dev": true,
       "requires": {
         "@types/minimatch": "3.0.3",
         "fs-extra": "^8.1.0",
-        "handlebars": "^4.5.3",
-        "highlight.js": "^9.16.2",
+        "handlebars": "^4.1.2",
+        "highlight.js": "^9.15.8",
         "lodash": "^4.17.15",
         "marked": "^0.7.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.3",
-        "typedoc-default-themes": "^0.6.1",
-        "typescript": "3.7.x"
+        "typedoc-default-themes": "^0.6.0",
+        "typescript": "3.5.x"
       },
       "dependencies": {
         "fs-extra": {
@@ -13075,24 +13075,6 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
-        },
-        "handlebars": {
-          "version": "4.5.3",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-          "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
-          "dev": true,
-          "requires": {
-            "neo-async": "^2.6.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.6.1",
-            "uglify-js": "^3.1.4"
-          }
-        },
-        "typescript": {
-          "version": "3.7.2",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
-          "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
-          "dev": true
         }
       }
     },

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -71,7 +71,7 @@
     "ts-node": "^8.5.2",
     "typechain": "^1.0.3",
     "typechain-target-ethers": "^1.0.3",
-    "typedoc": "0.15.3",
+    "typedoc": "0.15.0",
     "typedoc-plugin-markdown": "^2.2.11",
     "typescript": "3.5.3",
     "vuepress": "^1.2.0"


### PR DESCRIPTION
Reverts raiden-network/light-client#618
Because doc generation still fails https://circleci.com/workflow-run/e78b3007-3886-4753-a4dc-4c4ab27295d3