### PR TITLE
Aligning content according to screen size

### DIFF
--- a/raiden-dapp/src/components/SplashScreen.vue
+++ b/raiden-dapp/src/components/SplashScreen.vue
@@ -104,6 +104,7 @@ export default class Loading extends Vue {
   display: flex;
   height: 100%;
   padding-left: 10px;
+  white-space: nowrap;
   @media only screen and (max-width: 1263px) {
     justify-content: center;
     padding: 30px 0px 0px 0px;

--- a/raiden-dapp/src/components/SplashScreen.vue
+++ b/raiden-dapp/src/components/SplashScreen.vue
@@ -1,29 +1,31 @@
 <template>
-  <v-container fluid class="splash-screen fill-height">
-    <v-row align="center" justify="center" no-gutters>
-      <v-col cols="4" lg="4" md="6" sm="8">
-        <div class="splash-screen__wrapper display-3">
-          <div class="splash-screen__logo-container">
-            <v-img
-              :src="require('../assets/logo.svg')"
-              min-width="50px"
-              class="splash-screen__logo"
-              aspect-ratio="1"
-              contain
-            />
-          </div>
-          <div class="splash-screen__app-name">
-            <div>
-              {{ name }}
-            </div>
-          </div>
+  <v-container class="splash-screen fill-height">
+    <v-row no-gutters justify="center">
+      <v-col cols="8" xl="2" lg="2" md="8" sm="8">
+        <div class="splash-screen__logo-container">
+          <v-img
+            :src="require('../assets/logo.svg')"
+            min-width="50px"
+            class="splash-screen__logo"
+            aspect-ratio="1"
+            contain
+          />
         </div>
-        <div class="font-weight-light text-center splash-screen__disclaimer">
+      </v-col>
+      <v-col cols="8" xl="4" lg="5" md="8" sm="8">
+        <div class="splash-screen__app-name display-3">
+          {{ name }}
+        </div>
+      </v-col>
+      <v-col cols="8">
+        <div class="splash-screen__text font-weight-light text-center">
           {{ $t('splash-screen.disclaimer') }}
-        </div>
-        <div class="font-weight-light text-center splash-screen__matrix_sign">
+          <br />
+          <br />
           {{ $t('splash-screen.matrix-sign') }}
         </div>
+      </v-col>
+      <v-col cols="8">
         <div class="splash-screen__button">
           <action-button
             v-if="injectedProvider"
@@ -36,6 +38,8 @@
             {{ $t('splash-screen.no-provider') }}
           </span>
         </div>
+      </v-col>
+      <v-col cols="8">
         <div class="splash-screen__message">
           <no-access-message
             v-if="accessDenied"
@@ -80,51 +84,47 @@ export default class Loading extends Vue {
 </script>
 
 <style lang="scss" scoped>
+.splash-screen__logo-container {
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 10px;
+  @media only screen and (max-width: 1263px) {
+    justify-content: center;
+    padding: 0;
+  }
+}
+
 .splash-screen__logo {
   filter: invert(100%);
+  max-width: 6rem;
 }
 
-$name-horizontal-margin: 2rem;
 .splash-screen__app-name {
-  margin-left: $name-horizontal-margin;
-  margin-right: $name-horizontal-margin;
-}
-
-.splash-screen__wrapper__logo-container {
-  width: 8rem;
-  padding: 1.4rem;
-}
-
-.splash-screen__wrapper {
-  display: flex;
   align-items: center;
-  justify-content: center;
+  display: flex;
+  height: 100%;
+  padding-left: 10px;
+  @media only screen and (max-width: 1263px) {
+    justify-content: center;
+    padding: 30px 0px 0px 0px;
+  }
 }
 
-.splash-screen__disclaimer {
-  margin-top: 60px;
-  font-size: 16px;
-}
-
+.splash-screen__text,
 .splash-screen__button {
-  display: flex;
-  margin-top: 30px;
-  align-items: center;
-  justify-content: center;
-}
-
-.splash-screen__message {
-  margin-top: 40px;
-  height: 35px;
+  margin-top: 60px;
 }
 
 .splash-screen__no-provider {
-  font-weight: 500;
+  display: flex;
+  justify-content: center;
   font-size: 24px;
+  font-weight: 500;
+  text-align: center;
 }
 
-.splash-screen__matrix_sign {
-  margin-top: 90px;
-  color: rgba(255, 255, 255, 0.8);
+.splash-screen__message {
+  height: 35px;
+  margin-top: 40px;
 }
 </style>

--- a/raiden-dapp/src/components/SplashScreen.vue
+++ b/raiden-dapp/src/components/SplashScreen.vue
@@ -18,10 +18,10 @@
         </div>
       </v-col>
       <v-col cols="8">
-        <div class="splash-screen__text font-weight-light text-center">
+        <div class="splash-screen__disclaimer font-weight-light text-center">
           {{ $t('splash-screen.disclaimer') }}
-          <br />
-          <br />
+        </div>
+        <div class="splash-screen__matrix-sign font-weight-light text-center">
           {{ $t('splash-screen.matrix-sign') }}
         </div>
       </v-col>
@@ -111,9 +111,13 @@ export default class Loading extends Vue {
   }
 }
 
-.splash-screen__text,
+.splash-screen__disclaimer,
 .splash-screen__button {
   margin-top: 60px;
+}
+
+.splash-screen__matrix-sign {
+  margin-top: 30px;
 }
 
 .splash-screen__no-provider {


### PR DESCRIPTION
The content on the welcome screen is now aligned nicely for different screen sizes. On smaller screens the Raiden logo appears on top of the app name and on larger screens it appears to the left of the app name.

**Smaller Screens**
![Screenshot 2019-12-04 at 12 27 44](https://user-images.githubusercontent.com/43838780/70138959-bcb0e500-1691-11ea-8395-adaa15d61310.png)

**Larger Screens**
![Screenshot 2019-12-04 at 12 29 52](https://user-images.githubusercontent.com/43838780/70138998-d4886900-1691-11ea-8fd7-9e7fe84f647f.png)
 