### PR TITLE
Adds CHANGELOG.md for both the dApp and SDK

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,6 +2,79 @@
 
 ## [Unreleased]
 ### Changed
-- Added project skeleton
+- User can now dismiss/hide the transfer progress dialog.
+- Fix utility token display on PFS route selection.
 
-[Unreleased]: https://github.com/raiden-network/light-client
+### Fixed
+
+## [0.2] - 2019-11-29
+### Added
+- Add PFS route selection functionality.
+- Add PFS service selection functionality.
+- Add hint that additional messages may pop up and require signing.
+- Add flow for selecting PathFinding Service and route. 
+- Add mint and deposit functionality for PathFinding service flow.
+- Add new Home screen.
+- Add offline detection and notification.
+- Add update notification when there is a new version deployed.
+
+### Changed
+- Optimize token loading.
+- Add query parameters to routes.
+- Implement new token Transfer screen.
+- Change wording on user interface from 'Payment' to 'Transfer'.
+- Button style in a some screens.
+- Minor layout changes to be consistent with the designs.
+- Change token amount display across the dApp.
+
+### Fixed
+- Fix Address and Amount input validation.
+- Fix performance issues when changing network.
+- Fix lose of query parameters when redirecting to SPA.
+- Fix account address copy button tooltip.
+- Fix address input invalidation when resolving an ens address.
+- Fix typo in then dialog when closing a closing.
+- Fix stepper background color.
+- Fix scrollbar color and theme on Firefox and Webkit based browsers.
+- Fix UI implementation/design inconsistencies. 
+
+### Removed 
+- Remove back button from transfer screen.
+- Remove connected token screen.
+
+## [0.1.1] - 2019-10-07
+### Added
+- Add route guards.
+
+### Changed
+- Simplifies transfer screen.
+- Change transfer to proper monitor transfer state.
+
+### Fixed
+- Fix channel stepper view.
+- Fix address input error message cutoff and alignment.
+- Fix deposit modal (on transfer screen) closing after a successful deposit.
+- Fix transfer/deposit erroneously allowing the user to deposit/transfer when no open channel exists.
+
+## [0.1] - 2019-08-21
+
+### Added
+- Add a basic dApp layout.
+- Add an error screen when no provider is detected.
+- Add integration with the channel lifecycle (open/close/settle).
+- Add channel deposit screen. 
+- Add channel monitoring.
+- Add checksum address validation to address input.
+- Add basic loading screen.
+- Add token list screen.
+- Add channel list screen.
+- Add noscript error message.
+- Add network information on the header.
+- Add disclaimer to the footer of the dApp.
+- Add link to privacy policy.
+- Add basic transfer screen.
+
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v0.2...HEAD
+[0.2]: https://github.com/raiden-network/light-client/compare/v0.1.1...v0.2
+[0.1.1]: https://github.com/raiden-network/light-client/compare/v0.1...v0.1.1
+[0.1]: https://github.com/raiden-network/light-client/releases/tag/v0.1

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+## [Unreleased]
+### Changed
+- Improve PFS url matching.
+
+## [0.2] - 2019-11-29
+### Added
+- Add withdraw request support.
+- Add chainId and registry address to the state.
+- Add SDK configuration.
+- Add PFS find routes functionality.
+- Add PFS Capacity Update.
+- Add configuration for global rooms & PFS rooms.
+- Add PFS safety margin.
+- Add ServiceRegistry monitoring.
+- Add find PFS functionality.
+- Add token minting for testnets
+- Add IOU fetching and signing.
+- Add UserDeposit capacity retrieving function to the public API.
+- Add UserDeposit token address to the public API.
+- Add UserDeposit deposit function to the public API.
+- Add direct route checking function to the public API.
+
+### Changed
+- Update raiden contracts to support Alderaan.
+- Update message packing and signature to confront with Alderaan format.
+- Optimize past event scanning.
+- Make transfer parameters consistent with openChannel.
+- Update previous transfer initialization to monitor pending transfers. 
+- Update the transfer mechanism to accept transfers that are reduced up to 10% due to fees. 
+- Increase time before leaving unknown rooms.
+- Reduce the minimum settle timeout to 20.
+- Remove fee field from LockedTransfer to comply with raiden-py.
+- Improve matrix transport invite, join algorithm.
+- BigNumbers are decoded/encoded as string.
+
+### Fixed
+- Fix matrix error handling on user presence.
+- Fix matrix re-authentication on config change.
+- Fix WithdrawExpired to comply with raiden-py.
+- Fix lossless state loading.
+- Fix scheduling issues with matrix epics.
+- Fix lossless parsing of PFS information.
+- Fix past log ordering.
+- Fix logging disable not working properly.
+
+### Removed
+- Remove Kovan network support.
+- Remove requirement for monitored token when calling getTokenInfo|getTokenBalance.
+
+## [0.1.1] - 2019-10-07
+### Added
+- Add RaidenChannels alias.
+- Add monitoring for transfers based on secret hash.
+
+### Changed
+- Change transfer api return secret hash. 
+
+## [0.1] - 2019-08-21
+### Added
+- Add token monitoring.
+- Add channel lifecycle integration (open/close/settle) with contracts.
+- Add channel deposit functionality.
+- Add channels$ to the public API.
+- Add getTokenBalance and getTokenInfo to public API.
+- Add network and events$ to the public API.
+- Add account change and network change monitoring.
+- Add matrix sdk/transport integration.
+- Add protocol message implementation.
+
+
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v0.2...HEAD
+[0.2]: https://github.com/raiden-network/light-client/compare/v0.1.1...v0.2
+[0.1.1]: https://github.com/raiden-network/light-client/compare/v0.1...v0.1.1
+[0.1]: https://github.com/raiden-network/light-client/releases/tag/v0.1


### PR DESCRIPTION
Closes #643 

Follows the https://keepachangelog.com/en/1.0.0/ format.
Old entries might not be 100% accurate. 

If you have any improvement suggestions please let me know.