### PR TITLE
Fixes AddressInput.vue validity not updating on presence changes

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,15 +2,21 @@
 
 ## [Unreleased]
 ### Added
-- [#218] Matrix availability check to address inputs
+- [#218] Matrix availability check to address inputs.
 
 ### Changed
 - User can now dismiss/hide the transfer progress dialog.
 - Fix utility token display on PFS route selection.
 
 ### Fixed
-- [#704] Amount and address input styles
-- [#740] Fixed empty start screen on first time connect
+- [#712] Fix AddressInput.vue validity not updating on presence changes.
+- [#704] Amount and address input styles.
+- [#740] Fix empty start screen on first time connect.
+
+[#740]: https://github.com/raiden-network/light-client/issues/740
+[#712]: https://github.com/raiden-network/light-client/issues/712
+[#704]: https://github.com/raiden-network/light-client/issues/704
+[#218]: https://github.com/raiden-network/light-client/issues/218
 
 ## [0.2] - 2019-11-29
 ### Added

--- a/raiden-dapp/src/components/AddressInput.vue
+++ b/raiden-dapp/src/components/AddressInput.vue
@@ -67,8 +67,6 @@ import BlockieMixin from '@/mixins/blockie-mixin';
 
 @Component({ computed: { ...mapState(['presences']) } })
 export default class AddressInput extends Mixins(BlockieMixin) {
-  private timeout: number = 0;
-
   @Prop({})
   disabled!: boolean;
   @Prop({ required: true })
@@ -115,6 +113,15 @@ export default class AddressInput extends Mixins(BlockieMixin) {
       this.address = this.value;
       this.updateValue(this.value);
     }
+  }
+
+  @Watch('presences')
+  onPresenceUpdate() {
+    if (!this.address) {
+      return;
+    }
+
+    this.updateValue(this.address);
   }
 
   @Watch('value')


### PR DESCRIPTION
- I also removed a function that seemed to be unused.
- I tested by hand, by restarting the Raiden node and the input/button would properly react to the state updates.

Closes #712 