### PR TITLE
Providing link to the getting started guide

### DIFF
--- a/raiden-dapp/src/components/SplashScreen.vue
+++ b/raiden-dapp/src/components/SplashScreen.vue
@@ -21,15 +21,18 @@
         <div class="splash-screen__disclaimer font-weight-light text-center">
           {{ $t('splash-screen.disclaimer') }}
         </div>
-        <div
+        <i18n
+          path="splash-screen.getting-started.description"
+          tag="div"
           class="splash-screen__getting-started font-weight-light text-center"
-          v-html="
-            $t('splash-screen.getting-started', {
-              url:
-                'https://github.com/raiden-network/light-client#getting-started'
-            })
-          "
-        ></div>
+        >
+          <a
+            href="https://github.com/raiden-network/light-client#getting-started"
+            target="_blank"
+          >
+            {{ $t('splash-screen.getting-started.link-name') }}
+          </a>
+        </i18n>
         <div class="splash-screen__matrix-sign font-weight-light text-center">
           {{ $t('splash-screen.matrix-sign') }}
         </div>

--- a/raiden-dapp/src/components/SplashScreen.vue
+++ b/raiden-dapp/src/components/SplashScreen.vue
@@ -21,6 +21,15 @@
         <div class="splash-screen__disclaimer font-weight-light text-center">
           {{ $t('splash-screen.disclaimer') }}
         </div>
+        <div
+          class="splash-screen__getting-started font-weight-light text-center"
+          v-html="
+            $t('splash-screen.getting-started', {
+              url:
+                'https://github.com/raiden-network/light-client#getting-started'
+            })
+          "
+        ></div>
         <div class="splash-screen__matrix-sign font-weight-light text-center">
           {{ $t('splash-screen.matrix-sign') }}
         </div>
@@ -85,6 +94,12 @@ export default class Loading extends Vue {
 
 <style lang="scss" scoped>
 .splash-screen {
+  ::v-deep {
+    a {
+      text-decoration: none;
+    }
+  }
+
   &__logo-container {
     display: flex;
     justify-content: flex-end;
@@ -117,6 +132,7 @@ export default class Loading extends Vue {
     margin-top: 60px;
   }
 
+  &__getting-started,
   &__matrix-sign {
     margin-top: 30px;
   }

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -144,7 +144,10 @@
   "splash-screen": {
     "disclaimer": "The Raiden dApp is a reference implementation of the Raiden Light Client SDK. It is work in progress and can just be used on the Ethereum Testnets.",
     "matrix-sign": "On the first launch you get asked to sign two messages to connect to the Raiden transport layer. You sign the matrix server name and the public user name.",
-    "getting-started": "Read the <a href='{url}' target='_blank'>getting started guide</a> for detailed information on how to use the Raiden dApp.",
+    "getting-started": {
+      "description": "Read the {0} for detailed information on how to use the Raiden dApp.",
+      "link-name": "getting started guide"
+    },
     "connect-button": "Connect",
     "no-provider": "No web3 provider was detected. Please install e.g. MetaMask"
   },

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -144,6 +144,7 @@
   "splash-screen": {
     "disclaimer": "The Raiden dApp is a reference implementation of the Raiden Light Client SDK. It is work in progress and can just be used on the Ethereum Testnets.",
     "matrix-sign": "On the first launch you get asked to sign two messages to connect to the Raiden transport layer. You sign the matrix server name and the public user name.",
+    "getting-started": "Read the <a href='{url}' target='_blank'>getting started guide</a> for detailed information on how to use the Raiden dApp.",
     "connect-button": "Connect",
     "no-provider": "No web3 provider was detected. Please install e.g. MetaMask"
   },


### PR DESCRIPTION
The start screen now has a link to the getting started guide in our README so that any user who wants that information easily can access it when starting the dApp.