### PR TITLE
Serializable actions

### DIFF
--- a/raiden-ts/package-lock.json
+++ b/raiden-ts/package-lock.json
@@ -12948,11 +12948,6 @@
         }
       }
     },
-    "typesafe-actions": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/typesafe-actions/-/typesafe-actions-4.4.2.tgz",
-      "integrity": "sha512-QW61P4cOX8dCNmrfpcUMjvU/MF/sFTC8/PlG9215W1gKDzZUBjRGdyYSO6ZcEUNsn491S2VpryJOHSIVSDqJrg=="
-    },
     "typescript": {
       "version": "3.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -74,20 +74,19 @@
     "vuepress": "^1.2.0"
   },
   "dependencies": {
+    "@types/lodash": "^4.14.149",
     "abort-controller": "^3.0.0",
     "ethers": "^4.0.41",
     "fp-ts": "^2.3.1",
     "io-ts": "^2.0.2",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.15",
-    "@types/lodash": "^4.14.149",
     "lossless-json": "^1.0.3",
     "matrix-js-sdk": "^2.4.6",
     "redux": "^4.0.5",
     "redux-logger": "^3.0.6",
     "redux-observable": "^1.2.0",
-    "rxjs": "^6.5.3",
-    "typesafe-actions": "^4.4.2"
+    "rxjs": "^6.5.3"
   },
   "peerDependencies": {
     "ethers": "^4.0.41"

--- a/raiden-ts/src/actions.ts
+++ b/raiden-ts/src/actions.ts
@@ -1,26 +1,45 @@
+/* eslint-disable @typescript-eslint/class-name-casing */
 /**
  * Aggregate types and exported properties from actions from all modules
  */
-import { pick } from 'lodash';
-import { ActionType, createStandardAction, getType, Action } from 'typesafe-actions';
-import { ShutdownReason } from './constants';
+import * as t from 'io-ts';
 
+import { ShutdownReason } from './constants';
 import { RaidenConfig } from './config';
+import { ActionType, createAction, Action } from './utils/actions';
+import { ErrorCodec } from './utils/types';
+
 import * as ChannelsActions from './channels/actions';
 import * as TransportActions from './transport/actions';
 import * as MessagesActions from './messages/actions';
 import * as TransfersActions from './transfers/actions';
 import * as PathFindActions from './path/actions';
 
-export const raidenShutdown = createStandardAction('raidenShutdown')<{
-  reason: ShutdownReason | Error;
-}>();
+export const raidenShutdown = createAction(
+  'raidenShutdown',
+  t.type({
+    reason: t.union([
+      t.literal(ShutdownReason.STOP),
+      t.literal(ShutdownReason.ACCOUNT_CHANGED),
+      t.literal(ShutdownReason.NETWORK_CHANGED),
+      ErrorCodec,
+    ]),
+  }),
+);
+export interface raidenShutdown extends ActionType<typeof raidenShutdown> {}
 
-export const raidenConfigUpdate = createStandardAction('raidenConfigUpdate')<{
-  config: Partial<RaidenConfig>;
-}>();
+export const raidenConfigUpdate = createAction(
+  'raidenConfigUpdate',
+  t.type({
+    config: t.intersection([
+      t.partial(RaidenConfig.type.types['0'].props),
+      RaidenConfig.type.types['1'],
+    ]),
+  }),
+);
+export interface raidenConfigUpdate extends ActionType<typeof raidenConfigUpdate> {}
 
-export const RaidenActions = {
+const RaidenActions = {
   raidenShutdown,
   raidenConfigUpdate,
   ...ChannelsActions,
@@ -35,14 +54,11 @@ export const RaidenActions = {
 export type RaidenAction = Action;
 
 /* Mapping { [type: string]: Action } of a subset of RaidenActions exposed as events */
-export const RaidenEvents = pick(
-  RaidenActions,
-  [
-    RaidenActions.raidenShutdown,
-    RaidenActions.newBlock,
-    RaidenActions.matrixPresenceUpdate,
-    RaidenActions.tokenMonitored,
-  ].map(getType),
-);
+export const RaidenEvents = [
+  RaidenActions.raidenShutdown,
+  RaidenActions.newBlock,
+  RaidenActions.matrixPresenceUpdate,
+  RaidenActions.tokenMonitored,
+];
 /* Tagged union of RaidenEvents actions */
 export type RaidenEvent = ActionType<typeof RaidenEvents>;

--- a/raiden-ts/src/channels/actions.ts
+++ b/raiden-ts/src/channels/actions.ts
@@ -1,25 +1,36 @@
-import { createStandardAction } from 'typesafe-actions';
+/* eslint-disable @typescript-eslint/class-name-casing */
+import * as t from 'io-ts';
 
-import { Address, Hash, UInt } from '../utils/types';
+import { createAction, ActionType } from '../utils/actions';
+import { Address, Hash, UInt, ErrorCodec } from '../utils/types';
 
 // interfaces need to be exported, and we need/want to support `import * as RaidenActions`
-type ChannelId = {
-  tokenNetwork: Address;
-  partner: Address;
-};
+const ChannelId = t.type({
+  tokenNetwork: Address,
+  partner: Address,
+});
 
 /* A new head in the blockchain is detected by provider */
-export const newBlock = createStandardAction('newBlock')<{ blockNumber: number }>();
+export const newBlock = createAction('newBlock', t.type({ blockNumber: t.number }));
+export interface newBlock extends ActionType<typeof newBlock> {}
 
 /**
  * A new token network is detected in the TokenNetworkRegistry instance
  * fromBlock is only set on the first time, to fetch and handle past events
  */
-export const tokenMonitored = createStandardAction('tokenMonitored')<{
-  token: Address;
-  tokenNetwork: Address;
-  fromBlock?: number;
-}>();
+export const tokenMonitored = createAction(
+  'tokenMonitored',
+  t.intersection([
+    t.type({
+      token: Address,
+      tokenNetwork: Address,
+    }),
+    t.partial({
+      fromBlock: t.number,
+    }),
+  ]),
+);
+export interface tokenMonitored extends ActionType<typeof tokenMonitored> {}
 
 /**
  * Channel actions receive ChannelId as 'meta' action property
@@ -27,93 +38,121 @@ export const tokenMonitored = createStandardAction('tokenMonitored')<{
  */
 
 /* Request a channel to be opened with meta={ tokenNetwork, partner } and payload.settleTimeout */
-export const channelOpen = createStandardAction('channelOpen')<
-  { settleTimeout?: number; subkey?: boolean },
-  ChannelId
->();
+export const channelOpen = createAction(
+  'channelOpen',
+  t.partial({ settleTimeout: t.number, subkey: t.boolean }),
+  ChannelId,
+);
+export interface channelOpen extends ActionType<typeof channelOpen> {}
 
 /* A channel is detected on-chain. Also works as 'success' for channelOpen action */
-export const channelOpened = createStandardAction('channelOpened')<
-  {
-    id: number;
-    settleTimeout: number;
-    openBlock: number;
-    isFirstParticipant: boolean;
-    txHash: Hash;
-  },
-  ChannelId
->();
+export const channelOpened = createAction(
+  'channelOpened',
+  t.type({
+    id: t.number,
+    settleTimeout: t.number,
+    openBlock: t.number,
+    isFirstParticipant: t.boolean,
+    txHash: Hash,
+  }),
+  ChannelId,
+);
+export interface channelOpened extends ActionType<typeof channelOpened> {}
 
 /* A channelOpen request action (with meta: ChannelId) failed with payload=Error */
-export const channelOpenFailed = createStandardAction(
-  'channelOpenFailed',
-).map((payload: Error, meta: ChannelId) => ({ payload, error: true, meta }));
+export const channelOpenFailed = createAction('channelOpenFailed', ErrorCodec, ChannelId, true);
+export interface channelOpenFailed extends ActionType<typeof channelOpenFailed> {}
 
 /* Channel with meta:ChannelId + payload.id should be monitored */
-export const channelMonitored = createStandardAction('channelMonitored')<
-  { id: number; fromBlock?: number },
-  ChannelId
->();
+export const channelMonitored = createAction(
+  'channelMonitored',
+  t.intersection([t.type({ id: t.number }), t.partial({ fromBlock: t.number })]),
+  ChannelId,
+);
+export interface channelMonitored extends ActionType<typeof channelMonitored> {}
 
 /* Request a payload.deposit to be made to channel meta:ChannelId */
-export const channelDeposit = createStandardAction('channelDeposit')<
-  { deposit: UInt<32>; subkey?: boolean },
-  ChannelId
->();
+export const channelDeposit = createAction(
+  'channelDeposit',
+  t.intersection([t.type({ deposit: UInt(32) }), t.partial({ subkey: t.boolean })]),
+  ChannelId,
+);
+export interface channelDeposit extends ActionType<typeof channelDeposit> {}
 
 /* A deposit is detected on-chain. Also works as 'success' for channelDeposit action */
-export const channelDeposited = createStandardAction('channelDeposited')<
-  { id: number; participant: Address; totalDeposit: UInt<32>; txHash: Hash },
-  ChannelId
->();
+export const channelDeposited = createAction(
+  'channelDeposited',
+  t.type({ id: t.number, participant: Address, totalDeposit: UInt(32), txHash: Hash }),
+  ChannelId,
+);
+export interface channelDeposited extends ActionType<typeof channelDeposited> {}
 
 /* A channelDeposit request action (with meta: ChannelId) failed with payload=Error */
-export const channelDepositFailed = createStandardAction(
+export const channelDepositFailed = createAction(
   'channelDepositFailed',
-).map((payload: Error, meta: ChannelId) => ({ payload, error: true, meta }));
+  ErrorCodec,
+  ChannelId,
+  true,
+);
+export interface channelDepositFailed extends ActionType<typeof channelDepositFailed> {}
 
 /* A withdraw is detected on-chain */
-export const channelWithdrawn = createStandardAction('channelWithdrawn')<
-  { id: number; participant: Address; totalWithdraw: UInt<32>; txHash: Hash },
-  ChannelId
->();
+export const channelWithdrawn = createAction(
+  'channelWithdrawn',
+  t.type({ id: t.number, participant: Address, totalWithdraw: UInt(32), txHash: Hash }),
+  ChannelId,
+);
+export interface channelWithdrawn extends ActionType<typeof channelWithdrawn> {}
 
 /* Request channel meta:ChannelId to be closed */
-export const channelClose = createStandardAction('channelClose')<
-  { subkey?: boolean } | undefined,
-  ChannelId
->();
+export const channelClose = createAction(
+  'channelClose',
+  t.union([t.partial({ subkey: t.boolean }), t.undefined]),
+  ChannelId,
+);
+export interface channelClose extends ActionType<typeof channelClose> {}
 
 /* A close channel event is detected on-chain. Also works as 'success' for channelClose action */
-export const channelClosed = createStandardAction('channelClosed')<
-  { id: number; participant: Address; closeBlock: number; txHash: Hash },
-  ChannelId
->();
+export const channelClosed = createAction(
+  'channelClosed',
+  t.type({ id: t.number, participant: Address, closeBlock: t.number, txHash: Hash }),
+  ChannelId,
+);
+export interface channelClosed extends ActionType<typeof channelClosed> {}
 
 /* A channelClose request action (with meta: ChannelId) failed with payload=Error */
-export const channelCloseFailed = createStandardAction(
-  'channelCloseFailed',
-).map((payload: Error, meta: ChannelId) => ({ payload, error: true, meta }));
+export const channelCloseFailed = createAction('channelCloseFailed', ErrorCodec, ChannelId, true);
+export interface channelCloseFailed extends ActionType<typeof channelCloseFailed> {}
 
 /* A channel meta:ChannelId becomes settleable, starting from payload.settleableBlock */
-export const channelSettleable = createStandardAction('channelSettleable')<
-  { settleableBlock: number },
-  ChannelId
->();
+export const channelSettleable = createAction(
+  'channelSettleable',
+  t.type({ settleableBlock: t.number }),
+  ChannelId,
+);
+export interface channelSettleable extends ActionType<typeof channelSettleable> {}
 
 /* Request channel meta:ChannelId to be settled */
-export const channelSettle = createStandardAction('channelSettle')<
-  { subkey?: boolean } | undefined,
-  ChannelId
->();
+export const channelSettle = createAction(
+  'channelSettle',
+  t.union([t.partial({ subkey: t.boolean }), t.undefined]),
+  ChannelId,
+);
+export interface channelSettle extends ActionType<typeof channelSettle> {}
 
 /* A settle channel event is detected on-chain. Also works as 'success' for channelSettle action */
-export const channelSettled = createStandardAction('channelSettled')<
-  { id: number; settleBlock: number; txHash: Hash },
-  ChannelId
->();
+export const channelSettled = createAction(
+  'channelSettled',
+  t.type({ id: t.number, settleBlock: t.number, txHash: Hash }),
+  ChannelId,
+);
+export interface channelSettled extends ActionType<typeof channelSettled> {}
 
 /* A channelSettle request action (with meta: ChannelId) failed with payload=Error */
-export const channelSettleFailed = createStandardAction(
+export const channelSettleFailed = createAction(
   'channelSettleFailed',
-).map((payload: Error, meta: ChannelId) => ({ payload, error: true, meta }));
+  ErrorCodec,
+  ChannelId,
+  true,
+);
+export interface channelSettleFailed extends ActionType<typeof channelSettleFailed> {}

--- a/raiden-ts/src/channels/reducer.ts
+++ b/raiden-ts/src/channels/reducer.ts
@@ -1,8 +1,8 @@
-import { isActionOf } from 'typesafe-actions';
 import { get, set, unset } from 'lodash/fp';
 import { Zero } from 'ethers/constants';
 
 import { UInt } from '../utils/types';
+import { isActionOf } from '../utils/actions';
 import { partialCombineReducers } from '../utils/redux';
 import { RaidenState, initialState } from '../state';
 import { RaidenAction } from '../actions';

--- a/raiden-ts/src/epics.ts
+++ b/raiden-ts/src/epics.ts
@@ -9,7 +9,6 @@ import {
   startWith,
   map,
 } from 'rxjs/operators';
-import { isActionOf } from 'typesafe-actions';
 import { negate } from 'lodash';
 
 import { RaidenState } from './state';
@@ -18,6 +17,7 @@ import { RaidenAction, raidenShutdown } from './actions';
 import { getPresences$ } from './transport/utils';
 import { pfsListUpdated } from './path/actions';
 import { Address } from './utils/types';
+import { isActionOf } from './utils/actions';
 
 import * as ChannelsEpics from './channels/epics';
 import * as TransportEpics from './transport/epics';
@@ -51,7 +51,7 @@ export const getLatest$ = (action$: Observable<RaidenAction>, state$: Observable
     })),
   );
 
-export const RaidenEpics = {
+const RaidenEpics = {
   ...ChannelsEpics,
   ...TransportEpics,
   ...TransfersEpics,

--- a/raiden-ts/src/messages/actions.ts
+++ b/raiden-ts/src/messages/actions.ts
@@ -1,13 +1,17 @@
-import { createStandardAction } from 'typesafe-actions';
+/* eslint-disable @typescript-eslint/class-name-casing */
+import * as t from 'io-ts';
 
 import { Message } from './types';
+import { createAction, ActionType } from '../utils/actions';
 import { Address, Signed } from '../utils/types';
 
 /** One-shot send payload.message to meta.address user in transport */
-export const messageSend = createStandardAction('messageSend')<
-  { message: string | Signed<Message> },
-  { address: Address }
->();
+export const messageSend = createAction(
+  'messageSend',
+  t.type({ message: t.union([t.string, Signed(Message)]) }),
+  t.type({ address: Address }),
+);
+export interface messageSend extends ActionType<typeof messageSend> {}
 
 /**
  * Success action when message is actually sent
@@ -19,36 +23,39 @@ export const messageSend = createStandardAction('messageSend')<
  * Useful to control retry without queueing multiple identical messages while the first is still
  * pending
  */
-export const messageSent = createStandardAction('messageSent')<
-  { message: string | Signed<Message> },
-  { address: Address }
->();
+export const messageSent = createAction(
+  'messageSent',
+  t.type({ message: t.union([t.string, Signed(Message)]) }),
+  t.type({ address: Address }),
+);
+export interface messageSent extends ActionType<typeof messageSent> {}
 
 /** One-shot send payload.message to a global room in transport */
-export const messageGlobalSend = createStandardAction('messageGlobalSend')<
-  { message: string | Signed<Message> },
-  { roomName: string }
->();
+export const messageGlobalSend = createAction(
+  'messageGlobalSend',
+  t.type({ message: t.union([t.string, Signed(Message)]) }),
+  t.type({ roomName: t.string }),
+);
+export interface messageGlobalSend extends ActionType<typeof messageGlobalSend> {}
 
 /**
  * payload.message was received on payload.ts (timestamp) from meta.address
  * payload.userId and payload.roomId are optional and specific to matrix transport, as sender info
  */
-export const messageReceived = createStandardAction('messageReceived').map(
-  (
-    {
-      text,
-      message,
-      ts,
-      userId,
-      roomId,
-    }: {
-      text: string;
-      message?: Signed<Message>;
-      ts?: number;
-      userId?: string;
-      roomId?: string;
-    },
-    meta: { address: Address },
-  ) => ({ payload: { text, message, ts: ts || Date.now(), userId, roomId }, meta }),
+export const messageReceived = createAction(
+  'messageReceived',
+  t.intersection([
+    t.type({
+      text: t.string,
+      ts: t.number,
+    }),
+    t.partial({
+      message: Signed(Message),
+      userId: t.string,
+      roomId: t.string,
+    }),
+  ]),
+
+  t.type({ address: Address }),
 );
+export interface messageReceived extends ActionType<typeof messageReceived> {}

--- a/raiden-ts/src/path/actions.ts
+++ b/raiden-ts/src/path/actions.ts
@@ -1,39 +1,42 @@
-import { createStandardAction } from 'typesafe-actions';
+/* eslint-disable @typescript-eslint/class-name-casing */
+import * as t from 'io-ts';
 
-import { Address, UInt, Signed } from '../utils/types';
+import { createAction, ActionType } from '../utils/actions';
+import { Address, UInt, Signed, ErrorCodec } from '../utils/types';
 import { Paths, PFS, IOU } from './types';
 
-type PathId = {
-  tokenNetwork: Address;
-  target: Address;
-  value: UInt<32>;
-};
+const PathId = t.type({
+  tokenNetwork: Address,
+  target: Address,
+  value: UInt(32),
+});
 
-type ServiceId = {
-  tokenNetwork: Address;
-  serviceAddress: Address;
-};
+const ServiceId = t.type({
+  tokenNetwork: Address,
+  serviceAddress: Address,
+});
 
-export const pathFind = createStandardAction('pathFind')<
-  { paths?: Paths; pfs?: PFS | null },
-  PathId
->();
+export const pathFind = createAction(
+  'pathFind',
+  t.partial({ paths: Paths, pfs: t.union([PFS, t.null]) }),
+  PathId,
+);
+export interface pathFind extends ActionType<typeof pathFind> {}
 
-export const pathFound = createStandardAction('pathFound')<{ paths: Paths }, PathId>();
+export const pathFound = createAction('pathFound', t.type({ paths: Paths }), PathId);
+export interface pathFound extends ActionType<typeof pathFound> {}
 
-export const pathFindFailed = createStandardAction(
-  'pathFindFailed',
-).map((payload: Error, meta: PathId) => ({ payload, error: true, meta }));
+export const pathFindFailed = createAction('pathFindFailed', ErrorCodec, PathId, true);
+export interface pathFindFailed extends ActionType<typeof pathFindFailed> {}
 
-export const pfsListUpdated = createStandardAction('pfsListUpdated')<{
-  pfsList: readonly Address[];
-}>();
+export const pfsListUpdated = createAction(
+  'pfsListUpdated',
+  t.type({ pfsList: t.readonlyArray(Address) }),
+);
+export interface pfsListUpdated extends ActionType<typeof pfsListUpdated> {}
 
-export const iouPersist = createStandardAction('iouPersist')<
-  {
-    iou: Signed<IOU>;
-  },
-  ServiceId
->();
+export const iouPersist = createAction('iouPersist', t.type({ iou: Signed(IOU) }), ServiceId);
+export interface iouPersist extends ActionType<typeof iouPersist> {}
 
-export const iouClear = createStandardAction('iouClear')<undefined, ServiceId>();
+export const iouClear = createAction('iouClear', undefined, ServiceId);
+export interface iouClear extends ActionType<typeof iouClear> {}

--- a/raiden-ts/src/path/epics.ts
+++ b/raiden-ts/src/path/epics.ts
@@ -22,7 +22,6 @@ import {
   withLatestFrom,
 } from 'rxjs/operators';
 import { fromFetch } from 'rxjs/fetch';
-import { ActionType, isActionOf } from 'typesafe-actions';
 import { Signer } from 'ethers';
 import { Event } from 'ethers/contract';
 import { BigNumber, bigNumberify, toUtf8Bytes, verifyMessage, concat } from 'ethers/utils';
@@ -41,6 +40,7 @@ import { channelDeposited } from '../channels/actions';
 import { ChannelState } from '../channels/state';
 import { channelAmounts } from '../channels/utils';
 import { Address, decode, Int, Signature, Signed, UInt } from '../utils/types';
+import { isActionOf } from '../utils/actions';
 import { encode, losslessParse, losslessStringify } from '../utils/data';
 import { getEventsStream } from '../utils/ethers';
 import {
@@ -188,9 +188,7 @@ export const pathFindServiceEpic = (
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
   deps: RaidenEpicDeps,
-): Observable<ActionType<
-  typeof pathFound | typeof pathFindFailed | typeof iouPersist | typeof iouClear
->> =>
+): Observable<pathFound | pathFindFailed | iouPersist | iouClear> =>
   combineLatest(
     state$,
     getPresences$(action$),
@@ -399,7 +397,7 @@ export const pfsCapacityUpdateEpic = (
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
   { address, network, signer, config$ }: RaidenEpicDeps,
-): Observable<ActionType<typeof messageGlobalSend>> =>
+): Observable<messageGlobalSend> =>
   action$.pipe(
     filter(isActionOf(channelDeposited)),
     filter(action => action.payload.participant === address),
@@ -458,7 +456,7 @@ export const pfsServiceRegistryMonitorEpic = (
   {}: Observable<RaidenAction>,
   {}: Observable<RaidenState>,
   { serviceRegistryContract, contractsInfo, config$ }: RaidenEpicDeps,
-): Observable<ActionType<typeof pfsListUpdated>> =>
+): Observable<pfsListUpdated> =>
   config$.pipe(
     // monitors config.pfs, and only monitors contract if it's undefined
     pluck('pfs'),

--- a/raiden-ts/src/path/reducer.ts
+++ b/raiden-ts/src/path/reducer.ts
@@ -6,12 +6,13 @@
  * @param action - RaidenAction to handle
  * @returns New RaidenState['path'] slice
  */
+import { set, unset } from 'lodash/fp';
+
 import { RaidenAction } from '../actions';
 import { initialState, RaidenState } from '../state';
 import { partialCombineReducers } from '../utils/redux';
-import { isActionOf } from 'typesafe-actions';
-import { iouClear, iouPersist } from '../path/actions';
-import { set, unset } from 'lodash/fp';
+import { isActionOf } from '../utils/actions';
+import { iouClear, iouPersist } from './actions';
 
 function path(state: RaidenState['path'] = initialState.path, action: RaidenAction) {
   if (isActionOf(iouPersist, action)) {

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -7,7 +7,6 @@ import { Zero } from 'ethers/constants';
 import { MatrixClient } from 'matrix-js-sdk';
 import { applyMiddleware, createStore, Store } from 'redux';
 import { createEpicMiddleware, EpicMiddleware } from 'redux-observable';
-import { isActionOf } from 'typesafe-actions';
 import { createLogger } from 'redux-logger';
 
 import { constant, memoize, isEmpty } from 'lodash';
@@ -61,6 +60,7 @@ import { pathFind, pathFound, pathFindFailed } from './path/actions';
 import { Paths, RaidenPaths, PFS, RaidenPFS, IOU } from './path/types';
 import { pfsListInfo } from './path/utils';
 import { Address, Secret, Storage, Hash, UInt, decode, assert } from './utils/types';
+import { isActionOf } from './utils/actions';
 import { patchSignSend } from './utils/ethers';
 import { pluckDistinct } from './utils/rx';
 import {
@@ -164,7 +164,7 @@ export class Raiden {
     this.action$ = latest$.pipe(pluckDistinct('action'), skip(1));
     this.channels$ = this.state$.pipe(map(state => mapTokenToPartner(state)));
     this.transfers$ = initTransfers$(this.state$);
-    this.events$ = this.action$.pipe(filter(isActionOf(Object.values(RaidenEvents))));
+    this.events$ = this.action$.pipe(filter(isActionOf(RaidenEvents)));
 
     this.getTokenInfo = memoize(async function(this: Raiden, token: string) {
       assert(Address.is(token), 'Invalid address');

--- a/raiden-ts/src/reducer.ts
+++ b/raiden-ts/src/reducer.ts
@@ -1,6 +1,6 @@
-import { isActionOf } from 'typesafe-actions';
 import { isEmpty } from 'lodash/fp';
 
+import { isActionOf } from './utils/actions';
 import { channelsReducer } from './channels/reducer';
 import { pathReducer } from './path/reducer';
 import { transportReducer } from './transport/reducer';

--- a/raiden-ts/src/transfers/actions.ts
+++ b/raiden-ts/src/transfers/actions.ts
@@ -1,6 +1,8 @@
-import { createStandardAction } from 'typesafe-actions';
+/* eslint-disable @typescript-eslint/class-name-casing */
+import * as t from 'io-ts';
 
-import { Address, UInt, Int, Secret, Hash, Signed } from '../utils/types';
+import { Address, UInt, Int, Secret, Hash, Signed, ErrorCodec } from '../utils/types';
+import { createAction, ActionType } from '../utils/actions';
 import { SignedBalanceProof } from '../channels/types';
 import {
   LockedTransfer,
@@ -15,95 +17,127 @@ import {
 } from '../messages/types';
 import { Paths } from '../path/types';
 
-type TransferId = { secrethash: Hash };
+const TransferId = t.type({ secrethash: Hash });
 
 /** A request to initiate a transfer */
-export const transfer = createStandardAction('transfer')<
-  {
-    tokenNetwork: Address;
-    target: Address;
-    value: UInt<32>;
-    paths: Paths;
-    paymentId: UInt<8>;
-    secret?: Secret;
-  },
-  TransferId
->();
+export const transfer = createAction(
+  'transfer',
+  t.intersection([
+    t.type({
+      tokenNetwork: Address,
+      target: Address,
+      value: UInt(32),
+      paths: Paths,
+      paymentId: UInt(8),
+    }),
+    t.partial({
+      secret: Secret,
+    }),
+  ]),
+  TransferId,
+);
+export interface transfer extends ActionType<typeof transfer> {}
 
 /** A LockedTransfer was signed and should be sent to partner */
-export const transferSigned = createStandardAction('transferSigned')<
-  { message: Signed<LockedTransfer>; fee: Int<32> },
-  TransferId
->();
+export const transferSigned = createAction(
+  'transferSigned',
+  t.type({ message: Signed(LockedTransfer), fee: Int(32) }),
+  TransferId,
+);
+export interface transferSigned extends ActionType<typeof transferSigned> {}
 
 /** Partner acknowledge they received and processed our LockedTransfer */
-export const transferProcessed = createStandardAction('transferProcessed')<
-  { message: Signed<Processed> },
-  TransferId
->();
+export const transferProcessed = createAction(
+  'transferProcessed',
+  t.type({ message: Signed(Processed) }),
+  TransferId,
+);
+export interface transferProcessed extends ActionType<typeof transferProcessed> {}
 
 /** Register a secret */
-export const transferSecret = createStandardAction('transferSecret')<
-  { secret: Secret; registerBlock?: number },
-  TransferId
->();
+export const transferSecret = createAction(
+  'transferSecret',
+  t.intersection([t.type({ secret: Secret }), t.partial({ registerBlock: t.number })]),
+  TransferId,
+);
+export interface transferSecret extends ActionType<typeof transferSecret> {}
 
 /** A valid SecretRequest received from target */
-export const transferSecretRequest = createStandardAction('transferSecretRequest')<
-  { message: Signed<SecretRequest> },
-  TransferId
->();
+export const transferSecretRequest = createAction(
+  'transferSecretRequest',
+  t.type({ message: Signed(SecretRequest) }),
+  TransferId,
+);
+export interface transferSecretRequest extends ActionType<typeof transferSecretRequest> {}
 
 /** A SecretReveal sent to target */
-export const transferSecretReveal = createStandardAction('transferSecretReveal')<
-  { message: Signed<SecretReveal> },
-  TransferId
->();
+export const transferSecretReveal = createAction(
+  'transferSecretReveal',
+  t.type({ message: Signed(SecretReveal) }),
+  TransferId,
+);
+export interface transferSecretReveal extends ActionType<typeof transferSecretReveal> {}
 
 /** Unlock request after partner also revealed they know the secret */
-export const transferUnlock = createStandardAction('transferUnlock')<undefined, TransferId>();
+export const transferUnlock = createAction('transferUnlock', undefined, TransferId);
+export interface transferUnlock extends ActionType<typeof transferUnlock> {}
 
 /** Signed Unlock to be sent to partner */
-export const transferUnlocked = createStandardAction('transferUnlocked')<
-  { message: Signed<Unlock> },
-  TransferId
->();
+export const transferUnlocked = createAction(
+  'transferUnlocked',
+  t.type({ message: Signed(Unlock) }),
+  TransferId,
+);
+export interface transferUnlocked extends ActionType<typeof transferUnlocked> {}
 
 /** Partner acknowledge they received and processed our Unlock */
-export const transferUnlockProcessed = createStandardAction('transferUnlockProcessed')<
-  { message: Signed<Processed> },
-  TransferId
->();
+export const transferUnlockProcessed = createAction(
+  'transferUnlockProcessed',
+  t.type({ message: Signed(Processed) }),
+  TransferId,
+);
+export interface transferUnlockProcessed extends ActionType<typeof transferUnlockProcessed> {}
 
 /** A request to expire a given transfer */
-export const transferExpire = createStandardAction('transferExpire')<undefined, TransferId>();
+export const transferExpire = createAction('transferExpire', undefined, TransferId);
+export interface transferExpire extends ActionType<typeof transferExpire> {}
 
 /** A transfer LockExpired message/BalanceProof successfuly generated */
-export const transferExpired = createStandardAction('transferExpired')<
-  { message: Signed<LockExpired> },
-  TransferId
->();
+export const transferExpired = createAction(
+  'transferExpired',
+  t.type({ message: Signed(LockExpired) }),
+  TransferId,
+);
+export interface transferExpired extends ActionType<typeof transferExpired> {}
 
 /**
  * A transfer expiration request failed for any reason
  * e.g. user rejected sign promopt. It should eventually get prompted again, on a future newBlock
  * action which sees this transfer should be expired but sent.lockExpired didn't get set yet.
  */
-export const transferExpireFailed = createStandardAction(
+export const transferExpireFailed = createAction(
   'transferExpireFailed',
-).map((payload: Error, meta: TransferId) => ({ payload, error: true, meta }));
+  ErrorCodec,
+  TransferId,
+  true,
+);
+export interface transferExpireFailed extends ActionType<typeof transferExpireFailed> {}
 
 /** Partner acknowledge they received and processed our LockExpired */
-export const transferExpireProcessed = createStandardAction('transferExpireProcessed')<
-  { message: Signed<Processed> },
-  TransferId
->();
+export const transferExpireProcessed = createAction(
+  'transferExpireProcessed',
+  t.type({ message: Signed(Processed) }),
+  TransferId,
+);
+export interface transferExpireProcessed extends ActionType<typeof transferExpireProcessed> {}
 
 /** A transfer was refunded */
-export const transferRefunded = createStandardAction('transferRefunded')<
-  { message: Signed<RefundTransfer> },
-  TransferId
->();
+export const transferRefunded = createAction(
+  'transferRefunded',
+  t.type({ message: Signed(RefundTransfer) }),
+  TransferId,
+);
+export interface transferRefunded extends ActionType<typeof transferRefunded> {}
 
 /**
  * A transfer completed successfuly
@@ -117,10 +151,12 @@ export const transferRefunded = createStandardAction('transferRefunded')<
  * (e.g.  channel closed), the secret was revealed (so target was paid) but for any reason the
  * unlock didn't happen yet.
  */
-export const transferred = createStandardAction('transferred')<
-  { balanceProof?: SignedBalanceProof },
-  TransferId
->();
+export const transferred = createAction(
+  'transferred',
+  t.partial({ balanceProof: SignedBalanceProof }),
+  TransferId,
+);
+export interface transferred extends ActionType<typeof transferred> {}
 
 /**
  * A transfer failed and can't succeed anymore
@@ -130,30 +166,34 @@ export const transferred = createStandardAction('transferred')<
  * Promises) that the transfer failed and won't be paid (eventually, locked amount will be
  * recovered by expiring the lock).
  */
-export const transferFailed = createStandardAction(
-  'transferFailed',
-).map((payload: Error, meta: TransferId) => ({ payload, error: true, meta }));
+export const transferFailed = createAction('transferFailed', ErrorCodec, TransferId, true);
+export interface transferFailed extends ActionType<typeof transferFailed> {}
 
 /** A pending transfer isn't needed anymore and should be cleared from state */
-export const transferClear = createStandardAction('transferClear')<undefined, TransferId>();
+export const transferClear = createAction('transferClear', undefined, TransferId);
+export interface transferClear extends ActionType<typeof transferClear> {}
 
 // Withdraw actions
 
-type WithdrawId = {
-  tokenNetwork: Address;
-  partner: Address;
-  totalWithdraw: UInt<32>;
-  expiration: number;
-};
+const WithdrawId = t.type({
+  tokenNetwork: Address,
+  partner: Address,
+  totalWithdraw: UInt(32),
+  expiration: t.number,
+});
 
 /** A WithdrawRequest was received from partner */
-export const withdrawReceiveRequest = createStandardAction('withdrawReceiveRequest')<
-  { message: Signed<WithdrawRequest> },
-  WithdrawId
->();
+export const withdrawReceiveRequest = createAction(
+  'withdrawReceiveRequest',
+  t.type({ message: Signed(WithdrawRequest) }),
+  WithdrawId,
+);
+export interface withdrawReceiveRequest extends ActionType<typeof withdrawReceiveRequest> {}
 
 /** A WithdrawConfirmation was signed and must be sent to partner */
-export const withdrawSendConfirmation = createStandardAction('withdrawSendConfirmation')<
-  { message: Signed<WithdrawConfirmation> },
-  WithdrawId
->();
+export const withdrawSendConfirmation = createAction(
+  'withdrawSendConfirmation',
+  t.type({ message: Signed(WithdrawConfirmation) }),
+  WithdrawId,
+);
+export interface withdrawSendConfirmation extends ActionType<typeof withdrawSendConfirmation> {}

--- a/raiden-ts/src/transfers/reducer.ts
+++ b/raiden-ts/src/transfers/reducer.ts
@@ -1,4 +1,3 @@
-import { isActionOf } from 'typesafe-actions';
 import { get, set, unset, mapValues } from 'lodash/fp';
 import { Zero, HashZero } from 'ethers/constants';
 import { hexlify } from 'ethers/utils';
@@ -11,6 +10,7 @@ import { channelClosed } from '../channels/actions';
 import { getLocksroot } from './utils';
 import { SignatureZero } from '../constants';
 import { timed, UInt, Signature, Hash } from '../utils/types';
+import { isActionOf } from '../utils/actions';
 import { getBalanceProofFromEnvelopeMessage } from '../messages/utils';
 import { SentTransfer } from './state';
 import {

--- a/raiden-ts/src/transport/actions.ts
+++ b/raiden-ts/src/transport/actions.ts
@@ -1,46 +1,60 @@
-import { createStandardAction } from 'typesafe-actions';
+/* eslint-disable @typescript-eslint/class-name-casing */
+import * as t from 'io-ts';
 
-import { Address } from '../utils/types';
+import { createAction, ActionType } from '../utils/actions';
+import { Address, ErrorCodec } from '../utils/types';
 import { RaidenMatrixSetup } from './state';
 
+const NodeId = t.type({ address: Address });
+
 /* MatrixClient instance is ready and logged in to payload.server with credentials payload.setup */
-export const matrixSetup = createStandardAction('matrixSetup')<{
-  server: string;
-  setup: RaidenMatrixSetup;
-}>();
+export const matrixSetup = createAction(
+  'matrixSetup',
+  t.type({
+    server: t.string,
+    setup: RaidenMatrixSetup,
+  }),
+);
+export interface matrixSetup extends ActionType<typeof matrixSetup> {}
 
 /* Request matrix to start monitoring presence updates for meta.address */
-export const matrixRequestMonitorPresence = createStandardAction('matrixRequestMonitorPresence')<
+export const matrixRequestMonitorPresence = createAction(
+  'matrixRequestMonitorPresence',
   undefined,
-  { address: Address }
->();
+  NodeId,
+);
+export interface matrixRequestMonitorPresence
+  extends ActionType<typeof matrixRequestMonitorPresence> {}
 
 /**
  * Monitored user meta.address presence updated.
  * First event for this address also works as 'success' for matrixRequestMonitorPresence
  */
-export const matrixPresenceUpdate = createStandardAction(
+export const matrixPresenceUpdate = createAction(
   'matrixPresenceUpdate',
-).map(
-  (
-    { userId, available, ts }: { userId: string; available: boolean; ts?: number },
-    meta: { address: Address },
-  ) => ({ payload: { userId, available, ts: ts || Date.now() }, meta }),
+  t.type({ userId: t.string, available: t.boolean, ts: t.number }),
+  NodeId,
 );
+export interface matrixPresenceUpdate extends ActionType<typeof matrixPresenceUpdate> {}
 
 /* A matrixRequestMonitorPresence request action (with meta.address) failed with payload=Error */
-export const matrixRequestMonitorPresenceFailed = createStandardAction(
+export const matrixRequestMonitorPresenceFailed = createAction(
   'matrixRequestMonitorPresenceFailed',
-).map((payload: Error, meta: { address: Address }) => ({ payload, error: true, meta }));
+  ErrorCodec,
+  NodeId,
+  true,
+);
+export interface matrixRequestMonitorPresenceFailed
+  extends ActionType<typeof matrixRequestMonitorPresenceFailed> {}
 
 /* payload.roomId must go front on meta.address's room queue */
-export const matrixRoom = createStandardAction('matrixRoom')<
-  { roomId: string },
-  { address: Address }
->();
+export const matrixRoom = createAction('matrixRoom', t.type({ roomId: t.string }), NodeId);
+export interface matrixRoom extends ActionType<typeof matrixRoom> {}
 
 /* payload.roomId must be excluded from meta.address room queue, if present */
-export const matrixRoomLeave = createStandardAction('matrixRoomLeave')<
-  { roomId: string },
-  { address: Address }
->();
+export const matrixRoomLeave = createAction(
+  'matrixRoomLeave',
+  t.type({ roomId: t.string }),
+  NodeId,
+);
+export interface matrixRoomLeave extends ActionType<typeof matrixRoomLeave> {}

--- a/raiden-ts/src/transport/reducer.ts
+++ b/raiden-ts/src/transport/reducer.ts
@@ -1,7 +1,7 @@
-import { isActionOf } from 'typesafe-actions';
 import { get, getOr, isEmpty, set, unset } from 'lodash/fp';
 
 import { partialCombineReducers } from '../utils/redux';
+import { isActionOf } from '../utils/actions';
 import { RaidenState, initialState } from '../state';
 import { RaidenAction } from '../actions';
 import { matrixSetup, matrixRoom, matrixRoomLeave } from './actions';

--- a/raiden-ts/src/transport/types.ts
+++ b/raiden-ts/src/transport/types.ts
@@ -1,6 +1,5 @@
-import { ActionType } from 'typesafe-actions';
 import { matrixPresenceUpdate } from './actions';
 
 export interface Presences {
-  [address: string]: ActionType<typeof matrixPresenceUpdate>;
+  [address: string]: matrixPresenceUpdate;
 }

--- a/raiden-ts/src/transport/utils.ts
+++ b/raiden-ts/src/transport/utils.ts
@@ -1,12 +1,12 @@
 import { Observable, of, fromEvent } from 'rxjs';
 import { filter, scan, startWith, share, take } from 'rxjs/operators';
-import { isActionOf } from 'typesafe-actions';
 import { memoize, curry } from 'lodash';
 import { MatrixClient, Room } from 'matrix-js-sdk';
 
 import { RaidenAction } from '../actions';
 import { RaidenConfig } from '../config';
 import { isntNil } from '../utils/types';
+import { isActionOf } from '../utils/actions';
 import { Presences } from './types';
 import { matrixPresenceUpdate } from './actions';
 

--- a/raiden-ts/src/utils/actions.ts
+++ b/raiden-ts/src/utils/actions.ts
@@ -1,0 +1,259 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as t from 'io-ts';
+
+/**
+ * The type of a generic action
+ */
+export type Action<TType extends string = string> = { type: TType };
+
+/**
+ * The ActionCreator's ReturnType, equivalent but more efficient than t.TypeOf<ActionCodec>
+ */
+type _Action<
+  TType extends string,
+  TPayload extends t.Mixed | undefined = undefined,
+  TMeta extends t.Mixed | undefined = undefined,
+  TError extends boolean | undefined = undefined
+> = TError extends boolean
+  ? TMeta extends t.Mixed
+    ? TPayload extends t.Mixed
+      ? {
+          type: TType;
+          payload: TPayload['_A'];
+          meta: TMeta['_A'];
+          error: TError;
+        }
+      : { type: TType; meta: TMeta['_A']; error: TError }
+    : TPayload extends t.Mixed
+    ? { type: TType; payload: TPayload['_A']; error: TError }
+    : { type: TType; error: TError }
+  : TMeta extends t.Mixed
+  ? TPayload extends t.Mixed
+    ? { type: TType; payload: TPayload['_A']; meta: TMeta['_A'] }
+    : { type: TType; meta: TMeta['_A'] }
+  : TPayload extends t.Mixed
+  ? { type: TType; payload: TPayload['_A'] }
+  : { type: TType };
+
+/**
+ * The codec of an ActionCreator, from type tag, payloadCodec, metaCodec & error boolean
+ */
+type ActionCodec<
+  TType extends string,
+  TPayload extends t.Mixed | undefined = undefined,
+  TMeta extends t.Mixed | undefined = undefined,
+  TError extends boolean | undefined = undefined
+> = TError extends boolean
+  ? TMeta extends t.Mixed
+    ? TPayload extends t.Mixed
+      ? t.TypeC<{
+          type: t.LiteralC<TType>;
+          payload: TPayload;
+          meta: TMeta;
+          error: t.LiteralC<TError>;
+        }>
+      : t.TypeC<{ type: t.LiteralC<TType>; meta: TMeta; error: t.LiteralC<TError> }>
+    : TPayload extends t.Mixed
+    ? t.TypeC<{ type: t.LiteralC<TType>; payload: TPayload; error: t.LiteralC<TError> }>
+    : t.TypeC<{ type: t.LiteralC<TType>; error: t.LiteralC<TError> }>
+  : TMeta extends t.Mixed
+  ? TPayload extends t.Mixed
+    ? t.TypeC<{ type: t.LiteralC<TType>; payload: TPayload; meta: TMeta }>
+    : t.TypeC<{ type: t.LiteralC<TType>; meta: TMeta }>
+  : TPayload extends t.Mixed
+  ? t.TypeC<{ type: t.LiteralC<TType>; payload: TPayload }>
+  : t.TypeC<{ type: t.LiteralC<TType> }>;
+
+/**
+ * The factory function part of an ActionCreator
+ */
+type ActionFactory<
+  TType extends string,
+  TPayload extends t.Mixed | undefined = undefined,
+  TMeta extends t.Mixed | undefined = undefined,
+  TError extends boolean | undefined = undefined
+> = TPayload extends t.Mixed
+  ? TMeta extends t.Mixed
+    ? (
+        payload: t.TypeOf<TPayload>,
+        meta: t.TypeOf<TMeta>,
+      ) => _Action<TType, TPayload, TMeta, TError>
+    : (payload: t.TypeOf<TPayload>) => _Action<TType, TPayload, TMeta, TError>
+  : TMeta extends t.Mixed
+  ? (_: undefined, meta: t.TypeOf<TMeta>) => _Action<TType, TPayload, TMeta, TError>
+  : () => _Action<TType, TPayload, TMeta, TError>;
+
+/**
+ * The ActionCreator member properties part which can be introspected
+ * - type: tag string literal
+ * - codec: the 'io-ts' codec/validator of the action
+ * - is: member typeguard function. Notice at production, for performance reasons, it checks only
+ *      the 'type' tag. If one needs explicit full validation, use codec.is/codec.decode directly
+ * - error: boolean literal, present only if it's an error action (false or true)
+ */
+type ActionCreatorMembers<
+  TType extends string,
+  TPayload extends t.Mixed | undefined = undefined,
+  TMeta extends t.Mixed | undefined = undefined,
+  TError extends boolean | undefined = undefined
+> = {
+  codec: ActionCodec<TType, TPayload, TMeta, TError>;
+  type: TType;
+  is: (action: unknown) => action is _Action<TType, TPayload, TMeta, TError>;
+} & (TError extends boolean ? { error: TError } : {});
+
+/**
+ * ActionCreator type, factory function extended (intersection) with members
+ */
+export type ActionCreator<
+  TType extends string,
+  TPayload extends t.Mixed | undefined = undefined,
+  TMeta extends t.Mixed | undefined = undefined,
+  TError extends boolean | undefined = undefined
+> = ActionFactory<TType, TPayload, TMeta, TError> &
+  ActionCreatorMembers<TType, TPayload, TMeta, TError>;
+
+/**
+ * Type helper to extract the type of an action or a mapping of actions
+ * Usage: const action: ActionType<typeof actionCreator>;
+ */
+export type ActionType<Creators> = Creators extends ActionCreator<
+  infer TType,
+  infer TPayload,
+  infer TMeta,
+  infer TError
+>
+  ? _Action<TType, TPayload, TMeta, TError>
+  : Creators extends any[]
+  ? {
+      [K in keyof Creators]: ActionType<Creators[K]>;
+    }[number]
+  : Creators extends Record<any, any>
+  ? {
+      [K in keyof Creators]: ActionType<Creators[K]>;
+    }[keyof Creators]
+  : never;
+
+// isActionOf curry overloads
+export function isActionOf<AC extends ActionCreator<any, any, any, any>>(
+  ac: AC | AC[],
+  action: unknown,
+): action is ReturnType<AC>;
+export function isActionOf<AC extends ActionCreator<any, any, any, any>>(
+  ac: AC | AC[],
+): (action: unknown) => action is ReturnType<AC>;
+
+/**
+ * Curried typeguard function (arity=2) which validates 2nd param is of type of some ActionCreators
+ *
+ * @param ac - Single or array of ActionCreators
+ * @param args - if an object is passed, verify it, else returns a function which does
+ * @returns boolean indicating object is of type of action, if passing 2nd argument,
+ *      or typeguard function
+ */
+export function isActionOf<AC extends ActionCreator<any, any, any, any>>(
+  ac: AC | AC[],
+  ...args: any[]
+) {
+  const arr = Array.isArray(ac) ? ac : [ac];
+  function _isActionOf(action: unknown): action is ReturnType<AC> {
+    return action != null && arr.some(a => a.is(action));
+  }
+  if (args.length > 0) return _isActionOf(args[0]);
+  return _isActionOf;
+}
+
+/**
+ * Tuples for typesafe params/arguments for createAction function
+ */
+type ActionParams<
+  TType extends string,
+  TPayload extends t.Mixed | undefined = undefined,
+  TMeta extends t.Mixed | undefined = undefined,
+  TError extends boolean | undefined = undefined
+> = TError extends boolean
+  ? TMeta extends t.Mixed
+    ? TPayload extends t.Mixed
+      ? [TType, TPayload, TMeta, TError]
+      : [TType, undefined, TMeta, TError]
+    : TPayload extends t.Mixed
+    ? [TType, TPayload, undefined, TError]
+    : [TType, undefined, undefined, TError]
+  : TMeta extends t.Mixed
+  ? TPayload extends t.Mixed
+    ? [TType, TPayload, TMeta]
+    : [TType, undefined, TMeta]
+  : TPayload extends t.Mixed
+  ? [TType, TPayload]
+  : [TType];
+
+// overloads with correct number of parameters
+export function createAction<TType extends string>(type: TType): ActionCreator<TType>;
+export function createAction<TType extends string, TPayload extends t.Mixed | undefined>(
+  type: TType,
+  payload: TPayload,
+): ActionCreator<TType, TPayload>;
+export function createAction<
+  TType extends string,
+  TPayload extends t.Mixed | undefined,
+  TMeta extends t.Mixed | undefined
+>(type: TType, payload: TPayload, meta: TMeta): ActionCreator<TType, TPayload, TMeta>;
+export function createAction<
+  TType extends string,
+  TPayload extends t.Mixed | undefined,
+  TMeta extends t.Mixed | undefined,
+  TError extends boolean | undefined
+>(
+  type: TType,
+  payload: TPayload,
+  meta: TMeta,
+  error: TError,
+): ActionCreator<TType, TPayload, TMeta, TError>;
+
+/**
+ * Create a typesafe, serializable ActionCreator from type, payload codec, meta codec & error flag
+ *
+ * Pass undefined for indermediary arguments if they aren't needed
+ * e.g. action with meta and without payload:
+ *   const addTodo = createAction('ADD_TODO', undefined, t.type({ folder: t.string }));
+ *
+ * @param args - typesafe args tuple
+ * @param args.0 - type literal string tag for action
+ * @param args.1 - payload codec, optional
+ * @param args.2 - meta codec, optional
+ * @param args.3 - error flag, will only be present if defined (either false or true)
+ * @returns ActionCreator factory function with useful properties. See [[ActionCreatorMembers]]
+ */
+export function createAction<
+  TType extends string,
+  TPayload extends t.Mixed | undefined = undefined,
+  TMeta extends t.Mixed | undefined = undefined,
+  TError extends boolean | undefined = undefined
+>(
+  ...args: ActionParams<TType, TPayload, TMeta, TError>
+): ActionCreator<TType, TPayload, TMeta, TError> {
+  const [type, payloadC, metaC, error] = args;
+  // action codec
+  const codec = t.type({
+    type: t.literal(type),
+    ...(payloadC ? { payload: payloadC } : null),
+    ...(metaC ? { meta: metaC } : null),
+    ...(error ? { error: t.literal(error) } : null),
+  });
+  // member typeguard
+  // like codec.is, but on production, switches to more performant check of 'type' tag only
+  const is =
+    process.env.NODE_ENV === 'development'
+      ? (action: unknown) => codec.is(action)
+      : (action: unknown) => (action as any)?.['type'] === type;
+  return Object.assign(
+    (payload?: t.TypeOf<NonNullable<TPayload>>, meta?: t.TypeOf<NonNullable<TMeta>>) => ({
+      type,
+      ...(payloadC ? { payload } : null),
+      ...(metaC ? { meta } : null),
+      ...(error !== undefined ? { error } : null),
+    }),
+    { codec, type, is },
+    error !== undefined ? { error } : null,
+  ) as ActionCreator<TType, TPayload, TMeta, TError>;
+}

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -2,7 +2,6 @@
 import { first, filter } from 'rxjs/operators';
 import { Zero } from 'ethers/constants';
 import { parseEther, parseUnits, bigNumberify, BigNumber, keccak256, Network } from 'ethers/utils';
-import { getType, isActionOf } from 'typesafe-actions';
 import { get } from 'lodash';
 
 import { TestProvider } from './provider';
@@ -18,6 +17,7 @@ import { raidenShutdown } from 'raiden-ts/actions';
 import { newBlock, tokenMonitored } from 'raiden-ts/channels/actions';
 import { ChannelState } from 'raiden-ts/channels/state';
 import { Storage, Secret, Address } from 'raiden-ts/utils/types';
+import { isActionOf } from 'raiden-ts/utils/actions';
 import { ContractsInfo } from 'raiden-ts/types';
 import { RaidenConfig } from 'raiden-ts/config';
 import { RaidenSentTransfer, RaidenSentTransferStatus } from 'raiden-ts/transfers/state';
@@ -515,7 +515,7 @@ describe('Raiden', () => {
       const promise = raiden.events$.toPromise();
       raiden.stop();
       await expect(promise).resolves.toMatchObject({
-        type: getType(raidenShutdown),
+        type: raidenShutdown.type,
         payload: { reason: ShutdownReason.STOP },
       });
     });
@@ -531,7 +531,7 @@ describe('Raiden', () => {
         .toPromise();
       await provider.mine(10);
       await expect(promise).resolves.toMatchObject({
-        type: getType(newBlock),
+        type: newBlock.type,
         payload: { blockNumber: expect.any(Number) },
       });
     });
@@ -546,7 +546,7 @@ describe('Raiden', () => {
       // deploy a new token & tokenNetwork
       const { token, tokenNetwork } = await provider.deployTokenNetwork(contractsInfo);
       await expect(promise).resolves.toMatchObject({
-        type: getType(tokenMonitored),
+        type: tokenMonitored.type,
         payload: { fromBlock: expect.any(Number), token, tokenNetwork },
       });
     });

--- a/raiden-ts/tests/unit/actions.spec.ts
+++ b/raiden-ts/tests/unit/actions.spec.ts
@@ -1,11 +1,13 @@
 import { bigNumberify } from 'ethers/utils';
+import * as t from 'io-ts';
 
 import {
   channelDeposit,
   channelDepositFailed,
   channelMonitored,
 } from 'raiden-ts/channels/actions';
-import { Address, UInt } from 'raiden-ts/utils/types';
+import { Address, UInt, ErrorCodec, decode } from 'raiden-ts/utils/types';
+import { createAction, ActionType, isActionOf } from 'raiden-ts/utils/actions';
 
 describe('action factories not tested in reducers.spec.ts', () => {
   const tokenNetwork = '0x0000000000000000000000000000000000020001' as Address,
@@ -38,4 +40,91 @@ describe('action factories not tested in reducers.spec.ts', () => {
       error: true,
     });
   });
+});
+
+test('utils/actions', () => {
+  const actionT = createAction('TEST1');
+  const actionTP = createAction('TEST2', t.type({ a: t.number }));
+  const actionTPM = createAction('TEST3', t.type({ a: t.number }), t.type({ m: t.string }));
+  const actionTM = createAction('TEST4', undefined, t.type({ m: t.string }));
+  const actionTE = createAction('TEST5', undefined, undefined, true);
+  const actionTPE = createAction('TEST6', t.type({ a: t.number }), undefined, false);
+  const actionTPME = createAction('TEST7', t.type({ a: t.number }), t.type({ m: t.string }), true);
+  const actionTME = createAction('TEST8', undefined, t.type({ m: t.string }), false);
+  const actionUnd = createAction('TEST_U', t.union([t.type({ a: t.number }), t.undefined]));
+
+  const actionFailed = createAction(
+    'TEST_FAILED',
+    ErrorCodec,
+    t.type({ context: t.string }),
+    true,
+  );
+
+  expect(actionT.type).toBe('TEST1');
+  expect(actionTPME.error).toBe(true);
+  expect(actionFailed.error).toBe(true);
+
+  expect(actionT()).toStrictEqual({ type: 'TEST1' });
+  expect(actionTP({ a: 1 })).toStrictEqual({ type: 'TEST2', payload: { a: 1 } });
+  expect(actionTPM({ a: 1 }, { m: 'abc' })).toStrictEqual({
+    type: 'TEST3',
+    payload: { a: 1 },
+    meta: { m: 'abc' },
+  });
+  expect(actionTM(undefined, { m: 'abc' })).toStrictEqual({ type: 'TEST4', meta: { m: 'abc' } });
+  expect(actionTE()).toStrictEqual({ type: 'TEST5', error: true });
+  expect(actionTPE({ a: 1 })).toStrictEqual({ type: 'TEST6', payload: { a: 1 }, error: false });
+  expect(actionTPME({ a: 1 }, { m: 'abc' })).toStrictEqual({
+    type: 'TEST7',
+    payload: { a: 1 },
+    meta: { m: 'abc' },
+    error: true,
+  });
+  expect(actionTME(undefined, { m: 'abc' })).toStrictEqual({
+    type: 'TEST8',
+    meta: { m: 'abc' },
+    error: false,
+  });
+
+  // test action with payload unioned with undefined
+  expect(actionUnd({ a: 1 })).toStrictEqual({ type: 'TEST_U', payload: { a: 1 } });
+  expect(actionUnd(undefined)).toStrictEqual({ type: 'TEST_U', payload: undefined });
+  expect(actionUnd.is(actionUnd(undefined))).toBe(true);
+
+  try {
+    throw new Error('Failed');
+  } catch (e) {
+    expect(actionFailed(e, { context: 'init' })).toStrictEqual({
+      type: 'TEST_FAILED',
+      payload: expect.any(Error),
+      meta: { context: 'init' },
+      error: true,
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const a1: any = {
+    type: 'TEST7',
+    payload: { a: 1 },
+    meta: { m: 'metaOfTest7' },
+    error: true,
+  };
+
+  // type narrowing
+  let b1: ActionType<typeof actionTPME>;
+  expect(actionTPME.is(a1)).toBe(true);
+  if (actionTPME.is(a1)) {
+    b1 = a1;
+    expect(b1).toStrictEqual(a1);
+  }
+
+  expect(isActionOf(actionTPME, a1)).toBe(true);
+
+  expect(isActionOf([actionTM, actionTPM, actionTME, actionTPME])(a1)).toBe(true);
+  if (isActionOf([actionTM, actionTPM, actionTME, actionTPME])(a1)) {
+    // can access member of union
+    expect(a1.meta).toStrictEqual({ m: 'metaOfTest7' });
+  }
+
+  expect(decode(actionTPME.codec, a1)).toEqual(a1);
 });

--- a/raiden-ts/tests/unit/epics/channels.spec.ts
+++ b/raiden-ts/tests/unit/epics/channels.spec.ts
@@ -8,7 +8,6 @@ import { ContractTransaction } from 'ethers/contract';
 import { bigNumberify } from 'ethers/utils';
 import { Zero, HashZero } from 'ethers/constants';
 import { defaultAbiCoder } from 'ethers/utils/abi-coder';
-import { getType } from 'typesafe-actions';
 import { range } from 'lodash';
 
 import { UInt } from 'raiden-ts/utils/types';
@@ -116,7 +115,7 @@ describe('channels epic', () => {
         state$ = of<RaidenState>(curState);
 
       await expect(channelOpenEpic(action$, state$, depsMock).toPromise()).resolves.toMatchObject({
-        type: getType(channelOpenFailed),
+        type: channelOpenFailed.type,
         payload: expect.any(Error),
         error: true,
         meta: { tokenNetwork, partner },
@@ -147,7 +146,7 @@ describe('channels epic', () => {
       tokenNetworkContract.functions.openChannel.mockResolvedValueOnce(tx);
 
       await expect(channelOpenEpic(action$, state$, depsMock).toPromise()).resolves.toMatchObject({
-        type: getType(channelOpenFailed),
+        type: channelOpenFailed.type,
         payload: expect.any(Error),
         error: true,
         meta: { tokenNetwork, partner },
@@ -235,7 +234,7 @@ describe('channels epic', () => {
         state$ = of<RaidenState>(curState);
 
       await expect(channelOpenedEpic(action$, state$).toPromise()).resolves.toMatchObject({
-        type: getType(channelMonitored),
+        type: channelMonitored.type,
         payload: { id: channelId, fromBlock: 125 },
         meta: { tokenNetwork, partner },
       });
@@ -285,7 +284,7 @@ describe('channels epic', () => {
           .pipe(first())
           .toPromise(),
       ).resolves.toMatchObject({
-        type: getType(channelDeposited),
+        type: channelDeposited.type,
         payload: { id: channelId, participant: depsMock.address, totalDeposit: deposit },
         meta: { tokenNetwork, partner },
       });
@@ -317,7 +316,7 @@ describe('channels epic', () => {
       );
 
       await expect(promise).resolves.toMatchObject({
-        type: getType(channelDeposited),
+        type: channelDeposited.type,
         payload: { id: channelId, participant: partner, totalDeposit: deposit },
         meta: { tokenNetwork, partner },
       });
@@ -364,7 +363,7 @@ describe('channels epic', () => {
       const result = await promise;
       expect(result).toHaveLength(1);
       expect(result[0]).toMatchObject({
-        type: getType(channelDeposited),
+        type: channelDeposited.type,
         payload: { id: channelId, participant: depsMock.address, totalDeposit: deposit },
         meta: { tokenNetwork, partner },
       });
@@ -409,7 +408,7 @@ describe('channels epic', () => {
       );
 
       await expect(promise).resolves.toMatchObject({
-        type: getType(channelWithdrawn),
+        type: channelWithdrawn.type,
         payload: { id: channelId, participant: partner, totalWithdraw: withdraw, txHash },
         meta: { tokenNetwork, partner },
       });
@@ -443,7 +442,7 @@ describe('channels epic', () => {
       );
 
       await expect(promise).resolves.toMatchObject({
-        type: getType(channelClosed),
+        type: channelClosed.type,
         payload: { id: channelId, participant: partner, closeBlock, txHash },
         meta: { tokenNetwork, partner },
       });
@@ -505,7 +504,7 @@ describe('channels epic', () => {
       await expect(
         channelDepositEpic(action$, state$, depsMock).toPromise(),
       ).resolves.toMatchObject({
-        type: getType(channelDepositFailed),
+        type: channelDepositFailed.type,
         payload: expect.any(Error),
         error: true,
         meta: { tokenNetwork, partner },
@@ -526,7 +525,7 @@ describe('channels epic', () => {
       await expect(
         channelDepositEpic(action$, state$, depsMock).toPromise(),
       ).resolves.toMatchObject({
-        type: getType(channelDepositFailed),
+        type: channelDepositFailed.type,
         payload: expect.any(Error),
         error: true,
         meta: { tokenNetwork, partner },
@@ -562,7 +561,7 @@ describe('channels epic', () => {
       await expect(
         channelDepositEpic(action$, state$, depsMock).toPromise(),
       ).resolves.toMatchObject({
-        type: getType(channelDepositFailed),
+        type: channelDepositFailed.type,
         payload: expect.any(Error),
         error: true,
         meta: { tokenNetwork, partner },
@@ -612,7 +611,7 @@ describe('channels epic', () => {
       await expect(
         channelDepositEpic(action$, state$, depsMock).toPromise(),
       ).resolves.toMatchObject({
-        type: getType(channelDepositFailed),
+        type: channelDepositFailed.type,
         payload: expect.any(Error),
         error: true,
         meta: { tokenNetwork, partner },
@@ -698,7 +697,7 @@ describe('channels epic', () => {
 
       await expect(channelCloseEpic(action$, state$, depsMock).toPromise()).resolves.toMatchObject(
         {
-          type: getType(channelCloseFailed),
+          type: channelCloseFailed.type,
           payload: expect.any(Error),
           error: true,
           meta: { tokenNetwork, partner },
@@ -718,7 +717,7 @@ describe('channels epic', () => {
 
       await expect(channelCloseEpic(action$, state$, depsMock).toPromise()).resolves.toMatchObject(
         {
-          type: getType(channelCloseFailed),
+          type: channelCloseFailed.type,
           payload: expect.any(Error),
           error: true,
           meta: { tokenNetwork, partner },
@@ -754,7 +753,7 @@ describe('channels epic', () => {
 
       await expect(channelCloseEpic(action$, state$, depsMock).toPromise()).resolves.toMatchObject(
         {
-          type: getType(channelCloseFailed),
+          type: channelCloseFailed.type,
           payload: expect.any(Error),
           error: true,
           meta: { tokenNetwork, partner },
@@ -821,7 +820,7 @@ describe('channels epic', () => {
       await expect(
         channelSettleEpic(action$, state$, depsMock).toPromise(),
       ).resolves.toMatchObject({
-        type: getType(channelSettleFailed),
+        type: channelSettleFailed.type,
         payload: expect.any(Error),
         error: true,
         meta: { tokenNetwork, partner },
@@ -848,7 +847,7 @@ describe('channels epic', () => {
       await expect(
         channelSettleEpic(action$, state$, depsMock).toPromise(),
       ).resolves.toMatchObject({
-        type: getType(channelSettleFailed),
+        type: channelSettleFailed.type,
         payload: expect.any(Error),
         error: true,
         meta: { tokenNetwork, partner },
@@ -891,7 +890,7 @@ describe('channels epic', () => {
       await expect(
         channelSettleEpic(action$, state$, depsMock).toPromise(),
       ).resolves.toMatchObject({
-        type: getType(channelSettleFailed),
+        type: channelSettleFailed.type,
         payload: expect.any(Error),
         error: true,
         meta: { tokenNetwork, partner },

--- a/raiden-ts/tests/unit/epics/path.spec.ts
+++ b/raiden-ts/tests/unit/epics/path.spec.ts
@@ -3,7 +3,6 @@ import { of, BehaviorSubject, EMPTY, timer } from 'rxjs';
 import { first, takeUntil, toArray, pluck, withLatestFrom } from 'rxjs/operators';
 import { bigNumberify, defaultAbiCoder } from 'ethers/utils';
 import { Zero, AddressZero, One } from 'ethers/constants';
-import { getType } from 'typesafe-actions';
 
 import { UInt, Int, Address, Signature } from 'raiden-ts/utils/types';
 import {
@@ -112,8 +111,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork: token, target, value }),
       );
 
@@ -132,8 +137,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: false }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: false, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork, target, value }),
       );
 
@@ -152,8 +163,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind(
           { paths: [{ path: [depsMock.address, partner, target], fee }] },
           { tokenNetwork, target, value },
@@ -173,8 +190,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork, target: partner, value }),
       );
 
@@ -194,8 +217,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind(
           {
             pfs: {
@@ -244,8 +273,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork, target, value }),
       );
 
@@ -298,8 +333,14 @@ describe('PFS: pathFindServiceEpic', () => {
         pfsListUpdated({
           pfsList: [pfsAddress1, pfsAddress2, pfsAddress3, pfsAddress],
         }),
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork, target, value }),
       );
 
@@ -406,8 +447,14 @@ describe('PFS: pathFindServiceEpic', () => {
         pfsListUpdated({
           pfsList: [pfsAddress, pfsAddress, pfsAddress],
         }),
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork, target, value }),
       );
 
@@ -435,8 +482,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork, target, value }),
       );
 
@@ -478,8 +531,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork, target, value }),
       );
 
@@ -518,8 +577,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork, target, value }),
       );
 
@@ -568,8 +633,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork, target, value }),
       );
 
@@ -619,8 +690,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork, target, value }),
       );
 
@@ -676,8 +753,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork, target, value }),
       );
 
@@ -733,8 +816,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(80000000) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind(
           { paths: [{ path: [depsMock.address, partner, target], fee }] },
           { tokenNetwork, target, value },
@@ -756,8 +845,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork, target, value }),
       );
 
@@ -823,8 +918,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork, target, value }),
       );
 
@@ -863,8 +964,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork, target, value }),
       );
 
@@ -911,8 +1018,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork, target, value }),
       );
 
@@ -978,8 +1091,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
-        matrixPresenceUpdate({ userId: targetUserId, available: true }, { address: target }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
+        matrixPresenceUpdate(
+          { userId: targetUserId, available: true, ts: Date.now() },
+          { address: target },
+        ),
         pathFind({}, { tokenNetwork, target, value }),
       );
 
@@ -1188,7 +1307,7 @@ describe('PFS: pfsServiceRegistryMonitorEpic', () => {
     );
 
     await expect(promise).resolves.toMatchObject({
-      type: getType(pfsListUpdated),
+      type: pfsListUpdated.type,
       payload: { pfsList: [pfsAddress] },
     });
   });

--- a/raiden-ts/tests/unit/epics/raiden.spec.ts
+++ b/raiden-ts/tests/unit/epics/raiden.spec.ts
@@ -26,7 +26,6 @@ import {
 } from 'rxjs/operators';
 import { bigNumberify } from 'ethers/utils';
 import { defaultAbiCoder } from 'ethers/utils/abi-coder';
-import { getType } from 'typesafe-actions';
 import { range } from 'lodash';
 
 import { UInt, Address, Signed } from 'raiden-ts/utils/types';
@@ -312,7 +311,7 @@ describe('raiden epic', () => {
         .toPromise();
 
       await expect(promise).resolves.toMatchObject({
-        type: getType(channelOpened),
+        type: channelOpened.type,
         payload: { id: channelId, settleTimeout, openBlock: 121 },
         meta: { tokenNetwork, partner },
       });
@@ -351,7 +350,7 @@ describe('raiden epic', () => {
       );
 
       await expect(promise).resolves.toMatchObject({
-        type: getType(channelOpened),
+        type: channelOpened.type,
         payload: { id: channelId, settleTimeout, openBlock: 125 },
         meta: { tokenNetwork, partner },
       });
@@ -392,7 +391,7 @@ describe('raiden epic', () => {
       const result = await promise;
       expect(result).toHaveLength(1);
       expect(result[0]).toMatchObject({
-        type: getType(channelOpened),
+        type: channelOpened.type,
         payload: { id: channelId, settleTimeout, openBlock: 125 },
         meta: { tokenNetwork, partner },
       });
@@ -432,7 +431,7 @@ describe('raiden epic', () => {
       const output = await promise;
       expect(output).toHaveLength(2);
       expect(output[1]).toMatchObject({
-        type: getType(messageSend),
+        type: messageSend.type,
         payload: {
           message: {
             type: MessageType.DELIVERED,

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -9,7 +9,6 @@ patchVerifyMessage();
 import { BehaviorSubject, of, timer, EMPTY, Subject, Observable } from 'rxjs';
 import { first, tap, takeUntil, toArray, delay } from 'rxjs/operators';
 import { fakeSchedulers } from 'rxjs-marbles/jest';
-import { getType } from 'typesafe-actions';
 import { verifyMessage, BigNumber } from 'ethers/utils';
 
 import { RaidenAction } from 'raiden-ts/actions';
@@ -326,7 +325,7 @@ describe('transport epic', () => {
       await expect(
         matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise(),
       ).resolves.toMatchObject({
-        type: getType(matrixRequestMonitorPresenceFailed),
+        type: matrixRequestMonitorPresenceFailed.type,
         payload: expect.any(Error),
         error: true,
         meta: { address: partner },
@@ -348,7 +347,7 @@ describe('transport epic', () => {
       await expect(
         matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise(),
       ).resolves.toMatchObject({
-        type: getType(matrixRequestMonitorPresenceFailed),
+        type: matrixRequestMonitorPresenceFailed.type,
         payload: expect.any(Error),
         error: true,
         meta: { address: partner },
@@ -371,7 +370,7 @@ describe('transport epic', () => {
       await expect(
         matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise(),
       ).resolves.toMatchObject({
-        type: getType(matrixRequestMonitorPresenceFailed),
+        type: matrixRequestMonitorPresenceFailed.type,
         payload: expect.any(Error),
         error: true,
         meta: { address: partner },
@@ -395,7 +394,7 @@ describe('transport epic', () => {
       await expect(
         matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise(),
       ).resolves.toMatchObject({
-        type: getType(matrixRequestMonitorPresenceFailed),
+        type: matrixRequestMonitorPresenceFailed.type,
         payload: expect.any(Error),
         error: true,
         meta: { address: partner },
@@ -405,7 +404,7 @@ describe('transport epic', () => {
     test('success with previously monitored user', async () => {
       expect.assertions(1);
       const presence = matrixPresenceUpdate(
-          { userId: partnerUserId, available: false },
+          { userId: partnerUserId, available: false, ts: Date.now() },
           { address: partner },
         ),
         action$ = new Subject<RaidenAction>(),
@@ -431,7 +430,7 @@ describe('transport epic', () => {
       await expect(
         matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise(),
       ).resolves.toMatchObject({
-        type: getType(matrixPresenceUpdate),
+        type: matrixPresenceUpdate.type,
         payload: { userId: partnerUserId, available: true, ts: expect.any(Number) },
         meta: { address: partner },
       });
@@ -456,7 +455,7 @@ describe('transport epic', () => {
       await expect(
         matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise(),
       ).resolves.toMatchObject({
-        type: getType(matrixPresenceUpdate),
+        type: matrixPresenceUpdate.type,
         payload: { userId: partnerUserId, available: true, ts: expect.any(Number) },
         meta: { address: partner },
       });
@@ -485,7 +484,7 @@ describe('transport epic', () => {
       });
 
       await expect(promise).resolves.toMatchObject({
-        type: getType(matrixPresenceUpdate),
+        type: matrixPresenceUpdate.type,
         payload: { userId: partnerUserId, available: false, ts: expect.any(Number) },
         meta: { address: partner },
       });
@@ -597,7 +596,7 @@ describe('transport epic', () => {
         .toPromise();
 
       await expect(promise).resolves.toMatchObject({
-        type: getType(matrixRoom),
+        type: matrixRoom.type,
         payload: { roomId: expect.stringMatching(new RegExp(`^!.*:${matrixServer}$`)) },
         meta: { address: partner },
       });
@@ -687,7 +686,7 @@ describe('transport epic', () => {
       );
 
       await expect(promise).resolves.toMatchObject({
-        type: getType(matrixRoom),
+        type: matrixRoom.type,
         payload: { roomId },
         meta: { address: partner },
       });
@@ -715,11 +714,14 @@ describe('transport epic', () => {
       );
 
       action$.next(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
       );
 
       await expect(promise).resolves.toMatchObject({
-        type: getType(matrixRoom),
+        type: matrixRoom.type,
         payload: { roomId },
         meta: { address: partner },
       });
@@ -772,7 +774,7 @@ describe('transport epic', () => {
       const promise = matrixLeaveExcessRoomsEpic(action$, state$, depsMock).toPromise();
 
       await expect(promise).resolves.toMatchObject({
-        type: getType(matrixRoomLeave),
+        type: matrixRoomLeave.type,
         payload: { roomId },
         meta: { address: partner },
       });
@@ -886,7 +888,7 @@ describe('transport epic', () => {
       matrix.emit('Room.myMembership', { roomId }, 'leave');
 
       await expect(promise).resolves.toMatchObject({
-        type: getType(matrixRoomLeave),
+        type: matrixRoomLeave.type,
         payload: { roomId },
         meta: { address: partner },
       });
@@ -901,7 +903,10 @@ describe('transport epic', () => {
         message = processed,
         signed = await signMessage(depsMock.signer, message),
         action$ = of(
-          matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
+          matrixPresenceUpdate(
+            { userId: partnerUserId, available: true, ts: Date.now() },
+            { address: partner },
+          ),
           messageSend({ message: signed }, { address: partner }),
         ),
         state$ = of(raidenReducer(state, matrixRoom({ roomId }, { address: partner })));
@@ -939,7 +944,10 @@ describe('transport epic', () => {
       const roomId = partnerRoomId,
         message = 'test message',
         action$ = of(
-          matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
+          matrixPresenceUpdate(
+            { userId: partnerUserId, available: true, ts: Date.now() },
+            { address: partner },
+          ),
           messageSend({ message }, { address: partner }),
         ),
         state$ = of(raidenReducer(state, matrixRoom({ roomId }, { address: partner })));
@@ -1019,7 +1027,10 @@ describe('transport epic', () => {
 
       // actions sees presence update for partner only later
       action$.next(
-        matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
+        matrixPresenceUpdate(
+          { userId: partnerUserId, available: true, ts: Date.now() },
+          { address: partner },
+        ),
       );
       // state includes room for partner only later
       state$.next(
@@ -1028,7 +1039,7 @@ describe('transport epic', () => {
 
       // then it resolves
       await expect(promise).resolves.toMatchObject({
-        type: getType(messageReceived),
+        type: messageReceived.type,
         payload: {
           text: message,
           ts: expect.any(Number),
@@ -1046,7 +1057,10 @@ describe('transport epic', () => {
         signed = await signMessage(partnerSigner, processed),
         message = encodeJsonMessage(signed),
         action$ = of(
-          matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
+          matrixPresenceUpdate(
+            { userId: partnerUserId, available: true, ts: Date.now() },
+            { address: partner },
+          ),
         );
       state$.next(
         [matrixRoom({ roomId }, { address: partner })].reduce(raidenReducer, state$.value),
@@ -1071,7 +1085,7 @@ describe('transport epic', () => {
 
       // then it resolves
       await expect(promise).resolves.toMatchObject({
-        type: getType(messageReceived),
+        type: messageReceived.type,
         payload: {
           text: message,
           message: {
@@ -1095,7 +1109,10 @@ describe('transport epic', () => {
         signed = await signMessage(depsMock.signer, processed),
         message = encodeJsonMessage(signed),
         action$ = of(
-          matrixPresenceUpdate({ userId: partnerUserId, available: true }, { address: partner }),
+          matrixPresenceUpdate(
+            { userId: partnerUserId, available: true, ts: Date.now() },
+            { address: partner },
+          ),
         );
       state$.next(
         [matrixRoom({ roomId }, { address: partner })].reduce(raidenReducer, state$.value),
@@ -1120,7 +1137,7 @@ describe('transport epic', () => {
 
       // then it resolves
       await expect(promise).resolves.toMatchObject({
-        type: getType(messageReceived),
+        type: messageReceived.type,
         payload: {
           text: message,
           message: undefined,

--- a/raiden-ts/tests/unit/utils.spec.ts
+++ b/raiden-ts/tests/unit/utils.spec.ts
@@ -10,7 +10,17 @@ import { BigNumber, bigNumberify, keccak256, hexDataLength } from 'ethers/utils'
 import { LosslessNumber } from 'lossless-json';
 
 import { fromEthersEvent, getEventsStream, patchSignSend } from 'raiden-ts/utils/ethers';
-import { Address, BigNumberC, HexString, UInt, Secret, Timed, timed } from 'raiden-ts/utils/types';
+import {
+  Address,
+  BigNumberC,
+  HexString,
+  UInt,
+  Secret,
+  Timed,
+  timed,
+  ErrorCodec,
+  decode,
+} from 'raiden-ts/utils/types';
 import { LruCache } from 'raiden-ts/utils/lru';
 import { encode, losslessParse, losslessStringify } from 'raiden-ts/utils/data';
 import { getLocksroot, makeSecret, getSecrethash } from 'raiden-ts/transfers/utils';
@@ -255,6 +265,27 @@ describe('types', () => {
       data: TimedAddress = timed(address);
     expect(TimedAddress.is(data)).toBe(true);
     expect(TimedAddress.is(['invalid number', address])).toBe(false);
+  });
+
+  test('ErrorCodec', () => {
+    let err;
+    try {
+      throw new Error('error message');
+    } catch (e) {
+      err = e;
+    }
+    expect(ErrorCodec.is(err)).toBe(true);
+    const encoded = ErrorCodec.encode(err);
+    expect(encoded).toStrictEqual({
+      name: 'Error',
+      message: 'error message',
+      stack: expect.any(String),
+    });
+    expect(decode(ErrorCodec, err)).toBe(err);
+    const decoded = decode(ErrorCodec, encoded);
+    expect(decoded).toBeInstanceOf(Error);
+    expect(decoded.message).toBe('error message');
+    expect(decoded.stack).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
Fix #591 
- [x] actions creators based on `io-ts`, typesafe
  - [x] supports optional `payload`, `meta` & `error` flag, as per `FSA` pattern
  - [x] Includes useful properties and helper funtions, to replace all functionality we currently use from `typesafe-actions`:
   - [x] `action.type` string literal, for inspection & narrowing
   - [x] `action.error` boolean literal, for error actions
   - [x] `action.codec` for direct codec access
   - [x] `action.is` member typeguard function
   - [x] `ActionType` type helper
   - [x] `isActionOf` type guard supporting single and arrays of action creators
- [x] `Error` codec (so Error objects can be [de]serialized)
- [x] Implement in all our actions, replacing `typesafe-actions`
- [x] Tests