### PR TITLE
Fixes vue renderer evaluation warning

### DIFF
--- a/raiden-dapp/src/components/TokenOverlay.vue
+++ b/raiden-dapp/src/components/TokenOverlay.vue
@@ -1,6 +1,6 @@
 <template>
   <v-overlay :value="show" absolute opacity="1.0" class="token-network-overlay">
-    <v-container class="token-network__container">
+    <v-container v-if="show" class="token-network__container">
       <v-row no-gutters justify="end">
         <v-btn icon class="token-network-overlay__close-button" @click="cancel">
           <v-icon>mdi-close</v-icon>


### PR DESCRIPTION
After a small investigation, the warning seems to happen because when vue tries to evaluate the renderer for some reason the `this.$store.getters` is not yet initialized. This doesn't seem to directly affect the functionality (that is why there is no changelog entry). 

I found out that the easiest way to remove the warning is by not rendering the container if the overlay is not visible. The v-if was not put in the overlay itself because it would hinder the animation. 