### PR TITLE
Async actions

### DIFF
--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -117,7 +117,7 @@ export default class RaidenService {
           }
 
           // Update presences on matrix presence updates
-          if (value.type === 'matrixPresenceUpdate') {
+          if (value.type === 'matrix/presence/success') {
             this.store.commit('updatePresence', {
               [value.meta.address]: value.payload.available
             });

--- a/raiden-ts/src/actions.ts
+++ b/raiden-ts/src/actions.ts
@@ -57,7 +57,7 @@ export type RaidenAction = Action;
 export const RaidenEvents = [
   RaidenActions.raidenShutdown,
   RaidenActions.newBlock,
-  RaidenActions.matrixPresenceUpdate,
+  RaidenActions.matrixPresence.success,
   RaidenActions.tokenMonitored,
 ];
 /* Tagged union of RaidenEvents actions */

--- a/raiden-ts/src/messages/actions.ts
+++ b/raiden-ts/src/messages/actions.ts
@@ -1,34 +1,25 @@
+/* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/class-name-casing */
 import * as t from 'io-ts';
 
 import { Message } from './types';
-import { createAction, ActionType } from '../utils/actions';
+import { createAction, ActionType, createAsyncAction } from '../utils/actions';
 import { Address, Signed } from '../utils/types';
 
 /** One-shot send payload.message to meta.address user in transport */
-export const messageSend = createAction(
-  'messageSend',
+export const messageSend = createAsyncAction(
+  t.type({ address: Address, msgId: t.string }),
+  'message/send/request',
+  'message/send/success',
+  'message/send/failure',
   t.type({ message: t.union([t.string, Signed(Message)]) }),
-  t.type({ address: Address }),
+  undefined,
 );
-export interface messageSend extends ActionType<typeof messageSend> {}
-
-/**
- * Success action when message is actually sent
- * messageSend doesn't fail (except unexpectedly, like network errors), instead just hang there
- * until a suitable set of conditions is met, i.e.: there's a room for recipient's address, an
- * online validated user for this address, and it had joined that room, then the message is sent
- * and this success action is emitted. 'payload.message' and 'meta.address' should be kept strictly
- * equal to messageSend (even by reference, in case of Message), to ease filtering.
- * Useful to control retry without queueing multiple identical messages while the first is still
- * pending
- */
-export const messageSent = createAction(
-  'messageSent',
-  t.type({ message: t.union([t.string, Signed(Message)]) }),
-  t.type({ address: Address }),
-);
-export interface messageSent extends ActionType<typeof messageSent> {}
+export namespace messageSend {
+  export interface request extends ActionType<typeof messageSend.request> {}
+  export interface success extends ActionType<typeof messageSend.success> {}
+  export interface failure extends ActionType<typeof messageSend.failure> {}
+}
 
 /** One-shot send payload.message to a global room in transport */
 export const messageGlobalSend = createAction(

--- a/raiden-ts/src/path/actions.ts
+++ b/raiden-ts/src/path/actions.ts
@@ -1,8 +1,9 @@
+/* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/class-name-casing */
 import * as t from 'io-ts';
 
-import { createAction, ActionType } from '../utils/actions';
-import { Address, UInt, Signed, ErrorCodec } from '../utils/types';
+import { createAction, ActionType, createAsyncAction } from '../utils/actions';
+import { Address, UInt, Signed } from '../utils/types';
 import { Paths, PFS, IOU } from './types';
 
 const PathId = t.type({
@@ -16,18 +17,20 @@ const ServiceId = t.type({
   serviceAddress: Address,
 });
 
-export const pathFind = createAction(
-  'pathFind',
-  t.partial({ paths: Paths, pfs: t.union([PFS, t.null]) }),
+export const pathFind = createAsyncAction(
   PathId,
+  'path/find/request',
+  'path/find/success',
+  'path/find/failure',
+  t.partial({ paths: Paths, pfs: t.union([PFS, t.null]) }),
+  t.type({ paths: Paths }),
 );
-export interface pathFind extends ActionType<typeof pathFind> {}
 
-export const pathFound = createAction('pathFound', t.type({ paths: Paths }), PathId);
-export interface pathFound extends ActionType<typeof pathFound> {}
-
-export const pathFindFailed = createAction('pathFindFailed', ErrorCodec, PathId, true);
-export interface pathFindFailed extends ActionType<typeof pathFindFailed> {}
+export namespace pathFind {
+  export interface request extends ActionType<typeof pathFind.request> {}
+  export interface success extends ActionType<typeof pathFind.success> {}
+  export interface failure extends ActionType<typeof pathFind.failure> {}
+}
 
 export const pfsListUpdated = createAction(
   'pfsListUpdated',

--- a/raiden-ts/src/path/epics.ts
+++ b/raiden-ts/src/path/epics.ts
@@ -43,14 +43,7 @@ import { Address, decode, Int, Signature, Signed, UInt } from '../utils/types';
 import { isActionOf } from '../utils/actions';
 import { encode, losslessParse, losslessStringify } from '../utils/data';
 import { getEventsStream } from '../utils/ethers';
-import {
-  iouClear,
-  pathFind,
-  pathFindFailed,
-  pathFound,
-  iouPersist,
-  pfsListUpdated,
-} from './actions';
+import { iouClear, pathFind, iouPersist, pfsListUpdated } from './actions';
 import { channelCanRoute, pfsInfo, pfsListInfo } from './utils';
 import { IOU, LastIOUResults, PathResults, Paths, PFS } from './types';
 
@@ -179,16 +172,16 @@ const prepareNextIOU$ = (
 /**
  * Check if a transfer can be made and return a set of paths for it.
  *
- * @param action$ - Observable of pathFind actions
+ * @param action$ - Observable of pathFind.request actions
  * @param state$ - Observable of RaidenStates
  * @param deps - RaidenEpicDeps object
- * @returns Observable of pathFound|pathFindFailed actions
+ * @returns Observable of pathFind.{success|failure} actions
  */
 export const pathFindServiceEpic = (
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
   deps: RaidenEpicDeps,
-): Observable<pathFound | pathFindFailed | iouPersist | iouClear> =>
+): Observable<pathFind.success | pathFind.failure | iouPersist | iouClear> =>
   combineLatest(
     state$,
     getPresences$(action$),
@@ -201,7 +194,7 @@ export const pathFindServiceEpic = (
   ).pipe(
     publishReplay(1, undefined, cached$ => {
       return action$.pipe(
-        filter(isActionOf(pathFind)),
+        filter(isActionOf(pathFind.request)),
         concatMap(action =>
           cached$.pipe(
             first(),
@@ -375,11 +368,11 @@ export const pathFindServiceEpic = (
                     filteredPaths.push({ path, fee });
                   }
                   if (!filteredPaths.length) throw new Error(`PFS: no valid routes found`);
-                  yield pathFound({ paths: filteredPaths }, action.meta);
+                  yield pathFind.success({ paths: filteredPaths }, action.meta);
                 })(),
               ),
             ),
-            catchError(err => of(pathFindFailed(err, action.meta))),
+            catchError(err => of(pathFind.failure(err, action.meta))),
           ),
         ),
       );

--- a/raiden-ts/src/path/epics.ts
+++ b/raiden-ts/src/path/epics.ts
@@ -36,7 +36,7 @@ import { getPresences$ } from '../transport/utils';
 import { messageGlobalSend } from '../messages/actions';
 import { MessageType, PFSCapacityUpdate } from '../messages/types';
 import { MessageTypeId, signMessage } from '../messages/utils';
-import { channelDeposited } from '../channels/actions';
+import { channelDeposit } from '../channels/actions';
 import { ChannelState } from '../channels/state';
 import { channelAmounts } from '../channels/utils';
 import { Address, decode, Int, Signature, Signed, UInt } from '../utils/types';
@@ -389,7 +389,7 @@ export const pathFindServiceEpic = (
 /**
  * Sends a [[PFSCapacityUpdate]] to PFS global room on new deposit on our side of channels
  *
- * @param action$ - Observable of channelDeposited actions
+ * @param action$ - Observable of channelDeposit.success actions
  * @param state$ - Observable of RaidenStates
  * @returns Observable of messageGlobalSend actions
  */
@@ -399,7 +399,7 @@ export const pfsCapacityUpdateEpic = (
   { address, network, signer, config$ }: RaidenEpicDeps,
 ): Observable<messageGlobalSend> =>
   action$.pipe(
-    filter(isActionOf(channelDeposited)),
+    filter(isActionOf(channelDeposit.success)),
     filter(action => action.payload.participant === address),
     debounceTime(10e3),
     withLatestFrom(state$, config$),

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -36,11 +36,7 @@ import {
   raidenConfigUpdate,
 } from './actions';
 import { channelOpen, channelDeposit, channelClose, channelSettle } from './channels/actions';
-import {
-  matrixPresenceUpdate,
-  matrixRequestMonitorPresenceFailed,
-  matrixRequestMonitorPresence,
-} from './transport/actions';
+import { matrixPresence } from './transport/actions';
 import { transfer, transferFailed, transferSigned } from './transfers/actions';
 import { makeSecret, getSecrethash, makePaymentId } from './transfers/utils';
 import { pathFind } from './path/actions';
@@ -586,18 +582,9 @@ export class Raiden {
     address: string,
   ): Promise<{ userId: string; available: boolean; ts: number }> {
     assert(Address.is(address), 'Invalid address');
-    const promise = this.action$
-      .pipe(
-        filter(isActionOf([matrixPresenceUpdate, matrixRequestMonitorPresenceFailed])),
-        filter(action => action.meta.address === address),
-        first(),
-        map(action => {
-          if (isActionOf(matrixRequestMonitorPresenceFailed, action)) throw action.payload;
-          return action.payload;
-        }),
-      )
-      .toPromise();
-    this.store.dispatch(matrixRequestMonitorPresence(undefined, { address }));
+    const meta = { address };
+    const promise = asyncActionToPromise(matrixPresence, meta, this.action$);
+    this.store.dispatch(matrixPresence.request(undefined, meta));
     return promise;
   }
 

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -37,7 +37,7 @@ import {
 } from './actions';
 import { channelOpen, channelDeposit, channelClose, channelSettle } from './channels/actions';
 import { matrixPresence } from './transport/actions';
-import { transfer, transferFailed, transferSigned } from './transfers/actions';
+import { transfer, transferSigned } from './transfers/actions';
 import { makeSecret, getSecrethash, makePaymentId } from './transfers/utils';
 import { pathFind } from './path/actions';
 import { Paths, RaidenPaths, PFS, RaidenPFS, IOU } from './path/types';
@@ -673,17 +673,17 @@ export class Raiden {
           merge(
             // wait for transfer response
             this.action$.pipe(
-              filter(isActionOf([transferSigned, transferFailed])),
+              filter(isActionOf([transferSigned, transfer.failure])),
               first(action => action.meta.secrethash === secrethash),
               map(action => {
-                if (isActionOf(transferFailed, action)) throw action.payload;
+                if (transfer.failure.is(action)) throw action.payload;
                 return secrethash;
               }),
             ),
             // request transfer with returned/validated paths at 'merge' subscription time
             defer(() => {
               this.store.dispatch(
-                transfer(
+                transfer.request(
                   {
                     tokenNetwork,
                     target,

--- a/raiden-ts/src/transfers/epics.ts
+++ b/raiden-ts/src/transfers/epics.ts
@@ -47,7 +47,7 @@ import { Channel, ChannelState } from '../channels/state';
 import { Lock, SignedBalanceProof } from '../channels/types';
 import { channelClose, newBlock } from '../channels/actions';
 import { RaidenConfig } from '../config';
-import { matrixRequestMonitorPresence } from '../transport/actions';
+import { matrixPresence } from '../transport/actions';
 import { pluckDistinct } from '../utils/rx';
 import {
   transfer,
@@ -822,9 +822,7 @@ export const transferAutoExpireEpic = (
 export const initQueuePendingEnvelopeMessagesEpic = (
   {}: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-): Observable<
-  matrixRequestMonitorPresence | transferSigned | transferUnlocked | transferExpired
-> =>
+): Observable<matrixPresence.request | transferSigned | transferUnlocked | transferExpired> =>
   state$.pipe(
     first(),
     mergeMap(function*(state) {
@@ -834,7 +832,7 @@ export const initQueuePendingEnvelopeMessagesEpic = (
         // transfer already completed or channelClosed
         if (sent.unlockProcessed || sent.lockExpiredProcessed || sent.channelClosed) continue;
         // on init, request monitor presence of any pending transfer target
-        yield matrixRequestMonitorPresence(undefined, { address: sent.transfer[1].target });
+        yield matrixPresence.request(undefined, { address: sent.transfer[1].target });
         // Processed not received yet for LockedTransfer
         if (!sent.transferProcessed)
           yield transferSigned({ message: sent.transfer[1], fee: sent.fee }, { secrethash });

--- a/raiden-ts/src/transfers/epics.ts
+++ b/raiden-ts/src/transfers/epics.ts
@@ -45,7 +45,7 @@ import {
 import { getBalanceProofFromEnvelopeMessage, signMessage } from '../messages/utils';
 import { Channel, ChannelState } from '../channels/state';
 import { Lock, SignedBalanceProof } from '../channels/types';
-import { channelClose, channelClosed, newBlock } from '../channels/actions';
+import { channelClose, newBlock } from '../channels/actions';
 import { RaidenConfig } from '../config';
 import { matrixRequestMonitorPresence } from '../transport/actions';
 import { pluckDistinct } from '../utils/rx';
@@ -1108,7 +1108,7 @@ export const transferExpireProcessedEpic = (
  * Transfer is considered successful if secret was revealed (as it could be claimed on-chain),
  * else it's considered as failed as couldn't succeed inside expiration timeout
  *
- * @param action$ - Observable of channelClose|channelClosed actions
+ * @param action$ - Observable of channelClose.{requet,success} actions
  * @param state$ - Observable of RaidenStates
  * @returns Observable of transferred|transferFailed actions
  */
@@ -1117,7 +1117,7 @@ export const transferChannelClosedEpic = (
   state$: Observable<RaidenState>,
 ): Observable<transferred | transferFailed> =>
   action$.pipe(
-    filter(isActionOf([channelClose, channelClosed])),
+    filter(isActionOf([channelClose.request, channelClose.success])),
     withLatestFrom(state$),
     mergeMap(function*([action, state]) {
       for (const [key, sent] of Object.entries(state.sent)) {

--- a/raiden-ts/src/transfers/epics.ts
+++ b/raiden-ts/src/transfers/epics.ts
@@ -61,22 +61,16 @@ import { pluckDistinct } from '../utils/rx';
 import {
   transfer,
   transferExpire,
-  transferExpired,
-  transferExpireFailed,
   transferExpireProcessed,
-  transferFailed,
   transferProcessed,
-  transferred,
   transferRefunded,
   transferSecret,
   transferSecretRequest,
   transferSecretReveal,
   transferSigned,
   transferUnlock,
-  transferUnlocked,
   transferUnlockProcessed,
-  withdrawReceiveRequest,
-  withdrawSendConfirmation,
+  withdrawReceive,
 } from './actions';
 import { getLocksroot, getSecrethash, makeMessageId } from './utils';
 
@@ -160,13 +154,13 @@ function getChannelLocksroot(channel: Channel, secrethash: Hash): Hash {
  */
 function makeAndSignTransfer$(
   state: RaidenState,
-  action: transfer,
+  action: transfer.request,
   { revealTimeout }: RaidenConfig,
   deps: RaidenEpicDeps,
 ): Observable<transferSecret | transferSigned> {
   const { address, network, signer } = deps;
   if (action.meta.secrethash in state.sent) {
-    // don't throw to avoid emitting transferFailed, to just wait for already pending transfer
+    // don't throw to avoid emitting transfer.failure, to just wait for already pending transfer
     console.error('transfer already present', action.meta);
     return EMPTY;
   }
@@ -249,17 +243,17 @@ function makeAndSignTransfer$(
  * @param state$ - Observable of current state
  * @param action - transfer request action to be sent
  * @param deps - RaidenEpicDeps
- * @returns Observable of transferSigned|transferSecret|transferFailed actions
+ * @returns Observable of transferSigned|transferSecret|transfer.failure actions
  */
 function makeAndSignTransfer(
   state$: Observable<RaidenState>,
-  action: transfer,
+  action: transfer.request,
   deps: RaidenEpicDeps,
-): Observable<transferSecret | transferSigned | transferFailed> {
+): Observable<transferSecret | transferSigned | transfer.failure> {
   return combineLatest([state$, deps.config$]).pipe(
     first(),
     mergeMap(([state, config]) => makeAndSignTransfer$(state, action, config, deps)),
-    catchError(err => of(transferFailed(err, action.meta))),
+    catchError(err => of(transfer.failure(err, action.meta))),
   );
 }
 
@@ -268,16 +262,16 @@ function makeAndSignTransfer(
  *
  * @param state$ - Observable of the latest app state.
  * @param state - Contains The current state of the app
- * @param action - The transfer unlock action that will generate the transferUnlocked action.
+ * @param action - The transfer unlock action that will generate the transferUnlock.success action.
  * @param signer - The signer that will sign the message
- * @returns Observable of {@link transferUnlocked} action.
+ * @returns Observable of {@link transferUnlock.success} action.
  */
 function makeAndSignUnlock$(
   state$: Observable<RaidenState>,
   state: RaidenState,
-  action: transferUnlock,
+  action: transferUnlock.request,
   signer: Signer,
-): Observable<transferUnlocked> {
+): Observable<transferUnlock.success> {
   const secrethash = action.meta.secrethash;
   assert(secrethash in state.sent, 'unknown transfer');
   const transfer = state.sent[secrethash].transfer[1];
@@ -323,7 +317,7 @@ function makeAndSignUnlock$(
     mergeMap(function*([signed, state]) {
       assert(transfer.lock.expiration.gt(state.blockNumber), 'lock expired!');
       assert(!state.sent[secrethash].channelClosed, 'channel closed!');
-      yield transferUnlocked({ message: signed }, action.meta);
+      yield transferUnlock.success({ message: signed }, action.meta);
       // messageSend Unlock handled by transferUnlockedRetryMessageEpic
       // we don't check if transfer was refunded. If partner refunded the transfer but still
       // forwarded the payment, we still act honestly and unlock if they revealed
@@ -332,27 +326,27 @@ function makeAndSignUnlock$(
 }
 
 /**
- * Create an observable to compose and sign a Unlock message/transferUnlocked action
+ * Create an observable to compose and sign a Unlock message/transferUnlock.success action
  * As it's an async observable which depends on state and may return an action which changes it,
  * the returned observable must be subscribed in a serialized context that ensures non-concurrent
  * write access to the channel's balance proof (e.g. concatMap)
  *
  * @param state$ - Observable of current state
- * @param action - transferUnlock request action to be sent
+ * @param action - transferUnlock.request request action to be sent
  * @param signer - RaidenEpicDeps members
- * @returns Observable of transferUnlocked actions
+ * @returns Observable of transferUnlock.success actions
  */
 function makeAndSignUnlock(
   state$: Observable<RaidenState>,
-  action: transferUnlock,
+  action: transferUnlock.request,
   { signer }: RaidenEpicDeps,
-): Observable<transferUnlocked> {
+): Observable<transferUnlock.success | transferUnlock.failure> {
   return state$.pipe(
     first(),
     mergeMap(state => makeAndSignUnlock$(state$, state, action, signer)),
     catchError(err => {
       console.error('Error when trying to unlock after SecretReveal', err);
-      return EMPTY;
+      return of(transferUnlock.failure(err, action.meta));
     }),
   );
 }
@@ -363,13 +357,13 @@ function makeAndSignUnlock(
  * @param state - Contains The current state of the app
  * @param action - The transfer expire action.
  * @param signer - RaidenEpicDeps members
- * @returns Observable of transferExpired actions
+ * @returns Observable of transferExpire.success actions
  */
 function makeAndSignLockExpired$(
   state: RaidenState,
-  action: transferExpire,
+  action: transferExpire.request,
   signer: Signer,
-): Observable<transferExpired> {
+): Observable<transferExpire.success> {
   const secrethash = action.meta.secrethash;
   assert(secrethash in state.sent, 'unknown transfer');
   const transfer = state.sent[secrethash].transfer[1];
@@ -411,12 +405,12 @@ function makeAndSignLockExpired$(
 
   return signed$.pipe(
     // messageSend LockExpired handled by transferExpiredRetryMessageEpic
-    map(signed => transferExpired({ message: signed }, action.meta)),
+    map(signed => transferExpire.success({ message: signed }, action.meta)),
   );
 }
 
 /**
- * Create an observable to compose and sign a LockExpired message/transferExpired action
+ * Create an observable to compose and sign a LockExpired message/transferExpire.success action
  * As it's an async observable which depends on state and may return an action which changes it,
  * the returned observable must be subscribed in a serialized context that ensures non-concurrent
  * write access to the channel's balance proof (e.g. concatMap)
@@ -424,23 +418,23 @@ function makeAndSignLockExpired$(
  * @param state$ - Observable of current state
  * @param action - transfer request action to be sent
  * @param signer - RaidenEpicDeps members
- * @returns Observable of transferExpired|transferExpireFailed actions
+ * @returns Observable of transferExpire.success|transferExpire.failure actions
  */
 function makeAndSignLockExpired(
   state$: Observable<RaidenState>,
-  action: transferExpire,
+  action: transferExpire.request,
   { signer }: RaidenEpicDeps,
-): Observable<transferExpired | transferExpireFailed> {
+): Observable<transferExpire.success | transferExpire.failure> {
   return state$.pipe(
     first(),
     mergeMap(state => makeAndSignLockExpired$(state, action, signer)),
-    catchError(err => of(transferExpireFailed(err, action.meta))),
+    catchError(err => of(transferExpire.failure(err, action.meta))),
   );
 }
 
 function makeAndSignWithdrawConfirmation$(
   state: RaidenState,
-  action: withdrawReceiveRequest,
+  action: withdrawReceive.request,
   signer: Signer,
   cache: LruCache<string, Signed<WithdrawConfirmation>>,
 ) {
@@ -495,7 +489,7 @@ function makeAndSignWithdrawConfirmation$(
     signed$ = from(signMessage(signer, confirmation)).pipe(tap(signed => cache.put(key, signed)));
   }
 
-  return signed$.pipe(map(signed => withdrawSendConfirmation({ message: signed }, action.meta)));
+  return signed$.pipe(map(signed => withdrawReceive.success({ message: signed }, action.meta)));
 }
 
 /**
@@ -518,14 +512,14 @@ function makeAndSignWithdrawConfirmation$(
  * @param action - Withdraw request which caused this handling
  * @param signer - RaidenEpicDeps members
  * @param cache - A Map to store and reuse previously Signed<WithdrawConfirmation>
- * @returns Observable of transferExpired|transferExpireFailed actions
+ * @returns Observable of transferExpire.success|transferExpire.failure actions
  */
 function makeAndSignWithdrawConfirmation(
   state$: Observable<RaidenState>,
-  action: withdrawReceiveRequest,
+  action: withdrawReceive.request,
   { signer }: RaidenEpicDeps,
   cache: LruCache<string, Signed<WithdrawConfirmation>>,
-): Observable<withdrawSendConfirmation> {
+): Observable<withdrawReceive.success> {
   return state$.pipe(
     first(),
     mergeMap(state => makeAndSignWithdrawConfirmation$(state, action, signer, cache)),
@@ -554,25 +548,33 @@ export const transferGenerateAndSignEnvelopeMessageEpic = (
 ): Observable<
   | transferSigned
   | transferSecret
-  | transferUnlocked
-  | transferFailed
-  | transferExpired
-  | transferExpireFailed
-  | withdrawSendConfirmation
+  | transferUnlock.success
+  | transferUnlock.failure
+  | transfer.failure
+  | transferExpire.success
+  | transferExpire.failure
+  | withdrawReceive.success
 > => {
   const withdrawCache = new LruCache<string, Signed<WithdrawConfirmation>>(32);
   const latestState$ = deps.latest$.pipe(pluckDistinct('state'));
   return action$.pipe(
-    filter(isActionOf([transfer, transferUnlock, transferExpire, withdrawReceiveRequest])),
+    filter(
+      isActionOf([
+        transfer.request,
+        transferUnlock.request,
+        transferExpire.request,
+        withdrawReceive.request,
+      ]),
+    ),
     concatMap(action => {
       switch (action.type) {
-        case transfer.type:
+        case transfer.request.type:
           return makeAndSignTransfer(latestState$, action, deps);
-        case transferUnlock.type:
+        case transferUnlock.request.type:
           return makeAndSignUnlock(latestState$, action, deps);
-        case transferExpire.type:
+        case transferExpire.request.type:
           return makeAndSignLockExpired(latestState$, action, deps);
-        case withdrawReceiveRequest.type:
+        case withdrawReceive.request.type:
           return makeAndSignWithdrawConfirmation(latestState$, action, deps, withdrawCache);
       }
     }),
@@ -637,16 +639,16 @@ export const transferSignedRetryMessageEpic = (
 /**
  * Core logic of {@link transferUnlockedRetryMessageEpic}
  *
- * @param action$ - Observable of transferUnlocked actions
+ * @param action$ - Observable of transferUnlock.success actions
  * @param state$ - Observable of the latest RaidenStates
- * @param action - the transferUnlocked action
+ * @param action - the transferUnlock.success action
  * @param state - Contains the current state of the app
  * @returns Observable of {@link messageSend.request} actions
  */
 const transferUnlockedRetryMessage$ = (
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-  action: transferUnlocked,
+  action: transferUnlock.success,
   state: RaidenState,
 ): Observable<messageSend.request> => {
   const secrethash = action.meta.secrethash;
@@ -668,11 +670,11 @@ const transferUnlockedRetryMessage$ = (
 };
 
 /**
- * Handles a transferUnlocked action and retry messageSend until confirmed.
- * transferUnlocked for pending Unlock's may be re-emitted on startup for pending transfer, to
+ * Handles a transferUnlock.success action and retry messageSend until confirmed.
+ * transferUnlock.success for pending Unlock's may be re-emitted on startup for pending transfer, to
  * start retrying sending the message again until stop condition is met.
  *
- * @param action$ - Observable of transferUnlocked actions
+ * @param action$ - Observable of transferUnlock.success actions
  * @param state$ - Observable of RaidenStates
  * @param deps - RaidenEpicDeps
  * @returns Observable of messageSend.request actions
@@ -683,7 +685,7 @@ export const transferUnlockedRetryMessageEpic = (
   { latest$ }: RaidenEpicDeps,
 ): Observable<messageSend.request> =>
   action$.pipe(
-    filter(isActionOf(transferUnlocked)),
+    filter(isActionOf(transferUnlock.success)),
     withLatestFrom(latest$.pipe(pluckDistinct('state'))),
     mergeMap(([action, state]) =>
       transferUnlockedRetryMessage$(action$, latest$.pipe(pluckDistinct('state')), action, state),
@@ -693,16 +695,16 @@ export const transferUnlockedRetryMessageEpic = (
 /**
  * Core logic of {@link transferExpiredRetryMessageEpic}.
  *
- * @param action$ - Observable of transferUnlocked actions
+ * @param action$ - Observable of transferUnlock.success actions
  * @param state$ - Observable of RaidenStates
- * @param action - transferExpired action
+ * @param action - transferExpire.success action
  * @param state - The current state of the app
  * @returns Observable of {@link messageSend.request} actions
  */
 const expiredRetryMessages$ = (
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-  action: transferExpired,
+  action: transferExpire.success,
   state: RaidenState,
 ): Observable<messageSend.request> => {
   const secrethash = action.meta.secrethash;
@@ -724,12 +726,12 @@ const expiredRetryMessages$ = (
 };
 
 /**
- * Handles a transferExpired action and retry messageSend.request until transfer is gone (completed
+ * Handles a transferExpire.success action and retry messageSend.request until transfer is gone (completed
  * with success or error).
- * transferExpired for pending LockExpired's may be re-emitted on startup for pending transfer, to
+ * transferExpire.success for pending LockExpired's may be re-emitted on startup for pending transfer, to
  * start retrying sending the message again until stop condition is met.
  *
- * @param action$ - Observable of transferExpired actions
+ * @param action$ - Observable of transferExpire.success actions
  * @param state$ - Observable of RaidenStates
  * @param latest$ - RaidenEpicDeps latest
  * @returns Observable of messageSend.request actions
@@ -740,7 +742,7 @@ export const transferExpiredRetryMessageEpic = (
   { latest$ }: RaidenEpicDeps,
 ): Observable<messageSend.request> =>
   action$.pipe(
-    filter(isActionOf(transferExpired)),
+    filter(isActionOf(transferExpire.success)),
     withLatestFrom(latest$.pipe(pluckDistinct('state'))),
     mergeMap(([action, state]) =>
       expiredRetryMessages$(action$, latest$.pipe(pluckDistinct('state')), action, state),
@@ -753,14 +755,14 @@ export const transferExpiredRetryMessageEpic = (
  * @param state - Contains The current state of the app
  * @param blockNumber - The current block number
  * @param action$ - Observable of {@link RaidenAction} actions
- * @returns Observable of {@link transferExpire} or {@link transferFailed} actions
+ * @returns Observable of {@link transferExpire.request} or {@link transfer.failure} actions
  */
 function autoExpire$(
   state: RaidenState,
   blockNumber: number,
   action$: Observable<RaidenAction>,
-): Observable<transferExpire | transferFailed> {
-  const requests$: Observable<transferExpire | transferFailed>[] = [];
+): Observable<transferExpire.request | transfer.failure> {
+  const requests$: Observable<transferExpire.request | transfer.failure>[] = [];
 
   for (const [key, sent] of Object.entries(state.sent)) {
     if (
@@ -774,15 +776,14 @@ function autoExpire$(
     // this observable acts like a Promise: emits request once, completes on success/failure
     const requestAndWait$ = dispatchAndWait$(
       action$,
-      transferExpire(undefined, { secrethash }),
-      a =>
-        isActionOf([transferExpired, transferExpireFailed], a) && a.meta.secrethash === secrethash,
+      transferExpire.request(undefined, { secrethash }),
+      isResponseOf(transferExpire, { secrethash }),
     );
     requests$.push(requestAndWait$);
     // notify users that this transfer failed definitely
     requests$.push(
       of(
-        transferFailed(
+        transfer.failure(
           new Error(`transfer expired at block=${sent.transfer[1].lock.expiration.toString()}`),
           { secrethash },
         ),
@@ -795,19 +796,19 @@ function autoExpire$(
 }
 
 /**
- * Process newBlocks, emits transferExpire (request to compose&sign LockExpired for a transfer)
+ * Process newBlocks, emits transferExpire.request (request to compose&sign LockExpired for a transfer)
  * if pending transfer's lock expired and transfer didn't unlock (succeed) in time
- * Also, emits transferFailed, to notify users that a transfer has failed (although it'll only be
+ * Also, emits transfer.failure, to notify users that a transfer has failed (although it'll only be
  * considered as completed with fail once the transferExpireProcessed arrives).
  *
- * @param action$ - Observable of newBlock|transferExpired|transferExpireFailed actions
+ * @param action$ - Observable of newBlock|transferExpire.success|transferExpire.failure actions
  * @param state$ - Observable of RaidenStates
- * @returns Observable of transferExpire|transferFailed actions
+ * @returns Observable of transferExpire.request|transfer.failure actions
  */
 export const transferAutoExpireEpic = (
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-): Observable<transferExpire | transferFailed> =>
+): Observable<transferExpire.request | transfer.failure> =>
   action$.pipe(
     filter(isActionOf(newBlock)),
     withLatestFrom(state$),
@@ -829,12 +830,14 @@ export const transferAutoExpireEpic = (
  *
  * @param action$ - Observable of RaidenActions
  * @param state$ - Observable of RaidenStates
- * @returns Observable of transferSigned|transferUnlocked actions
+ * @returns Observable of transferSigned|transferUnlock.success actions
  */
 export const initQueuePendingEnvelopeMessagesEpic = (
   {}: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-): Observable<matrixPresence.request | transferSigned | transferUnlocked | transferExpired> =>
+): Observable<
+  matrixPresence.request | transferSigned | transferUnlock.success | transferExpire.success
+> =>
   state$.pipe(
     first(),
     mergeMap(function*(state) {
@@ -849,10 +852,10 @@ export const initQueuePendingEnvelopeMessagesEpic = (
         if (!sent.transferProcessed)
           yield transferSigned({ message: sent.transfer[1], fee: sent.fee }, { secrethash });
         // already unlocked, but Processed not received yet for Unlock
-        if (sent.unlock) yield transferUnlocked({ message: sent.unlock[1] }, { secrethash });
+        if (sent.unlock) yield transferUnlock.success({ message: sent.unlock[1] }, { secrethash });
         // lock expired, but Processed not received yet for LockExpired
         if (sent.lockExpired)
-          yield transferExpired({ message: sent.lockExpired[1] }, { secrethash });
+          yield transferExpire.success({ message: sent.lockExpired[1] }, { secrethash });
       }
     }),
   );
@@ -1006,7 +1009,7 @@ export const transferSecretRevealEpic = (
 /**
  * Handles receiving a valid SecretReveal from recipient (neighbor/partner)
  * This indicates that the partner knowws the secret, and we should Unlock to avoid going on-chain.
- * The transferUnlock action is a request for the unlocking to be generated and sent.
+ * The transferUnlock.request action is a request for the unlocking to be generated and sent.
  *
  * @param action$ - Observable of RaidenActions
  * @param state$ - Observable of RaidenStates
@@ -1015,7 +1018,7 @@ export const transferSecretRevealEpic = (
 export const transferSecretRevealedEpic = (
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-): Observable<transferUnlock | transferSecret> =>
+): Observable<transferUnlock.request | transferSecret> =>
   action$.pipe(
     filter(isActionOf(messageReceived)),
     withLatestFrom(state$),
@@ -1036,7 +1039,7 @@ export const transferSecretRevealedEpic = (
       // transferSecret is noop if we already know the secret (e.g. we're the initiator)
       yield transferSecret({ secret: message.secret }, { secrethash });
       // request unlock to be composed, signed & sent to partner
-      yield transferUnlock(undefined, { secrethash });
+      yield transferUnlock.request(undefined, { secrethash });
     }),
   );
 
@@ -1047,12 +1050,12 @@ export const transferSecretRevealedEpic = (
  *
  * @param action$ - Observable of messageReceived actions
  * @param state$ - Observable of RaidenStates
- * @returns Observable of transferred|transferUnlockProcessed actions
+ * @returns Observable of transfer.success|transferUnlockProcessed actions
  */
 export const transferUnlockProcessedReceivedEpic = (
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-): Observable<transferred | transferUnlockProcessed> =>
+): Observable<transfer.success | transferUnlockProcessed> =>
   action$.pipe(
     filter(isActionOf(messageReceived)),
     withLatestFrom(state$),
@@ -1071,7 +1074,7 @@ export const transferUnlockProcessedReceivedEpic = (
         }
       }
       if (!secrethash) return;
-      yield transferred(
+      yield transfer.success(
         {
           balanceProof: getBalanceProofFromEnvelopeMessage(state.sent[secrethash].unlock![1]),
         },
@@ -1084,7 +1087,7 @@ export const transferUnlockProcessedReceivedEpic = (
 /**
  * Handles receiving a signed Processed for some sent LockExpired
  * It marks the end of the unhappy case, by setting sent.lockExpiredProcessed
- * transferFailed was already sent at newBlock handling/transferExpire time
+ * transfer.failure was already sent at newBlock handling/transferExpire.request time
  *
  * @param action$ - Observable of RaidenActions
  * @param state$ - Observable of RaidenStates
@@ -1123,38 +1126,38 @@ export const transferExpireProcessedEpic = (
  *
  * @param action$ - Observable of channelClose.{requet,success} actions
  * @param state$ - Observable of RaidenStates
- * @returns Observable of transferred|transferFailed actions
+ * @returns Observable of transfer.{success|failure} actions
  */
 export const transferChannelClosedEpic = (
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-): Observable<transferred | transferFailed> =>
+): Observable<transfer.success | transfer.failure> =>
   action$.pipe(
     filter(isActionOf([channelClose.request, channelClose.success])),
     withLatestFrom(state$),
     mergeMap(function*([action, state]) {
       for (const [key, sent] of Object.entries(state.sent)) {
         const secrethash = key as Hash;
-        const transfer = sent.transfer[1];
+        const sentTransfer = sent.transfer[1];
         if (
-          transfer.token_network_address !== action.meta.tokenNetwork ||
-          transfer.recipient !== action.meta.partner
+          sentTransfer.token_network_address !== action.meta.tokenNetwork ||
+          sentTransfer.recipient !== action.meta.partner
         )
           continue;
         // as we can't know for sure if recipient/partner received the secret or unlock,
         //consider transfer failed iff neither the secret was revealed nor the unlock happened
         if (!sent.secretReveal && !sent.unlock)
-          yield transferFailed(new Error(`Channel closed before revealing or unlocking`), {
+          yield transfer.failure(new Error(`Channel closed before revealing or unlocking`), {
             secrethash,
           });
         else if (state.sent[secrethash].unlock)
-          yield transferred(
+          yield transfer.success(
             {
               balanceProof: getBalanceProofFromEnvelopeMessage(state.sent[secrethash].unlock![1]),
             },
             { secrethash },
           );
-        else yield transferred({}, { secrethash });
+        else yield transfer.success({}, { secrethash });
       }
     }),
   );
@@ -1164,12 +1167,12 @@ export const transferChannelClosedEpic = (
  *
  * @param action$ - Observable of messageReceived actions
  * @param state$ - Observable of RaidenStates
- * @returns Observable of transferFailed|transferRefunded actions
+ * @returns Observable of transfer.failure|transferRefunded actions
  */
 export const transferRefundedEpic = (
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-): Observable<transferRefunded | transferFailed> =>
+): Observable<transferRefunded | transfer.failure> =>
   action$.pipe(
     filter(isActionOf(messageReceived)),
     withLatestFrom(state$),
@@ -1178,12 +1181,12 @@ export const transferRefundedEpic = (
       if (!message || !Signed(RefundTransfer).is(message)) return;
       const secrethash = message.lock.secrethash;
       if (!(secrethash in state.sent)) return;
-      const [, transfer] = state.sent[secrethash].transfer;
+      const [, sent] = state.sent[secrethash].transfer;
       if (
-        message.initiator !== transfer.recipient ||
-        !message.payment_identifier.eq(transfer.payment_identifier) ||
-        !message.lock.amount.eq(transfer.lock.amount) ||
-        !message.lock.expiration.eq(transfer.lock.expiration) ||
+        message.initiator !== sent.recipient ||
+        !message.payment_identifier.eq(sent.payment_identifier) ||
+        !message.lock.amount.eq(sent.lock.amount) ||
+        !message.lock.expiration.eq(sent.lock.expiration) ||
         state.sent[secrethash].unlock || // already unlocked
         state.sent[secrethash].lockExpired || // already expired
         state.sent[secrethash].channelClosed || // channel closed
@@ -1191,7 +1194,7 @@ export const transferRefundedEpic = (
       )
         return;
       yield transferRefunded({ message }, { secrethash });
-      yield transferFailed(new Error('transfer refunded'), { secrethash });
+      yield transfer.failure(new Error('transfer refunded'), { secrethash });
     }),
   );
 
@@ -1258,15 +1261,15 @@ export const transferReceivedReplyProcessedEpic = (
 };
 
 /**
- * When receiving a [[WithdrawRequest]] message, create the respective [[withdrawReceiveRequest]]
+ * When receiving a [[WithdrawRequest]] message, create the respective [[withdrawReceive.request]]
  * action
  *
  * @param action$ - Observable of messageReceived actions
- * @returns Observable of withdrawReceiveRequest actions
+ * @returns Observable of withdrawReceive.request actions
  */
 export const withdrawRequestReceivedEpic = (
   action$: Observable<RaidenAction>,
-): Observable<withdrawReceiveRequest> =>
+): Observable<withdrawReceive.request> =>
   action$.pipe(
     filter(isActionOf(messageReceived)),
     mergeMap(function*(action) {
@@ -1277,7 +1280,7 @@ export const withdrawRequestReceivedEpic = (
         message.participant !== action.meta.address
       )
         return;
-      yield withdrawReceiveRequest(
+      yield withdrawReceive.request(
         { message },
         {
           tokenNetwork: message.token_network_address,
@@ -1290,16 +1293,16 @@ export const withdrawRequestReceivedEpic = (
   );
 
 /**
- * sendMessage when a [[withdrawSendConfirmation]] action is fired
+ * sendMessage when a [[withdrawReceive.success]] action is fired
  *
- * @param action$ - Observable of withdrawSendConfirmation actions
+ * @param action$ - Observable of withdrawReceive.success actions
  * @returns Observable of messageSend.request actions
  */
 export const withdrawSendConfirmationEpic = (
   action$: Observable<RaidenAction>,
 ): Observable<messageSend.request> =>
   action$.pipe(
-    filter(isActionOf(withdrawSendConfirmation)),
+    filter(isActionOf(withdrawReceive.success)),
     map(action =>
       messageSend.request(
         { message: action.payload.message },

--- a/raiden-ts/src/transfers/reducer.ts
+++ b/raiden-ts/src/transfers/reducer.ts
@@ -6,7 +6,7 @@ import { RaidenState, initialState } from '../state';
 import { RaidenAction } from '../actions';
 import { Channel, ChannelState } from '../channels/state';
 import { SignedBalanceProof } from '../channels/types';
-import { channelClosed } from '../channels/actions';
+import { channelClose } from '../channels/actions';
 import { getLocksroot } from './utils';
 import { SignatureZero } from '../constants';
 import { timed, UInt, Signature, Hash } from '../utils/types';
@@ -228,7 +228,7 @@ export function transfersReducer(
         },
       },
     };
-  } else if (isActionOf(channelClosed, action)) {
+  } else if (isActionOf(channelClose.success, action)) {
     return {
       ...state,
       sent: mapValues(

--- a/raiden-ts/src/transfers/reducer.ts
+++ b/raiden-ts/src/transfers/reducer.ts
@@ -17,14 +17,14 @@ import {
   transferSigned,
   transferSecret,
   transferProcessed,
-  transferUnlocked,
-  transferExpired,
+  transferUnlock,
+  transferExpire,
   transferSecretReveal,
   transferRefunded,
   transferUnlockProcessed,
   transferExpireProcessed,
   transferClear,
-  withdrawSendConfirmation,
+  withdrawReceive,
 } from './actions';
 
 /**
@@ -116,7 +116,7 @@ export function transfersReducer(
         },
       },
     };
-  } else if (isActionOf(transferUnlocked, action)) {
+  } else if (isActionOf(transferUnlock.success, action)) {
     const unlock = action.payload.message,
       secrethash = action.meta.secrethash;
     if (!(secrethash in state.sent) || state.sent[secrethash].unlock) return state;
@@ -150,7 +150,7 @@ export function transfersReducer(
     state = set(channelPath, channel, state);
     state = set(['sent', secrethash], sentTransfer, state);
     return state;
-  } else if (isActionOf(transferExpired, action)) {
+  } else if (isActionOf(transferExpire.success, action)) {
     const lockExpired = action.payload.message,
       secrethash = action.meta.secrethash;
     if (
@@ -246,7 +246,7 @@ export function transfersReducer(
     state = unset(['sent', action.meta.secrethash], state);
     state = unset(['secrets', action.meta.secrethash], state);
     return state;
-  } else if (isActionOf(withdrawSendConfirmation, action)) {
+  } else if (isActionOf(withdrawReceive.success, action)) {
     const message = action.payload.message,
       channelPath = ['channels', action.meta.tokenNetwork, action.meta.partner];
     let channel: Channel | undefined = get(channelPath, state);

--- a/raiden-ts/src/transport/actions.ts
+++ b/raiden-ts/src/transport/actions.ts
@@ -1,8 +1,9 @@
+/* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/class-name-casing */
 import * as t from 'io-ts';
 
-import { createAction, ActionType } from '../utils/actions';
-import { Address, ErrorCodec } from '../utils/types';
+import { createAction, ActionType, createAsyncAction } from '../utils/actions';
+import { Address } from '../utils/types';
 import { RaidenMatrixSetup } from './state';
 
 const NodeId = t.type({ address: Address });
@@ -17,35 +18,20 @@ export const matrixSetup = createAction(
 );
 export interface matrixSetup extends ActionType<typeof matrixSetup> {}
 
-/* Request matrix to start monitoring presence updates for meta.address */
-export const matrixRequestMonitorPresence = createAction(
-  'matrixRequestMonitorPresence',
+export const matrixPresence = createAsyncAction(
+  NodeId,
+  'matrix/presence/request',
+  'matrix/presence/success',
+  'matrix/presence/failure',
   undefined,
-  NodeId,
-);
-export interface matrixRequestMonitorPresence
-  extends ActionType<typeof matrixRequestMonitorPresence> {}
-
-/**
- * Monitored user meta.address presence updated.
- * First event for this address also works as 'success' for matrixRequestMonitorPresence
- */
-export const matrixPresenceUpdate = createAction(
-  'matrixPresenceUpdate',
   t.type({ userId: t.string, available: t.boolean, ts: t.number }),
-  NodeId,
 );
-export interface matrixPresenceUpdate extends ActionType<typeof matrixPresenceUpdate> {}
 
-/* A matrixRequestMonitorPresence request action (with meta.address) failed with payload=Error */
-export const matrixRequestMonitorPresenceFailed = createAction(
-  'matrixRequestMonitorPresenceFailed',
-  ErrorCodec,
-  NodeId,
-  true,
-);
-export interface matrixRequestMonitorPresenceFailed
-  extends ActionType<typeof matrixRequestMonitorPresenceFailed> {}
+export namespace matrixPresence {
+  export interface request extends ActionType<typeof matrixPresence.request> {}
+  export interface success extends ActionType<typeof matrixPresence.success> {}
+  export interface failure extends ActionType<typeof matrixPresence.failure> {}
+}
 
 /* payload.roomId must go front on meta.address's room queue */
 export const matrixRoom = createAction('matrixRoom', t.type({ roomId: t.string }), NodeId);

--- a/raiden-ts/src/transport/epics.ts
+++ b/raiden-ts/src/transport/epics.ts
@@ -54,7 +54,7 @@ import { Address, Signed, isntNil, assert } from '../utils/types';
 import { isActionOf } from '../utils/actions';
 import { RaidenEpicDeps } from '../types';
 import { RaidenAction } from '../actions';
-import { channelMonitored } from '../channels/actions';
+import { channelMonitor } from '../channels/actions';
 import {
   Message,
   MessageType,
@@ -629,7 +629,7 @@ export const matrixPresenceUpdateEpic = (
  * Create room (if needed) for a transfer's target, channel's partner or, as a fallback, for any
  * recipient of a messageSend action
  *
- * @param action$ - Observable of transferSigned|channelMonitored|messageSend actions
+ * @param action$ - Observable of transferSigned|channelMonitor|messageSend actions
  * @param state$ - Observable of RaidenStates
  * @param matrix$ - RaidenEpicDeps members
  * @returns Observable of matrixRoom actions
@@ -646,11 +646,11 @@ export const matrixCreateRoomEpic = (
       // actual output observable, selects addresses of interest from actions
       action$.pipe(
         // ensure there's a room for address of interest for each of these actions
-        filter(isActionOf([transferSigned, channelMonitored, messageSend])),
+        filter(isActionOf([transferSigned, channelMonitor, messageSend])),
         map(action =>
           isActionOf(transferSigned, action)
             ? action.payload.message.target
-            : isActionOf(channelMonitored, action)
+            : isActionOf(channelMonitor, action)
             ? action.meta.partner
             : action.meta.address,
         ),
@@ -1209,7 +1209,7 @@ export const matrixMonitorChannelPresenceEpic = (
   action$: Observable<RaidenAction>,
 ): Observable<matrixRequestMonitorPresence> =>
   action$.pipe(
-    filter(isActionOf(channelMonitored)),
+    filter(isActionOf(channelMonitor)),
     map(action => matrixRequestMonitorPresence(undefined, { address: action.meta.partner })),
   );
 

--- a/raiden-ts/src/transport/types.ts
+++ b/raiden-ts/src/transport/types.ts
@@ -1,5 +1,5 @@
-import { matrixPresenceUpdate } from './actions';
+import { matrixPresence } from './actions';
 
 export interface Presences {
-  [address: string]: matrixPresenceUpdate;
+  [address: string]: matrixPresence.success;
 }

--- a/raiden-ts/src/transport/utils.ts
+++ b/raiden-ts/src/transport/utils.ts
@@ -6,9 +6,8 @@ import { MatrixClient, Room } from 'matrix-js-sdk';
 import { RaidenAction } from '../actions';
 import { RaidenConfig } from '../config';
 import { isntNil } from '../utils/types';
-import { isActionOf } from '../utils/actions';
 import { Presences } from './types';
-import { matrixPresenceUpdate } from './actions';
+import { matrixPresence } from './actions';
 
 /**
  * Helper to map/get an aggregated Presences observable from action$ bus
@@ -21,7 +20,7 @@ import { matrixPresenceUpdate } from './actions';
 export const getPresences$ = memoize(
   (action$: Observable<RaidenAction>): Observable<Presences> =>
     action$.pipe(
-      filter(isActionOf(matrixPresenceUpdate)),
+      filter(matrixPresence.success.is),
       scan(
         // scan all presence update actions and populate/output a per-address mapping
         (presences, update) => ({

--- a/raiden-ts/tests/unit/actions.spec.ts
+++ b/raiden-ts/tests/unit/actions.spec.ts
@@ -4,11 +4,7 @@ import * as t from 'io-ts';
 import { from } from 'rxjs';
 import { bigNumberify } from 'ethers/utils';
 
-import {
-  channelDeposit,
-  channelDepositFailed,
-  channelMonitored,
-} from 'raiden-ts/channels/actions';
+import { channelDeposit, channelMonitor } from 'raiden-ts/channels/actions';
 import { Address, UInt, ErrorCodec, decode } from 'raiden-ts/utils/types';
 import {
   createAction,
@@ -25,26 +21,26 @@ describe('action factories not tested in reducers.spec.ts', () => {
   test('channelMonitor', () => {
     const id = 12,
       fromBlock = 5123;
-    expect(channelMonitored({ id, fromBlock }, { tokenNetwork, partner })).toEqual({
-      type: 'channelMonitored',
+    expect(channelMonitor({ id, fromBlock }, { tokenNetwork, partner })).toEqual({
+      type: channelMonitor.type,
       payload: { id, fromBlock },
       meta: { tokenNetwork, partner },
     });
   });
 
-  test('channelDeposit', () => {
+  test('channelDeposit request', () => {
     const deposit = bigNumberify(999) as UInt<32>;
-    expect(channelDeposit({ deposit }, { tokenNetwork, partner })).toEqual({
-      type: 'channelDeposit',
+    expect(channelDeposit.request({ deposit }, { tokenNetwork, partner })).toEqual({
+      type: channelDeposit.request.type,
       payload: { deposit },
       meta: { tokenNetwork, partner },
     });
   });
 
-  test('channelDepositFailed', () => {
+  test('channelDeposit failed', () => {
     const error = new Error('not enough funds');
-    expect(channelDepositFailed(error, { tokenNetwork, partner })).toEqual({
-      type: 'channelDepositFailed',
+    expect(channelDeposit.failure(error, { tokenNetwork, partner })).toEqual({
+      type: channelDeposit.failure.type,
       payload: error,
       meta: { tokenNetwork, partner },
       error: true,

--- a/raiden-ts/tests/unit/actions.spec.ts
+++ b/raiden-ts/tests/unit/actions.spec.ts
@@ -1,5 +1,8 @@
-import { bigNumberify } from 'ethers/utils';
+/* eslint-disable @typescript-eslint/class-name-casing */
+/* eslint-disable @typescript-eslint/no-namespace */
 import * as t from 'io-ts';
+import { from } from 'rxjs';
+import { bigNumberify } from 'ethers/utils';
 
 import {
   channelDeposit,
@@ -7,7 +10,14 @@ import {
   channelMonitored,
 } from 'raiden-ts/channels/actions';
 import { Address, UInt, ErrorCodec, decode } from 'raiden-ts/utils/types';
-import { createAction, ActionType, isActionOf } from 'raiden-ts/utils/actions';
+import {
+  createAction,
+  ActionType,
+  isActionOf,
+  createAsyncAction,
+  isResponseOf,
+  asyncActionToPromise,
+} from 'raiden-ts/utils/actions';
 
 describe('action factories not tested in reducers.spec.ts', () => {
   const tokenNetwork = '0x0000000000000000000000000000000000020001' as Address,
@@ -42,89 +52,147 @@ describe('action factories not tested in reducers.spec.ts', () => {
   });
 });
 
-test('utils/actions', () => {
-  const actionT = createAction('TEST1');
-  const actionTP = createAction('TEST2', t.type({ a: t.number }));
-  const actionTPM = createAction('TEST3', t.type({ a: t.number }), t.type({ m: t.string }));
-  const actionTM = createAction('TEST4', undefined, t.type({ m: t.string }));
-  const actionTE = createAction('TEST5', undefined, undefined, true);
-  const actionTPE = createAction('TEST6', t.type({ a: t.number }), undefined, false);
-  const actionTPME = createAction('TEST7', t.type({ a: t.number }), t.type({ m: t.string }), true);
-  const actionTME = createAction('TEST8', undefined, t.type({ m: t.string }), false);
-  const actionUnd = createAction('TEST_U', t.union([t.type({ a: t.number }), t.undefined]));
+describe('utils/actions', () => {
+  test('createAction + isActionOf + ActionType', () => {
+    const actionT = createAction('TEST1');
+    const actionTP = createAction('TEST2', t.type({ a: t.number }));
+    const actionTPM = createAction('TEST3', t.type({ a: t.number }), t.type({ m: t.string }));
+    const actionTM = createAction('TEST4', undefined, t.type({ m: t.string }));
+    const actionTE = createAction('TEST5', undefined, undefined, true);
+    const actionTPE = createAction('TEST6', t.type({ a: t.number }), undefined, false);
+    const actionTPME = createAction(
+      'TEST7',
+      t.type({ a: t.number }),
+      t.type({ m: t.string }),
+      true,
+    );
+    const actionTME = createAction('TEST8', undefined, t.type({ m: t.string }), false);
+    const actionUnd = createAction('TEST_U', t.union([t.type({ a: t.number }), t.undefined]));
 
-  const actionFailed = createAction(
-    'TEST_FAILED',
-    ErrorCodec,
-    t.type({ context: t.string }),
-    true,
-  );
+    const actionFailed = createAction(
+      'TEST_FAILED',
+      ErrorCodec,
+      t.type({ context: t.string }),
+      true,
+    );
 
-  expect(actionT.type).toBe('TEST1');
-  expect(actionTPME.error).toBe(true);
-  expect(actionFailed.error).toBe(true);
+    expect(actionT.type).toBe('TEST1');
+    expect(actionTPME.error).toBe(true);
+    expect(actionFailed.error).toBe(true);
 
-  expect(actionT()).toStrictEqual({ type: 'TEST1' });
-  expect(actionTP({ a: 1 })).toStrictEqual({ type: 'TEST2', payload: { a: 1 } });
-  expect(actionTPM({ a: 1 }, { m: 'abc' })).toStrictEqual({
-    type: 'TEST3',
-    payload: { a: 1 },
-    meta: { m: 'abc' },
-  });
-  expect(actionTM(undefined, { m: 'abc' })).toStrictEqual({ type: 'TEST4', meta: { m: 'abc' } });
-  expect(actionTE()).toStrictEqual({ type: 'TEST5', error: true });
-  expect(actionTPE({ a: 1 })).toStrictEqual({ type: 'TEST6', payload: { a: 1 }, error: false });
-  expect(actionTPME({ a: 1 }, { m: 'abc' })).toStrictEqual({
-    type: 'TEST7',
-    payload: { a: 1 },
-    meta: { m: 'abc' },
-    error: true,
-  });
-  expect(actionTME(undefined, { m: 'abc' })).toStrictEqual({
-    type: 'TEST8',
-    meta: { m: 'abc' },
-    error: false,
-  });
-
-  // test action with payload unioned with undefined
-  expect(actionUnd({ a: 1 })).toStrictEqual({ type: 'TEST_U', payload: { a: 1 } });
-  expect(actionUnd(undefined)).toStrictEqual({ type: 'TEST_U', payload: undefined });
-  expect(actionUnd.is(actionUnd(undefined))).toBe(true);
-
-  try {
-    throw new Error('Failed');
-  } catch (e) {
-    expect(actionFailed(e, { context: 'init' })).toStrictEqual({
-      type: 'TEST_FAILED',
-      payload: expect.any(Error),
-      meta: { context: 'init' },
+    expect(actionT()).toStrictEqual({ type: 'TEST1' });
+    expect(actionTP({ a: 1 })).toStrictEqual({ type: 'TEST2', payload: { a: 1 } });
+    expect(actionTPM({ a: 1 }, { m: 'abc' })).toStrictEqual({
+      type: 'TEST3',
+      payload: { a: 1 },
+      meta: { m: 'abc' },
+    });
+    expect(actionTM(undefined, { m: 'abc' })).toStrictEqual({ type: 'TEST4', meta: { m: 'abc' } });
+    expect(actionTE()).toStrictEqual({ type: 'TEST5', error: true });
+    expect(actionTPE({ a: 1 })).toStrictEqual({ type: 'TEST6', payload: { a: 1 }, error: false });
+    expect(actionTPME({ a: 1 }, { m: 'abc' })).toStrictEqual({
+      type: 'TEST7',
+      payload: { a: 1 },
+      meta: { m: 'abc' },
       error: true,
     });
-  }
+    expect(actionTME(undefined, { m: 'abc' })).toStrictEqual({
+      type: 'TEST8',
+      meta: { m: 'abc' },
+      error: false,
+    });
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const a1: any = {
-    type: 'TEST7',
-    payload: { a: 1 },
-    meta: { m: 'metaOfTest7' },
-    error: true,
-  };
+    // test action with payload unioned with undefined
+    expect(actionUnd({ a: 1 })).toStrictEqual({ type: 'TEST_U', payload: { a: 1 } });
+    expect(actionUnd(undefined)).toStrictEqual({ type: 'TEST_U', payload: undefined });
+    expect(actionUnd.is(actionUnd(undefined))).toBe(true);
 
-  // type narrowing
-  let b1: ActionType<typeof actionTPME>;
-  expect(actionTPME.is(a1)).toBe(true);
-  if (actionTPME.is(a1)) {
-    b1 = a1;
-    expect(b1).toStrictEqual(a1);
-  }
+    try {
+      throw new Error('Failed');
+    } catch (e) {
+      expect(actionFailed(e, { context: 'init' })).toStrictEqual({
+        type: 'TEST_FAILED',
+        payload: expect.any(Error),
+        meta: { context: 'init' },
+        error: true,
+      });
+    }
 
-  expect(isActionOf(actionTPME, a1)).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const a1: any = {
+      type: 'TEST7',
+      payload: { a: 1 },
+      meta: { m: 'metaOfTest7' },
+      error: true,
+    };
 
-  expect(isActionOf([actionTM, actionTPM, actionTME, actionTPME])(a1)).toBe(true);
-  if (isActionOf([actionTM, actionTPM, actionTME, actionTPME])(a1)) {
-    // can access member of union
-    expect(a1.meta).toStrictEqual({ m: 'metaOfTest7' });
-  }
+    // type narrowing
+    let b1: ActionType<typeof actionTPME>;
+    expect(actionTPME.is(a1)).toBe(true);
+    if (actionTPME.is(a1)) {
+      b1 = a1;
+      expect(b1).toStrictEqual(a1);
+    }
 
-  expect(decode(actionTPME.codec, a1)).toEqual(a1);
+    expect(isActionOf(actionTPME, a1)).toBe(true);
+
+    expect(isActionOf([actionTM, actionTPM, actionTME, actionTPME])(a1)).toBe(true);
+    if (isActionOf([actionTM, actionTPM, actionTME, actionTPME])(a1)) {
+      // can access member of union
+      expect(a1.meta).toStrictEqual({ m: 'metaOfTest7' });
+    }
+
+    expect(decode(actionTPME.codec, a1)).toEqual(a1);
+  });
+
+  test('createAsyncAction', async () => {
+    const asyncAction = createAsyncAction(
+      t.type({ id: t.number }),
+      'test/request',
+      'test/success',
+      'test/failure',
+      t.partial({ query: t.string }),
+      t.boolean,
+    );
+
+    const req: ActionType<typeof asyncAction.request> = asyncAction.request({}, { id: 123 });
+    expect(req).toStrictEqual({
+      type: 'test/request',
+      payload: {},
+      meta: { id: 123 },
+    });
+
+    const success = asyncAction.success(true, { id: 456 });
+    expect(success).toStrictEqual({
+      type: 'test/success',
+      payload: true,
+      meta: { id: 456 },
+    });
+
+    // isResponseOf
+    expect(isResponseOf(asyncAction, req.meta, success)).toBe(false);
+
+    const err = new Error('no entry with given id');
+    const fail: ActionType<typeof asyncAction.failure> = asyncAction.failure(err, {
+      id: 123,
+    });
+    expect(fail).toStrictEqual({
+      type: 'test/failure',
+      payload: err,
+      meta: { id: 123 },
+      error: true,
+    });
+
+    // ActionType of AsyncActionCreator is union of actions
+    const arr: ActionType<typeof asyncAction>[] = [success, fail];
+    const responseFilter = isResponseOf(asyncAction, req.meta);
+    expect(arr.filter(responseFilter)).toEqual([fail]);
+
+    // asyncActionToPromise
+    let action$ = from([success, fail]);
+    await expect(asyncActionToPromise(asyncAction, req.meta, action$)).rejects.toThrow('no entry');
+
+    action$ = from([asyncAction.success(true, { id: 123 }), fail]);
+    await expect(asyncActionToPromise(asyncAction, req.meta, action$)).resolves.toBe(true);
+  });
 });

--- a/raiden-ts/tests/unit/epics/path.spec.ts
+++ b/raiden-ts/tests/unit/epics/path.spec.ts
@@ -8,9 +8,9 @@ import { UInt, Int, Address, Signature } from 'raiden-ts/utils/types';
 import {
   newBlock,
   tokenMonitored,
-  channelOpened,
-  channelDeposited,
-  channelClosed,
+  channelOpen,
+  channelDeposit,
+  channelClose,
 } from 'raiden-ts/channels/actions';
 import { raidenConfigUpdate } from 'raiden-ts/actions';
 import { matrixPresenceUpdate } from 'raiden-ts/transport/actions';
@@ -88,11 +88,11 @@ describe('PFS: pathFindServiceEpic', () => {
       [
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         // a couple of channels with unrelated partners, with larger deposits
-        channelOpened(
+        channelOpen.success(
           { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
           { tokenNetwork, partner },
         ),
-        channelDeposited(
+        channelDeposit.success(
           {
             id: channelId,
             participant: depsMock.address,
@@ -766,7 +766,7 @@ describe('PFS: pathFindServiceEpic', () => {
 
     state$.next(
       [
-        channelClosed(
+        channelClose.success(
           { id: channelId, participant: partner, closeBlock: 126, txHash },
           { tokenNetwork, partner },
         ),
@@ -1136,7 +1136,7 @@ describe('PFS: pfsCapacityUpdateEpic', () => {
   beforeEach(async () => {
     openedState = [
       tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-      channelOpened(
+      channelOpen.success(
         { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
         { tokenNetwork, partner },
       ),
@@ -1144,11 +1144,11 @@ describe('PFS: pfsCapacityUpdateEpic', () => {
     ].reduce(raidenReducer, state);
   });
 
-  test('own channelDeposited triggers capacity update', async () => {
+  test('own channelDeposit.success triggers capacity update', async () => {
     expect.assertions(1);
 
     const deposit = bigNumberify(500) as UInt<32>,
-      action = channelDeposited(
+      action = channelDeposit.success(
         {
           id: channelId,
           participant: depsMock.address,
@@ -1180,7 +1180,7 @@ describe('PFS: pfsCapacityUpdateEpic', () => {
     expect.assertions(2);
 
     const deposit = bigNumberify(500) as UInt<32>,
-      action = channelDeposited(
+      action = channelDeposit.success(
         {
           id: channelId,
           participant: depsMock.address,

--- a/raiden-ts/tests/unit/epics/path.spec.ts
+++ b/raiden-ts/tests/unit/epics/path.spec.ts
@@ -13,7 +13,7 @@ import {
   channelClose,
 } from 'raiden-ts/channels/actions';
 import { raidenConfigUpdate } from 'raiden-ts/actions';
-import { matrixPresenceUpdate } from 'raiden-ts/transport/actions';
+import { matrixPresence } from 'raiden-ts/transport/actions';
 import { raidenReducer } from 'raiden-ts/reducer';
 import {
   pathFindServiceEpic,
@@ -104,11 +104,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -130,11 +130,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: false, ts: Date.now() },
           { address: target },
         ),
@@ -156,11 +156,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -186,11 +186,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -213,11 +213,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -269,11 +269,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -329,11 +329,11 @@ describe('PFS: pathFindServiceEpic', () => {
         pfsListUpdated({
           pfsList: [pfsAddress1, pfsAddress2, pfsAddress3, pfsAddress],
         }),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -443,11 +443,11 @@ describe('PFS: pathFindServiceEpic', () => {
         pfsListUpdated({
           pfsList: [pfsAddress, pfsAddress, pfsAddress],
         }),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -478,11 +478,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -527,11 +527,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -573,11 +573,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -629,11 +629,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -686,11 +686,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -749,11 +749,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -812,11 +812,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(80000000) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -841,11 +841,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -914,11 +914,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -960,11 +960,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -1014,11 +1014,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),
@@ -1087,11 +1087,11 @@ describe('PFS: pathFindServiceEpic', () => {
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: partnerUserId, available: true, ts: Date.now() },
           { address: partner },
         ),
-        matrixPresenceUpdate(
+        matrixPresence.success(
           { userId: targetUserId, available: true, ts: Date.now() },
           { address: target },
         ),

--- a/raiden-ts/tests/unit/epics/raiden.spec.ts
+++ b/raiden-ts/tests/unit/epics/raiden.spec.ts
@@ -431,7 +431,7 @@ describe('raiden epic', () => {
       const output = await promise;
       expect(output).toHaveLength(2);
       expect(output[1]).toMatchObject({
-        type: messageSend.type,
+        type: messageSend.request.type,
         payload: {
           message: {
             type: MessageType.DELIVERED,

--- a/raiden-ts/tests/unit/epics/transfers.spec.ts
+++ b/raiden-ts/tests/unit/epics/transfers.spec.ts
@@ -69,7 +69,7 @@ import {
   withdrawRequestReceivedEpic,
   withdrawSendConfirmationEpic,
 } from 'raiden-ts/transfers/epics';
-import { matrixPresenceUpdate, matrixRequestMonitorPresence } from 'raiden-ts/transport/actions';
+import { matrixPresence } from 'raiden-ts/transport/actions';
 import { raidenReducer } from 'raiden-ts/reducer';
 import { UInt, Address, Hash, Signed } from 'raiden-ts/utils/types';
 import { isActionOf, ActionType } from 'raiden-ts/utils/actions';
@@ -135,7 +135,7 @@ describe('transfers epic', () => {
         otherPartner2 = hexlify(randomBytes(20)) as Address,
         otherDeposit = bigNumberify(800) as UInt<32>,
         action$ = of(
-          matrixPresenceUpdate(
+          matrixPresence.success(
             {
               userId: `@${otherPartner1.toLowerCase()}:${matrixServer}`,
               available: true,
@@ -143,7 +143,7 @@ describe('transfers epic', () => {
             },
             { address: otherPartner1 },
           ),
-          matrixPresenceUpdate(
+          matrixPresence.success(
             {
               userId: `@${otherPartner2.toLowerCase()}:${matrixServer}`,
               available: true,
@@ -151,7 +151,7 @@ describe('transfers epic', () => {
             },
             { address: otherPartner2 },
           ),
-          matrixPresenceUpdate(
+          matrixPresence.success(
             { userId: partnerUserId, available: true, ts: Date.now() },
             { address: partner },
           ),
@@ -253,7 +253,7 @@ describe('transfers epic', () => {
 
       const closingPartner = '0x0100000000000000000000000000000000000000' as Address,
         action$ = of(
-          matrixPresenceUpdate(
+          matrixPresence.success(
             { userId: partnerUserId, available: true, ts: Date.now() },
             { address: partner },
           ),
@@ -319,7 +319,7 @@ describe('transfers epic', () => {
      */
     beforeEach(async () => {
       const action$: Observable<RaidenAction> = of(
-          matrixPresenceUpdate(
+          matrixPresence.success(
             { userId: partnerUserId, available: true, ts: Date.now() },
             { address: partner },
           ),
@@ -1028,7 +1028,7 @@ describe('transfers epic', () => {
             .pipe(toArray())
             .toPromise(),
         ).resolves.toEqual([
-          matrixRequestMonitorPresence(undefined, { address: partner }),
+          matrixPresence.request(undefined, { address: partner }),
           transferSigned({ message: signedTransfer, fee }, { secrethash }),
         ]);
       });
@@ -1049,7 +1049,7 @@ describe('transfers epic', () => {
             .toPromise(),
         ).resolves.toEqual(
           expect.arrayContaining([
-            matrixRequestMonitorPresence(undefined, { address: partner }),
+            matrixPresence.request(undefined, { address: partner }),
             unlocked,
           ]),
         );
@@ -1081,7 +1081,7 @@ describe('transfers epic', () => {
             .toPromise(),
         ).resolves.toEqual(
           expect.arrayContaining([
-            matrixRequestMonitorPresence(undefined, { address: partner }),
+            matrixPresence.request(undefined, { address: partner }),
             expired,
           ]),
         );

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -14,7 +14,7 @@ import { verifyMessage, BigNumber } from 'ethers/utils';
 import { RaidenAction } from 'raiden-ts/actions';
 import { raidenReducer } from 'raiden-ts/reducer';
 import { RaidenState } from 'raiden-ts/state';
-import { channelMonitored } from 'raiden-ts/channels/actions';
+import { channelMonitor } from 'raiden-ts/channels/actions';
 import {
   matrixRequestMonitorPresence,
   matrixPresenceUpdate,
@@ -287,9 +287,9 @@ describe('transport epic', () => {
   });
 
   describe('matrixMonitorChannelPresenceEpic', () => {
-    test('channelMonitored triggers matrixRequestMonitorPresence', async () => {
+    test('channelMonitor triggers matrixRequestMonitorPresence', async () => {
       const action$ = of<RaidenAction>(
-        channelMonitored({ id: channelId }, { tokenNetwork, partner }),
+        channelMonitor({ id: channelId }, { tokenNetwork, partner }),
       );
       const promise = matrixMonitorChannelPresenceEpic(action$).toPromise();
       await expect(promise).resolves.toEqual(

--- a/raiden-ts/tests/unit/reducers.spec.ts
+++ b/raiden-ts/tests/unit/reducers.spec.ts
@@ -25,14 +25,14 @@ import {
   transferSecret,
   transferSigned,
   transferProcessed,
-  transferUnlocked,
+  transferUnlock,
   transferClear,
-  transferExpired,
+  transferExpire,
   transferSecretReveal,
   transferRefunded,
   transferUnlockProcessed,
   transferExpireProcessed,
-  withdrawSendConfirmation,
+  withdrawReceive,
 } from 'raiden-ts/transfers/actions';
 import {
   LockedTransfer,
@@ -847,7 +847,7 @@ describe('raidenReducer', () => {
           secret,
           signature: makeSignature(),
         },
-        newState = [transferUnlocked({ message: unlock }, { secrethash })].reduce(
+        newState = [transferUnlock.success({ message: unlock }, { secrethash })].reduce(
           raidenReducer,
           state,
         );
@@ -856,14 +856,14 @@ describe('raidenReducer', () => {
 
       newState = [
         transferSigned({ message: transfer, fee }, { secrethash }),
-        transferUnlocked({ message: unlock }, { secrethash }),
+        transferUnlock.success({ message: unlock }, { secrethash }),
       ].reduce(raidenReducer, newState);
 
       // invalid lock because locked_amount isn't right
       expect(get(newState, ['sent', secrethash, 'unlock'])).toBeUndefined();
 
       unlock = { ...unlock, locked_amount: Zero as UInt<32> };
-      newState = [transferUnlocked({ message: unlock }, { secrethash })].reduce(
+      newState = [transferUnlock.success({ message: unlock }, { secrethash })].reduce(
         raidenReducer,
         newState,
       );
@@ -898,7 +898,7 @@ describe('raidenReducer', () => {
           recipient: partner,
           signature: makeSignature(),
         },
-        newState = [transferExpired({ message: lockExpired }, { secrethash })].reduce(
+        newState = [transferExpire.success({ message: lockExpired }, { secrethash })].reduce(
           raidenReducer,
           state,
         );
@@ -907,14 +907,14 @@ describe('raidenReducer', () => {
 
       newState = [
         transferSigned({ message: transfer, fee }, { secrethash }),
-        transferExpired({ message: lockExpired }, { secrethash }),
+        transferExpire.success({ message: lockExpired }, { secrethash }),
       ].reduce(raidenReducer, newState);
 
       // invalid lock because locked_amount isn't right
       expect(get(newState, ['sent', secrethash, 'lockExpired'])).toBeUndefined();
 
       lockExpired = { ...lockExpired, locked_amount: Zero as UInt<32> };
-      newState = [transferExpired({ message: lockExpired }, { secrethash })].reduce(
+      newState = [transferExpire.success({ message: lockExpired }, { secrethash })].reduce(
         raidenReducer,
         newState,
       );
@@ -1005,7 +1005,7 @@ describe('raidenReducer', () => {
 
     // withdraw request is under transfer just to use its pending transfer setup/vars
     describe('withdraw request', () => {
-      test('withdrawSendConfirmation', () => {
+      test('withdrawReceive.success', () => {
         let confirmation: Signed<WithdrawConfirmation> = {
           type: MessageType.WITHDRAW_CONFIRMATION,
           message_identifier: makeMessageId(),
@@ -1025,7 +1025,7 @@ describe('raidenReducer', () => {
           get(
             raidenReducer(
               state,
-              withdrawSendConfirmation(
+              withdrawReceive.success(
                 { message: confirmation },
                 {
                   tokenNetwork,
@@ -1056,14 +1056,14 @@ describe('raidenReducer', () => {
           // now, a state with a preent own.balanceProof due to a completed transfer
           newState = [
             transferSigned({ message: transfer, fee }, { secrethash }),
-            transferUnlocked({ message: unlock }, { secrethash }),
+            transferUnlock.success({ message: unlock }, { secrethash }),
           ].reduce(raidenReducer, state),
           prevNonce = newState.channels[tokenNetwork][partner].own.balanceProof!.nonce;
 
         // forgot to update nonce, reducer must be noop
         let newState2 = raidenReducer(
           newState,
-          withdrawSendConfirmation(
+          withdrawReceive.success(
             { message: confirmation },
             {
               tokenNetwork,
@@ -1085,7 +1085,7 @@ describe('raidenReducer', () => {
 
         newState2 = raidenReducer(
           newState,
-          withdrawSendConfirmation(
+          withdrawReceive.success(
             { message: confirmation },
             {
               tokenNetwork,


### PR DESCRIPTION
Based on top of #759 
Closes #662 
This also helps with #657 , as now we have helpers/utilities to link async actions through `meta` and [a]wait for responses/results and reducing some boilerplate out there.

Adds a `createAsyncAction`, which returns a `{ request, success, failure }` object, containing the respective legs of asynchronous actions. This all with strong types and serializable through `io-ts`.
- [x] `createAsyncActions`
- [x] `isResponseOf` helper
- [x] `asyncActionToPromise` helper
- [x] Tests
- [x] Implement in all asynchronous actions throughout the SDK