### PR TITLE
Simplify exported transfers reducer type, ChannelOpened filter

### DIFF
--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -212,16 +212,9 @@ export const tokenMonitoredEpic = (
 
           // type of elements emitted by getEventsStream (past and new events coming from
           // contract): [channelId, partner1, partner2, settleTimeout, Event]
-          type ChannelOpenedEvent = [BigNumber, Address, Address, BigNumber, Event];
-
-          const filters = [
-            tokenNetworkContract.filters.ChannelOpened(null, address, null, null),
-            tokenNetworkContract.filters.ChannelOpened(null, null, address, null),
-          ];
-
-          return getEventsStream<ChannelOpenedEvent>(
+          return getEventsStream<[BigNumber, Address, Address, BigNumber, Event]>(
             tokenNetworkContract,
-            filters,
+            [tokenNetworkContract.filters.ChannelOpened(null, null, null, null)],
             // if first time monitoring this token network,
             // fetch TokenNetwork's pastEvents since registry deployment as fromBlock$
             action.payload.fromBlock ? of(action.payload.fromBlock) : undefined,

--- a/raiden-ts/src/transfers/reducer.ts
+++ b/raiden-ts/src/transfers/reducer.ts
@@ -1,8 +1,10 @@
+import { Reducer } from 'redux';
 import { get, set, unset, mapValues } from 'lodash/fp';
 import { Zero, HashZero } from 'ethers/constants';
 import { hexlify } from 'ethers/utils';
 
 import { RaidenState, initialState } from '../state';
+import { RaidenAction } from '../actions';
 import { Channel, ChannelState } from '../channels/state';
 import { SignedBalanceProof } from '../channels/types';
 import { channelClose } from '../channels/actions';
@@ -319,7 +321,7 @@ function withdrawReceiveSuccessReducer(
 /**
  * Handles all transfers actions and requests
  */
-export const transfersReducer = createReducer(initialState)
+export const transfersReducer: Reducer<RaidenState, RaidenAction> = createReducer(initialState)
   .handle(transferSecret, transferSecretReducer)
   .handle(transferSigned, transferSignedReducer)
   .handle(transferProcessed, transferProcessedReducer)

--- a/raiden-ts/tests/unit/epics/raiden.spec.ts
+++ b/raiden-ts/tests/unit/epics/raiden.spec.ts
@@ -336,7 +336,7 @@ describe('raiden epic', () => {
         .toPromise();
 
       depsMock.provider.emit(
-        tokenNetworkContract.filters.ChannelOpened(null, depsMock.address, null, null),
+        tokenNetworkContract.filters.ChannelOpened(null, null, null, null),
         makeLog({
           blockNumber: 125,
           filter: tokenNetworkContract.filters.ChannelOpened(
@@ -375,7 +375,7 @@ describe('raiden epic', () => {
 
       // even though multiple tokenMonitored events were fired, blockchain fires a single event
       depsMock.provider.emit(
-        tokenNetworkContract.filters.ChannelOpened(null, depsMock.address, null, null),
+        tokenNetworkContract.filters.ChannelOpened(null, null, null, null),
         makeLog({
           blockNumber: 125,
           filter: tokenNetworkContract.filters.ChannelOpened(
@@ -397,7 +397,7 @@ describe('raiden epic', () => {
       });
 
       // one for channels with us, one for channels from us
-      expect(depsMock.provider.on).toHaveBeenCalledTimes(2);
+      expect(depsMock.provider.on).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
`createReducer` with many actions can have a heavy declaration, which slows down tsc/tsserver. We only  need full type (`handle`, etc) when declaring, afterwards it can be just considered an usual `Reducer`, reducing the type weight.
Additionally, `ChannelOpened` filter was making two requests, while only a single one was needed, and the participant could be easily filtered later on observable.