### PR TITLE
Monitors only tokens of interest

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - User can now dismiss/hide the transfer progress dialog.
 - Fix utility token display on PFS route selection.
+- Adjust the token fetching to work with the latest SDK changes.
 
 ### Fixed
 - [#712] Fix AddressInput.vue validity not updating on presence changes.

--- a/raiden-dapp/package-lock.json
+++ b/raiden-dapp/package-lock.json
@@ -17526,9 +17526,9 @@
       "requires": {
         "@types/lodash": "^4.14.149",
         "abort-controller": "^3.0.0",
-        "ethers": "^4.0.41",
-        "fp-ts": "^2.3.1",
-        "io-ts": "^2.0.2",
+        "ethers": "^4.0.42",
+        "fp-ts": "^2.4.0",
+        "io-ts": "^2.0.4",
         "isomorphic-fetch": "^2.2.1",
         "lodash": "^4.17.15",
         "lossless-json": "^1.0.3",
@@ -17797,9 +17797,9 @@
           }
         },
         "fp-ts": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.3.1.tgz",
-          "integrity": "sha512-KevPBnYt0aaJiuUzmU9YIxjrhC9AgJ8CLtLlXmwArovlNTeYM5NtEoKd86B0wHd7FIbzeE8sNXzCoYIOr7e6Iw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.4.0.tgz",
+          "integrity": "sha512-o96pqlRq4YB0dZpnInHrz6O6jHWTf+jDIpY6vsM/ZxAPfOhW9gl9ng62wfyhFHFeH+Ldn2/zOF32xbR2O+/MEw=="
         },
         "getpass": {
           "version": "0.1.7",
@@ -17866,9 +17866,9 @@
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "io-ts": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.0.3.tgz",
-          "integrity": "sha512-PLSW+/QELUEmt68jmS+1JOxDzK3jrNlfiCTb62mQYV7RfixuUHga+Up4gszLqLAtNOUSjv9UmqNX0n/tgpzniA=="
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.0.4.tgz",
+          "integrity": "sha512-GqCi13q6FFWbHZa6a+Aza6pJ66OqfYvEQwZyvKbKs21bez207NEQWhXH43JvwYIFk6R7rYidG8p/xqTYzvX2tQ=="
         },
         "is-stream": {
           "version": "1.1.0",

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -1,6 +1,6 @@
-import { Raiden, RaidenSentTransfer, RaidenPaths, RaidenPFS } from 'raiden-ts';
+import { Raiden, RaidenPaths, RaidenPFS, RaidenSentTransfer } from 'raiden-ts';
 import { Store } from 'vuex';
-import { RootState } from '@/types';
+import { RootState, Tokens } from '@/types';
 import { Web3Provider } from '@/services/web3-provider';
 import { BalanceUtils } from '@/utils/balance-utils';
 import { DeniedReason, Progress, Token, TokenModel } from '@/model/types';
@@ -38,6 +38,20 @@ export default class RaidenService {
     } else {
       return this._raiden;
     }
+  }
+
+  async fetchTokenList() {
+    const allTokens = await this.raiden.getTokenList();
+    const toFetch: string[] = [];
+    const placeholders: Tokens = {};
+
+    for (const token of allTokens) {
+      toFetch.push(token);
+      placeholders[token] = { address: token };
+    }
+
+    this.store.commit('updateTokens', placeholders);
+    await this.fetchTokenData(toFetch);
   }
 
   constructor(store: Store<RootState>) {
@@ -154,6 +168,7 @@ export default class RaidenService {
 
     this.store.commit('loadComplete');
   }
+
   disconnect() {
     this.raiden.stop();
   }

--- a/raiden-dapp/src/views/SelectToken.vue
+++ b/raiden-dapp/src/views/SelectToken.vue
@@ -10,7 +10,7 @@
         <recycle-scroller
           #default="{ item }"
           :items="allTokens"
-          :buffer="20"
+          :buffer="400"
           :item-size="105"
           key-field="address"
           class="select-token__tokens"
@@ -71,16 +71,17 @@ import { Token } from '@/model/types';
 import NavigationMixin from '@/mixins/navigation-mixin';
 import BlockieMixin from '@/mixins/blockie-mixin';
 import ListHeader from '@/components/ListHeader.vue';
+import Spinner from '@/components/Spinner.vue';
 
 @Component({
-  components: { ListHeader },
+  components: { Spinner, ListHeader },
   computed: mapGetters(['allTokens'])
 })
 export default class SelectToken extends Mixins(BlockieMixin, NavigationMixin) {
   allTokens!: Token[];
 
-  mounted() {
-    this.$raiden.fetchTokenData(Object.keys(this.$store.state.tokens));
+  async mounted() {
+    await this.$raiden.fetchTokenList();
   }
 }
 </script>
@@ -117,6 +118,11 @@ export default class SelectToken extends Mixins(BlockieMixin, NavigationMixin) {
       height: calc(100% - 150px);
       overflow-y: auto;
       @extend .themed-scrollbar;
+
+      .col {
+        height: 100%;
+        max-height: 1000px;
+      }
     }
 
     &__token {

--- a/raiden-dapp/tests/unit/views/select-token.spec.ts
+++ b/raiden-dapp/tests/unit/views/select-token.spec.ts
@@ -37,7 +37,7 @@ describe('SelectToken.vue', () => {
         $identicon: $identicon(),
         $raiden: {
           getToken: jest.fn().mockResolvedValue(TestData.token),
-          fetchTokenData: jest.fn().mockResolvedValue(null)
+          fetchTokenList: jest.fn().mockResolvedValue(null)
         },
         $t: (msg: string) => msg
       }

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#172] Add derived subkey support
 
 ### Changed
+- [#834] Optimize ethers events polling for several tokens
 - [#684] Support and require Typescript 3.7
 - [#593] Improve PFS url matching.
 

--- a/raiden-ts/package-lock.json
+++ b/raiden-ts/package-lock.json
@@ -4720,9 +4720,9 @@
       "dev": true
     },
     "events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+      "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg==",
       "dev": true
     },
     "eventsource": {
@@ -11480,9 +11480,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.0.tgz",
-      "integrity": "sha512-a/mxFfU00QT88umAJQsNWOnUKckhNCqOl028N48e7wFmo2/EHpTo9Wso+iJJCMrQnmFvcjto5RJdAHEvVhcyUQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
       "dev": true
     },
     "serve-index": {
@@ -12440,9 +12440,9 @@
       "dev": true
     },
     "terser": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.4.0.tgz",
-      "integrity": "sha512-oDG16n2WKm27JO8h4y/w3iqBGAOSCtq7k8dRmrn4Wf9NouL0b2WpMHGChFGZq4nFAQy1FsNJrVQHfurXOSTmOA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.2.tgz",
+      "integrity": "sha512-6FUjJdY2i3WZAtYBtnV06OOcOfzl+4hSKYE9wgac8rkLRBToPDDrBB2AcHwQD/OKDxbnvhVy2YgOPWO2SsKWqg==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -12451,28 +12451,20 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-      "integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+      "integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
       "dev": true,
       "requires": {
         "cacache": "^12.0.2",
         "find-cache-dir": "^2.1.0",
         "is-wsl": "^1.1.0",
         "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.7.0",
+        "serialize-javascript": "^2.1.2",
         "source-map": "^0.6.1",
         "terser": "^4.1.2",
         "webpack-sources": "^1.4.0",
         "worker-farm": "^1.7.0"
-      },
-      "dependencies": {
-        "serialize-javascript": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-          "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
-          "dev": true
-        }
       }
     },
     "test-exclude": {
@@ -13313,18 +13305,18 @@
       "dev": true
     },
     "vue-server-renderer": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.10.tgz",
-      "integrity": "sha512-UYoCEutBpKzL2fKCwx8zlRtRtwxbPZXKTqbl2iIF4yRZUNO/ovrHyDAJDljft0kd+K0tZhN53XRHkgvCZoIhug==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.11.tgz",
+      "integrity": "sha512-V3faFJHr2KYfdSIalL+JjinZSHYUhlrvJ9pzCIjjwSh77+pkrsXpK4PucdPcng57+N77pd1LrKqwbqjQdktU1A==",
       "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "hash-sum": "^1.0.2",
         "he": "^1.1.0",
-        "lodash.template": "^4.4.0",
+        "lodash.template": "^4.5.0",
         "lodash.uniq": "^4.5.0",
         "resolve": "^1.2.0",
-        "serialize-javascript": "^1.3.0",
+        "serialize-javascript": "^2.1.2",
         "source-map": "0.5.6"
       },
       "dependencies": {
@@ -13352,12 +13344,6 @@
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
           }
-        },
-        "serialize-javascript": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-          "integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==",
-          "dev": true
         },
         "source-map": {
           "version": "0.5.6",
@@ -13525,9 +13511,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.41.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.2.tgz",
-      "integrity": "sha512-Zhw69edTGfbz9/8JJoyRQ/pq8FYUoY0diOXqW0T6yhgdhCv6wr0hra5DwwWexNRns2Z2+gsnrNcbe9hbGBgk/A==",
+      "version": "4.41.5",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.41.5.tgz",
+      "integrity": "sha512-wp0Co4vpyumnp3KlkmpM5LWuzvZYayDwM2n17EHFr4qxBBbRokC7DJawPJC7TfSFZ9HZ6GsdH40EBj4UV0nmpw==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.8.5",
@@ -13550,7 +13536,7 @@
         "node-libs-browser": "^2.2.1",
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.1",
+        "terser-webpack-plugin": "^1.4.3",
         "watchpack": "^1.6.0",
         "webpack-sources": "^1.4.1"
       },

--- a/raiden-ts/src/channels/reducer.ts
+++ b/raiden-ts/src/channels/reducer.ts
@@ -3,7 +3,7 @@ import { Zero } from 'ethers/constants';
 import { Reducer } from 'redux';
 
 import { UInt } from '../utils/types';
-import { createReducer, isActionOf } from '../utils/actions';
+import { createReducer } from '../utils/actions';
 import { partialCombineReducers } from '../utils/redux';
 import { RaidenState, initialState } from '../state';
 import { RaidenAction } from '../actions';
@@ -20,17 +20,16 @@ import {
 import { Channel, ChannelState } from './state';
 
 // state.blockNumber specific reducer, handles only newBlock action
-function blockNumber(state: number = initialState.blockNumber, action: RaidenAction) {
-  if (isActionOf(newBlock, action)) return action.payload.blockNumber;
-  else return state;
-}
+const blockNumber = createReducer(initialState.blockNumber).handle(
+  newBlock,
+  ({}, { payload }) => payload.blockNumber,
+);
 
 // state.tokens specific reducer, handles only tokenMonitored action
-function tokens(state: RaidenState['tokens'] = initialState.tokens, action: RaidenAction) {
-  if (isActionOf(tokenMonitored, action))
-    return set([action.payload.token], action.payload.tokenNetwork, state);
-  else return state;
-}
+const tokens = createReducer(initialState.tokens).handle(
+  tokenMonitored,
+  (state, { payload: { token, tokenNetwork } }) => ({ ...state, [token]: tokenNetwork }),
+);
 
 // Reducers for different actions
 function channelOpenRequestReducer(

--- a/raiden-ts/tests/unit/epics/raiden.spec.ts
+++ b/raiden-ts/tests/unit/epics/raiden.spec.ts
@@ -3,32 +3,13 @@ import { epicFixtures } from '../fixtures';
 import { raidenEpicDeps, makeLog, makeSignature } from '../mocks';
 
 import { marbles } from 'rxjs-marbles/jest';
-import {
-  of,
-  from,
-  timer,
-  BehaviorSubject,
-  Subject,
-  Observable,
-  EMPTY,
-  merge,
-  ReplaySubject,
-} from 'rxjs';
-import {
-  first,
-  takeUntil,
-  toArray,
-  delay,
-  tap,
-  ignoreElements,
-  take,
-  finalize,
-} from 'rxjs/operators';
+import { of, from, timer, Observable, EMPTY, merge, ReplaySubject } from 'rxjs';
+import { first, takeUntil, toArray, delay, tap, ignoreElements } from 'rxjs/operators';
 import { bigNumberify } from 'ethers/utils';
 import { defaultAbiCoder } from 'ethers/utils/abi-coder';
 import { range } from 'lodash';
 
-import { UInt, Address, Signed } from 'raiden-ts/utils/types';
+import { UInt, Signed } from 'raiden-ts/utils/types';
 import { MessageType, Processed, Delivered } from 'raiden-ts/messages/types';
 import { RaidenAction, raidenShutdown } from 'raiden-ts/actions';
 import { RaidenState } from 'raiden-ts/state';
@@ -48,7 +29,7 @@ import { deliveredEpic } from 'raiden-ts/transport/epics';
 import {
   initMonitorProviderEpic,
   tokenMonitoredEpic,
-  initMonitorRegistryEpic,
+  initTokensRegistryEpic,
 } from 'raiden-ts/channels/epics';
 import { ShutdownReason } from 'raiden-ts/constants';
 import { makeMessageId } from 'raiden-ts/transfers/utils';
@@ -170,18 +151,7 @@ describe('raiden epic', () => {
       }),
     );
 
-    test('monitorRegistry: fetch past and new tokenNetworks', async () => {
-      expect.assertions(2);
-      const state$ = new BehaviorSubject(state),
-        action$ = new Subject<RaidenAction>(),
-        otherToken = '0x0000000000000000000000000000000000080001' as Address,
-        otherTokenNetwork = '0x0000000000000000000000000000000000090001' as Address;
-
-      action$.subscribe(action => state$.next(raidenReducer(state$.value, action)));
-
-      state$.next(raidenReducer(state$.value, newBlock({ blockNumber: 126 })));
-      depsMock.provider.resetEventsBlock(state$.value.blockNumber);
-
+    test('initTokensRegistryEpic: scan initially, monitor previous then', async () => {
       depsMock.provider.getLogs.mockResolvedValueOnce([
         makeLog({
           blockNumber: 121,
@@ -189,47 +159,73 @@ describe('raiden epic', () => {
         }),
       ]);
 
-      const output = initMonitorRegistryEpic(action$, state$, depsMock)
-        .pipe(
-          tap(action => state$.next(raidenReducer(state$.value, action))),
-          take(2),
-          finalize(() => (action$.complete(), state$.complete())),
-          toArray(),
-        )
-        .toPromise();
+      // without an open channel, TokenNetwork isn't of interest and shouldn't be monitored
+      await expect(
+        initTokensRegistryEpic(EMPTY, of(state), depsMock).toPromise(),
+      ).resolves.toBeUndefined();
 
-      depsMock.provider.resetEventsBlock(127);
-      action$.next(newBlock({ blockNumber: 127 }));
-
-      setTimeout(
-        () =>
-          depsMock.provider.emit(
-            depsMock.registryContract.filters.TokenNetworkCreated(null, null),
-            makeLog({
-              blockNumber: 127,
-              filter: depsMock.registryContract.filters.TokenNetworkCreated(
-                otherToken,
-                otherTokenNetwork,
-              ),
-            }),
-          ),
-        10,
-      );
-
-      await expect(output).resolves.toEqual([
-        tokenMonitored({ token, tokenNetwork, fromBlock: 121 }),
-        tokenMonitored({ token: otherToken, tokenNetwork: otherTokenNetwork, fromBlock: 127 }),
-      ]);
+      expect(depsMock.provider.getLogs).toHaveBeenCalledTimes(3);
       expect(depsMock.provider.getLogs).toHaveBeenCalledWith(
         expect.objectContaining({
           ...depsMock.registryContract.filters.TokenNetworkCreated(null, null),
           fromBlock: depsMock.contractsInfo.TokenNetworkRegistry.block_number,
-          toBlock: 126,
+          toBlock: 'latest',
         }),
       );
 
-      action$.complete();
-      state$.complete();
+      depsMock.provider.getLogs.mockClear();
+
+      // mocks getLogs for TokenNetworkCreated events
+      depsMock.provider.getLogs.mockResolvedValueOnce([
+        makeLog({
+          blockNumber: 121,
+          filter: depsMock.registryContract.filters.TokenNetworkCreated(token, tokenNetwork),
+        }),
+      ]);
+
+      // mocks getLogs for TokenNetworkCreated events
+      depsMock.provider.getLogs.mockResolvedValueOnce([
+        makeLog({
+          blockNumber: 122,
+          filter: tokenNetworkContract.filters.ChannelOpened(
+            channelId,
+            depsMock.address,
+            partner,
+            null,
+          ),
+          data: defaultAbiCoder.encode(['uint256'], [settleTimeout]),
+        }),
+      ]);
+
+      await expect(
+        initTokensRegistryEpic(EMPTY, of(state), depsMock)
+          .pipe(toArray())
+          .toPromise(),
+      ).resolves.toEqual([tokenMonitored({ token, tokenNetwork, fromBlock: 121 })]);
+
+      expect(depsMock.provider.getLogs).toHaveBeenCalledTimes(2);
+      expect(depsMock.provider.getLogs).toHaveBeenCalledWith(
+        expect.objectContaining({
+          address: tokenNetwork,
+          topics: expect.arrayContaining([
+            expect.stringMatching(depsMock.address.substr(2).toLowerCase()),
+          ]),
+          toBlock: 'latest',
+        }),
+      );
+
+      depsMock.provider.getLogs.mockClear();
+
+      await expect(
+        initTokensRegistryEpic(
+          EMPTY,
+          of([tokenMonitored({ token, tokenNetwork })].reduce(raidenReducer, state)),
+          depsMock,
+        )
+          .pipe(toArray())
+          .toPromise(),
+      ).resolves.toEqual([tokenMonitored({ token, tokenNetwork })]);
+      expect(depsMock.provider.getLogs).toHaveBeenCalledTimes(0);
     });
 
     test('ShutdownReason.ACCOUNT_CHANGED', async () => {


### PR DESCRIPTION
Fix #834 
- At first state initialization, all found token networks are scanned for past and future channels with us
  - If any found, we consider this a TokenNetwork of **interest**, and start monitoring it for channels from beginning (and keep monitoring on each new block on current and future sessions)
  - Otherwise, we ignore the TokenNetwork and don't monitor it (which is expensive)
- A new `Raiden.monitorToken` public method is exposed, which allows user to trigger scanning and monitoring a token network from beginning (even if state is already initialized). Even if no channel is found, this token network is now also considered of interest, and also monitored throughout current and future sessions
- All on-chain registered token networks can still be retrieved through `Raiden.getTokenList` method (which can be a bit more slow, since it needs to fetch all logs from registry, and should be cached)
- Requesting a channel to be opened in an unmonitored token network causes it to also become of interest and be monitored from now on.

TODO:
- [ ] adapt dApp to fetch and cache tokens for a new connection from `getTokenList` instead of internal state which depended on `tokenMonitored` events

PS: already initialized instances don't benefit from the optimization, as all currently registered token networks are considered of interest on old state. One needs to clean state (if no transfers were made on any possibly open channel) or manually edit localStorage on browser and remove all entries from `tokens` property, to trigger it to be populated again with only networks of interest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/raiden-network/light-client/870)
<!-- Reviewable:end -->
