### PR TITLE
Adds matrix filters to avoid fetching unneeded events

### DIFF
--- a/raiden-ts/src/transport/epics.ts
+++ b/raiden-ts/src/transport/epics.ts
@@ -132,6 +132,9 @@ function createFilter(matrix: MatrixClient, roomIds: string[]): Observable<Filte
       ephemeral: {
         not_types: ['m.receipt'],
       },
+      state: {
+        lazy_load_members: true,
+      },
     })),
     map((roomFilter: RoomFilterJson) => ({
       room: roomFilter,

--- a/raiden-ts/src/transport/epics.ts
+++ b/raiden-ts/src/transport/epics.ts
@@ -57,6 +57,7 @@ import {
   RoomFilterJson,
   FilterDefinition,
   Filter,
+  User,
 } from 'matrix-js-sdk';
 import matrixLogger from 'matrix-js-sdk/lib/logger';
 
@@ -203,6 +204,16 @@ function searchAddressPresence$(matrix: MatrixClient, address: Address) {
         } catch (err) {
           continue;
         }
+
+        const profile = matrix.getUser(user.user_id);
+        if (!profile) {
+          const newUser = new User(user.user_id);
+          newUser.setDisplayName(user.display_name);
+          matrix.store.users[user.user_id] = newUser;
+        } else {
+          profile.setDisplayName(user.display_name);
+        }
+
         yield user.user_id;
       }
     }),

--- a/raiden-ts/src/transport/epics.ts
+++ b/raiden-ts/src/transport/epics.ts
@@ -102,7 +102,7 @@ const userRe = /^@(0x[0-9a-f]{40})[.:]/i;
  */
 async function createFilter(config: RaidenConfig, server: string, matrix: MatrixClient) {
   const { pfsRoom, discoveryRoom } = config;
-  const transport = server.split('://')[1];
+  const transport = getServerName(server);
 
   const filteredRooms = [];
 

--- a/raiden-ts/src/transport/epics.ts
+++ b/raiden-ts/src/transport/epics.ts
@@ -135,7 +135,7 @@ function createFilter(matrix: MatrixClient, roomIds: string[]): Observable<Filte
     map((roomFilter: RoomFilterJson) => ({
       room: roomFilter,
       presence: {
-        not_types: ['m.presence'],
+        types: ['m.presence'],
       },
     })),
     mergeMap((filterDefinition: FilterDefinition) => from(matrix.createFilter(filterDefinition))),

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -481,7 +481,11 @@ describe('transport epic', () => {
         ),
         state$ = of(state);
 
-      matrix.getUser.mockImplementationOnce(userId => ({ userId, presence: 'unavailable' }));
+      matrix.getUser.mockImplementationOnce(userId => ({
+        userId,
+        presence: 'unavailable',
+        setDisplayName: jest.fn(),
+      }));
 
       const promise = matrixPresenceUpdateEpic(action$, state$, depsMock)
         .pipe(takeUntil(timer(50)))
@@ -510,6 +514,7 @@ describe('transport epic', () => {
         userId,
         presence: 'offline',
         displayName: `partner_display_name`,
+        setDisplayName: jest.fn(),
       }));
       (verifyMessage as jest.Mock).mockReturnValueOnce(token);
 

--- a/raiden-ts/tests/unit/messages.spec.ts
+++ b/raiden-ts/tests/unit/messages.spec.ts
@@ -334,7 +334,7 @@ describe('sign/verify, pack & encode/decode ', () => {
   });
 
   test('decodeJsonMessage invalid', () => {
-    expect(() => decodeJsonMessage('{"type":"Invalid"}')).toThrowError('/type:');
+    expect(() => decodeJsonMessage('{"type":"Invalid"}')).toThrowError(/\btype\b/);
     expect(() =>
       decodeJsonMessage('{"type":"Processed","message_identifier":123456}'),
     ).toThrowError('Invalid value undefined');

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -289,7 +289,7 @@ export function makeMatrix(userId: string, server: string): jest.Mocked<MatrixCl
     })),
     getUserId: jest.fn(() => userId),
     getUsers: jest.fn(() => []),
-    getUser: jest.fn(userId => ({ userId, presence: 'offline' })),
+    getUser: jest.fn(userId => ({ userId, presence: 'offline', setDisplayName: jest.fn() })),
     getProfileInfo: jest.fn(async userId => ({ displayname: `${userId}_display_name` })),
     createRoom: jest.fn(async ({ visibility, invite }) => ({
       room_id: `!roomId_${visibility || 'public'}_with_${(invite || []).join('_')}:${server}`,

--- a/raiden-ts/typings/matrix-js-sdk/index.d.ts
+++ b/raiden-ts/typings/matrix-js-sdk/index.d.ts
@@ -31,7 +31,9 @@ declare module 'matrix-js-sdk' {
     avatar_url?: string;
   }
 
-  export interface User {
+  export class User {
+    constructor(userId: string);
+    setDisplayName(displayName: string): void;
     userId: string;
     displayName?: string;
     avatarUrl?: string;
@@ -289,6 +291,10 @@ declare module 'matrix-js-sdk' {
     ): Promise<RoomIdForAlias>;
     public getRoomPushRule(scope: string, roomId: string): object | undefined;
     public getRooms(): Room[];
+
+    store: {
+      users: {[userId: string]: User }
+    }
   }
 
   export interface RoomIdForAlias {
@@ -646,6 +652,7 @@ declare module 'matrix-js-sdk' {
 
       }
   }
+
   declare namespace Matrix.Store {
 
       export class MatrixInMemoryStore implements IMatrixStore {

--- a/raiden-ts/typings/matrix-js-sdk/index.d.ts
+++ b/raiden-ts/typings/matrix-js-sdk/index.d.ts
@@ -354,9 +354,13 @@ declare module 'matrix-js-sdk' {
     rooms?: string[];
     ephemeral?: RoomEventFilterJson;
     include_leave?: boolean; // default: false
-    state?: RoomEventFilterJson;
+    state?: StateFilter;
     timeline?: RoomEventFilterJson;
     account_data?: RoomEventFilterJson;
+  }
+
+  export interface StateFilter extends RoomFilterJson {
+    lazy_load_members?: boolean;
   }
 
   export interface FilterDefinition {

--- a/raiden-ts/typings/matrix-js-sdk/index.d.ts
+++ b/raiden-ts/typings/matrix-js-sdk/index.d.ts
@@ -187,7 +187,7 @@ declare module 'matrix-js-sdk' {
       roomId: string,
       callback?: requestCallback,
     ): Promise<any> | MatrixError | void;
-    public createFilter(content: object): Promise<object> | MatrixError;
+    public createFilter(content: object): Promise<Filter>;
     public createGroup(content: {
       localpart: string;
       profile: object;
@@ -286,9 +286,14 @@ declare module 'matrix-js-sdk' {
     public getRoomIdForAlias(
       alias: string,
       callback?: requestCallback,
-    ): Promise<object> | MatrixError | void;
+    ): Promise<RoomIdForAlias>;
     public getRoomPushRule(scope: string, roomId: string): object | undefined;
     public getRooms(): Room[];
+  }
+
+  export interface RoomIdForAlias {
+    readonly room_id: string;
+    readonly servers: string[];
   }
   /*
   export class MatrixScheduler implements IMatrixScheduler {

--- a/raiden-ts/typings/matrix-js-sdk/index.d.ts
+++ b/raiden-ts/typings/matrix-js-sdk/index.d.ts
@@ -291,10 +291,6 @@ declare module 'matrix-js-sdk' {
     ): Promise<RoomIdForAlias>;
     public getRoomPushRule(scope: string, roomId: string): object | undefined;
     public getRooms(): Room[];
-
-    store: {
-      users: {[userId: string]: User }
-    }
   }
 
   export interface RoomIdForAlias {


### PR DESCRIPTION
Closes #746 

- [x] Create filter before the first sync to filter out broadcast room events.
- [x] Ensure that presence monitoring works properly for the addresses we are interested in.
- [x] Tests