### PR TITLE
Updates link to private chain guide

### DIFF
--- a/docs/sdk-docs/connecting/README.md
+++ b/docs/sdk-docs/connecting/README.md
@@ -20,4 +20,4 @@ Contract info is a JSON file that is generated when you deploy [raiden-contracts
 
 ## Using the SDK in a Private Chain or a Development Environment
 
-If you want to use the SDK in a private chain or a development environment, you can follow [this guide](https://github.com/raiden-network/light-client/wiki/Using-the-SDK-in-a-private-chain-or-a-development-environment).
+If you want to use the SDK in a private chain, you can follow [this guide](../private-chain/README.md).


### PR DESCRIPTION
As part of the extra steps in #750, it updates the link to point to the new private chain guide.