### PR TITLE
Document the release process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,122 @@
+# Releasing new versions of raiden-ts
+
+## Table of Contents
+- [Table of Contents](#table-of-contents)
+- [Preface](#preface)
+- [Preparing a new release](#preparing-a-new-release)
+    * [Increasing the version](#increasing-the-version)
+        - [Using the script](#using-the-script)
+        - [Manually preparing the release](#manually-preparing-the-release)
+- [Creating a Pull Request](#creating-a-pull-request)
+- [Publishing on Github](#publishing-on-github)
+- [Publishing on npm](#publishing-on-npm)
+    * [Login](#login)
+    * [Publishing](#publishing)
+
+## Preface
+In this guide we cover the steps required to create and publish a new release of the `raiden-ts` package. To create a new release you need to update the version of the package and proceed to publish to `GitHub` and `npm`.
+
+A new release might happen when a valid reason for it exists. Reasons for a new release include protocol upgrades, new features, bug fixes etc.
+
+> Note! This only considers the SDK versioning and releasing and not the dApp.
+
+Through this guide we assume that you work on a fork of the repository. We reference to the fork remote repository using `origin`, and to the Light Client repository using `upstream`.
+
+## Preparing a new release
+A new release starts with the increment of the package version. Ensure that you navigated in the project root directory.
+
+In preparation for the release changes create a new branch:
+```bash
+git checkout -b prepare_release
+```
+
+Please ensure that you also update the [CHANGELOG.md](./raiden-ts/CHANGELOG.md) accordingly. You should have the changes for the new version tracked as `[Unreleased]`. You only need to replace `[Unreleased]` with the new version. 
+
+### Increasing the version
+Initially you need to decide if the new release would require `patch`, `minor`, `major` upgrade. For more you can check the [npm version](https://docs.npmjs.com/cli/version) documentation.
+
+#### Using the script
+
+Then you can proceed with the version upgrade and commit creation. If you use an environment that can execute bash scripts then you can just run [prepare-release.sh](https://github.com/raiden-network/light-client/blob/master/prepare-release.sh). 
+
+```bash
+./prepare-release.sh
+```
+
+This script will bump the version according to the provided parameter and then it will create a commit with the message that looks like `0.22.0->0.22.1`.
+
+#### Manually preparing the release
+If for any reason you cannot run the script, you can proceed to prepare the release Pull Request manually.
+
+Go to the `raiden-ts` directory to start bump the package version.
+
+```bash
+cd raiden-ts
+```
+
+Then run `npm version` to bump the version for both `package.json` and `package-lock.json`. Let's assume that we prepare for a new release containing a couple of minor bug fixes. You have to run the following command: 
+
+```bash
+npm version patch
+```
+
+Assuming `raiden-ts` was at version `0.22.0`, the command will update the package files' version tag to `0.22.1`. 
+
+
+Then you need to create a new commit with the message `0.22.0->0.22.1`. After the new commit
+
+```bash
+git add package.json
+git add package-lock.json
+git commit -m '0.22.0->0.22.1'
+```
+
+## Creating a Pull Request
+After committing the CHANGELOG changes, along with the version bump you can proceed with the creation of the Pull Request.
+
+Push your local branch to GitHub and proceed to create a Pull Request.
+
+```bash
+git push origin -u prepare_release
+```
+
+You need one approval for your Pull Request to get merged to master. After merging to master, you need to tag the release.
+
+## Publishing on Github
+Since you need to deal with the GitHub release interface we strongly suggested to use for the creation of the tag too.
+
+To draft a new GitHub release, visit the [release interface](https://github.com/kelsos/light-client/releases) and press the `Draft a new release` button. Then set `v0.22.1` as the `Tag version` and keep master as the `Target`. Then use `v0.22.1` as the release title.
+
+Now you need prepare the release description. Don't forget to include the changelog entries for the specific version.
+
+Proceed to publish the new release. A new release gets automatically tagged. Tagging will trigger the CI release flow that will also publish the artifact to `npm`.
+
+## Publishing on npm
+Before we proceed to publish on npm, we need to synchronize our local master with `upstream`.
+
+```bash
+git checkout master
+git pull upstream master
+```
+
+> Note! Please keep in mind that you need to have the appropriate permissions to publish updates of the [raiden-ts](https://www.npmjs.com/package/raiden-ts) package.
+
+### Login
+If you never published an update before you, need to login to `npm` with the cli utility.
+
+```bash
+npm login
+```  
+
+You should follow the prompts displayed by the command. The command should create an `.npmrc` file in your home directory. This file contains your `authToken`. 
+
+### Publishing
+To publish you just need to run:
+
+```bash
+npm run publish
+```
+
+The command will take care of the building and publishing of the package to `npm`.
+
+Check the [npm publish](https://docs.npmjs.com/cli/publish) documentation for more information about the available flags.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,7 +9,7 @@
         - [Manually preparing the release](#manually-preparing-the-release)
 - [Creating a Pull Request](#creating-a-pull-request)
 - [Publishing on Github](#publishing-on-github)
-- [Publishing on npm](#publishing-on-npm)
+- [Publishing on npm](#publishing-on-npm-manually)
     * [Login](#login)
     * [Publishing](#publishing)
 
@@ -33,7 +33,7 @@ git checkout -b prepare_release
 Please ensure that you also update the [CHANGELOG.md](./raiden-ts/CHANGELOG.md) accordingly. You should have the changes for the new version tracked as `[Unreleased]`. You only need to replace `[Unreleased]` with the new version. 
 
 ### Increasing the version
-Initially you need to decide if the new release would require `patch`, `minor`, `major` upgrade. For more you can check the [npm version](https://docs.npmjs.com/cli/version) documentation.
+Initially you need to decide if the new release would require `patch`, `minor`, `major` upgrade. For more information you can check the [npm version](https://docs.npmjs.com/cli/version) documentation.
 
 #### Using the script
 
@@ -83,7 +83,7 @@ git push origin -u prepare_release
 You need one approval for your Pull Request to get merged to master. After merging to master, you need to tag the release.
 
 ## Publishing on Github
-Since you need to deal with the GitHub release interface we strongly suggested to use for the creation of the tag too.
+Since you need to deal with the GitHub release interface we strongly suggested you use it for the creation of the tag too.
 
 To draft a new GitHub release, visit the [release interface](https://github.com/kelsos/light-client/releases) and press the `Draft a new release` button. Then set `v0.22.1` as the `Tag version` and keep master as the `Target`. Then use `v0.22.1` as the release title.
 
@@ -91,7 +91,8 @@ Now you need prepare the release description. Don't forget to include the change
 
 Proceed to publish the new release. A new release gets automatically tagged. Tagging will trigger the CI release flow that will also publish the artifact to `npm`.
 
-## Publishing on npm
+## Publishing on npm (manually)
+Regularily the publishing step will be handled automatically by the CI infrastructure. If for any reason the automatic publishing does not work you can alternatively publish the package manually to `npm`.
 Before we proceed to publish on npm, we need to synchronize our local master with `upstream`.
 
 ```bash

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+if [[ "$#" -ne 1 ]]; then
+    VERSION_PARAMS=`npm version --help | grep -oPm1 'npm version (.*)' | sed 's/npm version/''/g'`
+    echo "USAGE: $0 $VERSION_PARAMS"
+    exit 1
+fi
+
+cd raiden-ts
+
+PACKAGE_VERSION=$(cat package.json \
+  | grep version \
+  | head -1 \
+  | awk -F: '{ print $2 }' \
+  | sed 's/[",]//g' \
+  | tr -d '[[:space:]]')
+
+# Using `--no-git-tag-version` in January 2020 serves no purpose due to `npm version`
+# expecting the command to run from the same directory that also hosts the `.git` folder
+# You can find more information on https://github.com/npm/npm/issues/9111.
+# We disable the whole functionality because there no option exists to disable only automatic tagging.
+VERSION=$(npm --no-git-tag-version version $1)
+MESSAGE="$PACKAGE_VERSION -> $VERSION";
+
+echo "Preparing to commit version update $MESSAGE"
+
+git add package.json
+git add package-lock.json
+
+git commit -m "$MESSAGE"


### PR DESCRIPTION
Closes #702

I created a basic draft on the release process, also describing the manual steps.
I added a script to bump the version and commit but I am not sure how easy it is to automate other steps.

The release should look like this
1. Update CHANGELOG.md (either create commit or git add)
2. Run script to bump version and create commit.
3. Push branch to remote
4. Create PR
5. Approve
6. Merge PR
7. Create and publish GitHub Release (also makes tag and triggers CI)
