### PR TITLE
Updates environment variable for jest-junit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
           name: Run unit tests
           command: npm run test -- --ci --runInBand --reporters=default --reporters=jest-junit
           environment:
-            JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
+            JEST_JUNIT_OUTPUT_DIR: "reports/junit"
       - store_test_results:
           path: reports/junit
       - store_artifacts:
@@ -108,7 +108,7 @@ jobs:
           name: Run unit tests
           command: npm run test:unit -- --ci --runInBand --reporters=default --reporters=jest-junit
           environment:
-            JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
+            JEST_JUNIT_OUTPUT_DIR: "reports/junit"
       - store_test_results:
           path: reports/junit
       - store_artifacts:


### PR DESCRIPTION
This should fix the reporting for the tests on CircleCI. This should make it again possible to see the tests that failed in CI without having to look at the logs.