### PR TITLE
Track open handles on SDK tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
       - attach_workspace: *attach_options
       - run:
           name: Run unit tests
-          command: npm run test -- --ci --runInBand --reporters=default --reporters=jest-junit
+          command: npm run test -- --ci --runInBand --reporters=default --reporters=jest-junit --detectOpenHandles
           environment:
             JEST_JUNIT_OUTPUT_DIR: "reports/junit"
       - store_test_results:


### PR DESCRIPTION
Since jest hangs a lot lately making things hard I am merging this until we resolve #925 to at least have a better picture until the issue is resolved.
