### PR TITLE
Implement tx confirmation for channelOpen

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
       - attach_workspace: *attach_options
       - run:
           name: Run unit tests
-          command: npm run test -- --ci --runInBand --reporters=default --reporters=jest-junit --detectOpenHandles
+          command: npm run test -- --ci --runInBand --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: "reports/junit"
       - store_test_results:

--- a/raiden-ts/src/actions.ts
+++ b/raiden-ts/src/actions.ts
@@ -57,3 +57,25 @@ export const RaidenEvents = [
 ];
 /* Tagged union of RaidenEvents actions */
 export type RaidenEvent = ActionType<typeof RaidenEvents>;
+
+/**
+ * Set of [serializable] actions which are first emitted with
+ * payload.confirmed=undefined, then, after confirmation blocks, either with confirmed=true if tx
+ * is still present on blockchain, or confirmed=false if it got removed by a reorg.
+ *
+ * These actions must comply with the following type:
+ * {
+ *   payload: {
+ *     txHash: Hash;
+ *     txBlock: number;
+ *     confirmed: undefined | boolean;
+ *   };
+ *   meta: any;
+ * }
+ */
+export const ConfirmableActions = [ChannelsActions.channelOpen.success];
+/**
+ * Union of codecs of actions above
+ */
+export const ConfirmableAction = ChannelsActions.channelOpen.success.codec;
+export type ConfirmableAction = ChannelsActions.channelOpen.success;

--- a/raiden-ts/src/channels/actions.ts
+++ b/raiden-ts/src/channels/actions.ts
@@ -46,9 +46,10 @@ export const channelOpen = createAsyncAction(
   t.type({
     id: t.number,
     settleTimeout: t.number,
-    openBlock: t.number,
     isFirstParticipant: t.boolean,
     txHash: Hash,
+    txBlock: t.number,
+    confirmed: t.union([t.undefined, t.boolean]),
   }),
 );
 export namespace channelOpen {

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -27,7 +27,7 @@ const logLevels = t.keyof({
  * - pfsSafetyMargin - Safety margin to be added to fees received from PFS. Use `1.1` to add a 10% safety margin.
  * - matrixExcessRooms - Keep this much rooms for a single user of interest (partner, target).
  *                       Leave LRU beyond this threshold.
- *   confirmationBlocks - How much blocks to wait before considering a transaction as confirmed
+ * - confirmationBlocks - How many blocks to wait before considering a transaction as confirmed
  * - matrixServer? - Specify a matrix server to use.
  * - logger? - String specifying the console log level of redux-logger. Use '' to disable.
  *             Defaults to 'debug' if undefined and process.env.NODE_ENV === 'development'

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -4,6 +4,15 @@ import { Network } from 'ethers/utils';
 import { Address } from './utils/types';
 import { getNetworkName } from './utils/ethers';
 
+const logLevels = t.keyof({
+  ['']: null,
+  trace: null,
+  debug: null,
+  info: null,
+  warn: null,
+  error: null,
+});
+
 /**
  * A Raiden configuration object with required parameters and
  * optional parameters from [[PartialRaidenConfig]].
@@ -18,22 +27,15 @@ import { getNetworkName } from './utils/ethers';
  * - pfsSafetyMargin - Safety margin to be added to fees received from PFS. Use `1.1` to add a 10% safety margin.
  * - matrixExcessRooms - Keep this much rooms for a single user of interest (partner, target).
  *                       Leave LRU beyond this threshold.
+ *   confirmationBlocks - How much blocks to wait before considering a transaction as confirmed
  * - matrixServer? - Specify a matrix server to use.
  * - logger? - String specifying the console log level of redux-logger. Use '' to disable.
  *             Defaults to 'debug' if undefined and process.env.NODE_ENV === 'development'
- * - pfs - Path Finding Service URL or Address. Set to null to disable, or leave undefined to
- *             enable automatic fetching from ServiceRegistry.
- * - subkey - When using subkey, this sets the behavior when { subkey } option isn't explicitly set
- *            in on-chain method calls. false (default) = use main key; true = use subkey
+ * - pfs? - Path Finding Service URL or Address. Set to null to disable, or leave undefined to
+ *          enable automatic fetching from ServiceRegistry.
+ * - subkey? - When using subkey, this sets the behavior when { subkey } option isn't explicitly set
+ *             in on-chain method calls. false (default) = use main key; true = use subkey
  */
-const logLevels = t.keyof({
-  ['']: null,
-  trace: null,
-  debug: null,
-  info: null,
-  warn: null,
-  error: null,
-});
 export const RaidenConfig = t.readonly(
   t.intersection([
     t.type({
@@ -45,6 +47,7 @@ export const RaidenConfig = t.readonly(
       pfsRoom: t.union([t.string, t.null]),
       pfsSafetyMargin: t.number,
       matrixExcessRooms: t.number,
+      confirmationBlocks: t.number,
     }),
     t.partial({
       matrixServer: t.string,
@@ -87,5 +90,6 @@ export function makeDefaultConfig({ network }: { network: Network }): RaidenConf
     pfsRoom: `raiden_${getNetworkName(network)}_path_finding`,
     matrixExcessRooms: 3,
     pfsSafetyMargin: 1.0,
+    confirmationBlocks: 5,
   };
 }

--- a/raiden-ts/src/path/utils.ts
+++ b/raiden-ts/src/path/utils.ts
@@ -41,7 +41,7 @@ export function channelCanRoute(
     return `path: channel with "${partner}" in state "${channel.state}" instead of "${ChannelState.open}"`;
   const { ownCapacity: capacity } = channelAmounts(channel);
   if (capacity.lt(value))
-    return `path: channel with "${partner}" don't have enough capacity=${capacity.toString()}`;
+    return `path: channel with "${partner}" doesn't have enough capacity=${capacity.toString()}`;
   return true;
 }
 

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -520,7 +520,8 @@ export class Raiden {
     assert(!options.subkey || this.deps.main, "Can't send tx from subkey if not set");
 
     const meta = { tokenNetwork, partner };
-    const promise = asyncActionToPromise(channelOpen, meta, this.action$).then(
+    // wait for confirmation
+    const promise = asyncActionToPromise(channelOpen, meta, this.action$, true).then(
       ({ txHash }) => txHash, // pluck txHash
     );
     this.store.dispatch(channelOpen.request(options, meta));

--- a/raiden-ts/src/state.ts
+++ b/raiden-ts/src/state.ts
@@ -5,6 +5,7 @@ import { debounce, merge as _merge } from 'lodash';
 
 import { PartialRaidenConfig } from './config';
 import { ContractsInfo } from './types';
+import { ConfirmableAction } from './actions';
 import { losslessParse, losslessStringify } from './utils/data';
 import { Address, Secret, decode, Signed, Storage } from './utils/types';
 import { Channel } from './channels/state';
@@ -61,6 +62,7 @@ export const RaidenState = t.readonly(
         ),
       ),
     }),
+    pendingTxs: t.readonlyArray(ConfirmableAction),
   }),
 );
 
@@ -131,6 +133,7 @@ export function makeInitialState(
     path: {
       iou: {},
     },
+    pendingTxs: [],
   };
 }
 

--- a/raiden-ts/src/utils/redux.ts
+++ b/raiden-ts/src/utils/redux.ts
@@ -20,7 +20,7 @@ export function partialCombineReducers<S, A extends Action = AnyAction>(
     for (const key in reducers) {
       const reducer = reducers[key];
       if (!reducer) continue; // shouldn't happen, only here for type safety below
-      const subState = state[key] || initialState[key];
+      const subState = state[key] ?? initialState[key];
       const newSubState = reducer(subState, action);
       if (newSubState !== subState) {
         state = { ...state, [key]: newSubState };

--- a/raiden-ts/tests/e2e/provider.ts
+++ b/raiden-ts/tests/e2e/provider.ts
@@ -4,7 +4,7 @@ import memdown from 'memdown';
 import { range } from 'lodash';
 import asyncPool from 'tiny-async-pool';
 
-import { Web3Provider } from 'ethers/providers';
+import { Web3Provider, AsyncSendable } from 'ethers/providers';
 import { MaxUint256, AddressZero } from 'ethers/constants';
 import { ContractFactory } from 'ethers/contract';
 import { parseUnits, ParamType } from 'ethers/utils';
@@ -19,17 +19,18 @@ import { UserDeposit } from 'raiden-ts/contracts/UserDeposit';
 import Contracts from '../../raiden-contracts/raiden_contracts/data/contracts.json';
 
 export class TestProvider extends Web3Provider {
-  public constructor(opts?: GanacheServerOptions) {
+  public constructor(web3?: AsyncSendable, opts?: GanacheServerOptions) {
     super(
-      ganache.provider({
-        total_accounts: 3,
-        default_balance_ether: 5,
-        seed: 'testrpc_provider',
-        network_id: 1338,
-        db: memdown(),
-        // logger: console,
-        ...opts,
-      }),
+      web3 ??
+        ganache.provider({
+          total_accounts: 3,
+          default_balance_ether: 5,
+          seed: 'testrpc_provider',
+          network_id: 1338,
+          db: memdown(),
+          // logger: console,
+          ...opts,
+        }),
     );
     this.pollingInterval = 10;
   }
@@ -45,17 +46,32 @@ export class TestProvider extends Web3Provider {
   public async mine(count = 1): Promise<number> {
     const blockNumber = await this.getBlockNumber();
     console.debug(`mining ${count} blocks after blockNumber=${blockNumber}`);
-    const promise = new Promise(resolve => {
+    const promise = new Promise<number>(resolve => {
       const cb = (b: number): void => {
         if (b < blockNumber + count) return;
         this.removeListener('block', cb);
-        resolve();
+        resolve(b);
       };
       this.on('block', cb);
     });
-    await asyncPool(10, range(count), () => this.send('evm_mine', null));
-    await promise;
-    return this.blockNumber;
+    asyncPool(10, range(count), () => this.send('evm_mine', null));
+    return promise;
+  }
+
+  public async mineUntil(block: number): Promise<number> {
+    const blockNumber = await this.getBlockNumber();
+    console.debug(`mining until block=${block} from ${blockNumber}`);
+    if (blockNumber >= block) return blockNumber;
+    const promise = new Promise<number>(resolve => {
+      const cb = (b: number): void => {
+        if (b < block) return;
+        this.removeListener('block', cb);
+        resolve(b);
+      };
+      this.on('block', cb);
+    });
+    asyncPool(10, range(block - blockNumber), () => this.send('evm_mine', null));
+    return promise;
   }
 
   public async deployRegistry(): Promise<ContractsInfo> {

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -42,10 +42,50 @@ describe('Raiden', () => {
     pfsInfoResponse: any,
     pfsAddress: string,
     pfsUrl: string;
-  const config: PartialRaidenConfig = { settleTimeout: 20, revealTimeout: 5 };
+  const config: PartialRaidenConfig = {
+    settleTimeout: 20,
+    revealTimeout: 5,
+    confirmationBlocks: 2,
+  };
 
   let httpBackend: MockMatrixRequestFn;
   const matrixServer = 'matrix.raiden.test';
+
+  async function createRaiden(
+    account: number | string,
+    stateOrStorage?: RaidenState | Storage,
+    subkey?: true,
+  ): Promise<Raiden> {
+    const raiden = await Raiden.create(
+      // we need to create a new test provider, to avoid sharing provider instances,
+      // but with same underlying ganache instance
+      new TestProvider(provider._web3Provider),
+      account,
+      stateOrStorage,
+      contractsInfo,
+      config,
+      subkey,
+    );
+    raiden.action$
+      .pipe(
+        filter(
+          (
+            a: any, // eslint-disable-line @typescript-eslint/no-explicit-any
+          ): a is {
+            payload: { txHash: string; txBlock: number; confirmed: undefined | boolean };
+          } =>
+            a &&
+            a.payload?.['txHash'] &&
+            a.payload['txBlock'] &&
+            'confirmed' in a.payload &&
+            a.payload.confirmed === undefined,
+        ),
+      )
+      .subscribe(a =>
+        provider.mineUntil(a.payload.txBlock + raiden.config.confirmationBlocks + 1),
+      );
+    return raiden;
+  }
 
   const fetch = jest.fn(async () => ({
     ok: true,
@@ -94,15 +134,15 @@ describe('Raiden', () => {
   beforeEach(async () => {
     if (snapId !== undefined) await provider.revert(snapId);
     snapId = await provider.snapshot();
+    await provider.getBlockNumber();
     storage = new MockStorage();
 
     // setup matrix mock http backend
     httpBackend = new MockMatrixRequestFn(matrixServer);
     request(httpBackend.requestFn.bind(httpBackend));
 
-    raiden = await Raiden.create(provider, 0, storage, contractsInfo, config);
+    raiden = await createRaiden(0, storage);
     raiden.start();
-    await raiden.events$.pipe(first()).toPromise();
   });
 
   afterEach(() => {
@@ -335,7 +375,7 @@ describe('Raiden', () => {
     beforeEach(async () => {
       await raiden.openChannel(token, partner);
       await raiden.depositChannel(token, partner, 200);
-      raiden1 = await Raiden.create(provider, partner, undefined, contractsInfo, config);
+      raiden1 = await createRaiden(partner, undefined);
       raiden1.start();
     });
 
@@ -389,25 +429,27 @@ describe('Raiden', () => {
       expect(raidenState!.tokens).toEqual({ [token]: tokenNetwork });
       // expect & save block when raiden was stopped
       expect(raidenState).toMatchObject({ blockNumber: expect.any(Number) });
-      const stopBlock = raidenState!.blockNumber;
 
       // edge case 1: ChannelClosed event happens right after raiden is stopped
-      await raiden1.closeChannel(token, raiden.address);
-      await provider.mine(2);
+      const closeBlock = (
+        await provider.getTransactionReceipt(await raiden1.closeChannel(token, raiden.address))
+      ).blockNumber!;
+      await provider.mine();
 
       // deploy new token network while raiden is offline (raiden1/partner isn't)
       const { token: newToken, tokenNetwork: newTokenNetwork } = await provider.deployTokenNetwork(
         contractsInfo,
       );
-      await provider.mine(4);
+      await provider.mine();
 
       // open a new channel from partner to main instance on the new tokenNetwork
       // edge case 2: ChannelOpened at exact block when raiden is restarted
-      await raiden1.openChannel(newToken, raiden.address);
-      const restartBlock = provider.blockNumber;
+      const restartBlock = (
+        await provider.getTransactionReceipt(await raiden1.openChannel(newToken, raiden.address))
+      ).blockNumber!;
 
       raidenState = undefined;
-      raiden = await Raiden.create(provider, 0, storage, contractsInfo, config);
+      raiden = await createRaiden(0, storage);
       raiden.state$.subscribe(state => (raidenState = state));
       raiden.start();
 
@@ -433,7 +475,9 @@ describe('Raiden', () => {
         },
         channels: {
           // test edge case 1: channel closed at stop block is picked up correctly
-          [tokenNetwork]: { [partner]: { state: ChannelState.closed, closeBlock: stopBlock + 1 } },
+          [tokenNetwork]: {
+            [partner]: { state: ChannelState.closed, closeBlock },
+          },
           // test edge case 2: channel opened at restart block is picked up correctly
           [newTokenNetwork]: { [partner]: { state: ChannelState.open, openBlock: restartBlock } },
         },
@@ -506,7 +550,11 @@ describe('Raiden', () => {
     test('success', async () => {
       expect.assertions(3);
       await provider.mine(config.settleTimeout! + 1);
-      await expect(raiden.channels$.pipe(first()).toPromise()).resolves.toMatchObject({
+      await expect(
+        raiden.channels$
+          .pipe(first(c => c[token]?.[partner]?.state === ChannelState.settleable))
+          .toPromise(),
+      ).resolves.toMatchObject({
         [token]: {
           [partner]: {
             token,
@@ -536,30 +584,28 @@ describe('Raiden', () => {
 
     test('newBlock', async () => {
       expect.assertions(1);
-      await provider.mine(5);
-      const promise = raiden.events$
-        .pipe(
-          filter(value => value.type === 'newBlock'),
-          first(),
-        )
-        .toPromise();
-      await provider.mine(10);
-      await expect(promise).resolves.toMatchObject({
-        type: newBlock.type,
-        payload: { blockNumber: expect.any(Number) },
-      });
+      console.warn(
+        'RAIDEN NEW BLOCK',
+        raiden.address,
+        await raiden.getBlockNumber(),
+        provider.blockNumber,
+      );
+      const promise = raiden.events$.pipe(first(newBlock.is)).toPromise();
+      provider.mine(10);
+      await expect(promise).resolves.toEqual(newBlock({ blockNumber: expect.any(Number) }));
     });
 
     test('tokenMonitored', async () => {
       expect.assertions(4);
-      await provider.mine(5);
+
       const promise = raiden.events$
-        .pipe(first(value => value.type === 'tokenMonitored' && !!value.payload.fromBlock))
+        .pipe(first(value => tokenMonitored.is(value) && !!value.payload.fromBlock))
         .toPromise();
 
       // deploy a new token & tokenNetwork
       const { token, tokenNetwork } = await provider.deployTokenNetwork(contractsInfo);
 
+      // despite deployed, new token network isn't picked as it isn't of interest
       await expect(
         raiden.state$
           .pipe(
@@ -572,28 +618,34 @@ describe('Raiden', () => {
       // promise should only resolve after we explicitly monitor this token
       await expect(raiden.monitorToken(token)).resolves.toBe(tokenNetwork);
 
-      await expect(promise).resolves.toMatchObject({
-        type: tokenMonitored.type,
-        payload: { fromBlock: expect.any(Number), token, tokenNetwork },
-      });
+      await expect(promise).resolves.toEqual(
+        tokenMonitored({
+          fromBlock: expect.any(Number),
+          token: token as Address,
+          tokenNetwork: tokenNetwork as Address,
+        }),
+      );
 
       // while partner is not yet initialized, open a channel with them
       await raiden.openChannel(token, partner);
 
-      const raiden1 = await Raiden.create(provider, partner, undefined, contractsInfo, config);
+      const raiden1 = await createRaiden(partner, undefined);
 
       const promise1 = raiden1.events$
-        .pipe(first(value => value.type === 'tokenMonitored' && !!value.payload.fromBlock))
+        .pipe(first(value => tokenMonitored.is(value) && !!value.payload.fromBlock))
         .toPromise();
 
       raiden1.start();
 
       // promise1, contrary to promise, should resolve at initialization, upon first scan
       // detects tokenNetwork as being of interest for having a channel with parner
-      await expect(promise1).resolves.toMatchObject({
-        type: tokenMonitored.type,
-        payload: { fromBlock: expect.any(Number), token, tokenNetwork },
-      });
+      await expect(promise1).resolves.toEqual(
+        tokenMonitored({
+          fromBlock: expect.any(Number),
+          token: token as Address,
+          tokenNetwork: tokenNetwork as Address,
+        }),
+      );
 
       raiden1.stop();
     });
@@ -608,11 +660,9 @@ describe('Raiden', () => {
       );
 
       // success when using address of account on provider and initial state
-      const raiden1 = await Raiden.create(
-        provider,
+      const raiden1 = await createRaiden(
         accounts[2],
         makeInitialState({ network, contractsInfo, address: accounts[2] as Address }, { config }),
-        contractsInfo,
       );
       expect(raiden1).toBeInstanceOf(Raiden);
       raiden1.start();
@@ -706,16 +756,21 @@ describe('Raiden', () => {
       let raiden1: Raiden;
 
       beforeEach(async () => {
-        raiden1 = await Raiden.create(
-          provider,
+        raiden1 = await createRaiden(
           partner,
           makeInitialState({ network, contractsInfo, address: partner as Address }, { config }),
-          contractsInfo,
         );
         raiden1.start();
 
         // await raiden1 client matrix initialization
         await raiden1.action$.pipe(filter(isActionOf(matrixSetup)), first()).toPromise();
+        await raiden1.state$
+          .pipe(
+            first(
+              state => state.channels[tokenNetwork]?.[raiden.address]?.state === ChannelState.open,
+            ),
+          )
+          .toPromise();
 
         await expect(raiden.getAvailability(partner)).resolves.toMatchObject({
           userId: `@${partner.toLowerCase()}:${matrixServer}`,
@@ -752,11 +807,9 @@ describe('Raiden', () => {
         expect.assertions(7);
 
         const target = accounts[2],
-          raiden2 = await Raiden.create(
-            provider,
+          raiden2 = await createRaiden(
             target,
             makeInitialState({ network, contractsInfo, address: target as Address }, { config }),
-            contractsInfo,
           ),
           matrix2Promise = raiden2.action$
             .pipe(filter(isActionOf(matrixSetup)), first())
@@ -898,17 +951,13 @@ describe('Raiden', () => {
       await raiden.openChannel(token, partner);
       await raiden.depositChannel(token, partner, 200);
 
-      raiden1 = await Raiden.create(
-        provider,
+      raiden1 = await createRaiden(
         partner,
         makeInitialState({ network, contractsInfo, address: partner as Address }, { config }),
-        contractsInfo,
       );
-      raiden2 = await Raiden.create(
-        provider,
+      raiden2 = await createRaiden(
         target,
         makeInitialState({ network, contractsInfo, address: target as Address }, { config }),
-        contractsInfo,
       );
       raiden1.start();
       raiden2.start();
@@ -1121,7 +1170,7 @@ describe('Raiden', () => {
     test('should throw exception on main net', async () => {
       expect.assertions(1);
       raiden = await Raiden.create(
-        new TestProvider({ network_id: 1 }),
+        new TestProvider(undefined, { network_id: 1 }),
         0,
         storage,
         contractsInfo,
@@ -1160,7 +1209,7 @@ describe('Raiden', () => {
 
   test('subkey', async () => {
     expect.assertions(28);
-    const sub = await Raiden.create(provider, 0, storage, contractsInfo, config, true);
+    const sub = await createRaiden(0, storage, true);
 
     const subStarted = sub.action$.pipe(filter(isActionOf(matrixSetup)), first()).toPromise();
     sub.start();
@@ -1197,8 +1246,13 @@ describe('Raiden', () => {
     const newMainTokenBalance = await sub.getTokenBalance(token, sub.mainAddress);
     expect(newMainTokenBalance).toEqual(mainTokenBalance.sub(200));
 
-    await expect(sub.closeChannel(token, partner)).resolves.toMatch(/^0x/);
-    await provider.mine(config.settleTimeout! + 1);
+    let closeTxHash = await sub.closeChannel(token, partner);
+    expect(closeTxHash).toMatch(/^0x/);
+    let closeTx = await provider.getTransaction(closeTxHash);
+    await provider.mineUntil(closeTx.blockNumber! + config.settleTimeout! + 1);
+    await sub.channels$
+      .pipe(first(c => c[token]?.[partner]?.state === ChannelState.settleable))
+      .toPromise();
     await expect(sub.settleChannel(token, partner)).resolves.toMatch(/^0x/);
 
     // settled tokens go to subkey
@@ -1224,12 +1278,15 @@ describe('Raiden', () => {
     // test changing through config.subkey
     sub.updateConfig({ subkey: true });
 
-    const closeTxHash = await sub.closeChannel(token, partner);
+    closeTxHash = await sub.closeChannel(token, partner);
     expect(closeTxHash).toMatch(/^0x/);
-    const closeTx = await provider.getTransaction(closeTxHash);
+    closeTx = await provider.getTransaction(closeTxHash);
     expect(closeTx.from).toBe(sub.address);
 
-    await provider.mine(config.settleTimeout! + 1);
+    await provider.mineUntil(closeTx.blockNumber! + config.settleTimeout! + 1);
+    await sub.channels$
+      .pipe(first(c => c[token]?.[partner]?.state === ChannelState.settleable))
+      .toPromise();
     await expect(sub.settleChannel(token, partner)).resolves.toMatch(/^0x/);
 
     // gas for close+settle paid from subkey

--- a/raiden-ts/tests/unit/epics/channels.spec.ts
+++ b/raiden-ts/tests/unit/epics/channels.spec.ts
@@ -62,7 +62,14 @@ describe('channels epic', () => {
       const newState = [
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock: 121, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: 121,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
         channelClose.success(
@@ -99,7 +106,14 @@ describe('channels epic', () => {
         curState = [
           tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
           channelOpen.success(
-            { id: channelId, settleTimeout, openBlock: 125, isFirstParticipant, txHash },
+            {
+              id: channelId,
+              settleTimeout,
+              isFirstParticipant,
+              txHash,
+              txBlock: 125,
+              confirmed: true,
+            },
             { tokenNetwork, partner },
           ),
         ].reduce(raidenReducer, state);
@@ -195,15 +209,32 @@ describe('channels epic', () => {
       jest.clearAllMocks();
     });
 
-    test("filter out if channel isn't in 'open' state", async () => {
-      // channel.state is 'opening'
+    test("filter out if channel isn't in 'open' state or unconfirmed channel", async () => {
       const curState = [
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         channelOpen.request({ settleTimeout }, { tokenNetwork, partner }),
       ].reduce(raidenReducer, state);
       const action$ = of<RaidenAction>(
           channelOpen.success(
-            { id: channelId, settleTimeout, openBlock: 125, isFirstParticipant, txHash },
+            {
+              id: channelId,
+              settleTimeout,
+              isFirstParticipant,
+              txHash,
+              txBlock: 125,
+              confirmed: undefined,
+            },
+            { tokenNetwork, partner },
+          ),
+          channelOpen.success(
+            {
+              id: channelId,
+              settleTimeout,
+              isFirstParticipant,
+              txHash,
+              txBlock: 125,
+              confirmed: true,
+            },
             { tokenNetwork, partner },
           ),
         ),
@@ -213,9 +244,15 @@ describe('channels epic', () => {
     });
 
     test('channelOpen.success triggers channel monitoring', async () => {
-      // channel.state is 'opening'
       const action = channelOpen.success(
-          { id: channelId, settleTimeout, openBlock: 125, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: 125,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
         curState = [tokenMonitored({ token, tokenNetwork, fromBlock: 1 }), action].reduce(
@@ -225,11 +262,9 @@ describe('channels epic', () => {
       const action$ = of<RaidenAction>(action),
         state$ = of<RaidenState>(curState);
 
-      await expect(channelOpenedEpic(action$, state$).toPromise()).resolves.toMatchObject({
-        type: channelMonitor.type,
-        payload: { id: channelId, fromBlock: 125 },
-        meta: { tokenNetwork, partner },
-      });
+      await expect(channelOpenedEpic(action$, state$).toPromise()).resolves.toMatchObject(
+        channelMonitor({ id: channelId, fromBlock: 125 }, { tokenNetwork, partner }),
+      );
     });
   });
 
@@ -250,7 +285,14 @@ describe('channels epic', () => {
       const curState = [
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
       ].reduce(raidenReducer, state);
@@ -287,7 +329,14 @@ describe('channels epic', () => {
         curState = [
           tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
           channelOpen.success(
-            { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+            {
+              id: channelId,
+              settleTimeout,
+              isFirstParticipant,
+              txHash,
+              txBlock: openBlock,
+              confirmed: true,
+            },
             { tokenNetwork, partner },
           ),
         ].reduce(raidenReducer, state);
@@ -319,7 +368,14 @@ describe('channels epic', () => {
       const curState = [
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
       ].reduce(raidenReducer, state);
@@ -365,7 +421,14 @@ describe('channels epic', () => {
       const curState = [
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
         channelDeposit.success(
@@ -408,7 +471,14 @@ describe('channels epic', () => {
       const curState = [
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
       ].reduce(raidenReducer, state);
@@ -442,7 +512,14 @@ describe('channels epic', () => {
       const curState = [
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
         channelClose.success(
@@ -529,7 +606,14 @@ describe('channels epic', () => {
       const curState = [
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
       ].reduce(raidenReducer, state);
@@ -567,7 +651,14 @@ describe('channels epic', () => {
       const curState = [
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
       ].reduce(raidenReducer, state);
@@ -619,7 +710,14 @@ describe('channels epic', () => {
       const curState = [
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
         // own initial deposit of 330
@@ -727,7 +825,14 @@ describe('channels epic', () => {
       const curState = [
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
       ].reduce(raidenReducer, state);
@@ -763,7 +868,14 @@ describe('channels epic', () => {
       const curState = [
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
       ].reduce(raidenReducer, state);
@@ -831,7 +943,14 @@ describe('channels epic', () => {
       const curState = [
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
         newBlock({ blockNumber: closeBlock }),
@@ -860,7 +979,14 @@ describe('channels epic', () => {
       const curState = [
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
         newBlock({ blockNumber: closeBlock }),
@@ -905,7 +1031,14 @@ describe('channels epic', () => {
       const curState = [
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
         newBlock({ blockNumber: closeBlock }),

--- a/raiden-ts/tests/unit/epics/path.spec.ts
+++ b/raiden-ts/tests/unit/epics/path.spec.ts
@@ -82,7 +82,14 @@ describe('PFS: pathFindServiceEpic', () => {
         tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
         // a couple of channels with unrelated partners, with larger deposits
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
         channelDeposit.success(
@@ -1146,7 +1153,14 @@ describe('PFS: pfsCapacityUpdateEpic', () => {
     openedState = [
       tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
       channelOpen.success(
-        { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+        {
+          id: channelId,
+          settleTimeout,
+          isFirstParticipant,
+          txHash,
+          txBlock: openBlock,
+          confirmed: true,
+        },
         { tokenNetwork, partner },
       ),
       newBlock({ blockNumber: 125 }),

--- a/raiden-ts/tests/unit/epics/raiden.spec.ts
+++ b/raiden-ts/tests/unit/epics/raiden.spec.ts
@@ -11,7 +11,12 @@ import { range } from 'lodash';
 
 import { UInt, Signed } from 'raiden-ts/utils/types';
 import { MessageType, Processed, Delivered } from 'raiden-ts/messages/types';
-import { RaidenAction, raidenShutdown } from 'raiden-ts/actions';
+import {
+  RaidenAction,
+  raidenShutdown,
+  raidenConfigUpdate,
+  ConfirmableAction,
+} from 'raiden-ts/actions';
 import { RaidenState } from 'raiden-ts/state';
 import {
   newBlock,
@@ -30,6 +35,7 @@ import {
   initMonitorProviderEpic,
   tokenMonitoredEpic,
   initTokensRegistryEpic,
+  confirmationEpic,
 } from 'raiden-ts/channels/epics';
 import { ShutdownReason } from 'raiden-ts/constants';
 import { makeMessageId } from 'raiden-ts/transfers/utils';
@@ -52,6 +58,8 @@ describe('raiden epic', () => {
       matrixServer,
       partnerRoomId,
       partnerUserId,
+      state$,
+      action$,
     } = epicFixtures(depsMock);
 
   const fetch = jest.fn(async () => ({
@@ -76,6 +84,8 @@ describe('raiden epic', () => {
       matrixServer,
       partnerRoomId,
       partnerUserId,
+      state$,
+      action$,
     } = epicFixtures(depsMock));
   });
 
@@ -90,7 +100,14 @@ describe('raiden epic', () => {
         const newState = [
           tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
           channelOpen.success(
-            { id: channelId, settleTimeout, openBlock: 121, isFirstParticipant, txHash },
+            {
+              id: channelId,
+              settleTimeout,
+              isFirstParticipant,
+              txHash,
+              txBlock: 121,
+              confirmed: true,
+            },
             { tokenNetwork, partner },
           ),
           channelDeposit.success(
@@ -306,11 +323,19 @@ describe('raiden epic', () => {
         .pipe(first())
         .toPromise();
 
-      await expect(promise).resolves.toMatchObject({
-        type: channelOpen.success.type,
-        payload: { id: channelId, settleTimeout, openBlock: 121 },
-        meta: { tokenNetwork, partner },
-      });
+      await expect(promise).resolves.toEqual(
+        channelOpen.success(
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant: true,
+            txHash: expect.any(String),
+            txBlock: 121,
+            confirmed: undefined,
+          },
+          { tokenNetwork, partner },
+        ),
+      );
 
       expect(depsMock.provider.getLogs).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -345,11 +370,19 @@ describe('raiden epic', () => {
         }),
       );
 
-      await expect(promise).resolves.toMatchObject({
-        type: channelOpen.success.type,
-        payload: { id: channelId, settleTimeout, openBlock: 125 },
-        meta: { tokenNetwork, partner },
-      });
+      await expect(promise).resolves.toEqual(
+        channelOpen.success(
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant: true,
+            txHash: expect.any(String),
+            txBlock: 125,
+            confirmed: undefined,
+          },
+          { tokenNetwork, partner },
+        ),
+      );
     });
 
     test("ensure multiple tokenMonitored don't produce duplicated events", async () => {
@@ -386,11 +419,19 @@ describe('raiden epic', () => {
 
       const result = await promise;
       expect(result).toHaveLength(1);
-      expect(result[0]).toMatchObject({
-        type: channelOpen.success.type,
-        payload: { id: channelId, settleTimeout, openBlock: 125 },
-        meta: { tokenNetwork, partner },
-      });
+      expect(result[0]).toEqual(
+        channelOpen.success(
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant: true,
+            txHash: expect.any(String),
+            txBlock: 125,
+            confirmed: undefined,
+          },
+          { tokenNetwork, partner },
+        ),
+      );
 
       // one for channels with us, one for channels from us
       expect(depsMock.provider.on).toHaveBeenCalledTimes(1);
@@ -472,6 +513,135 @@ describe('raiden epic', () => {
       await expect(promise).resolves.toBeUndefined();
       expect(signerSpy).toHaveBeenCalledTimes(0);
       signerSpy.mockRestore();
+    });
+  });
+
+  describe('confirmationEpic', () => {
+    beforeEach(() => action$.next(raidenConfigUpdate({ config: { confirmationBlocks: 5 } })));
+
+    test('confirmed', async () => {
+      expect.assertions(7);
+      let output: ConfirmableAction | undefined = undefined;
+
+      const sub = confirmationEpic(action$, state$, depsMock).subscribe(o => {
+        action$.next(o);
+        output = o;
+      });
+
+      const currentState = async () =>
+        depsMock.latest$.pipe(pluckDistinct('state'), first()).toPromise();
+
+      const pending = channelOpen.success(
+        {
+          id: channelId,
+          settleTimeout,
+          isFirstParticipant,
+          txHash,
+          txBlock: 122,
+          confirmed: undefined,
+        },
+        { tokenNetwork, partner },
+      );
+
+      action$.next(newBlock({ blockNumber: 121 }));
+      action$.next(pending);
+      action$.next(newBlock({ blockNumber: 122 }));
+
+      // pending tx (confirmed=undefined) is stored in state
+      await expect(currentState()).resolves.toMatchObject({
+        blockNumber: 122,
+        config: { confirmationBlocks: 5 },
+        pendingTxs: [pending],
+      });
+      expect(output).toBeUndefined();
+
+      // at least confirmationBlocks passed, but getTransactionReceipt returns invalid
+      depsMock.provider.getTransactionReceipt.mockResolvedValueOnce(null as any);
+      action$.next(newBlock({ blockNumber: 127 }));
+
+      expect(depsMock.provider.getTransactionReceipt).toHaveBeenCalledTimes(1);
+      expect(output).toBeUndefined();
+
+      // give some time to exhaustMap to be free'd
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // now, confirmed, but reorged to block=123
+      depsMock.provider.getTransactionReceipt.mockResolvedValueOnce({
+        confirmations: 6,
+        blockNumber: 123,
+      } as any);
+      action$.next(newBlock({ blockNumber: 129 }));
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(depsMock.provider.getTransactionReceipt).toHaveBeenCalledTimes(2);
+      expect(output).toMatchObject({
+        payload: {
+          txHash,
+          txBlock: 123,
+          confirmed: true,
+        },
+      });
+      await expect(currentState()).resolves.toMatchObject({
+        blockNumber: 129,
+        pendingTxs: [],
+      });
+
+      sub.unsubscribe();
+    });
+
+    test('confirmed', async () => {
+      expect.assertions(4);
+      let output: ConfirmableAction | undefined = undefined;
+
+      const sub = confirmationEpic(action$, state$, depsMock).subscribe(o => {
+        action$.next(o);
+        output = o;
+      });
+
+      const currentState = async () =>
+        depsMock.latest$.pipe(pluckDistinct('state'), first()).toPromise();
+
+      const pending = channelOpen.success(
+        {
+          id: channelId,
+          settleTimeout,
+          isFirstParticipant,
+          txHash,
+          txBlock: 122,
+          confirmed: undefined,
+        },
+        { tokenNetwork, partner },
+      );
+
+      action$.next(newBlock({ blockNumber: 121 }));
+      action$.next(pending);
+
+      // can't get receipt, confirmationBlocks < n < 2*confirmationBlocks passed
+      depsMock.provider.getTransactionReceipt.mockResolvedValueOnce(null as any);
+      action$.next(newBlock({ blockNumber: 129 }));
+      await new Promise(resolve => setTimeout(resolve, 10));
+      expect(output).toBeUndefined();
+
+      // still can't get receipt, n > 2*confirmationBlocks passed
+      depsMock.provider.getTransactionReceipt.mockResolvedValueOnce(null as any);
+      action$.next(newBlock({ blockNumber: 133 }));
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(depsMock.provider.getTransactionReceipt).toHaveBeenCalledTimes(2);
+      expect(output).toMatchObject({
+        payload: {
+          txHash,
+          txBlock: 122,
+          confirmed: false,
+        },
+      });
+      await expect(currentState()).resolves.toMatchObject({
+        blockNumber: 133,
+        pendingTxs: [],
+      });
+
+      sub.unsubscribe();
     });
   });
 });

--- a/raiden-ts/tests/unit/epics/transfers.spec.ts
+++ b/raiden-ts/tests/unit/epics/transfers.spec.ts
@@ -164,7 +164,14 @@ describe('transfers epic', () => {
             tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
             // a couple of channels with unrelated partners, with larger deposits
             channelOpen.success(
-              { id: channelId - 2, settleTimeout, openBlock, isFirstParticipant, txHash },
+              {
+                id: channelId - 2,
+                settleTimeout,
+                isFirstParticipant,
+                txHash,
+                txBlock: openBlock,
+                confirmed: true,
+              },
               { tokenNetwork, partner: otherPartner2 },
             ),
             channelDeposit.success(
@@ -177,7 +184,14 @@ describe('transfers epic', () => {
               { tokenNetwork, partner: otherPartner2 },
             ),
             channelOpen.success(
-              { id: channelId - 1, settleTimeout, openBlock, isFirstParticipant, txHash },
+              {
+                id: channelId - 1,
+                settleTimeout,
+                isFirstParticipant,
+                txHash,
+                txBlock: openBlock,
+                confirmed: true,
+              },
               { tokenNetwork, partner: otherPartner1 },
             ),
             channelDeposit.success(
@@ -191,7 +205,14 @@ describe('transfers epic', () => {
             ),
             // but transfer should prefer this direct channel
             channelOpen.success(
-              { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+              {
+                id: channelId,
+                settleTimeout,
+                isFirstParticipant,
+                txHash,
+                txBlock: openBlock,
+                confirmed: true,
+              },
               { tokenNetwork, partner },
             ),
             channelDeposit.success(
@@ -271,7 +292,14 @@ describe('transfers epic', () => {
             tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
             // channel with closingPartner: closed
             channelOpen.success(
-              { id: channelId + 1, settleTimeout, openBlock, isFirstParticipant, txHash },
+              {
+                id: channelId + 1,
+                settleTimeout,
+                isFirstParticipant,
+                txHash,
+                txBlock: openBlock,
+                confirmed: true,
+              },
               { tokenNetwork, partner: closingPartner },
             ),
             channelClose.success(
@@ -329,7 +357,14 @@ describe('transfers epic', () => {
           [
             tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
             channelOpen.success(
-              { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+              {
+                id: channelId,
+                settleTimeout,
+                isFirstParticipant,
+                txHash,
+                txBlock: openBlock,
+                confirmed: true,
+              },
               { tokenNetwork, partner },
             ),
             channelDeposit.success(

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -208,7 +208,12 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
       { network, address, contractsInfo },
       {
         blockNumber,
-        config: { pfsSafetyMargin: 1.1, pfs: 'https://pfs.raiden.test', httpTimeout: 3e3 },
+        config: {
+          pfsSafetyMargin: 1.1,
+          pfs: 'https://pfs.raiden.test',
+          httpTimeout: 3e3,
+          confirmationBlocks: 2,
+        },
       },
     ),
     defaultConfig = makeDefaultConfig({ network });

--- a/raiden-ts/tests/unit/reducers.spec.ts
+++ b/raiden-ts/tests/unit/reducers.spec.ts
@@ -128,11 +128,36 @@ describe('raidenReducer', () => {
       });
     });
 
-    test('channelOpen.success', () => {
+    test('channelOpen.success unconfirmed', () => {
       const newState = raidenReducer(
         state,
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: undefined,
+          },
+          { tokenNetwork, partner },
+        ),
+      );
+      expect(newState.channels[tokenNetwork]?.[partner]).toBeUndefined();
+    });
+
+    test('channelOpen.success confirmed', () => {
+      const newState = raidenReducer(
+        state,
+        channelOpen.success(
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
       );
@@ -165,7 +190,14 @@ describe('raidenReducer', () => {
       state = raidenReducer(
         state,
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
       );
@@ -246,7 +278,14 @@ describe('raidenReducer', () => {
     beforeEach(() => {
       state = [
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
         channelDeposit.success(
@@ -349,7 +388,14 @@ describe('raidenReducer', () => {
       state = raidenReducer(
         state,
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
       );
@@ -389,7 +435,14 @@ describe('raidenReducer', () => {
       state = raidenReducer(
         state,
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
       );
@@ -425,7 +478,14 @@ describe('raidenReducer', () => {
       // channel in closing state
       state = [
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
         channelClose.request(undefined, { tokenNetwork, partner }),
@@ -454,7 +514,14 @@ describe('raidenReducer', () => {
       // channel in "open" state
       state = [
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
       ].reduce(raidenReducer, state);
@@ -502,7 +569,14 @@ describe('raidenReducer', () => {
       // channel in "closed" state
       state = [
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
         channelClose.success(
@@ -562,7 +636,14 @@ describe('raidenReducer', () => {
       // channel starts in "opened" state
       state = [
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
       ].reduce(raidenReducer, state);
@@ -727,7 +808,14 @@ describe('raidenReducer', () => {
       state = raidenReducer(
         state,
         channelOpen.success(
-          { id: channelId, settleTimeout, openBlock, isFirstParticipant, txHash },
+          {
+            id: channelId,
+            settleTimeout,
+            isFirstParticipant,
+            txHash,
+            txBlock: openBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
       );

--- a/raiden-ts/tests/unit/state.spec.ts
+++ b/raiden-ts/tests/unit/state.spec.ts
@@ -38,6 +38,7 @@ describe('RaidenState codecs', () => {
       secrets: {},
       sent: {},
       path: { iou: {} },
+      pendingTxs: [],
     };
     expect(JSON.parse(encodeRaidenState(state))).toEqual({
       address,
@@ -63,6 +64,7 @@ describe('RaidenState codecs', () => {
       secrets: {},
       sent: {},
       path: { iou: {} },
+      pendingTxs: [],
     });
   });
 
@@ -95,6 +97,7 @@ describe('RaidenState codecs', () => {
         secrets: {},
         sent: {},
         path: { iou: {} },
+        pendingTxs: [],
       }),
     ).toThrow('Invalid value "unknownstate"');
 
@@ -124,6 +127,7 @@ describe('RaidenState codecs', () => {
         secrets: {},
         sent: {},
         path: { iou: {} },
+        pendingTxs: [],
       }),
     ).toEqual({
       address,
@@ -149,6 +153,7 @@ describe('RaidenState codecs', () => {
       secrets: {},
       sent: {},
       path: { iou: {} },
+      pendingTxs: [],
     });
   });
 });


### PR DESCRIPTION
Part of #613 
Todo in a later PR, is to extend this method to all on-chain transactions.
First time the on-chain transaction is seen, it gets dispatched with `payload.confirmed` property present but set as `undefined`, meaning pending. Reducer will persist/serialize it to `state.pendingTx` (thanks to #759).

Then, on each block, the possibly confirmed actions (when more than `config.confirmationBlocks` have passed since first/pending action) gets fetched with `getTransactionReceipt`, and if the transaction is still present on-chain, it gets re-emitted with `confirmed=true`, which also removes it from the pendintTx state.
If it isn't present, on each block until `2 * confirmationBlocks`, check again. If it still isn't there/confirmed after this timeout, consider the transaction as having been removed by a chain reorg, and re-emit it, now with `confirmed=false`, which also removes it from `pendingTx` and rejects any pending promise.
.
The confirmable actions always being emitted twice (first as pending, later as confirmed or removed) enables each part of the codebase to chose which actions/events to react to, be it first time seeing a tx event, or upon confirmation: e.g. the transfer epics can react early to `channelClose` and avoid accepting new transfers or mediating (in the future), while accepting deposits as increasing the channel's capacity is done only after it has been confirmed.

The `confirmationEpic` reacting on state ensures this algorithm is safe upon shutdown and later client restart, even with to-be-confirmed actions being able to be picked up again after much time (as long as receipt can be fetched by eth client, which may not be the case without full or even archiving node with enormous block ranges, but we'd consider this as an unexpected edge case).