### PR TITLE
Make channelClose & channelSettle success actions confirmable

### DIFF
--- a/raiden-ts/src/actions.ts
+++ b/raiden-ts/src/actions.ts
@@ -77,6 +77,8 @@ export const ConfirmableActions = [
   ChannelsActions.channelOpen.success,
   ChannelsActions.channelDeposit.success,
   ChannelsActions.channelWithdrawn,
+  ChannelsActions.channelClose.success,
+  ChannelsActions.channelSettle.success,
 ];
 /**
  * Union of codecs of actions above
@@ -85,8 +87,12 @@ export const ConfirmableAction = t.union([
   ChannelsActions.channelOpen.success.codec,
   ChannelsActions.channelDeposit.success.codec,
   ChannelsActions.channelWithdrawn.codec,
+  ChannelsActions.channelClose.success.codec,
+  ChannelsActions.channelSettle.success.codec,
 ]);
 export type ConfirmableAction =
   | ChannelsActions.channelOpen.success
   | ChannelsActions.channelDeposit.success
-  | ChannelsActions.channelWithdrawn;
+  | ChannelsActions.channelWithdrawn
+  | ChannelsActions.channelClose.success
+  | ChannelsActions.channelSettle.success;

--- a/raiden-ts/src/channels/actions.ts
+++ b/raiden-ts/src/channels/actions.ts
@@ -109,7 +109,13 @@ export const channelClose = createAsyncAction(
   'channel/close/success',
   'channel/close/failure',
   t.union([t.partial({ subkey: t.boolean }), t.undefined]),
-  t.type({ id: t.number, participant: Address, closeBlock: t.number, txHash: Hash }),
+  t.type({
+    id: t.number,
+    participant: Address,
+    txHash: Hash,
+    txBlock: t.number,
+    confirmed: t.union([t.undefined, t.boolean]),
+  }),
 );
 
 export namespace channelClose {
@@ -132,7 +138,12 @@ export const channelSettle = createAsyncAction(
   'channel/settle/success',
   'channel/settle/failure',
   t.union([t.partial({ subkey: t.boolean }), t.undefined]),
-  t.type({ id: t.number, settleBlock: t.number, txHash: Hash }),
+  t.type({
+    id: t.number,
+    txHash: Hash,
+    txBlock: t.number,
+    confirmed: t.union([t.undefined, t.boolean]),
+  }),
 );
 
 export namespace channelSettle {

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -590,7 +590,7 @@ export class Raiden {
     assert(!subkey || this.deps.main, "Can't send tx from subkey if not set");
 
     const meta = { tokenNetwork, partner };
-    const promise = asyncActionToPromise(channelClose, meta, this.action$).then(
+    const promise = asyncActionToPromise(channelClose, meta, this.action$, true).then(
       ({ txHash }) => txHash,
     );
     this.store.dispatch(channelClose.request(subkey ? { subkey } : undefined, meta));
@@ -625,7 +625,7 @@ export class Raiden {
 
     // wait for the corresponding success or error action
     const meta = { tokenNetwork, partner };
-    const promise = asyncActionToPromise(channelSettle, meta, this.action$).then(
+    const promise = asyncActionToPromise(channelSettle, meta, this.action$, true).then(
       ({ txHash }) => txHash,
     );
     this.store.dispatch(channelSettle.request(subkey ? { subkey } : undefined, meta));

--- a/raiden-ts/src/transfers/reducer.ts
+++ b/raiden-ts/src/transfers/reducer.ts
@@ -225,10 +225,11 @@ function channelCloseSuccessReducer(
 ): RaidenState {
   let sent = state.sent;
   for (const [secrethash, v] of Object.entries(sent)) {
+    const transfer = v.transfer[1];
     if (
-      !v.transfer[1].channel_identifier.eq(action.payload.id) ||
-      v.transfer[1].recipient !== action.meta.partner ||
-      v.transfer[1].token_network_address !== action.meta.tokenNetwork
+      !transfer.channel_identifier.eq(action.payload.id) ||
+      transfer.recipient !== action.meta.partner ||
+      transfer.token_network_address !== action.meta.tokenNetwork
     )
       continue;
     sent = { ...sent, [secrethash]: { ...v, channelClosed: timed(action.payload.txHash) } };

--- a/raiden-ts/src/transfers/reducer.ts
+++ b/raiden-ts/src/transfers/reducer.ts
@@ -1,5 +1,5 @@
 import { Reducer } from 'redux';
-import { get, set, unset, mapValues } from 'lodash/fp';
+import { get, set, unset } from 'lodash/fp';
 import { Zero, HashZero } from 'ethers/constants';
 import { hexlify } from 'ethers/utils';
 
@@ -206,7 +206,7 @@ function transferStateReducer(
   } else {
     return state;
   }
-
+  if (state.sent[secrethash][key]) return state;
   return {
     ...state,
     sent: {
@@ -223,18 +223,18 @@ function channelCloseSuccessReducer(
   state: RaidenState,
   action: channelClose.success,
 ): RaidenState {
-  return {
-    ...state,
-    sent: mapValues(
-      (v: SentTransfer): SentTransfer =>
-        // if transfer was on this channel, persist CloseChannel txHash, else pass
-        v.transfer[1].channel_identifier.eq(action.payload.id) &&
-        v.transfer[1].recipient === action.meta.partner &&
-        v.transfer[1].token_network_address === action.meta.tokenNetwork
-          ? { ...v, channelClosed: timed(action.payload.txHash) }
-          : v,
-    )(state.sent),
-  };
+  let sent = state.sent;
+  for (const [secrethash, v] of Object.entries(sent)) {
+    if (
+      !v.transfer[1].channel_identifier.eq(action.payload.id) ||
+      v.transfer[1].recipient !== action.meta.partner ||
+      v.transfer[1].token_network_address !== action.meta.tokenNetwork
+    )
+      continue;
+    sent = { ...sent, [secrethash]: { ...v, channelClosed: timed(action.payload.txHash) } };
+  }
+  if (sent === state.sent) return state;
+  return { ...state, sent };
 }
 
 function transferClearReducer(state: RaidenState, action: transferClear): RaidenState {
@@ -249,6 +249,8 @@ function withdrawReceiveSuccessReducer(
   state: RaidenState,
   action: withdrawReceive.success,
 ): RaidenState {
+  // TODO: subtract this pending withdraw request from partner's capacity (maybe some pending
+  // withdraws state), revert upon expiration or consolidate on confirmed channelWithdrawn
   const message = action.payload.message;
   const channelPath = ['channels', action.meta.tokenNetwork, action.meta.partner];
   let channel: Channel | undefined = get(channelPath, state);

--- a/raiden-ts/tests/e2e/provider.ts
+++ b/raiden-ts/tests/e2e/provider.ts
@@ -60,8 +60,8 @@ export class TestProvider extends Web3Provider {
 
   public async mineUntil(block: number): Promise<number> {
     const blockNumber = await this.getBlockNumber();
+    block = Math.max(block, blockNumber + 1);
     console.debug(`mining until block=${block} from ${blockNumber}`);
-    if (blockNumber >= block) return blockNumber;
     const promise = new Promise<number>(resolve => {
       const cb = (b: number): void => {
         if (b < block) return;

--- a/raiden-ts/tests/unit/epics/channels.spec.ts
+++ b/raiden-ts/tests/unit/epics/channels.spec.ts
@@ -76,8 +76,9 @@ describe('channels epic', () => {
           {
             id: channelId,
             participant: depsMock.address,
-            closeBlock,
             txHash,
+            txBlock: closeBlock,
+            confirmed: true,
           },
           { tokenNetwork, partner },
         ),
@@ -531,7 +532,13 @@ describe('channels epic', () => {
 
       await expect(promise).resolves.toEqual(
         channelClose.success(
-          { id: channelId, participant: partner, closeBlock, txHash },
+          {
+            id: channelId,
+            participant: partner,
+            txHash,
+            txBlock: closeBlock,
+            confirmed: undefined,
+          },
           { tokenNetwork, partner },
         ),
       );
@@ -552,7 +559,13 @@ describe('channels epic', () => {
           { tokenNetwork, partner },
         ),
         channelClose.success(
-          { id: channelId, participant: depsMock.address, closeBlock, txHash },
+          {
+            id: channelId,
+            participant: depsMock.address,
+            txHash,
+            txBlock: closeBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ), // channel is in "closed" state already
       ].reduce(raidenReducer, state);
@@ -579,7 +592,10 @@ describe('channels epic', () => {
       );
 
       await expect(promise).resolves.toEqual(
-        channelSettle.success({ id: channelId, settleBlock, txHash }, { tokenNetwork, partner }),
+        channelSettle.success(
+          { id: channelId, txHash, txBlock: settleBlock, confirmed: undefined },
+          { tokenNetwork, partner },
+        ),
       );
 
       // ensure ChannelSettledAction completed channel monitoring and unsubscribed from events
@@ -946,7 +962,13 @@ describe('channels epic', () => {
         ),
         newBlock({ blockNumber: closeBlock }),
         channelClose.success(
-          { id: channelId, participant: depsMock.address, closeBlock, txHash },
+          {
+            id: channelId,
+            participant: depsMock.address,
+            txHash,
+            txBlock: closeBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
       ].reduce(raidenReducer, state);
@@ -977,7 +999,13 @@ describe('channels epic', () => {
         ),
         newBlock({ blockNumber: closeBlock }),
         channelClose.success(
-          { id: channelId, participant: depsMock.address, closeBlock, txHash },
+          {
+            id: channelId,
+            participant: depsMock.address,
+            txHash,
+            txBlock: closeBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
         newBlock({ blockNumber: settleBlock }),
@@ -1024,7 +1052,13 @@ describe('channels epic', () => {
         ),
         newBlock({ blockNumber: closeBlock }),
         channelClose.success(
-          { id: channelId, participant: depsMock.address, closeBlock, txHash },
+          {
+            id: channelId,
+            participant: depsMock.address,
+            txHash,
+            txBlock: closeBlock,
+            confirmed: true,
+          },
           { tokenNetwork, partner },
         ),
         newBlock({ blockNumber: settleBlock }),

--- a/raiden-ts/tests/unit/epics/path.spec.ts
+++ b/raiden-ts/tests/unit/epics/path.spec.ts
@@ -784,7 +784,7 @@ describe('PFS: pathFindServiceEpic', () => {
     state$.next(
       [
         channelClose.success(
-          { id: channelId, participant: partner, closeBlock: 126, txHash },
+          { id: channelId, participant: partner, txHash, txBlock: 126, confirmed: true },
           { tokenNetwork, partner },
         ),
       ].reduce(raidenReducer, state$.value),

--- a/raiden-ts/tests/unit/epics/raiden.spec.ts
+++ b/raiden-ts/tests/unit/epics/raiden.spec.ts
@@ -134,7 +134,7 @@ describe('raiden epic', () => {
           ),
           newBlock({ blockNumber: 128 }),
           channelClose.success(
-            { id: channelId, participant: partner, closeBlock: 128, txHash },
+            { id: channelId, participant: partner, txHash, txBlock: 128, confirmed: true },
             { tokenNetwork, partner },
           ),
           newBlock({ blockNumber: 629 }),

--- a/raiden-ts/tests/unit/epics/transfers.spec.ts
+++ b/raiden-ts/tests/unit/epics/transfers.spec.ts
@@ -312,8 +312,9 @@ describe('transfers epic', () => {
               {
                 id: channelId + 1,
                 participant: closingPartner,
-                closeBlock: openBlock + 1,
                 txHash,
+                txBlock: openBlock + 1,
+                confirmed: true,
               },
               { tokenNetwork, partner: closingPartner },
             ),
@@ -457,12 +458,23 @@ describe('transfers epic', () => {
           state$ = of(
             [
               channelClose.success(
-                { id: channelId, participant: partner, closeBlock, txHash },
+                {
+                  id: channelId,
+                  participant: partner,
+                  txHash,
+                  txBlock: closeBlock,
+                  confirmed: true,
+                },
                 { tokenNetwork, partner },
               ),
               newBlock({ blockNumber: closeBlock + settleTimeout + 1 }),
               channelSettle.success(
-                { id: channelId, settleBlock: closeBlock + settleTimeout + 1, txHash },
+                {
+                  id: channelId,
+                  txHash,
+                  txBlock: closeBlock + settleTimeout + 1,
+                  confirmed: true,
+                },
                 { tokenNetwork, partner },
               ),
               newBlock({ blockNumber: closeBlock + settleTimeout + 2 }),
@@ -497,7 +509,13 @@ describe('transfers epic', () => {
           state$ = of(
             [
               channelClose.success(
-                { id: channelId, participant: partner, closeBlock, txHash },
+                {
+                  id: channelId,
+                  participant: partner,
+                  txHash,
+                  txBlock: closeBlock,
+                  confirmed: true,
+                },
                 { tokenNetwork, partner },
               ),
             ].reduce(raidenReducer, transferingState),
@@ -612,7 +630,13 @@ describe('transfers epic', () => {
           state$ = of(
             [
               channelClose.success(
-                { id: channelId, participant: partner, closeBlock, txHash },
+                {
+                  id: channelId,
+                  participant: partner,
+                  txHash,
+                  txBlock: closeBlock,
+                  confirmed: true,
+                },
                 { tokenNetwork, partner },
               ),
               newBlock({ blockNumber: signedTransfer.lock.expiration.toNumber() + 1 }),


### PR DESCRIPTION
Part of #613 
After #1009 & #1013 
Notice unconfirmed `ChannelClose` & `Settle` already puts the channels on states `closing` & `settling`, respectively. The former is important mainly because now we can stop accepting transfers on a channel on first sight of partner closing it, even before confirmation, which puts channel effectively in the `closed` state and allows for settling after `settleTimeout`.