### PR TITLE
Introduce loglevel logging framework

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#613] Implement waiting for confirmation blocks on on-chain transactions (configurable)
 
 ### Changed
+- [#926] Introduce loglevel logging framework (config.logger now specifies logging level)
 - [#1042] Support decoding addresses on messages on lowercased format
 
 ## [0.3.0] - 2020-02-07

--- a/raiden-ts/package-lock.json
+++ b/raiden-ts/package-lock.json
@@ -13570,9 +13570,9 @@
       "dev": true
     },
     "loglevel": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.6.tgz",
-      "integrity": "sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ=="
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
+      "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A=="
     },
     "lolex": {
       "version": "5.1.2",

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -82,6 +82,7 @@
     "io-ts": "^2.1.0",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.15",
+    "loglevel": "^1.6.7",
     "lossless-json": "^1.0.3",
     "matrix-js-sdk": "^3.0.0",
     "redux": "^4.0.5",

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -4,15 +4,6 @@ import { Network } from 'ethers/utils';
 import { Address } from './utils/types';
 import { getNetworkName } from './utils/ethers';
 
-const logLevels = t.keyof({
-  ['']: null,
-  trace: null,
-  debug: null,
-  info: null,
-  warn: null,
-  error: null,
-});
-
 /**
  * A Raiden configuration object with required parameters and
  * optional parameters from [[PartialRaidenConfig]].
@@ -48,18 +39,17 @@ export const RaidenConfig = t.readonly(
       pfsSafetyMargin: t.number,
       matrixExcessRooms: t.number,
       confirmationBlocks: t.number,
+      logger: t.keyof({
+        ['']: null, // silent/disabled
+        trace: null,
+        debug: null,
+        info: null,
+        warn: null,
+        error: null,
+      }),
     }),
     t.partial({
       matrixServer: t.string,
-      logger: t.union([
-        logLevels,
-        t.partial({
-          prevState: logLevels,
-          action: logLevels,
-          error: logLevels,
-          nextState: logLevels,
-        }),
-      ]),
       pfs: t.union([Address, t.string, t.null]),
       subkey: t.boolean,
     }),
@@ -91,5 +81,6 @@ export function makeDefaultConfig({ network }: { network: Network }): RaidenConf
     matrixExcessRooms: 3,
     pfsSafetyMargin: 1.0,
     confirmationBlocks: 5,
+    logger: 'info',
   };
 }

--- a/raiden-ts/src/messages/utils.ts
+++ b/raiden-ts/src/messages/utils.ts
@@ -3,6 +3,7 @@ import { Signer } from 'ethers';
 import { keccak256, RLP, verifyMessage } from 'ethers/utils';
 import { arrayify, concat, hexlify } from 'ethers/utils/bytes';
 import { HashZero } from 'ethers/constants';
+import logging from 'loglevel';
 
 import { Address, Hash, HexString, Signature, UInt, Signed, decode, assert } from '../utils/types';
 import { encode, losslessParse, losslessStringify } from '../utils/data';
@@ -322,9 +323,10 @@ export function decodeJsonMessage(text: string): Signed<Message> {
 export async function signMessage<M extends Message>(
   signer: Signer,
   message: M,
+  { log }: { log: logging.Logger } = { log: logging },
 ): Promise<Signed<M>> {
   if (isSigned(message)) return message;
-  console.log(`Signing message "${message.type}"`, message);
+  log.debug(`Signing message "${message.type}"`, message);
   const signature = (await signer.signMessage(arrayify(packMessage(message)))) as Signature;
   return { ...message, signature };
 }

--- a/raiden-ts/src/path/utils.ts
+++ b/raiden-ts/src/path/utils.ts
@@ -128,12 +128,13 @@ export function pfsListInfo(
   pfsList: readonly (string | Address)[],
   deps: RaidenEpicDeps,
 ): Observable<PFS[]> {
+  const { log } = deps;
   return from(pfsList).pipe(
     mergeMap(
       addrOrUrl =>
         pfsInfo(addrOrUrl, deps).pipe(
           catchError(err => {
-            console.warn(`Error trying to fetch PFS info for "${addrOrUrl}" - ignoring:`, err);
+            log.warn(`Error trying to fetch PFS info for "${addrOrUrl}" - ignoring:`, err);
             return EMPTY;
           }),
         ),

--- a/raiden-ts/src/transport/epics.ts
+++ b/raiden-ts/src/transport/epics.ts
@@ -524,13 +524,7 @@ export const initMatrixEpic = (
         // monitor config.logger & disable or re-enable matrix's logger accordingly
         config$.pipe(
           pluckDistinct('logger'),
-          tap(logger =>
-            matrixLogger.setLevel(
-              logger !== '' && (logger !== undefined || process.env.NODE_ENV === 'development')
-                ? 'debug'
-                : 'error',
-            ),
-          ),
+          tap(logger => matrixLogger.setLevel(logger || 'silent')),
           ignoreElements(),
         ),
       ),

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -3,6 +3,7 @@ import { Signer } from 'ethers';
 import { JsonRpcProvider } from 'ethers/providers';
 import { Network } from 'ethers/utils';
 import { MatrixClient } from 'matrix-js-sdk';
+import { Logger } from 'loglevel';
 
 import { TokenNetworkRegistry } from './contracts/TokenNetworkRegistry';
 import { ServiceRegistry } from './contracts/ServiceRegistry';
@@ -41,6 +42,7 @@ export interface RaidenEpicDeps {
   network: Network;
   signer: Signer;
   address: Address;
+  log: Logger;
   contractsInfo: ContractsInfo;
   registryContract: TokenNetworkRegistry;
   getTokenNetworkContract: (address: Address) => TokenNetwork;

--- a/raiden-ts/tests/e2e/provider.ts
+++ b/raiden-ts/tests/e2e/provider.ts
@@ -3,6 +3,7 @@ import ganache, { GanacheServerOptions } from 'ganache-cli';
 import memdown from 'memdown';
 import { range } from 'lodash';
 import asyncPool from 'tiny-async-pool';
+import log from 'loglevel';
 
 import { Web3Provider, AsyncSendable } from 'ethers/providers';
 import { MaxUint256, AddressZero } from 'ethers/constants';
@@ -45,7 +46,7 @@ export class TestProvider extends Web3Provider {
 
   public async mine(count = 1): Promise<number> {
     const blockNumber = await this.getBlockNumber();
-    console.debug(`mining ${count} blocks after blockNumber=${blockNumber}`);
+    log.debug(`mining ${count} blocks after blockNumber=${blockNumber}`);
     const promise = new Promise<number>(resolve => {
       const cb = (b: number): void => {
         if (b < blockNumber + count) return;
@@ -61,7 +62,7 @@ export class TestProvider extends Web3Provider {
   public async mineUntil(block: number): Promise<number> {
     const blockNumber = await this.getBlockNumber();
     block = Math.max(block, blockNumber + 1);
-    console.debug(`mining until block=${block} from ${blockNumber}`);
+    log.debug(`mining until block=${block} from ${blockNumber}`);
     const promise = new Promise<number>(resolve => {
       const cb = (b: number): void => {
         if (b < block) return;

--- a/raiden-ts/tests/unit/epics/transfers.spec.ts
+++ b/raiden-ts/tests/unit/epics/transfers.spec.ts
@@ -1219,9 +1219,9 @@ describe('transfers epic', () => {
           ),
           state$ = of(transferingState);
 
-        await expect(transferSecretRequestedEpic(action$, state$).toPromise()).resolves.toEqual(
-          transferSecretRequest({ message: signed }, { secrethash }),
-        );
+        await expect(
+          transferSecretRequestedEpic(action$, state$, depsMock).toPromise(),
+        ).resolves.toEqual(transferSecretRequest({ message: signed }, { secrethash }));
       });
 
       test('ignore invalid lock', async () => {
@@ -1243,7 +1243,7 @@ describe('transfers epic', () => {
           state$ = of(transferingState);
 
         await expect(
-          transferSecretRequestedEpic(action$, state$).toPromise(),
+          transferSecretRequestedEpic(action$, state$, depsMock).toPromise(),
         ).resolves.toBeUndefined();
       });
     });

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -8,6 +8,7 @@ import { AsyncSubject, of, BehaviorSubject } from 'rxjs';
 import { MatrixClient } from 'matrix-js-sdk';
 import { EventEmitter } from 'events';
 import { memoize } from 'lodash';
+import logging from 'loglevel';
 
 jest.mock('ethers/providers');
 import { JsonRpcProvider, EventType, Listener } from 'ethers/providers';
@@ -129,6 +130,7 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
     provider,
   );
   const address = signer.address as Address;
+  const log = logging.getLogger(`raiden:${address}`);
 
   const registryAddress = '0xregistry';
   const registryContract = TokenNetworkRegistryFactory.connect(
@@ -235,6 +237,7 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
     config$,
     matrix$: new AsyncSubject<MatrixClient>(),
     address,
+    log,
     network,
     contractsInfo,
     provider,


### PR DESCRIPTION
Fix #926 
Notice this comes with a slight behavior change: `config.logger`, instead of specifying the level of the emits by `redux-logger` only, now comply with the common case of specifying the minimum logging level of the whole SDK. So:
- before: `config.logger = 'info'` would make redux-logger logging be printed with `info` level on console
- now: `config.logger = 'info'` will omit anything logged with level < info, i.e. debug

Default levels for redux-logger are: `info` for action entry, `debug` for prev & next state. Default config is `info`. Therefore, on default config, anything `info` & above will be printed, and redux-logger will print only `action`, which is cleaner. To enable full debug logging, one must set with: `raiden.updateConfig({ config: { logger: 'debug' }});`.
This level also applies to matrix logger.