### PR TITLE
Aligns channels and deposit button with token dropdown button

### DIFF
--- a/raiden-dapp/src/views/Transfer.vue
+++ b/raiden-dapp/src/views/Transfer.vue
@@ -1,12 +1,7 @@
 <template>
   <v-form v-model="valid" autocomplete="off" class="transfer">
     <v-container fluid class="transfer__settings">
-      <v-row
-        align="center"
-        justify="center"
-        no-gutters
-        class="transfer__actions"
-      >
+      <v-row justify="center" no-gutters class="transfer__actions">
         <v-col cols="2" class="transfer__channels">
           <v-btn
             text
@@ -244,6 +239,11 @@ export default class Transfer extends Mixins(BlockieMixin, NavigationMixin) {
 .transfer {
   width: 100%;
   height: 100%;
+
+  &__channels,
+  &__deposit {
+    margin-top: 29px;
+  }
 
   &__actions {
     margin-top: 10px;


### PR DESCRIPTION
Adding some margin to the `Channels` and `Deposit` buttons which makes them align like so:

<img width="606" alt="Screenshot 2020-02-14 at 10 22 05" src="https://user-images.githubusercontent.com/43838780/74518330-ebf69480-4f13-11ea-8e27-61811620210a.png">
