### PR TITLE
Match confirmation actions per txHash instead of per meta

### DIFF
--- a/raiden-ts/src/channels/reducer.ts
+++ b/raiden-ts/src/channels/reducer.ts
@@ -3,7 +3,7 @@ import { Zero } from 'ethers/constants';
 import { Reducer } from 'redux';
 
 import { UInt } from '../utils/types';
-import { createReducer, matchMeta, isActionOf } from '../utils/actions';
+import { createReducer, isActionOf } from '../utils/actions';
 import { partialCombineReducers } from '../utils/redux';
 import { RaidenState, initialState } from '../state';
 import { RaidenAction, ConfirmableActions } from '../actions';
@@ -195,9 +195,11 @@ const pendingTxs: Reducer<RaidenState['pendingTxs'], RaidenAction> = (
   else if (action.payload.confirmed === undefined) return [...state, action];
   // else (either confirmed or removed), remove from state
   else {
-    const newState = state.filter(a => a.type !== action.type || !matchMeta(action.meta, a));
-    if (newState.length === state.length) return state;
-    else return newState;
+    const newState = state.filter(
+      a => a.type !== action.type || action.payload.txHash !== a.payload.txHash,
+    );
+    if (newState.length !== state.length) return newState;
+    return state;
   }
 };
 

--- a/raiden-ts/src/utils/actions.ts
+++ b/raiden-ts/src/utils/actions.ts
@@ -388,8 +388,8 @@ export function createAsyncAction<
 }
 
 // curried overloads
-export function matchMeta(meta: any, action: { meta: any }): boolean;
-export function matchMeta(meta: any): (action: { meta: any }) => boolean;
+function matchMeta(meta: any, action: { meta: any }): boolean;
+function matchMeta(meta: any): (action: { meta: any }) => boolean;
 
 /**
  * Match a passed meta with an action if returns true if metas are from corresponding actions
@@ -401,7 +401,7 @@ export function matchMeta(meta: any): (action: { meta: any }) => boolean;
  * @param args.0 - action to test meta against the 1st param
  * @returns true if metas are compatible, false otherwise
  */
-export function matchMeta(meta: any, ...args: [{ meta: any }] | []) {
+function matchMeta(meta: any, ...args: [{ meta: any }] | []) {
   const _match = (action: { meta: any }): boolean =>
     // like isEqual, but for BigNumbers, use .eq
     isMatchWith(action.meta, meta, (objVal, othVal) =>


### PR DESCRIPTION
Also, adds tests for pendingTxs reducer
Fix #1048 