### PR TITLE
Implement state upgrades and migration

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- [#614] Implement state upgrades and migration
 - [#613] Implement waiting for confirmation blocks on on-chain transactions (configurable)
 
 ### Changed

--- a/raiden-ts/src/index.ts
+++ b/raiden-ts/src/index.ts
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 export { Raiden } from './raiden';
-export { RaidenState } from './state';
+export { RaidenState, encodeRaidenState } from './state';
 export { RaidenEvent, RaidenAction } from './actions';
 export { ShutdownReason } from './constants';
 export { RaidenSentTransfer, RaidenSentTransferStatus } from './transfers/state';

--- a/raiden-ts/src/migration/0.ts
+++ b/raiden-ts/src/migration/0.ts
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Migrate previous state to version 0
+ *
+ * @param state - RaidenState version -1
+ * @returns State version 0
+ */
+export default function migrate0(state: any) {
+  return {
+    ...state,
+    version: 0, // not actually needed, migrateState will enforce version tag
+  };
+}

--- a/raiden-ts/src/migration/index.ts
+++ b/raiden-ts/src/migration/index.ts
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import logging from 'loglevel';
+
+import m0 from './0';
+
+// import above and populate this dict with new migrator functions
+// must be ordered, continuous, and last one MUST be state.CURRENT_STATE_VERSION
+const migrations = { 0: m0 };
+
+/**
+ * Migrate a RaidenState from any previous version to latest one
+ *
+ * @param state - Previous raiden state
+ * @returns A current RaidenState (hopefully), to be validated
+ */
+export default function migrateState(
+  state: any,
+  { log }: { log: logging.Logger } = { log: logging },
+) {
+  for (const [key, migrate] of Object.entries(migrations)) {
+    const version = +key;
+    if ((state?.version ?? -1) !== version - 1) continue;
+    try {
+      state = Object.assign(migrate(state), { version });
+    } catch (err) {
+      log.error(`Error migrating state from version ${version - 1} to ${version}`, state, err);
+      throw err;
+    }
+  }
+  // this must be validated as RaidenState, but is done in decodeRaidenState to avoid cyclic import
+  return state;
+}

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -273,7 +273,11 @@ export class Raiden {
   public static async create(
     connection: JsonRpcProvider | AsyncSendable | string,
     account: Signer | string | number,
-    storageOrState?: Storage | RaidenState | unknown,
+    storageOrState?:
+      | Storage
+      | RaidenState
+      | { storage: Storage; state?: RaidenState | unknown }
+      | unknown,
     contracts?: ContractsInfo,
     config?: PartialRaidenConfig,
     subkey?: true,

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -262,9 +262,9 @@ export class Raiden {
    *       <li>number index of a remote account loaded in provider
    *            (e.g. 0 for Metamask's loaded account)</li>
    *     </ul>
-   * @param storageOrState - Storage/localStorage-like synchronous object where to load and store
-   *     current state or initial RaidenState-like object instead. In this case, user must listen
-   *     state$ changes and update them on whichever persistency option is used
+   * @param storageOrState - Storage/localStorage-like object from where to load and store current
+   *     state, initial RaidenState-like object, or a { storage; state? } object containing both.
+   *     If a storage isn't provided, user must listen state$ changes on ensure it's persisted.
    * @param contracts - Contracts deployment info
    * @param config - Raiden configuration
    * @param subkey - Whether to use a derived subkey or not
@@ -361,7 +361,12 @@ export class Raiden {
     this.store.dispatch(raidenShutdown({ reason: ShutdownReason.STOP }));
   }
 
-  private get state(): RaidenState {
+  /**
+   * Get current RaidenState object. Can be serialized safely with [[encodeRaidenState]]
+   *
+   * @returns Current Raiden state
+   */
+  public get state(): RaidenState {
     return this.store.getState();
   }
 

--- a/raiden-ts/src/state.ts
+++ b/raiden-ts/src/state.ts
@@ -1,24 +1,30 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import * as t from 'io-ts';
 import { AddressZero } from 'ethers/constants';
 import { Network, getNetwork } from 'ethers/utils';
-import { debounce, merge as _merge } from 'lodash';
+import { debounce } from 'lodash';
+import logging from 'loglevel';
 
 import { PartialRaidenConfig } from './config';
 import { ContractsInfo } from './types';
 import { ConfirmableAction } from './actions';
+import migrateState from './migration';
 import { losslessParse, losslessStringify } from './utils/data';
-import { Address, Secret, decode, Signed, Storage } from './utils/types';
+import { Address, Secret, Signed, Storage, decode } from './utils/types';
 import { Channel } from './channels/state';
 import { RaidenMatrixSetup } from './transport/state';
 import { SentTransfers } from './transfers/state';
 import { IOU } from './path/types';
 import { getNetworkName } from './utils/ethers';
 
-// types
+// same as highest migrator function in migration.index.migrators
+export const CURRENT_STATE_VERSION = 0;
 
+// types
 export const RaidenState = t.readonly(
   t.type({
     address: Address,
+    version: t.literal(CURRENT_STATE_VERSION),
     chainId: t.number,
     registry: Address,
     blockNumber: t.number,
@@ -87,16 +93,26 @@ export function encodeRaidenState(state: RaidenState): string {
 }
 
 /**
- * Try to decode any data as a RaidenState.
+ * Try to migrate & decode data as RaidenState.
  * If handled a string, will parse it with lossless-json, to preserve BigNumbers encoded as JSON
- * 'number'.
+ * 'number'. The data may be migrated from previous versions, then validated as current RaidenState
  *
  * @param data - string | any which may be decoded as RaidenState
- * @returns RaidenState parsed and validated
+ * @returns RaidenState parsed, migrated and validated
  */
-export function decodeRaidenState(data: unknown): RaidenState {
+export function decodeRaidenState(
+  data: unknown,
+  { log }: { log: logging.Logger } = { log: logging },
+): RaidenState {
   if (typeof data === 'string') data = losslessParse(data);
-  return decode(RaidenState, data);
+  const state = migrateState(data, { log });
+  // validates and returns as current state
+  try {
+    return decode(RaidenState, state);
+  } catch (err) {
+    log.error(`Error validating migrated state version=${state?.version}`, state);
+    throw err;
+  }
 }
 
 // Partial<RaidenState> which allows 2nd-level config: PartialRaidenConfig
@@ -121,6 +137,7 @@ export function makeInitialState(
 ): RaidenState {
   return {
     address,
+    version: CURRENT_STATE_VERSION,
     chainId: network.chainId,
     registry: contractsInfo.TokenNetworkRegistry.address,
     blockNumber: contractsInfo.TokenNetworkRegistry.block_number,
@@ -157,11 +174,11 @@ export const initialState = makeInitialState({
 /**
  * Checks whether `storageOrState` is [[Storage]]
  *
- * @param storageOrState - either state or [[Storage]]
+ * @param storage - either state or [[Storage]]
  * @returns true if storageOrState is [[Storage]]
  */
-const isStorage = (storageOrState: unknown): storageOrState is Storage =>
-  storageOrState && typeof (storageOrState as Storage).getItem === 'function';
+const isStorage = (storage: unknown): storage is Storage =>
+  storage && typeof (storage as Storage).getItem === 'function';
 
 /**
  * Loads state from `storageOrState`. Returns the initial [[RaidenState]] if
@@ -170,7 +187,8 @@ const isStorage = (storageOrState: unknown): storageOrState is Storage =>
  * @param network - current network
  * @param contracts - current contracts
  * @param address - current address of the signer
- * @param storageOrState - either [[Storage]] or [[RaidenState]]
+ * @param storageOrState - either [[Storage]] or [[RaidenState]] or
+ *        { storage: [[Storage]]; state?: [[RaidenState]] }
  * @param config - raiden config
  * @returns true if storageOrState is [[Storage]]
  */
@@ -178,44 +196,78 @@ export const getState = async (
   network: Network,
   contracts: ContractsInfo,
   address: Address,
-  storageOrState?: unknown,
+  storageOrState?: any,
   config?: PartialRaidenConfig,
 ): Promise<{
   state: RaidenState;
   onState?: (state: RaidenState) => void;
   onStateComplete?: () => void;
 }> => {
-  let loadedState = makeInitialState({ network, address, contractsInfo: contracts }, { config });
+  const log = logging.getLogger(`raiden:${address}`);
   let onState;
   let onStateComplete;
 
-  if (storageOrState && isStorage(storageOrState)) {
+  let storage: Storage | undefined;
+  let providedState: any;
+
+  if (isStorage(storageOrState)) {
+    // stateOrStorage is storage
+    storage = storageOrState;
+    providedState = undefined;
+  } else if (isStorage(storageOrState?.storage)) {
+    // stateOrStorage is in the format { storage: Storage; state?: RaidenState | unknown }
+    storage = storageOrState.storage;
+    providedState = storageOrState.state;
+  } else {
+    // stateOrStorage is state, no storage provided
+    storage = undefined;
+    providedState = storageOrState;
+  }
+
+  let state: RaidenState | undefined = undefined;
+  if (providedState) {
+    state = decodeRaidenState(providedState, { log });
+  }
+
+  if (storage) {
     const ns = `raiden_${getNetworkName(network)}_${
       contracts.TokenNetworkRegistry.address
     }_${address}`;
-    const loaded = _merge(
-      {},
-      loadedState,
-      losslessParse((await storageOrState.getItem(ns)) || 'null'),
-    );
+    const storedData = await storage.getItem(ns);
 
-    loadedState = decodeRaidenState(loaded);
+    if (storedData) {
+      const storedState = decodeRaidenState(storedData, { log });
+      if (state /* provided */) {
+        // if both stored & provided state, ensure we weren't handed an older one!
+        if (state.blockNumber < storedState.blockNumber) {
+          throw new Error(
+            `Can't replace stored state @blockNumber=${storedState.blockNumber} with older provided state @blockNumber=${state.blockNumber}.`,
+          );
+        } else {
+          log.warn(
+            `Replacing stored state @blockNumber=${storedState.blockNumber} with newer provided state @blockNumber=${state.blockNumber}`,
+          );
+        }
+      } else {
+        // no provided state but there's a stored one, use it
+        state = storedState;
+      }
+    } // else, no stored state, initialize a new one below, if needed
 
     // to be subscribed on raiden.state$
     const debouncedState = debounce(
       (state: RaidenState): void => {
-        storageOrState.setItem(ns, encodeRaidenState(state));
+        storage!.setItem(ns, encodeRaidenState(state));
       },
       1000,
       { maxWait: 5000 },
     );
     onState = debouncedState;
     onStateComplete = () => debouncedState.flush();
-  } else if (storageOrState && RaidenState.is(storageOrState)) {
-    loadedState = storageOrState;
-  } else if (storageOrState) {
-    loadedState = decodeRaidenState(storageOrState);
   }
 
-  return { state: loadedState, onState, onStateComplete };
+  // if no provided nor stored state, initialize a pristine one
+  if (!state) state = makeInitialState({ network, address, contractsInfo: contracts }, { config });
+
+  return { state, onState, onStateComplete };
 };

--- a/raiden-ts/src/utils/types.ts
+++ b/raiden-ts/src/utils/types.ts
@@ -100,7 +100,7 @@ export const BigNumberC = new t.Type<BigNumber, string>(
       // decode by trying to bigNumberify string representation of anything
       return t.success(bigNumberify((u as any).toString()));
     } catch (err) {
-      return t.failure(u, c, err.message);
+      return t.failure(u, c);
     }
   },
   a => a.toString(),
@@ -224,14 +224,14 @@ export const Address = new t.Type<Address, string>(
     }
   },
   (u, c) => {
-    if (!HexString(20).is(u)) return t.failure(u, c, `Invalid value ${u}`);
+    if (!HexString(20).is(u)) return t.failure(u, c);
     let addr;
     try {
       addr = getAddress(u);
     } catch (e) {
-      return t.failure(u, c, e.toString());
+      return t.failure(u, c);
     }
-    if (!addr) return t.failure(u, c, 'Could not decode');
+    if (!addr) return t.failure(u, c);
     return t.success(addr as Address);
   },
   t.identity,

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -141,7 +141,35 @@ describe('Raiden', () => {
   });
 
   test('create from other params and RaidenState', async () => {
-    expect.assertions(10);
+    expect.assertions(13);
+
+    const raiden0State = await raiden.state$.pipe(first()).toPromise();
+    raiden.stop();
+
+    // state & storage object
+    await expect(
+      Raiden.create(
+        provider,
+        0,
+        { storage, state: { ...raiden0State, blockNumber: raiden0State.blockNumber - 2 } },
+        contractsInfo,
+        config,
+      ),
+    ).rejects.toThrow(/Can't replace.* with older/i);
+
+    await expect(
+      Raiden.create(
+        provider,
+        0,
+        { storage, state: { ...raiden0State, blockNumber: raiden0State.blockNumber + 2 } },
+        contractsInfo,
+        config,
+      ),
+    ).resolves.toBeInstanceOf(Raiden);
+
+    await expect(
+      Raiden.create(provider, 0, { storage }, contractsInfo, config),
+    ).resolves.toBeInstanceOf(Raiden);
 
     // token address not found as an account in provider
     await expect(Raiden.create(provider, token, storage, contractsInfo, config)).rejects.toThrow(

--- a/raiden-ts/tests/unit/states/-1_full.json
+++ b/raiden-ts/tests/unit/states/-1_full.json
@@ -1,0 +1,170 @@
+{
+  "address": "0x11111111111111111111111111aaaaaaaaaaaaaa",
+  "chainId": 1338,
+  "registry": "0x0000000000000000000000000000000000000070",
+  "blockNumber": 123,
+  "config": {
+    "matrixServerLookup": "http://raw.yaml",
+    "settleTimeout": 50,
+    "revealTimeout": 10,
+    "httpTimeout": 10e3,
+    "discoveryRoom": "raiden_test_discovery",
+    "pfsRoom": "raiden_test_path_finding",
+    "matrixExcessRooms": 2,
+    "pfsSafetyMargin": 1.1,
+    "confirmationBlocks": 2,
+    "logger": "debug"
+  },
+  "channels": {
+    "0x0000000000000000000000000000000000020001": {
+      "0x0000000000000000000000000000000000020002": {
+        "state": "open",
+        "id": 17,
+        "settleTimeout": 50,
+        "openBlock": 121,
+        "isFirstParticipant": true,
+        "own": {
+          "deposit": "1000",
+          "withdraw": "0",
+          "locks": [{
+            "amount": "20",
+            "expiration": 132,
+            "secrethash": "0x0000000000000000000000000000000000000020111111111111111111111111"
+          }],
+          "balanceProof": {
+            "chainId": "1338",
+            "tokenNetworkAddress": "0x0000000000000000000000000000000000020001",
+            "channelId": "17",
+            "nonce": "1",
+            "transferredAmount": "0",
+            "lockedAmount": "20",
+            "locksroot": "0x0000000000000000000000000000000000000020111111111111111111111111",
+            "messageHash": "0x0000000000000000000000000000000000000020111111111111111111111111",
+            "signature": "0x0000000000000000000000000000000000000020111111111111111111111111000000000000000000000000000000000000002011111111111111111111111101",
+            "sender": "0x0000000000000000000000000000000000020002"
+          }
+        },
+        "partner": {
+          "deposit": "80"
+        }
+      }
+    }
+  },
+  "tokens": {
+    "0x0000000000000000000000000000000000010001": "0x0000000000000000000000000000000000020001"
+  },
+  "transport": {
+    "matrix": {
+      "server": "https://matrix.raiden.test",
+      "setup": {
+        "userId": "@0x11111111111111111111111111aaaaaaaaaaaaaa:matrix.raiden.test",
+        "accessToken": "#access_token",
+        "deviceId": "!deviceId",
+        "displayName": "0x0000000000000000000000000000000000000020111111111111111111111111000000000000000000000000000000000000002011111111111111111111111101"
+      },
+      "rooms": { "0x0000000000000000000000000000000000020002": ["#roomId:matrix.raiden.test"] }
+    }
+  },
+  "secrets": {
+    "0x0000000000000000000000000000000000000020111111111111111111111111": {
+      "secret": "0x0000000000000000000000000000000000000020111111111111111111111111",
+      "registerBlock": 122
+    }
+  },
+  "sent": {
+    "0x0000000000000000000000000000000000000020111111111111111111111111": {
+      "transfer": [990, {
+        "type": "LockedTransfer",
+        "chain_id": "1338",
+        "message_identifier": "123456",
+        "payment_identifier": "1",
+        "nonce": "1",
+        "token_network_address": "0xe82ae5475589b828D3644e1B56546F93cD27d1a4",
+        "token": "0xc778417E063141139Fce010982780140Aa0cD5Ab",
+        "channel_identifier": "1338",
+        "transferred_amount": "0",
+        "locked_amount": "10",
+        "recipient": "0x2A915FDA69746F515b46C520eD511401d5CCD5e2",
+        "locksroot": "0x607e890c54e5ba67cd483bedae3ba9da9bf2ef2fbf237b9fb39a723b2296077b",
+        "lock": {
+          "amount": "10",
+          "expiration": "1",
+          "secrethash": "0x59cad5948673622c1d64e2322488bf01619f7ff45789741b15a9f782ce9290a8"
+        },
+        "target": "0x811957b07304d335B271feeBF46754696694b09e",
+        "initiator": "0x540B51eDc5900B8012091cc7c83caf2cb243aa86",
+        "metadata": {
+          "routes": [
+            {
+              "route": [
+                "0x2A915FDA69746F515b46C520eD511401d5CCD5e2",
+                "0x811957b07304d335B271feeBF46754696694b09e"
+              ]
+            }
+          ]
+        },
+        "signature": "0xa4beb47c2067e196de4cd9d5643d1c7af37caf4ac87de346e10ac27351505d405272f3d68960322bd53d1ea95460e4dd323dbef7c862fa6596444a57732ddb2b1c"
+      }],
+      "fee": "0",
+      "transferProcessed": [991, {
+        "type": "Processed",
+        "message_identifier": "123456",
+        "signature": "0xdc1647ec6cdd805d8d4af231c5d5b2105bda2e5c7e81b9a6314f37aef9e5db8e62c253189ddb9886201427e1908876aa68d7a3ec6c45aaa3b1de4587efc70a3f1c"
+      }],
+      "secretReveal": [992, {
+        "type": "RevealSecret",
+        "message_identifier": "123454",
+        "secret": "0x3bc51dd335dda4f6aee24b3f88d88c5ee0b0d43aea4ed25a384531ce29fb062e",
+        "signature": "0x758eace7b5443a3afb5daf06eda3d2d024ca4d2cdbd0e72b36bcc9408d5bbf0d32153f53fc180c4145fd7b6b3038554484b9d3a56382b03bfed5f3ce01c5ea1b1b"
+      }],
+      "unlock": [993, {
+        "type": "Unlock",
+        "chain_id": "337",
+        "message_identifier": "123457",
+        "payment_identifier": "1",
+        "secret": "0x3bc51dd335dda4f6aee24b3f88d88c5ee0b0d43aea4ed25a384531ce29fb062e",
+        "nonce": "1",
+        "token_network_address": "0xe82ae5475589b828D3644e1B56546F93cD27d1a4",
+        "channel_identifier": "1338",
+        "transferred_amount": "0",
+        "locked_amount": "10",
+        "locksroot": "0x607e890c54e5ba67cd483bedae3ba9da9bf2ef2fbf237b9fb39a723b2296077b",
+        "signature": "0xd153bbef8ca5462e62ba5dceda7929fc2ee7d866e983c033afe59e7f7958b8d80c734d5fba96028e8fb689300ca3c6a47764c0c0d6fbfffca9cf70729efb8e7e1c"
+      }],
+      "unlockProcessed": [994, {
+        "type": "Processed",
+        "message_identifier": "123457",
+        "signature": "0xdc1647ec6cdd805d8d4af231c5d5b2105bda2e5c7e81b9a6314f37aef9e5db8e62c253189ddb9886201427e1908876aa68d7a3ec6c45aaa3b1de4587efc70a3f1c"
+      }]
+    }
+  },
+  "path": {
+    "iou": {
+      "0x0000000000000000000000000000000000020001": {
+        "0x0000000000000000000000000000000000070002": {
+          "sender": "0x11111111111111111111111111aaaaaaaaaaaaaa",
+          "receiver": "0x0000000000000000000000000000000000070002",
+          "amount": "20",
+          "expiration_block": "132",
+          "one_to_n_address": "0x0000000000000000000000000000000000090002",
+          "chain_id": "1338",
+          "signature": "0xdc1647ec6cdd805d8d4af231c5d5b2105bda2e5c7e81b9a6314f37aef9e5db8e62c253189ddb9886201427e1908876aa68d7a3ec6c45aaa3b1de4587efc70a3f1c"
+        }
+      }
+    }
+  },
+  "pendingTxs": [{
+    "type": "channel/deposit/success",
+    "payload": {
+      "id": 17,
+      "participant": "0x11111111111111111111111111aaaaaaaaaaaaaa",
+      "totalDeposit": "100",
+      "txHash": "0x3bc51dd335dda4f6aee24b3f88d88c5ee0b0d43aea4ed25a384531ce29fb062e",
+      "txBlock": 123
+    },
+    "meta": {
+      "tokenNetwork": "0x0000000000000000000000000000000000020001",
+      "partner": "0x0000000000000000000000000000000000020002"
+    }
+  }]
+}

--- a/raiden-ts/tests/unit/states/-1_min.json
+++ b/raiden-ts/tests/unit/states/-1_min.json
@@ -1,0 +1,14 @@
+{
+  "address": "0x1111111111111111111111111111111111111111",
+  "chainId": 1338,
+  "registry": "0x0000000000000000000000000000000000000070",
+  "blockNumber": 123,
+  "config": {},
+  "channels": {},
+  "tokens": {},
+  "transport": {},
+  "secrets": {},
+  "sent": {},
+  "path": { "iou": {} },
+  "pendingTxs": []
+}

--- a/raiden-ts/tests/unit/states/0_full.json
+++ b/raiden-ts/tests/unit/states/0_full.json
@@ -1,0 +1,171 @@
+{
+  "address": "0x11111111111111111111111111aaaaaaaaaaaaaa",
+  "version": 0,
+  "chainId": 1338,
+  "registry": "0x0000000000000000000000000000000000000070",
+  "blockNumber": 123,
+  "config": {
+    "matrixServerLookup": "http://raw.yaml",
+    "settleTimeout": 50,
+    "revealTimeout": 10,
+    "httpTimeout": 10e3,
+    "discoveryRoom": "raiden_test_discovery",
+    "pfsRoom": "raiden_test_path_finding",
+    "matrixExcessRooms": 2,
+    "pfsSafetyMargin": 1.1,
+    "confirmationBlocks": 2,
+    "logger": "debug"
+  },
+  "channels": {
+    "0x0000000000000000000000000000000000020001": {
+      "0x0000000000000000000000000000000000020002": {
+        "state": "open",
+        "id": 17,
+        "settleTimeout": 50,
+        "openBlock": 121,
+        "isFirstParticipant": true,
+        "own": {
+          "deposit": "1000",
+          "withdraw": "0",
+          "locks": [{
+            "amount": "20",
+            "expiration": 132,
+            "secrethash": "0x0000000000000000000000000000000000000020111111111111111111111111"
+          }],
+          "balanceProof": {
+            "chainId": "1338",
+            "tokenNetworkAddress": "0x0000000000000000000000000000000000020001",
+            "channelId": "17",
+            "nonce": "1",
+            "transferredAmount": "0",
+            "lockedAmount": "20",
+            "locksroot": "0x0000000000000000000000000000000000000020111111111111111111111111",
+            "messageHash": "0x0000000000000000000000000000000000000020111111111111111111111111",
+            "signature": "0x0000000000000000000000000000000000000020111111111111111111111111000000000000000000000000000000000000002011111111111111111111111101",
+            "sender": "0x0000000000000000000000000000000000020002"
+          }
+        },
+        "partner": {
+          "deposit": "80"
+        }
+      }
+    }
+  },
+  "tokens": {
+    "0x0000000000000000000000000000000000010001": "0x0000000000000000000000000000000000020001"
+  },
+  "transport": {
+    "matrix": {
+      "server": "https://matrix.raiden.test",
+      "setup": {
+        "userId": "@0x11111111111111111111111111aaaaaaaaaaaaaa:matrix.raiden.test",
+        "accessToken": "#access_token",
+        "deviceId": "!deviceId",
+        "displayName": "0x0000000000000000000000000000000000000020111111111111111111111111000000000000000000000000000000000000002011111111111111111111111101"
+      },
+      "rooms": { "0x0000000000000000000000000000000000020002": ["#roomId:matrix.raiden.test"] }
+    }
+  },
+  "secrets": {
+    "0x0000000000000000000000000000000000000020111111111111111111111111": {
+      "secret": "0x0000000000000000000000000000000000000020111111111111111111111111",
+      "registerBlock": 122
+    }
+  },
+  "sent": {
+    "0x0000000000000000000000000000000000000020111111111111111111111111": {
+      "transfer": [990, {
+        "type": "LockedTransfer",
+        "chain_id": "1338",
+        "message_identifier": "123456",
+        "payment_identifier": "1",
+        "nonce": "1",
+        "token_network_address": "0xe82ae5475589b828D3644e1B56546F93cD27d1a4",
+        "token": "0xc778417E063141139Fce010982780140Aa0cD5Ab",
+        "channel_identifier": "1338",
+        "transferred_amount": "0",
+        "locked_amount": "10",
+        "recipient": "0x2A915FDA69746F515b46C520eD511401d5CCD5e2",
+        "locksroot": "0x607e890c54e5ba67cd483bedae3ba9da9bf2ef2fbf237b9fb39a723b2296077b",
+        "lock": {
+          "amount": "10",
+          "expiration": "1",
+          "secrethash": "0x59cad5948673622c1d64e2322488bf01619f7ff45789741b15a9f782ce9290a8"
+        },
+        "target": "0x811957b07304d335B271feeBF46754696694b09e",
+        "initiator": "0x540B51eDc5900B8012091cc7c83caf2cb243aa86",
+        "metadata": {
+          "routes": [
+            {
+              "route": [
+                "0x2A915FDA69746F515b46C520eD511401d5CCD5e2",
+                "0x811957b07304d335B271feeBF46754696694b09e"
+              ]
+            }
+          ]
+        },
+        "signature": "0xa4beb47c2067e196de4cd9d5643d1c7af37caf4ac87de346e10ac27351505d405272f3d68960322bd53d1ea95460e4dd323dbef7c862fa6596444a57732ddb2b1c"
+      }],
+      "fee": "0",
+      "transferProcessed": [991, {
+        "type": "Processed",
+        "message_identifier": "123456",
+        "signature": "0xdc1647ec6cdd805d8d4af231c5d5b2105bda2e5c7e81b9a6314f37aef9e5db8e62c253189ddb9886201427e1908876aa68d7a3ec6c45aaa3b1de4587efc70a3f1c"
+      }],
+      "secretReveal": [992, {
+        "type": "RevealSecret",
+        "message_identifier": "123454",
+        "secret": "0x3bc51dd335dda4f6aee24b3f88d88c5ee0b0d43aea4ed25a384531ce29fb062e",
+        "signature": "0x758eace7b5443a3afb5daf06eda3d2d024ca4d2cdbd0e72b36bcc9408d5bbf0d32153f53fc180c4145fd7b6b3038554484b9d3a56382b03bfed5f3ce01c5ea1b1b"
+      }],
+      "unlock": [993, {
+        "type": "Unlock",
+        "chain_id": "337",
+        "message_identifier": "123457",
+        "payment_identifier": "1",
+        "secret": "0x3bc51dd335dda4f6aee24b3f88d88c5ee0b0d43aea4ed25a384531ce29fb062e",
+        "nonce": "1",
+        "token_network_address": "0xe82ae5475589b828D3644e1B56546F93cD27d1a4",
+        "channel_identifier": "1338",
+        "transferred_amount": "0",
+        "locked_amount": "10",
+        "locksroot": "0x607e890c54e5ba67cd483bedae3ba9da9bf2ef2fbf237b9fb39a723b2296077b",
+        "signature": "0xd153bbef8ca5462e62ba5dceda7929fc2ee7d866e983c033afe59e7f7958b8d80c734d5fba96028e8fb689300ca3c6a47764c0c0d6fbfffca9cf70729efb8e7e1c"
+      }],
+      "unlockProcessed": [994, {
+        "type": "Processed",
+        "message_identifier": "123457",
+        "signature": "0xdc1647ec6cdd805d8d4af231c5d5b2105bda2e5c7e81b9a6314f37aef9e5db8e62c253189ddb9886201427e1908876aa68d7a3ec6c45aaa3b1de4587efc70a3f1c"
+      }]
+    }
+  },
+  "path": {
+    "iou": {
+      "0x0000000000000000000000000000000000020001": {
+        "0x0000000000000000000000000000000000070002": {
+          "sender": "0x11111111111111111111111111aaaaaaaaaaaaaa",
+          "receiver": "0x0000000000000000000000000000000000070002",
+          "amount": "20",
+          "expiration_block": "132",
+          "one_to_n_address": "0x0000000000000000000000000000000000090002",
+          "chain_id": "1338",
+          "signature": "0xdc1647ec6cdd805d8d4af231c5d5b2105bda2e5c7e81b9a6314f37aef9e5db8e62c253189ddb9886201427e1908876aa68d7a3ec6c45aaa3b1de4587efc70a3f1c"
+        }
+      }
+    }
+  },
+  "pendingTxs": [{
+    "type": "channel/deposit/success",
+    "payload": {
+      "id": 17,
+      "participant": "0x11111111111111111111111111aaaaaaaaaaaaaa",
+      "totalDeposit": "100",
+      "txHash": "0x3bc51dd335dda4f6aee24b3f88d88c5ee0b0d43aea4ed25a384531ce29fb062e",
+      "txBlock": 123
+    },
+    "meta": {
+      "tokenNetwork": "0x0000000000000000000000000000000000020001",
+      "partner": "0x0000000000000000000000000000000000020002"
+    }
+  }]
+}

--- a/raiden-ts/tests/unit/states/0_min.json
+++ b/raiden-ts/tests/unit/states/0_min.json
@@ -1,0 +1,15 @@
+{
+  "address": "0x1111111111111111111111111111111111111111",
+  "version": 0,
+  "chainId": 1338,
+  "registry": "0x0000000000000000000000000000000000000070",
+  "blockNumber": 123,
+  "config": {},
+  "channels": {},
+  "tokens": {},
+  "transport": {},
+  "secrets": {},
+  "sent": {},
+  "path": { "iou": {} },
+  "pendingTxs": []
+}


### PR DESCRIPTION
Fix #614 
Part of #152
- A new submodule is implemented: `src/migration/`
- State migration functions are implemented as a default exported function in numbered version modules, like `src/migration/0.ts`, which must always take a state from version N-1 and migrate to state N.
-  This function must  then be imported on `src/migration/index.ts`, and put in a corresponding versioning entry in the `migrations` mapping object, and is applied with a `migrateState` function (as `any`/type-unsafe input & output)
- `src/state/decodeRaidenState` function then calls `migrateState` to apply the needed upgrades in order on the parsed state object, throwing if anything goes wrong in each step, and then validating/decoding the resulting data against current `RaidenState` schema, throwing if it fails as well
- 3rd argument of `Raiden.create`, which previously accepted `localStorage` **xor** `state`, now also supports both through an object in the format `{ storage; state? }`, which can be used to upload a state, to be used instead of the stored one, while keeping `localStorage` setup (persistence).
- It fails if trying to load an old state on top of a newer one (determined through `blockNumber`), and manual state purging is required if one wants to force loading a state (backup) through it
- Migration is always applied to either stored or uploaded states, ensuring we can continue with previous state on new versions
- It applies only to state upgrades on the same contracts/blockchain/account. It doesn't help when network upgrades through a new contracts deployment.
- A set of JSON test files containing an example of minimum and full states for each version, always migrated, decoded & validated to current version, ensures present & future compliance and state upgradeability.