### PR TITLE
Monitor SecretRegistry and avoid expiring locks registered on-chain

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#1000] Implemented SDK error handling
 
 ### Changed
+- [#986] Don't expire locks which secret got registered on-chain
 - [#926] Introduce loglevel logging framework (config.logger now specifies logging level)
 - [#1042] Support decoding addresses on messages on lowercased format
 

--- a/raiden-ts/src/actions.ts
+++ b/raiden-ts/src/actions.ts
@@ -79,6 +79,7 @@ export const ConfirmableActions = [
   ChannelsActions.channelWithdrawn,
   ChannelsActions.channelClose.success,
   ChannelsActions.channelSettle.success,
+  TransfersActions.transferSecretRegistered,
 ];
 /**
  * Union of codecs of actions above
@@ -89,10 +90,12 @@ export const ConfirmableAction = t.union([
   ChannelsActions.channelWithdrawn.codec,
   ChannelsActions.channelClose.success.codec,
   ChannelsActions.channelSettle.success.codec,
+  TransfersActions.transferSecretRegistered.codec,
 ]);
 export type ConfirmableAction =
   | ChannelsActions.channelOpen.success
   | ChannelsActions.channelDeposit.success
   | ChannelsActions.channelWithdrawn
   | ChannelsActions.channelClose.success
-  | ChannelsActions.channelSettle.success;
+  | ChannelsActions.channelSettle.success
+  | TransfersActions.transferSecretRegistered;

--- a/raiden-ts/src/actions.ts
+++ b/raiden-ts/src/actions.ts
@@ -28,10 +28,7 @@ export const raidenShutdown = createAction(
 );
 export interface raidenShutdown extends ActionType<typeof raidenShutdown> {}
 
-export const raidenConfigUpdate = createAction(
-  'raidenConfigUpdate',
-  t.type({ config: PartialRaidenConfig }),
-);
+export const raidenConfigUpdate = createAction('raidenConfigUpdate', PartialRaidenConfig);
 export interface raidenConfigUpdate extends ActionType<typeof raidenConfigUpdate> {}
 
 const RaidenActions = {

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -58,7 +58,7 @@ export const RaidenConfig = t.readonly(
 export interface RaidenConfig extends t.TypeOf<typeof RaidenConfig> {}
 
 export const PartialRaidenConfig = t.readonly(
-  t.intersection([t.partial(RaidenConfig.type.types['0'].props), RaidenConfig.type.types['1']]),
+  t.partial({ ...RaidenConfig.type.types['0'].props, ...RaidenConfig.type.types['1'].props }),
 );
 export interface PartialRaidenConfig extends t.TypeOf<typeof PartialRaidenConfig> {}
 

--- a/raiden-ts/src/migration/1.ts
+++ b/raiden-ts/src/migration/1.ts
@@ -1,0 +1,23 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Move secrets to 'secret' member of the respective SentTransfer
+ *
+ * @param state - RaidenState version 0
+ * @returns State version 1
+ */
+export default function migrate1(state: any) {
+  const sent = state.sent;
+  for (const [h, t] of Object.entries<any>(sent)) {
+    if (state.secrets[h]) {
+      Object.assign(t, {
+        secret: [
+          t.secretReveal?.[0] ?? t.transfer[0],
+          { value: state.secrets[h].secret, registerBlock: state.secrets[h].registerBlock ?? 0 },
+        ],
+      });
+    }
+  }
+  delete state['secrets'];
+  return state;
+}

--- a/raiden-ts/src/migration/index.ts
+++ b/raiden-ts/src/migration/index.ts
@@ -2,10 +2,11 @@
 import logging from 'loglevel';
 
 import m0 from './0';
+import m1 from './1';
 
 // import above and populate this dict with new migrator functions
 // must be ordered, continuous, and last one MUST be state.CURRENT_STATE_VERSION
-const migrations = { 0: m0 };
+const migrations = { 0: m0, 1: m1 };
 
 /**
  * Migrate a RaidenState from any previous version to latest one

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -20,6 +20,7 @@ import { HumanStandardTokenFactory } from './contracts/HumanStandardTokenFactory
 import { ServiceRegistryFactory } from './contracts/ServiceRegistryFactory';
 import { CustomTokenFactory } from './contracts/CustomTokenFactory';
 import { UserDepositFactory } from './contracts/UserDepositFactory';
+import { SecretRegistryFactory } from './contracts/SecretRegistryFactory';
 
 import { ContractsInfo, EventTypes, OnChange, RaidenEpicDeps } from './types';
 import { ShutdownReason } from './constants';
@@ -203,6 +204,10 @@ export class Raiden {
       ),
       userDepositContract: UserDepositFactory.connect(
         contractsInfo.UserDeposit.address,
+        main?.signer ?? signer,
+      ),
+      secretRegistryContract: SecretRegistryFactory.connect(
+        contractsInfo.SecretRegistry.address,
         main?.signer ?? signer,
       ),
       main,

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -344,7 +344,7 @@ export class Raiden {
     // prevent start from being called again, turns this.started to true
     this.epicMiddleware = undefined;
     // dispatch a first, noop action, to next first state$ as current/initial state
-    this.store.dispatch(raidenConfigUpdate({ config: {} }));
+    this.store.dispatch(raidenConfigUpdate({}));
   }
 
   /**
@@ -440,7 +440,7 @@ export class Raiden {
    * @param config - Partial object containing keys and values to update in config
    */
   public updateConfig(config: PartialRaidenConfig) {
-    this.store.dispatch(raidenConfigUpdate({ config }));
+    this.store.dispatch(raidenConfigUpdate(config));
   }
 
   /**

--- a/raiden-ts/src/reducer.ts
+++ b/raiden-ts/src/reducer.ts
@@ -1,6 +1,5 @@
 import { isEmpty } from 'lodash/fp';
 
-import { isActionOf } from './utils/actions';
 import { channelsReducer } from './channels/reducer';
 import { pathReducer } from './path/reducer';
 import { transportReducer } from './transport/reducer';
@@ -11,9 +10,9 @@ import { RaidenState, initialState } from './state';
 
 // update state.config on raidenConfigUpdate action
 const configReducer = (state: RaidenState = initialState, action: RaidenAction) => {
-  if (isActionOf(raidenConfigUpdate, action)) {
-    if (!isEmpty(action.payload.config))
-      return { ...state, config: { ...state.config, ...action.payload.config } };
+  if (raidenConfigUpdate.is(action)) {
+    if (!isEmpty(action.payload))
+      return { ...state, config: { ...state.config, ...action.payload } };
   }
   return state;
 };

--- a/raiden-ts/src/state.ts
+++ b/raiden-ts/src/state.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/camelcase */
 import * as t from 'io-ts';
 import { AddressZero } from 'ethers/constants';
 import { Network, getNetwork } from 'ethers/utils';
@@ -163,12 +164,10 @@ export const initialState = makeInitialState({
   network: getNetwork('unspecified'),
   address: AddressZero as Address,
   contractsInfo: {
-    // eslint-disable-next-line @typescript-eslint/camelcase
     TokenNetworkRegistry: { address: AddressZero as Address, block_number: 0 },
-    // eslint-disable-next-line @typescript-eslint/camelcase
     ServiceRegistry: { address: AddressZero as Address, block_number: 0 },
-    // eslint-disable-next-line @typescript-eslint/camelcase
     UserDeposit: { address: AddressZero as Address, block_number: 0 },
+    SecretRegistry: { address: AddressZero as Address, block_number: 0 },
   },
 });
 

--- a/raiden-ts/src/state.ts
+++ b/raiden-ts/src/state.ts
@@ -11,7 +11,7 @@ import { ContractsInfo } from './types';
 import { ConfirmableAction } from './actions';
 import migrateState from './migration';
 import { losslessParse, losslessStringify } from './utils/data';
-import { Address, Secret, Signed, Storage, decode } from './utils/types';
+import { Address, Signed, Storage, decode } from './utils/types';
 import { Channel } from './channels/state';
 import { RaidenMatrixSetup } from './transport/state';
 import { SentTransfers } from './transfers/state';
@@ -20,7 +20,7 @@ import { getNetworkName } from './utils/ethers';
 import RaidenError, { ErrorCodes } from './utils/error';
 
 // same as highest migrator function in migration.index.migrators
-export const CURRENT_STATE_VERSION = 0;
+export const CURRENT_STATE_VERSION = 1;
 
 // types
 export const RaidenState = t.readonly(
@@ -52,14 +52,6 @@ export const RaidenState = t.readonly(
           ]),
         ),
       }),
-    ),
-    secrets: t.readonly(
-      t.record(
-        t.string /* secrethash: Hash */,
-        t.readonly(
-          t.intersection([t.type({ secret: Secret }), t.partial({ registerBlock: t.number })]),
-        ),
-      ),
     ),
     sent: SentTransfers,
     path: t.type({
@@ -147,7 +139,6 @@ export function makeInitialState(
     channels: {},
     tokens: {},
     transport: {},
-    secrets: {},
     sent: {},
     path: {
       iou: {},

--- a/raiden-ts/src/transfers/actions.ts
+++ b/raiden-ts/src/transfers/actions.ts
@@ -82,10 +82,23 @@ export interface transferProcessed extends ActionType<typeof transferProcessed> 
 /** Register a secret */
 export const transferSecret = createAction(
   'transferSecret',
-  t.intersection([t.type({ secret: Secret }), t.partial({ registerBlock: t.number })]),
+  t.type({ secret: Secret }),
   TransferId,
 );
 export interface transferSecret extends ActionType<typeof transferSecret> {}
+
+export const transferSecretRegistered = createAction(
+  'transferSecretRegistered',
+  t.type({
+    secret: Secret,
+    txHash: Hash,
+    txBlock: t.number,
+    // ConfirmableAction
+    confirmed: t.union([t.undefined, t.boolean]),
+  }),
+  TransferId,
+);
+export interface transferSecretRegistered extends ActionType<typeof transferSecretRegistered> {}
 
 /** A valid SecretRequest received from target */
 export const transferSecretRequest = createAction(

--- a/raiden-ts/src/transfers/epics.ts
+++ b/raiden-ts/src/transfers/epics.ts
@@ -877,7 +877,13 @@ export const initQueuePendingEnvelopeMessagesEpic = (
       for (const [key, sent] of Object.entries(state.sent)) {
         const secrethash = key as Hash;
         // transfer already completed or channelClosed
-        if (sent.unlockProcessed || sent.lockExpiredProcessed || sent.channelClosed) continue;
+        if (
+          sent.unlockProcessed ||
+          sent.lockExpiredProcessed ||
+          sent.secret?.[1]?.registerBlock ||
+          sent.channelClosed
+        )
+          continue;
         // on init, request monitor presence of any pending transfer target
         yield matrixPresence.request(undefined, { address: sent.transfer[1].target });
         // Processed not received yet for LockedTransfer
@@ -1090,6 +1096,7 @@ export const transferSecretRevealedEpic = (
         // don't unlock again if already unlocked, retry handled by transferUnlockedRetryMessageEpic
         // in the future, we may avoid retry until Processed, and [re]send once per SecretReveal
         state.sent[secrethash].unlock
+        // accepts secretReveal/unlock request even if registered on-chain
       )
         return;
       // transferSecret is noop if we already know the secret (e.g. we're the initiator)

--- a/raiden-ts/src/transfers/epics.ts
+++ b/raiden-ts/src/transfers/epics.ts
@@ -1403,3 +1403,18 @@ export const monitorSecretRegistryEpic = (
       ),
     ),
   );
+
+/**
+ * A simple epic to emit transfer.success when secret register is confirmed
+ *
+ * @param action$ - Observable of transferSecretRegistered actions
+ * @returns Observable of transfer.success actions
+ */
+export const transferSuccessOnSecretRegisteredEpic = (
+  action$: Observable<RaidenAction>,
+): Observable<transfer.success> =>
+  action$.pipe(
+    filter(transferSecretRegistered.is),
+    filter(action => !!action.payload.confirmed),
+    map(action => transfer.success({}, action.meta)),
+  );

--- a/raiden-ts/src/transfers/reducer.ts
+++ b/raiden-ts/src/transfers/reducer.ts
@@ -44,7 +44,7 @@ function transferSecretReducer(
   // don't overwrite registerBlock if secret already stored with it
   if (
     !(secrethash in state.sent) ||
-    state.sent[secrethash]?.secret?.[1]?.registerBlock === registerBlock
+    state.sent[secrethash].secret?.[1]?.registerBlock === registerBlock
   )
     return state;
   return {

--- a/raiden-ts/src/transfers/reducer.ts
+++ b/raiden-ts/src/transfers/reducer.ts
@@ -27,17 +27,34 @@ import {
   transferClear,
   withdrawReceive,
   transferSecretRequest,
+  transferSecretRegistered,
 } from './actions';
 
 // Reducers for different actions
-function transferSecretReducer(state: RaidenState, action: transferSecret): RaidenState {
+function transferSecretReducer(
+  state: RaidenState,
+  action: transferSecret | transferSecretRegistered,
+): RaidenState {
   const secrethash = action.meta.secrethash;
-  if (secrethash in state.secrets && state.secrets[secrethash].registerBlock) return state; // avoid storing without registerBlock if we already got with
+  // store when seeing unconfirmed, but registerBlock only after confirmation
+  const registerBlock =
+    transferSecretRegistered.is(action) && action.payload.confirmed
+      ? action.payload.txBlock
+      : state.sent[secrethash]?.secret?.[1]?.registerBlock ?? 0;
+  // don't overwrite registerBlock if secret already stored with it
+  if (
+    !(secrethash in state.sent) ||
+    state.sent[secrethash]?.secret?.[1]?.registerBlock === registerBlock
+  )
+    return state;
   return {
     ...state,
-    secrets: {
-      ...state.secrets,
-      [secrethash]: action.payload,
+    sent: {
+      ...state.sent,
+      [secrethash]: {
+        ...state.sent[secrethash],
+        secret: timed({ value: action.payload.secret, registerBlock }),
+      },
     },
   };
 }
@@ -261,7 +278,6 @@ function transferClearReducer(state: RaidenState, action: transferClear): Raiden
   const secrethash = action.meta.secrethash;
   if (!(secrethash in state.sent)) return state;
   state = unset(['sent', secrethash], state);
-  state = unset(['secrets', secrethash], state);
   return state;
 }
 
@@ -310,7 +326,7 @@ function withdrawReceiveSuccessReducer(
  * Handles all transfers actions and requests
  */
 export const transfersReducer: Reducer<RaidenState, RaidenAction> = createReducer(initialState)
-  .handle(transferSecret, transferSecretReducer)
+  .handle([transferSecret, transferSecretRegistered], transferSecretReducer)
   .handle(transferSigned, transferSignedReducer)
   .handle(
     [transferProcessed, transferUnlockProcessed, transferExpireProcessed, transferRefunded],

--- a/raiden-ts/src/transfers/state.ts
+++ b/raiden-ts/src/transfers/state.ts
@@ -11,7 +11,7 @@ import {
   Metadata,
   SecretRequest,
 } from '../messages/types';
-import { Address, Timed, Hash, Int, Signed } from '../utils/types';
+import { Address, Timed, Hash, Int, Signed, Secret } from '../utils/types';
 
 /**
  * This struct holds the relevant messages exchanged in a transfer
@@ -25,6 +25,11 @@ export const SentTransfer = t.readonly(
       fee: Int(32),
     }),
     t.partial({
+      /**
+       * Transfer secret, if known
+       * registerBlock is 0 if not yet registered on-chain
+       * */
+      secret: Timed(t.type({ value: Secret, registerBlock: t.number })),
       /** <- incoming processed for locked transfer */
       transferProcessed: Timed(Signed(Processed)),
       /**

--- a/raiden-ts/src/transfers/state.ts
+++ b/raiden-ts/src/transfers/state.ts
@@ -98,6 +98,7 @@ export enum RaidenSentTransferStatus {
   closed = 'CLOSED', // channel closed before revealing
   requested = 'REQUESTED', // secret requested by target
   revealed = 'REVEALED', // secret revealed to target
+  registered = 'REGISTERED', // secret registered on-chain before lock's expiration
   unlocking = 'UNLOCKING', // unlock sent to partner
   expiring = 'EXPIRING', // lock expired sent to partner
   unlocked = 'UNLOCKED', // unlock acknowledged by partner (complete with success)

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -10,6 +10,7 @@ import { ServiceRegistry } from './contracts/ServiceRegistry';
 import { TokenNetwork } from './contracts/TokenNetwork';
 import { HumanStandardToken } from './contracts/HumanStandardToken';
 import { UserDeposit } from './contracts/UserDeposit';
+import { SecretRegistry } from './contracts/SecretRegistry';
 
 import { RaidenAction } from './actions';
 import { RaidenState } from './state';
@@ -26,6 +27,7 @@ export interface ContractsInfo {
   TokenNetworkRegistry: Info;
   ServiceRegistry: Info;
   UserDeposit: Info;
+  SecretRegistry: Info;
 }
 
 export interface RaidenEpicDeps {
@@ -49,6 +51,7 @@ export interface RaidenEpicDeps {
   getTokenContract: (address: Address) => HumanStandardToken;
   serviceRegistryContract: ServiceRegistry;
   userDepositContract: UserDeposit;
+  secretRegistryContract: SecretRegistry;
   main?: { signer: Signer; address: Address };
 }
 

--- a/raiden-ts/src/utils/types.ts
+++ b/raiden-ts/src/utils/types.ts
@@ -175,9 +175,9 @@ export type Signature = string & t.Brand<HexStringB<65>>;
 export const Hash = HexString(32);
 export type Hash = string & t.Brand<HexStringB<32>>;
 
-// string brand: a secret bytearray, non-sized
-export const Secret = HexString();
-export type Secret = string & t.Brand<HexStringB<number>>;
+// string brand: a secret bytearray, 32 bytes
+export const Secret = HexString(32);
+export type Secret = string & t.Brand<HexStringB<32>>;
 
 // string brand: ECDSA private key, 32 bytes
 export const PrivateKey = HexString(32);

--- a/raiden-ts/tests/e2e/provider.ts
+++ b/raiden-ts/tests/e2e/provider.ts
@@ -17,6 +17,7 @@ import { CustomToken } from 'raiden-ts/contracts/CustomToken';
 import { ServiceRegistry } from 'raiden-ts/contracts/ServiceRegistry';
 import { TokenNetworkRegistryFactory } from 'raiden-ts/contracts/TokenNetworkRegistryFactory';
 import { UserDeposit } from 'raiden-ts/contracts/UserDeposit';
+import { SecretRegistry } from 'raiden-ts/contracts/SecretRegistry';
 import Contracts from '../../raiden-contracts/raiden_contracts/data/contracts.json';
 
 export class TestProvider extends Web3Provider {
@@ -80,12 +81,13 @@ export class TestProvider extends Web3Provider {
     const address = accounts[accounts.length - 1],
       signer = this.getSigner(address);
 
-    const secretRegistryContract = await new ContractFactory(
+    const secretRegistryContract = (await new ContractFactory(
       Contracts.contracts.SecretRegistry.abi as ParamType[],
       Contracts.contracts.SecretRegistry.bin,
       signer,
-    ).deploy();
+    ).deploy()) as SecretRegistry;
     await secretRegistryContract.deployed();
+    const secretRegistryDeployBlock = secretRegistryContract.deployTransaction.blockNumber;
 
     const registryContract = (await new ContractFactory(
       Contracts.contracts.TokenNetworkRegistry.abi as ParamType[],
@@ -157,6 +159,10 @@ export class TestProvider extends Web3Provider {
       UserDeposit: {
         address: userDepositContract.address as Address,
         block_number: userDepositDeployBlock!,
+      },
+      SecretRegistry: {
+        address: secretRegistryContract.address as Address,
+        block_number: secretRegistryDeployBlock!,
       },
     };
   }

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -209,6 +209,8 @@ describe('Raiden', () => {
                 ServiceRegistry: { address: partner as Address, block_number: 1 },
                 // eslint-disable-next-line @typescript-eslint/camelcase
                 UserDeposit: { address: partner as Address, block_number: 2 },
+                // eslint-disable-next-line @typescript-eslint/camelcase
+                SecretRegistry: { address: partner as Address, block_number: 3 },
               },
               address: accounts[1] as Address,
             },

--- a/raiden-ts/tests/unit/epics/path.spec.ts
+++ b/raiden-ts/tests/unit/epics/path.spec.ts
@@ -56,7 +56,7 @@ describe('PFS: pathFindServiceEpic', () => {
   const openBlock = 121,
     state$ = new BehaviorSubject(state);
 
-  getLatest$(of(raidenConfigUpdate({ config: {} })), state$, depsMock).subscribe(depsMock.latest$);
+  getLatest$(of(raidenConfigUpdate({})), state$, depsMock).subscribe(depsMock.latest$);
 
   afterAll(() => state$.complete());
 
@@ -347,7 +347,7 @@ describe('PFS: pathFindServiceEpic', () => {
   test('success request pfs from pfsList', async () => {
     expect.assertions(4);
     // put config.pfs into auto mode
-    state$.next(raidenReducer(state$.value, raidenConfigUpdate({ config: { pfs: undefined } })));
+    state$.next(raidenReducer(state$.value, raidenConfigUpdate({ pfs: undefined })));
 
     const value = bigNumberify(100) as UInt<32>,
       pfsAddress1 = '0x0800000000000000000000000000000000000091' as Address,
@@ -468,7 +468,7 @@ describe('PFS: pathFindServiceEpic', () => {
   test('fail request pfs from pfsList, empty', async () => {
     expect.assertions(1);
     // put config.pfs into auto mode
-    state$.next(raidenReducer(state$.value, raidenConfigUpdate({ config: { pfs: undefined } })));
+    state$.next(raidenReducer(state$.value, raidenConfigUpdate({ pfs: undefined })));
 
     const value = bigNumberify(100) as UInt<32>,
       action$ = of(
@@ -1122,7 +1122,7 @@ describe('PFS: pathFindServiceEpic', () => {
     expect.assertions(2);
 
     // disable pfs
-    state$.next(raidenReducer(state$.value, raidenConfigUpdate({ config: { pfs: null } })));
+    state$.next(raidenReducer(state$.value, raidenConfigUpdate({ pfs: null })));
 
     await expect(
       depsMock.latest$.pipe(pluckDistinct('config', 'pfs'), first()).toPromise(),
@@ -1263,7 +1263,7 @@ describe('PFS: pfsServiceRegistryMonitorEpic', () => {
     { state, pfsAddress } = epicFixtures(depsMock),
     state$ = new BehaviorSubject(state);
 
-  getLatest$(of(raidenConfigUpdate({ config: {} })), state$, depsMock).subscribe(depsMock.latest$);
+  getLatest$(of(raidenConfigUpdate({})), state$, depsMock).subscribe(depsMock.latest$);
 
   afterAll(() => state$.complete());
 
@@ -1275,7 +1275,7 @@ describe('PFS: pfsServiceRegistryMonitorEpic', () => {
     expect.assertions(2);
 
     // enable config.pfs auto (undefined)
-    state$.next(raidenReducer(state$.value, raidenConfigUpdate({ config: { pfs: undefined } })));
+    state$.next(raidenReducer(state$.value, raidenConfigUpdate({ pfs: undefined })));
 
     const validTill = bigNumberify(Math.floor(Date.now() / 1000) + 86400), // tomorrow
       registeredEncoded = defaultAbiCoder.encode(

--- a/raiden-ts/tests/unit/epics/raiden.spec.ts
+++ b/raiden-ts/tests/unit/epics/raiden.spec.ts
@@ -522,7 +522,7 @@ describe('raiden epic', () => {
   });
 
   describe('confirmationEpic', () => {
-    beforeEach(() => action$.next(raidenConfigUpdate({ config: { confirmationBlocks: 5 } })));
+    beforeEach(() => action$.next(raidenConfigUpdate({ confirmationBlocks: 5 })));
 
     test('confirmed', async () => {
       expect.assertions(7);

--- a/raiden-ts/tests/unit/epics/transfers.spec.ts
+++ b/raiden-ts/tests/unit/epics/transfers.spec.ts
@@ -392,7 +392,7 @@ describe('transfers epic', () => {
     });
 
     describe('transferUnlock.request', () => {
-      test('success and cached', async () => {
+      test('success and cached, after expiration with registered secret', async () => {
         expect.assertions(2);
 
         // secret revealed action is only ever emitted when received from recipient
@@ -407,6 +407,17 @@ describe('transfers epic', () => {
           .toPromise();
 
         [
+          // lock expired, but secret got registered, so unlock must still be accepted
+          transferSecretRegistered(
+            {
+              secret,
+              txBlock: signedTransfer.lock.expiration.toNumber() - 1,
+              txHash,
+              confirmed: true,
+            },
+            { secrethash },
+          ),
+          newBlock({ blockNumber: signedTransfer.lock.expiration.toNumber() + 1 }),
           transferUnlock.request(undefined, { secrethash }),
           transferUnlock.request(undefined, { secrethash }),
         ].forEach(a => action$.next(a));

--- a/raiden-ts/tests/unit/epics/transfers.spec.ts
+++ b/raiden-ts/tests/unit/epics/transfers.spec.ts
@@ -247,14 +247,8 @@ describe('transfers epic', () => {
 
       expect(output).toEqual(
         expect.arrayContaining([
-          {
-            type: transferSecret.type,
-            payload: { secret },
-            meta: { secrethash },
-          },
-          {
-            type: transferSigned.type,
-            payload: {
+          transferSigned(
+            {
               message: expect.objectContaining({
                 type: MessageType.LOCKED_TRANSFER,
                 message_identifier: expect.any(BigNumber),
@@ -262,8 +256,9 @@ describe('transfers epic', () => {
               }),
               fee,
             },
-            meta: { secrethash },
-          },
+            { secrethash },
+          ),
+          transferSecret({ secret }, { secrethash }),
         ]),
       );
 

--- a/raiden-ts/tests/unit/epics/transfers.spec.ts
+++ b/raiden-ts/tests/unit/epics/transfers.spec.ts
@@ -743,9 +743,7 @@ describe('transfers epic', () => {
     });
 
     describe('transfer*RetryMessageEpic', () => {
-      beforeEach(async () => {
-        action$.next(raidenConfigUpdate({ config: { httpTimeout: 50 } }));
-      });
+      beforeEach(() => action$.next(raidenConfigUpdate({ httpTimeout: 50 })));
 
       test('transferSigned', async () => {
         expect.assertions(2);
@@ -898,7 +896,7 @@ describe('transfers epic', () => {
     describe('transferAutoExpireEpic', () => {
       const confirmationBlocks = 2;
 
-      beforeEach(() => action$.next(raidenConfigUpdate({ config: { confirmationBlocks } })));
+      beforeEach(() => action$.next(raidenConfigUpdate({ confirmationBlocks })));
 
       test("don't emit if transfer didn't expire", async () => {
         expect.assertions(1);
@@ -1174,11 +1172,12 @@ describe('transfers epic', () => {
 
     describe('initQueuePendingEnvelopeMessagesEpic', () => {
       test('transferSigned', async () => {
-        const promise = initQueuePendingEnvelopeMessagesEpic(EMPTY, state$)
+        const promise = initQueuePendingEnvelopeMessagesEpic(
+          EMPTY,
+          depsMock.latest$.pipe(pluck('state')),
+        )
           .pipe(toArray())
           .toPromise();
-
-        action$.next(raidenConfigUpdate({ config: {} })); // noop action, to re-emit state$
         action$.complete();
 
         await expect(promise).resolves.toEqual([
@@ -1196,11 +1195,12 @@ describe('transfers epic', () => {
           .pipe(tap(a => action$.next(a)))
           .toPromise();
 
-        const promise = initQueuePendingEnvelopeMessagesEpic(EMPTY, state$)
+        const promise = initQueuePendingEnvelopeMessagesEpic(
+          EMPTY,
+          depsMock.latest$.pipe(pluck('state')),
+        )
           .pipe(toArray())
           .toPromise();
-
-        action$.next(raidenConfigUpdate({ config: {} })); // noop action, to re-emit state$
         action$.complete();
 
         await expect(promise).resolves.toEqual(
@@ -1222,11 +1222,12 @@ describe('transfers epic', () => {
           .pipe(tap(a => action$.next(a)))
           .toPromise();
 
-        const promise = initQueuePendingEnvelopeMessagesEpic(EMPTY, state$)
+        const promise = initQueuePendingEnvelopeMessagesEpic(
+          EMPTY,
+          depsMock.latest$.pipe(pluck('state')),
+        )
           .pipe(toArray())
           .toPromise();
-
-        action$.next(raidenConfigUpdate({ config: {} })); // noop action, to re-emit state$
         action$.complete();
 
         await expect(promise).resolves.toEqual(

--- a/raiden-ts/tests/unit/epics/transfers.spec.ts
+++ b/raiden-ts/tests/unit/epics/transfers.spec.ts
@@ -71,6 +71,7 @@ import {
   withdrawRequestReceivedEpic,
   withdrawSendConfirmationEpic,
   monitorSecretRegistryEpic,
+  transferSuccessOnSecretRegisteredEpic,
 } from 'raiden-ts/transfers/epics';
 import { matrixPresence } from 'raiden-ts/transport/actions';
 import { UInt, Address, Hash, Signed, isntNil } from 'raiden-ts/utils/types';
@@ -1083,6 +1084,31 @@ describe('transfers epic', () => {
           { secrethash },
         ),
       ]);
+    });
+
+    test('transferSuccessOnSecretRegisteredEpic', async () => {
+      const txBlock = 127;
+
+      // don't succeed transfer with unconfirmed action
+      await expect(
+        transferSuccessOnSecretRegisteredEpic(
+          of(
+            transferSecretRegistered(
+              { secret, txHash, txBlock, confirmed: undefined },
+              { secrethash },
+            ),
+          ),
+        ).toPromise(),
+      ).resolves.toBeUndefined();
+
+      // but do with confirmed
+      await expect(
+        transferSuccessOnSecretRegisteredEpic(
+          of(
+            transferSecretRegistered({ secret, txHash, txBlock, confirmed: true }, { secrethash }),
+          ),
+        ).toPromise(),
+      ).resolves.toEqual(transfer.success(expect.anything(), { secrethash }));
     });
 
     describe('transferProcessedReceivedEpic', () => {

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -152,7 +152,7 @@ describe('transport epic', () => {
         state$ = depsMock.latest$.pipe(pluckDistinct('state'));
 
       depsMock.latest$.pipe(first()).subscribe(l => {
-        const state = raidenReducer(l.state, raidenConfigUpdate({ config: { matrixServer } }));
+        const state = raidenReducer(l.state, raidenConfigUpdate({ matrixServer }));
         depsMock.latest$.next({ ...l, state, config: { ...l.config, ...state.config } });
       });
 
@@ -190,7 +190,7 @@ describe('transport epic', () => {
               displayName,
             },
           }),
-          raidenConfigUpdate({ config: { matrixServer } }),
+          raidenConfigUpdate({ matrixServer }),
         ].reduce(raidenReducer, l.state);
         depsMock.latest$.next({ ...l, state, config: { ...l.config, ...state.config } });
       });
@@ -896,7 +896,7 @@ describe('transport epic', () => {
   });
 
   describe('matrixMessageSendEpic', () => {
-    beforeEach(() => action$.next(raidenConfigUpdate({ config: { httpTimeout: 30 } })));
+    beforeEach(() => action$.next(raidenConfigUpdate({ httpTimeout: 30 })));
 
     test('send: all needed parts in place, errors once but retries successfully', async () => {
       expect.assertions(3);

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -236,7 +236,7 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
     defaultConfig = makeDefaultConfig({ network });
 
   const latest$: RaidenEpicDeps['latest$'] = new BehaviorSubject({
-      action: raidenConfigUpdate({ config: {} }) as RaidenAction,
+      action: raidenConfigUpdate({}) as RaidenAction,
       state,
       config: { ...defaultConfig, ...state.config },
       presences: {} as Presences,

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -21,12 +21,15 @@ import { TokenNetworkRegistry } from 'raiden-ts/contracts/TokenNetworkRegistry';
 import { TokenNetwork } from 'raiden-ts/contracts/TokenNetwork';
 import { HumanStandardToken } from 'raiden-ts/contracts/HumanStandardToken';
 import { ServiceRegistry } from 'raiden-ts/contracts/ServiceRegistry';
+import { UserDeposit } from 'raiden-ts/contracts/UserDeposit';
+import { SecretRegistry } from 'raiden-ts/contracts/SecretRegistry';
 
 import { TokenNetworkRegistryFactory } from 'raiden-ts/contracts/TokenNetworkRegistryFactory';
 import { TokenNetworkFactory } from 'raiden-ts/contracts/TokenNetworkFactory';
 import { HumanStandardTokenFactory } from 'raiden-ts/contracts/HumanStandardTokenFactory';
 import { ServiceRegistryFactory } from 'raiden-ts/contracts/ServiceRegistryFactory';
 import { UserDepositFactory } from 'raiden-ts/contracts/UserDepositFactory';
+import { SecretRegistryFactory } from 'raiden-ts/contracts/SecretRegistryFactory';
 
 import 'raiden-ts/polyfills';
 import { RaidenEpicDeps, ContractsInfo } from 'raiden-ts/types';
@@ -34,7 +37,6 @@ import { makeInitialState } from 'raiden-ts/state';
 import { Address, Signature } from 'raiden-ts/utils/types';
 import { getServerName } from 'raiden-ts/utils/matrix';
 import { pluckDistinct } from 'raiden-ts/utils/rx';
-import { UserDeposit } from 'raiden-ts/contracts/UserDeposit';
 import { raidenConfigUpdate, RaidenAction } from 'raiden-ts/actions';
 import { Presences } from 'raiden-ts/transport/types';
 import { makeDefaultConfig } from 'raiden-ts/config';
@@ -56,6 +58,7 @@ export interface MockRaidenEpicDeps extends RaidenEpicDeps {
   getTokenContract: (address: string) => MockedContract<HumanStandardToken>;
   serviceRegistryContract: MockedContract<ServiceRegistry>;
   userDepositContract: MockedContract<UserDeposit>;
+  secretRegistryContract: MockedContract<SecretRegistry>;
 }
 
 /**
@@ -192,6 +195,14 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
     '0x0A0000000000000000000000000000000000000a',
   );
 
+  const secretRegistryContract = SecretRegistryFactory.connect(address, signer) as MockedContract<
+    SecretRegistry
+  >;
+
+  for (const func in secretRegistryContract.functions) {
+    jest.spyOn(secretRegistryContract.functions, func as keyof SecretRegistry['functions']);
+  }
+
   const contractsInfo: ContractsInfo = {
       TokenNetworkRegistry: {
         address: registryContract.address as Address,
@@ -203,6 +214,10 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
       },
       UserDeposit: {
         address: userDepositContract.address as Address,
+        block_number: 102,
+      },
+      SecretRegistry: {
+        address: secretRegistryContract.address as Address,
         block_number: 102,
       },
     },
@@ -247,6 +262,7 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
     getTokenContract,
     serviceRegistryContract,
     userDepositContract,
+    secretRegistryContract,
   };
 }
 

--- a/raiden-ts/tests/unit/reducers.spec.ts
+++ b/raiden-ts/tests/unit/reducers.spec.ts
@@ -920,8 +920,12 @@ describe('raidenReducer', () => {
 
     test('secret register', () => {
       // normal secret register without blockNumber
-      let newState = [transferSecret({ secret }, { secrethash })].reduce(raidenReducer, state);
-      expect(newState.sent[secrethash].secret).toStrictEqual([
+      let newState = [
+        transferSigned({ message: transfer, fee }, { secrethash }),
+        transferSecret({ secret }, { secrethash }),
+      ].reduce(raidenReducer, state);
+
+      expect(newState.sent[secrethash]?.secret).toStrictEqual([
         expect.any(Number),
         { value: secret, registerBlock: 0 },
       ]);

--- a/raiden-ts/tests/unit/state.spec.ts
+++ b/raiden-ts/tests/unit/state.spec.ts
@@ -44,7 +44,6 @@ describe('RaidenState codecs', () => {
       },
       tokens: { [token]: tokenNetwork },
       transport: {},
-      secrets: {},
       sent: {},
       path: { iou: {} },
       pendingTxs: [],
@@ -71,7 +70,6 @@ describe('RaidenState codecs', () => {
       },
       tokens: { [token]: tokenNetwork },
       transport: {},
-      secrets: {},
       sent: {},
       path: { iou: {} },
       pendingTxs: [],
@@ -80,10 +78,10 @@ describe('RaidenState codecs', () => {
 
   test('decodeRaidenState', () => {
     // missing required properties
-    expect(() => decodeRaidenState({ address })).toThrow('Invalid value undefined');
+    expect(() => decodeRaidenState({ address })).toThrow();
 
     // property of wrong type
-    expect(() => decodeRaidenState({ address: 123 })).toThrow('Invalid value 123');
+    expect(() => decodeRaidenState({ address: 123 })).toThrow();
 
     // invalid deep enum value and BigNumber
     expect(() =>
@@ -104,7 +102,6 @@ describe('RaidenState codecs', () => {
         },
         tokens: {},
         transport: {},
-        secrets: {},
         sent: {},
         path: { iou: {} },
         pendingTxs: [],
@@ -135,7 +132,6 @@ describe('RaidenState codecs', () => {
         },
         tokens: { [token]: tokenNetwork },
         transport: {},
-        secrets: {},
         sent: {},
         path: { iou: {} },
         pendingTxs: [],
@@ -162,7 +158,6 @@ describe('RaidenState codecs', () => {
       },
       tokens: { [token]: tokenNetwork },
       transport: {},
-      secrets: {},
       sent: {},
       path: { iou: {} },
       pendingTxs: [],

--- a/raiden-ts/tests/unit/states/1_full.json
+++ b/raiden-ts/tests/unit/states/1_full.json
@@ -1,0 +1,166 @@
+{
+  "address": "0x11111111111111111111111111aaaaaaaaaaaaaa",
+  "version": 1,
+  "chainId": 1338,
+  "registry": "0x0000000000000000000000000000000000000070",
+  "blockNumber": 123,
+  "config": {
+    "matrixServerLookup": "http://raw.yaml",
+    "settleTimeout": 50,
+    "revealTimeout": 10,
+    "httpTimeout": 10e3,
+    "discoveryRoom": "raiden_test_discovery",
+    "pfsRoom": "raiden_test_path_finding",
+    "matrixExcessRooms": 2,
+    "pfsSafetyMargin": 1.1,
+    "confirmationBlocks": 2,
+    "logger": "debug"
+  },
+  "channels": {
+    "0x0000000000000000000000000000000000020001": {
+      "0x0000000000000000000000000000000000020002": {
+        "state": "open",
+        "id": 17,
+        "settleTimeout": 50,
+        "openBlock": 121,
+        "isFirstParticipant": true,
+        "own": {
+          "deposit": "1000",
+          "withdraw": "0",
+          "locks": [{
+            "amount": "20",
+            "expiration": 132,
+            "secrethash": "0x0000000000000000000000000000000000000020111111111111111111111111"
+          }],
+          "balanceProof": {
+            "chainId": "1338",
+            "tokenNetworkAddress": "0x0000000000000000000000000000000000020001",
+            "channelId": "17",
+            "nonce": "1",
+            "transferredAmount": "0",
+            "lockedAmount": "20",
+            "locksroot": "0x0000000000000000000000000000000000000020111111111111111111111111",
+            "messageHash": "0x0000000000000000000000000000000000000020111111111111111111111111",
+            "signature": "0x0000000000000000000000000000000000000020111111111111111111111111000000000000000000000000000000000000002011111111111111111111111101",
+            "sender": "0x0000000000000000000000000000000000020002"
+          }
+        },
+        "partner": {
+          "deposit": "80"
+        }
+      }
+    }
+  },
+  "tokens": {
+    "0x0000000000000000000000000000000000010001": "0x0000000000000000000000000000000000020001"
+  },
+  "transport": {
+    "matrix": {
+      "server": "https://matrix.raiden.test",
+      "setup": {
+        "userId": "@0x11111111111111111111111111aaaaaaaaaaaaaa:matrix.raiden.test",
+        "accessToken": "#access_token",
+        "deviceId": "!deviceId",
+        "displayName": "0x0000000000000000000000000000000000000020111111111111111111111111000000000000000000000000000000000000002011111111111111111111111101"
+      },
+      "rooms": { "0x0000000000000000000000000000000000020002": ["#roomId:matrix.raiden.test"] }
+    }
+  },
+  "sent": {
+    "0x0000000000000000000000000000000000000020111111111111111111111111": {
+      "transfer": [990, {
+        "type": "LockedTransfer",
+        "chain_id": "1338",
+        "message_identifier": "123456",
+        "payment_identifier": "1",
+        "nonce": "1",
+        "token_network_address": "0xe82ae5475589b828D3644e1B56546F93cD27d1a4",
+        "token": "0xc778417E063141139Fce010982780140Aa0cD5Ab",
+        "channel_identifier": "1338",
+        "transferred_amount": "0",
+        "locked_amount": "10",
+        "recipient": "0x2A915FDA69746F515b46C520eD511401d5CCD5e2",
+        "locksroot": "0x607e890c54e5ba67cd483bedae3ba9da9bf2ef2fbf237b9fb39a723b2296077b",
+        "lock": {
+          "amount": "10",
+          "expiration": "1",
+          "secrethash": "0x59cad5948673622c1d64e2322488bf01619f7ff45789741b15a9f782ce9290a8"
+        },
+        "target": "0x811957b07304d335B271feeBF46754696694b09e",
+        "initiator": "0x540B51eDc5900B8012091cc7c83caf2cb243aa86",
+        "metadata": {
+          "routes": [
+            {
+              "route": [
+                "0x2A915FDA69746F515b46C520eD511401d5CCD5e2",
+                "0x811957b07304d335B271feeBF46754696694b09e"
+              ]
+            }
+          ]
+        },
+        "signature": "0xa4beb47c2067e196de4cd9d5643d1c7af37caf4ac87de346e10ac27351505d405272f3d68960322bd53d1ea95460e4dd323dbef7c862fa6596444a57732ddb2b1c"
+      }],
+      "fee": "0",
+      "secret": [990, { "value": "0x0000000000000000000000000000000000000020111111111111111111111111", "registerBlock": 122 }],
+      "transferProcessed": [991, {
+        "type": "Processed",
+        "message_identifier": "123456",
+        "signature": "0xdc1647ec6cdd805d8d4af231c5d5b2105bda2e5c7e81b9a6314f37aef9e5db8e62c253189ddb9886201427e1908876aa68d7a3ec6c45aaa3b1de4587efc70a3f1c"
+      }],
+      "secretReveal": [992, {
+        "type": "RevealSecret",
+        "message_identifier": "123454",
+        "secret": "0x3bc51dd335dda4f6aee24b3f88d88c5ee0b0d43aea4ed25a384531ce29fb062e",
+        "signature": "0x758eace7b5443a3afb5daf06eda3d2d024ca4d2cdbd0e72b36bcc9408d5bbf0d32153f53fc180c4145fd7b6b3038554484b9d3a56382b03bfed5f3ce01c5ea1b1b"
+      }],
+      "unlock": [993, {
+        "type": "Unlock",
+        "chain_id": "337",
+        "message_identifier": "123457",
+        "payment_identifier": "1",
+        "secret": "0x3bc51dd335dda4f6aee24b3f88d88c5ee0b0d43aea4ed25a384531ce29fb062e",
+        "nonce": "1",
+        "token_network_address": "0xe82ae5475589b828D3644e1B56546F93cD27d1a4",
+        "channel_identifier": "1338",
+        "transferred_amount": "0",
+        "locked_amount": "10",
+        "locksroot": "0x607e890c54e5ba67cd483bedae3ba9da9bf2ef2fbf237b9fb39a723b2296077b",
+        "signature": "0xd153bbef8ca5462e62ba5dceda7929fc2ee7d866e983c033afe59e7f7958b8d80c734d5fba96028e8fb689300ca3c6a47764c0c0d6fbfffca9cf70729efb8e7e1c"
+      }],
+      "unlockProcessed": [994, {
+        "type": "Processed",
+        "message_identifier": "123457",
+        "signature": "0xdc1647ec6cdd805d8d4af231c5d5b2105bda2e5c7e81b9a6314f37aef9e5db8e62c253189ddb9886201427e1908876aa68d7a3ec6c45aaa3b1de4587efc70a3f1c"
+      }]
+    }
+  },
+  "path": {
+    "iou": {
+      "0x0000000000000000000000000000000000020001": {
+        "0x0000000000000000000000000000000000070002": {
+          "sender": "0x11111111111111111111111111aaaaaaaaaaaaaa",
+          "receiver": "0x0000000000000000000000000000000000070002",
+          "amount": "20",
+          "expiration_block": "132",
+          "one_to_n_address": "0x0000000000000000000000000000000000090002",
+          "chain_id": "1338",
+          "signature": "0xdc1647ec6cdd805d8d4af231c5d5b2105bda2e5c7e81b9a6314f37aef9e5db8e62c253189ddb9886201427e1908876aa68d7a3ec6c45aaa3b1de4587efc70a3f1c"
+        }
+      }
+    }
+  },
+  "pendingTxs": [{
+    "type": "channel/deposit/success",
+    "payload": {
+      "id": 17,
+      "participant": "0x11111111111111111111111111aaaaaaaaaaaaaa",
+      "totalDeposit": "100",
+      "txHash": "0x3bc51dd335dda4f6aee24b3f88d88c5ee0b0d43aea4ed25a384531ce29fb062e",
+      "txBlock": 123
+    },
+    "meta": {
+      "tokenNetwork": "0x0000000000000000000000000000000000020001",
+      "partner": "0x0000000000000000000000000000000000020002"
+    }
+  }]
+}

--- a/raiden-ts/tests/unit/states/1_min.json
+++ b/raiden-ts/tests/unit/states/1_min.json
@@ -1,0 +1,14 @@
+{
+  "address": "0x1111111111111111111111111111111111111111",
+  "version": 1,
+  "chainId": 1338,
+  "registry": "0x0000000000000000000000000000000000000070",
+  "blockNumber": 123,
+  "config": {},
+  "channels": {},
+  "tokens": {},
+  "transport": {},
+  "sent": {},
+  "path": { "iou": {} },
+  "pendingTxs": []
+}


### PR DESCRIPTION
Fix #986 
Also, refactored transfers tests for `action$` & `state$` subjects, which is more compliant with current architecture, took a bit hit of the diff, but excluding tests, the changes shouldn't be that big.
Includes some smallish improvements as well on some actions and types.