### PR TITLE
Send PFSCapacityUpdate once per channel per session

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- [#1120] Ensure PFS is updated by sending a PFSCapacityUpdate at least once per channel per session
+
 ## [0.4.0] - 2020-02-28
 ### Added
 - [#614] Implement state upgrades and migration

--- a/raiden-ts/src/path/epics.ts
+++ b/raiden-ts/src/path/epics.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import * as t from 'io-ts';
-import { combineLatest, defer, EMPTY, from, merge, Observable, of } from 'rxjs';
+import { defer, EMPTY, from, merge, Observable, of } from 'rxjs';
 import {
   catchError,
   concatMap,
@@ -13,9 +13,7 @@ import {
   map,
   mergeMap,
   pluck,
-  publishReplay,
   scan,
-  startWith,
   switchMap,
   tap,
   timeout,
@@ -26,17 +24,16 @@ import { Signer } from 'ethers';
 import { Event } from 'ethers/contract';
 import { BigNumber, bigNumberify, toUtf8Bytes, verifyMessage, concat } from 'ethers/utils';
 import { Two, Zero } from 'ethers/constants';
-import { memoize, get } from 'lodash';
+import { memoize } from 'lodash';
 
 import { UserDeposit } from '../contracts/UserDeposit';
 import { RaidenAction } from '../actions';
 import { RaidenState } from '../state';
 import { RaidenEpicDeps } from '../types';
-import { getPresences$ } from '../transport/utils';
 import { messageGlobalSend } from '../messages/actions';
 import { MessageType, PFSCapacityUpdate } from '../messages/types';
 import { MessageTypeId, signMessage } from '../messages/utils';
-import { channelDeposit } from '../channels/actions';
+import { channelDeposit, channelMonitor } from '../channels/actions';
 import { ChannelState } from '../channels/state';
 import { channelAmounts } from '../channels/utils';
 import { Address, decode, Int, Signature, Signed, UInt } from '../utils/types';
@@ -44,6 +41,7 @@ import { isActionOf } from '../utils/actions';
 import { encode, losslessParse, losslessStringify } from '../utils/data';
 import { getEventsStream } from '../utils/ethers';
 import { RaidenError, ErrorCodes } from '../utils/error';
+import { pluckDistinct } from '../utils/rx';
 import { iouClear, pathFind, iouPersist, pfsListUpdated } from './actions';
 import { channelCanRoute, pfsInfo, pfsListInfo } from './utils';
 import { IOU, LastIOUResults, PathResults, Paths, PFS } from './types';
@@ -114,17 +112,15 @@ const makeAndSignLastIOURequest$ = (sender: Address, receiver: Address, signer: 
 const prepareNextIOU$ = (
   pfs: PFS,
   tokenNetwork: Address,
-  state$: Observable<RaidenState>,
-  deps: RaidenEpicDeps,
+  { address, signer, network, userDepositContract, latest$ }: RaidenEpicDeps,
 ): Observable<Signed<IOU>> => {
-  return state$.pipe(
-    withLatestFrom(deps.config$),
+  return latest$.pipe(
     first(),
-    switchMap(([state, { httpTimeout }]) => {
-      const cachedIOU: IOU | undefined = get(state.path.iou, [tokenNetwork, pfs.address]);
+    switchMap(({ state, config: { httpTimeout } }) => {
+      const cachedIOU: IOU | undefined = state.path.iou[tokenNetwork]?.[pfs.address];
       return (cachedIOU
         ? of(cachedIOU)
-        : makeAndSignLastIOURequest$(deps.address, pfs.address, deps.signer).pipe(
+        : makeAndSignLastIOURequest$(address, pfs.address, signer).pipe(
             mergeMap(payload =>
               fromFetch(
                 `${pfs.url}/api/v1/${tokenNetwork}/payment/iou?${new URLSearchParams(
@@ -136,14 +132,14 @@ const prepareNextIOU$ = (
                 },
               ).pipe(timeout(httpTimeout)),
             ),
-            withLatestFrom(state$),
+            withLatestFrom(latest$.pipe(pluck('state'))),
             mergeMap(async ([response, { blockNumber }]) => {
               if (response.status === 404) {
                 return makeIOU(
-                  deps.address,
+                  address,
                   pfs.address,
-                  deps.network.chainId,
-                  await oneToNAddress(deps.userDepositContract),
+                  network.chainId,
+                  await oneToNAddress(userDepositContract),
                   blockNumber,
                 );
               }
@@ -156,17 +152,17 @@ const prepareNextIOU$ = (
 
               const { last_iou: lastIou } = decode(LastIOUResults, losslessParse(text));
               const signer = verifyMessage(packIOU(lastIou), lastIou.signature);
-              if (signer !== deps.address)
+              if (signer !== address)
                 throw new RaidenError(ErrorCodes.PFS_IOU_SIGNATURE_MISMATCH, {
                   signer,
-                  address: deps.address,
+                  address,
                 });
               return lastIou;
             }),
           )
       ).pipe(
         map(iou => updateIOU(iou, pfs.price)),
-        mergeMap(iou => signIOU$(iou, deps.signer)),
+        mergeMap(iou => signIOU$(iou, signer)),
       );
     }),
   );
@@ -182,207 +178,192 @@ const prepareNextIOU$ = (
  */
 export const pathFindServiceEpic = (
   action$: Observable<RaidenAction>,
-  state$: Observable<RaidenState>,
+  {}: Observable<RaidenState>,
   deps: RaidenEpicDeps,
-): Observable<pathFind.success | pathFind.failure | iouPersist | iouClear> =>
-  combineLatest(
-    state$,
-    getPresences$(action$),
-    deps.config$, // don't need to be cached, but here to avoid separate withLatestFrom
-    action$.pipe(
-      filter(isActionOf(pfsListUpdated)),
-      pluck('payload', 'pfsList'),
-      startWith([] as readonly Address[]),
-    ),
-  ).pipe(
-    publishReplay(1, undefined, cached$ => {
-      const { log } = deps;
-      return action$.pipe(
-        filter(isActionOf(pathFind.request)),
-        concatMap(action =>
-          cached$.pipe(
-            first(),
-            mergeMap(([state, presences, { pfs: configPfs, httpTimeout, pfsSafetyMargin }]) => {
-              const { tokenNetwork, target } = action.meta;
-              if (!(tokenNetwork in state.channels))
-                throw new RaidenError(ErrorCodes.PFS_UNKNOWN_TOKEN_NETWORK, { tokenNetwork });
-              if (!(target in presences) || !presences[target].payload.available)
-                throw new RaidenError(ErrorCodes.PFS_TARGET_OFFLINE, { target });
+): Observable<pathFind.success | pathFind.failure | iouPersist | iouClear> => {
+  const { log, latest$ } = deps;
+  return action$.pipe(
+    filter(isActionOf(pathFind.request)),
+    concatMap(action =>
+      latest$.pipe(
+        first(),
+        mergeMap(
+          ({ state, presences, config: { pfs: configPfs, httpTimeout, pfsSafetyMargin } }) => {
+            const { tokenNetwork, target } = action.meta;
+            if (!(tokenNetwork in state.channels))
+              throw new RaidenError(ErrorCodes.PFS_UNKNOWN_TOKEN_NETWORK, { tokenNetwork });
+            if (!(target in presences) || !presences[target].payload.available)
+              throw new RaidenError(ErrorCodes.PFS_TARGET_OFFLINE, { target });
 
-              // if pathFind received a set of paths, pass it through to validation/cleanup
-              if (action.payload.paths) return of({ paths: action.payload.paths, iou: undefined });
-              // else, if possible, use a direct transfer
-              else if (
-                channelCanRoute(state, presences, tokenNetwork, target, action.meta.value) === true
-              ) {
-                return of({
-                  paths: [{ path: [deps.address, target], fee: Zero as Int<32> }],
-                  iou: undefined,
-                });
-              } else if (
-                action.payload.pfs === null || // explicitly disabled in action
-                (!action.payload.pfs && configPfs === null) // disabled in config and not provided
-              ) {
-                // pfs not specified in action and disabled (null) in config
-                throw new RaidenError(ErrorCodes.PFS_DISABLED);
-              } else {
-                // else, request a route from PFS.
-                // pfs$ - Observable which emits one PFS info and then completes
-                const pfs$ = action.payload.pfs
-                  ? // first, honor action.payload.pfs
-                    of(action.payload.pfs)
-                  : configPfs != null
-                  ? // or if config.pfs isn't disabled nor auto (undefined), use it
-                    // configPfs is addr or url, so fetch pfsInfo from it
-                    pfsInfo(configPfs, deps)
-                  : // else (config.pfs undefined, auto mode)
-                    cached$.pipe(
-                      pluck(3), // get cached pfsList (4th combined value)
-                      // if needed, wait for list to be populated
-                      first(pfsList => pfsList.length > 0),
-                      // fetch pfsInfo from whole list & sort it
-                      mergeMap(pfsList => pfsListInfo(pfsList, deps)),
-                      tap(pfss => log.info('Auto-selecting best PFS from:', pfss)),
-                      // pop best ranked
-                      pluck(0),
-                    );
-                return pfs$.pipe(
-                  mergeMap(pfs =>
-                    pfs.price.isZero()
-                      ? of({ pfs, iou: undefined })
-                      : prepareNextIOU$(
-                          pfs,
-                          tokenNetwork,
-                          cached$.pipe(pluck(0)) /* cached state$ */,
-                          deps,
-                        ).pipe(map(iou => ({ pfs, iou }))),
+            // if pathFind received a set of paths, pass it through to validation/cleanup
+            if (action.payload.paths) return of({ paths: action.payload.paths, iou: undefined });
+            // else, if possible, use a direct transfer
+            else if (
+              channelCanRoute(state, presences, tokenNetwork, target, action.meta.value) === true
+            ) {
+              return of({
+                paths: [{ path: [deps.address, target], fee: Zero as Int<32> }],
+                iou: undefined,
+              });
+            } else if (
+              action.payload.pfs === null || // explicitly disabled in action
+              (!action.payload.pfs && configPfs === null) // disabled in config and not provided
+            ) {
+              // pfs not specified in action and disabled (null) in config
+              throw new RaidenError(ErrorCodes.PFS_DISABLED);
+            } else {
+              // else, request a route from PFS.
+              // pfs$ - Observable which emits one PFS info and then completes
+              const pfs$ = action.payload.pfs
+                ? // first, honor action.payload.pfs
+                  of(action.payload.pfs)
+                : configPfs != null
+                ? // or if config.pfs isn't disabled nor auto (undefined), use it
+                  // configPfs is addr or url, so fetch pfsInfo from it
+                  pfsInfo(configPfs, deps)
+                : // else (config.pfs undefined, auto mode)
+                  latest$.pipe(
+                    pluck('pfsList'), // get cached pfsList
+                    // if needed, wait for list to be populated
+                    first(pfsList => pfsList.length > 0),
+                    // fetch pfsInfo from whole list & sort it
+                    mergeMap(pfsList => pfsListInfo(pfsList, deps)),
+                    tap(pfss => log.info('Auto-selecting best PFS from:', pfss)),
+                    // pop best ranked
+                    pluck(0),
+                  );
+              return pfs$.pipe(
+                mergeMap(pfs =>
+                  pfs.price.isZero()
+                    ? of({ pfs, iou: undefined })
+                    : prepareNextIOU$(pfs, tokenNetwork, deps).pipe(map(iou => ({ pfs, iou }))),
+                ),
+                mergeMap(({ pfs, iou }) =>
+                  fromFetch(`${pfs.url}/api/v1/${tokenNetwork}/paths`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: losslessStringify({
+                      from: deps.address,
+                      to: target,
+                      value: UInt(32).encode(action.meta.value),
+                      max_paths: 10,
+                      iou: iou
+                        ? {
+                            ...iou,
+                            amount: UInt(32).encode(iou.amount),
+                            expiration_block: UInt(32).encode(iou.expiration_block),
+                            chain_id: UInt(32).encode(iou.chain_id),
+                          }
+                        : undefined,
+                    }),
+                  }).pipe(
+                    timeout(httpTimeout),
+                    map(response => ({ response, iou })),
                   ),
-                  mergeMap(({ pfs, iou }) =>
-                    fromFetch(`${pfs.url}/api/v1/${tokenNetwork}/paths`, {
-                      method: 'POST',
-                      headers: { 'Content-Type': 'application/json' },
-                      body: losslessStringify({
-                        from: deps.address,
-                        to: target,
-                        value: UInt(32).encode(action.meta.value),
-                        max_paths: 10,
-                        iou: iou
-                          ? {
-                              ...iou,
-                              amount: UInt(32).encode(iou.amount),
-                              expiration_block: UInt(32).encode(iou.expiration_block),
-                              chain_id: UInt(32).encode(iou.chain_id),
-                            }
-                          : undefined,
-                      }),
-                    }).pipe(
-                      timeout(httpTimeout),
-                      map(response => ({ response, iou })),
+                ),
+                mergeMap(async ({ response, iou }) => ({
+                  response,
+                  text: await response.text(),
+                  iou,
+                })),
+                map(({ response, text, iou }) => {
+                  // any decode error here will throw early and end up in catchError
+                  const data = losslessParse(text);
+                  if (!response.ok) {
+                    return { error: decode(PathError, data), iou };
+                  }
+                  return {
+                    paths: decode(PathResults, data).result.map(
+                      r =>
+                        ({
+                          path: r.path,
+                          // Add PFS safety margin to estimated fees
+                          fee: r.estimated_fee
+                            .mul(Math.round(pfsSafetyMargin * 1e6))
+                            .div(1e6) as Int<32>,
+                        } as const),
                     ),
-                  ),
-                  mergeMap(async ({ response, iou }) => ({
-                    response,
-                    text: await response.text(),
                     iou,
-                  })),
-                  map(({ response, text, iou }) => {
-                    // any decode error here will throw early and end up in catchError
-                    const data = losslessParse(text);
-                    if (!response.ok) {
-                      return { error: decode(PathError, data), iou };
-                    }
-                    return {
-                      paths: decode(PathResults, data).result.map(
-                        r =>
-                          ({
-                            path: r.path,
-                            // Add PFS safety margin to estimated fees
-                            fee: r.estimated_fee
-                              .mul(Math.round(pfsSafetyMargin * 1e6))
-                              .div(1e6) as Int<32>,
-                          } as const),
-                      ),
-                      iou,
-                    };
-                  }),
-                );
+                  };
+                }),
+              );
+            }
+          },
+        ),
+        withLatestFrom(latest$),
+        // validate/cleanup received routes/paths/results
+        mergeMap(([data, { state, presences }]) =>
+          // looks like mergeMap with generator doesn't handle exceptions correctly
+          // use from+iterator from iife generator instead
+          from(
+            (function*() {
+              const { iou } = data;
+              if (iou) {
+                // if not error or error_code of "no route found", iou accepted => persist
+                if (data.paths || data.error.error_code === 2201)
+                  yield iouPersist(
+                    { iou },
+                    { tokenNetwork: action.meta.tokenNetwork, serviceAddress: iou.receiver },
+                  );
+                // else (error and error_code of "iou rejected"), clear
+                else
+                  yield iouClear(undefined, {
+                    tokenNetwork: action.meta.tokenNetwork,
+                    serviceAddress: iou.receiver,
+                  });
               }
-            }),
-            withLatestFrom(cached$),
-            // validate/cleanup received routes/paths/results
-            mergeMap(([data, [state, presences]]) =>
-              // looks like mergeMap with generator doesn't handle exceptions correctly
-              // use from+iterator from iife generator instead
-              from(
-                (function*() {
-                  const { iou } = data;
-                  if (iou) {
-                    // if not error or error_code of "no route found", iou accepted => persist
-                    if (data.paths || data.error.error_code === 2201)
-                      yield iouPersist(
-                        { iou },
-                        { tokenNetwork: action.meta.tokenNetwork, serviceAddress: iou.receiver },
-                      );
-                    // else (error and error_code of "iou rejected"), clear
-                    else
-                      yield iouClear(undefined, {
-                        tokenNetwork: action.meta.tokenNetwork,
-                        serviceAddress: iou.receiver,
-                      });
-                  }
-                  // if error, don't proceed
-                  if (!data.paths) {
-                    throw new RaidenError(ErrorCodes.PFS_ERROR_RESPONSE, {
-                      errorCode: data.error.error_code,
-                      errors: data.error.errors,
-                    });
-                  }
-                  const filteredPaths: Paths = [],
-                    invalidatedRecipients = new Set<Address>();
-                  // eslint-disable-next-line prefer-const
-                  for (let { path, fee } of data.paths) {
-                    // if route has us as first hop, cleanup/shift
-                    if (path[0] === deps.address) path = path.slice(1);
-                    const recipient = path[0];
-                    // if this recipient was already invalidated in a previous iteration, skip
-                    if (invalidatedRecipients.has(recipient)) continue;
-                    // if we already found some valid route, allow only new routes through this peer
-                    const canTransferOrReason = !filteredPaths.length
-                      ? channelCanRoute(
-                          state,
-                          presences,
-                          action.meta.tokenNetwork,
-                          recipient,
-                          action.meta.value.add(fee) as UInt<32>,
-                        )
-                      : recipient !== filteredPaths[0].path[0]
-                      ? 'path: already selected another recipient'
-                      : fee.gt(filteredPaths[0].fee)
-                      ? 'path: already selected a smaller fee'
-                      : true;
-                    if (canTransferOrReason !== true) {
-                      log.warn(
-                        'Invalidated received route. Reason:',
-                        canTransferOrReason,
-                        'Route:',
-                        path,
-                      );
-                      invalidatedRecipients.add(recipient);
-                      continue;
-                    }
-                    filteredPaths.push({ path, fee });
-                  }
-                  if (!filteredPaths.length) throw new RaidenError(ErrorCodes.PFS_NO_ROUTES_FOUND);
-                  yield pathFind.success({ paths: filteredPaths }, action.meta);
-                })(),
-              ),
-            ),
-            catchError(err => of(pathFind.failure(err, action.meta))),
+              // if error, don't proceed
+              if (!data.paths) {
+                throw new RaidenError(ErrorCodes.PFS_ERROR_RESPONSE, {
+                  errorCode: data.error.error_code,
+                  errors: data.error.errors,
+                });
+              }
+              const filteredPaths: Paths = [],
+                invalidatedRecipients = new Set<Address>();
+              // eslint-disable-next-line prefer-const
+              for (let { path, fee } of data.paths) {
+                // if route has us as first hop, cleanup/shift
+                if (path[0] === deps.address) path = path.slice(1);
+                const recipient = path[0];
+                // if this recipient was already invalidated in a previous iteration, skip
+                if (invalidatedRecipients.has(recipient)) continue;
+                // if we already found some valid route, allow only new routes through this peer
+                const canTransferOrReason = !filteredPaths.length
+                  ? channelCanRoute(
+                      state,
+                      presences,
+                      action.meta.tokenNetwork,
+                      recipient,
+                      action.meta.value.add(fee) as UInt<32>,
+                    )
+                  : recipient !== filteredPaths[0].path[0]
+                  ? 'path: already selected another recipient'
+                  : fee.gt(filteredPaths[0].fee)
+                  ? 'path: already selected a smaller fee'
+                  : true;
+                if (canTransferOrReason !== true) {
+                  log.warn(
+                    'Invalidated received route. Reason:',
+                    canTransferOrReason,
+                    'Route:',
+                    path,
+                  );
+                  invalidatedRecipients.add(recipient);
+                  continue;
+                }
+                filteredPaths.push({ path, fee });
+              }
+              if (!filteredPaths.length) throw new RaidenError(ErrorCodes.PFS_NO_ROUTES_FOUND);
+              yield pathFind.success({ paths: filteredPaths }, action.meta);
+            })(),
           ),
         ),
-      );
-    }),
+        catchError(err => of(pathFind.failure(err, action.meta))),
+      ),
+    ),
   );
+};
 
 /**
  * Sends a [[PFSCapacityUpdate]] to PFS global room on new deposit on our side of channels
@@ -393,49 +374,59 @@ export const pathFindServiceEpic = (
  */
 export const pfsCapacityUpdateEpic = (
   action$: Observable<RaidenAction>,
-  state$: Observable<RaidenState>,
-  { log, address, network, signer, config$ }: RaidenEpicDeps,
+  {}: Observable<RaidenState>,
+  { log, address, network, signer, config$, latest$ }: RaidenEpicDeps,
 ): Observable<messageGlobalSend> =>
   action$.pipe(
-    filter(channelDeposit.success.is),
-    filter(action => !!action.payload.confirmed && action.payload.participant === address),
-    debounceTime(10e3),
-    withLatestFrom(state$, config$),
-    filter(([, , { pfsRoom }]) => !!pfsRoom), // ignore actions while/if config.pfsRoom isn't set
-    mergeMap(([action, state, { revealTimeout, pfsRoom }]) => {
-      const channel = state.channels[action.meta.tokenNetwork]?.[action.meta.partner];
-      if (!channel || channel.state !== ChannelState.open) return EMPTY;
+    filter(isActionOf([channelMonitor, channelDeposit.success])),
+    filter(
+      action =>
+        !channelDeposit.success.is(action) ||
+        (!!action.payload.confirmed && action.payload.participant === address),
+    ),
+    groupBy(({ meta: { tokenNetwork, partner } }) => `${partner}@${tokenNetwork}`),
+    withLatestFrom(config$),
+    mergeMap(([grouped$, { httpTimeout }]) =>
+      grouped$.pipe(
+        debounceTime(httpTimeout / 6),
+        withLatestFrom(latest$.pipe(pluckDistinct('state')), config$),
+        filter(([, , { pfsRoom }]) => !!pfsRoom), // ignore actions while/if config.pfsRoom isn't set
+        mergeMap(([action, state, { revealTimeout, pfsRoom }]) => {
+          const channel = state.channels[action.meta.tokenNetwork]?.[action.meta.partner];
+          if (channel?.state !== ChannelState.open) return EMPTY;
 
-      const { ownCapacity, partnerCapacity } = channelAmounts(channel);
+          const { ownCapacity, partnerCapacity } = channelAmounts(channel);
 
-      const message: PFSCapacityUpdate = {
-        type: MessageType.PFS_CAPACITY_UPDATE,
-        canonical_identifier: {
-          chain_identifier: bigNumberify(network.chainId) as UInt<32>,
-          token_network_address: action.meta.tokenNetwork,
-          channel_identifier: bigNumberify(channel.id) as UInt<32>,
-        },
-        updating_participant: address,
-        other_participant: action.meta.partner,
-        updating_nonce: channel.own.balanceProof
-          ? channel.own.balanceProof.nonce
-          : (Zero as UInt<8>),
-        other_nonce: channel.partner.balanceProof
-          ? channel.partner.balanceProof.nonce
-          : (Zero as UInt<8>),
-        updating_capacity: ownCapacity,
-        other_capacity: partnerCapacity,
-        reveal_timeout: bigNumberify(revealTimeout) as UInt<32>,
-      };
+          const message: PFSCapacityUpdate = {
+            type: MessageType.PFS_CAPACITY_UPDATE,
+            canonical_identifier: {
+              chain_identifier: bigNumberify(network.chainId) as UInt<32>,
+              token_network_address: action.meta.tokenNetwork,
+              channel_identifier: bigNumberify(channel.id) as UInt<32>,
+            },
+            updating_participant: address,
+            other_participant: action.meta.partner,
+            updating_nonce: channel.own.balanceProof
+              ? channel.own.balanceProof.nonce
+              : (Zero as UInt<8>),
+            other_nonce: channel.partner.balanceProof
+              ? channel.partner.balanceProof.nonce
+              : (Zero as UInt<8>),
+            updating_capacity: ownCapacity,
+            other_capacity: partnerCapacity,
+            reveal_timeout: bigNumberify(revealTimeout) as UInt<32>,
+          };
 
-      return from(signMessage(signer, message, { log })).pipe(
-        map(signed => messageGlobalSend({ message: signed }, { roomName: pfsRoom! })),
-        catchError(err => {
-          log.error('Error trying to generate & sign PFSCapacityUpdate', err);
-          return EMPTY;
+          return defer(() => signMessage(signer, message, { log })).pipe(
+            map(signed => messageGlobalSend({ message: signed }, { roomName: pfsRoom! })),
+            catchError(err => {
+              log.error('Error trying to generate & sign PFSCapacityUpdate', err);
+              return EMPTY;
+            }),
+          );
         }),
-      );
-    }),
+      ),
+    ),
   );
 
 /**

--- a/raiden-ts/src/utils/types.ts
+++ b/raiden-ts/src/utils/types.ts
@@ -72,7 +72,7 @@ export const BigNumberC = new t.Type<BigNumber, string>(
     if (BigNumber.isBigNumber(u)) return t.success(u);
     try {
       // decode by trying to bigNumberify string representation of anything
-      return t.success(bigNumberify((u as any).toString()));
+      return t.success(bigNumberify(((u as any)?._hex ?? (u as any)).toString()));
     } catch (err) {
       return t.failure(u, c);
     }

--- a/raiden-ts/tests/unit/epics/path.spec.ts
+++ b/raiden-ts/tests/unit/epics/path.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import { of, BehaviorSubject, EMPTY, timer } from 'rxjs';
+import { EMPTY, timer } from 'rxjs';
 import { first, takeUntil, toArray, pluck } from 'rxjs/operators';
 import { bigNumberify, defaultAbiCoder } from 'ethers/utils';
 import { Zero, AddressZero, One } from 'ethers/constants';
@@ -21,113 +21,141 @@ import {
   pfsServiceRegistryMonitorEpic,
 } from 'raiden-ts/path/epics';
 import { pathFind, pfsListUpdated, iouPersist, iouClear } from 'raiden-ts/path/actions';
-import { RaidenState } from 'raiden-ts/state';
 import { messageGlobalSend } from 'raiden-ts/messages/actions';
 import { MessageType } from 'raiden-ts/messages/types';
 import { losslessStringify } from 'raiden-ts/utils/data';
 
 import { epicFixtures } from '../fixtures';
 import { raidenEpicDeps, makeLog } from '../mocks';
-import { getLatest$ } from 'raiden-ts/epics';
 import { pluckDistinct } from 'raiden-ts/utils/rx';
 import { ErrorCodes } from 'raiden-ts/utils/error';
 
 describe('PFS: pathFindServiceEpic', () => {
-  const depsMock = raidenEpicDeps();
-  const {
-    token,
-    tokenNetwork,
-    channelId,
-    partner,
-    target,
-    settleTimeout,
-    isFirstParticipant,
-    txHash,
-    state,
-    partnerUserId,
-    targetUserId,
-    fee,
-    pfsAddress,
-    pfsTokenAddress,
-    pfsInfoResponse,
-    iou,
-  } = epicFixtures(depsMock);
+  let depsMock: ReturnType<typeof raidenEpicDeps>,
+    token: ReturnType<typeof epicFixtures>['token'],
+    tokenNetwork: ReturnType<typeof epicFixtures>['tokenNetwork'],
+    channelId: ReturnType<typeof epicFixtures>['channelId'],
+    partner: ReturnType<typeof epicFixtures>['partner'],
+    target: ReturnType<typeof epicFixtures>['target'],
+    settleTimeout: ReturnType<typeof epicFixtures>['settleTimeout'],
+    isFirstParticipant: ReturnType<typeof epicFixtures>['isFirstParticipant'],
+    txHash: ReturnType<typeof epicFixtures>['txHash'],
+    state: ReturnType<typeof epicFixtures>['state'],
+    partnerUserId: ReturnType<typeof epicFixtures>['partnerUserId'],
+    targetUserId: ReturnType<typeof epicFixtures>['targetUserId'],
+    fee: ReturnType<typeof epicFixtures>['fee'],
+    pfsAddress: ReturnType<typeof epicFixtures>['pfsAddress'],
+    pfsTokenAddress: ReturnType<typeof epicFixtures>['pfsTokenAddress'],
+    pfsInfoResponse: ReturnType<typeof epicFixtures>['pfsInfoResponse'],
+    iou: ReturnType<typeof epicFixtures>['iou'],
+    action$: ReturnType<typeof epicFixtures>['action$'],
+    state$: ReturnType<typeof epicFixtures>['state$'];
 
-  const openBlock = 121,
-    state$ = new BehaviorSubject(state);
+  const openBlock = 121;
 
-  getLatest$(of(raidenConfigUpdate({})), state$, depsMock).subscribe(depsMock.latest$);
+  const fetch = jest.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: jest.fn(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      async () => null as any,
+    ),
+    text: jest.fn(async () => losslessStringify(null)),
+  }));
+  Object.assign(global, { fetch });
 
-  afterAll(() => state$.complete());
+  beforeEach(() => {
+    depsMock = raidenEpicDeps();
+    ({
+      token,
+      tokenNetwork,
+      channelId,
+      partner,
+      target,
+      settleTimeout,
+      isFirstParticipant,
+      txHash,
+      state,
+      partnerUserId,
+      targetUserId,
+      fee,
+      pfsAddress,
+      pfsTokenAddress,
+      pfsInfoResponse,
+      iou,
+      action$,
+      state$,
+    } = epicFixtures(depsMock));
 
-  const result = { result: [{ path: [partner, target], estimated_fee: 1234 }] },
-    fetch = jest.fn(async () => ({
+    // state$ contains a channel opened & deposited with partner
+    [
+      raidenConfigUpdate({ httpTimeout: 30 }),
+      tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
+      // a couple of channels with unrelated partners, with larger deposits
+      channelOpen.success(
+        {
+          id: channelId,
+          settleTimeout,
+          isFirstParticipant,
+          txHash,
+          txBlock: openBlock,
+          confirmed: true,
+        },
+        { tokenNetwork, partner },
+      ),
+      channelDeposit.success(
+        {
+          id: channelId,
+          participant: depsMock.address,
+          totalDeposit: bigNumberify(50000000) as UInt<32>,
+          txHash,
+          txBlock: openBlock + 1,
+          confirmed: true,
+        },
+        { tokenNetwork, partner },
+      ),
+      newBlock({ blockNumber: 126 }),
+    ].forEach(a => action$.next(a));
+
+    const result = { result: [{ path: [partner, target], estimated_fee: 1234 }] };
+    fetch.mockImplementation(async () => ({
       ok: true,
       status: 200,
       json: jest.fn(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        async () => result as any,
+        async () => result,
       ),
       text: jest.fn(async () => losslessStringify(result)),
     }));
-  Object.assign(global, { fetch });
+  });
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  beforeEach(() => {
-    // state$ contains a channel opened & deposited with partner
-    state$.next(
-      [
-        tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        // a couple of channels with unrelated partners, with larger deposits
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant,
-            txHash,
-            txBlock: openBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-        channelDeposit.success(
-          {
-            id: channelId,
-            participant: depsMock.address,
-            totalDeposit: bigNumberify(50000000) as UInt<32>,
-            txHash,
-            txBlock: openBlock + 1,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-        newBlock({ blockNumber: 126 }),
-      ].reduce(raidenReducer, state),
-    );
+    action$.complete();
+    state$.complete();
+    depsMock.latest$.complete();
   });
 
   test('fail unknown tokenNetwork', async () => {
     expect.assertions(1);
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork: token, target, value }),
-      );
+    const value = bigNumberify(100) as UInt<32>;
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock).toPromise(),
-    ).resolves.toMatchObject(
+    const promise = pathFindServiceEpic(action$, state$, depsMock).toPromise();
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork: token, target, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject(
       pathFind.failure(
         expect.objectContaining({
           message: ErrorCodes.PFS_UNKNOWN_TOKEN_NETWORK,
@@ -141,22 +169,23 @@ describe('PFS: pathFindServiceEpic', () => {
   test('fail target not available', async () => {
     expect.assertions(1);
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: false, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork, target, value }),
-      );
+    const value = bigNumberify(100) as UInt<32>;
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock).toPromise(),
-    ).resolves.toMatchObject(
+    const promise = pathFindServiceEpic(action$, state$, depsMock).toPromise();
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: false, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork, target, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject(
       pathFind.failure(
         expect.objectContaining({
           message: ErrorCodes.PFS_TARGET_OFFLINE,
@@ -174,26 +203,27 @@ describe('PFS: pathFindServiceEpic', () => {
   test('success provided route', async () => {
     expect.assertions(1);
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request(
-          { paths: [{ path: [depsMock.address, partner, target], fee }] },
-          { tokenNetwork, target, value },
-        ),
-      );
+    const promise = pathFindServiceEpic(action$, state$, depsMock).toPromise();
+
+    const value = bigNumberify(100) as UInt<32>;
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request(
+        { paths: [{ path: [depsMock.address, partner, target], fee }] },
+        { tokenNetwork, target, value },
+      ),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
 
     // self should be taken out of route
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock).toPromise(),
-    ).resolves.toMatchObject(
+    await expect(promise).resolves.toMatchObject(
       pathFind.success(
         { paths: [{ path: [partner, target], fee }] },
         { tokenNetwork, target, value },
@@ -204,23 +234,24 @@ describe('PFS: pathFindServiceEpic', () => {
   test('success direct route', async () => {
     expect.assertions(1);
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork, target: partner, value }),
-      );
+    const value = bigNumberify(100) as UInt<32>;
+
+    const promise = pathFindServiceEpic(action$, state$, depsMock).toPromise();
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork, target: partner, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
 
     // self should be taken out of route
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock).toPromise(),
-    ).resolves.toMatchObject(
+    await expect(promise).resolves.toMatchObject(
       pathFind.success(
         { paths: [{ path: [partner], fee: Zero as Int<32> }] },
         { tokenNetwork, target: partner, value },
@@ -231,29 +262,7 @@ describe('PFS: pathFindServiceEpic', () => {
   test('success request pfs from action', async () => {
     expect.assertions(1);
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request(
-          {
-            pfs: {
-              address: pfsAddress,
-              url: state.config.pfs!,
-              rtt: 3,
-              price: One as UInt<32>,
-              token: pfsTokenAddress,
-            },
-          },
-          { tokenNetwork, target, value },
-        ),
-      );
+    const value = bigNumberify(100) as UInt<32>;
 
     fetch.mockResolvedValueOnce({
       ok: true,
@@ -265,13 +274,35 @@ describe('PFS: pathFindServiceEpic', () => {
     });
 
     let pfsSafetyMargin!: number;
-    depsMock.latest$
-      .pipe(first())
-      .subscribe(({ config }) => (pfsSafetyMargin = config.pfsSafetyMargin));
+    depsMock.config$.pipe(first()).subscribe(config => (pfsSafetyMargin = config.pfsSafetyMargin));
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock).toPromise(),
-    ).resolves.toMatchObject(
+    const promise = pathFindServiceEpic(action$, state$, depsMock).toPromise();
+
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request(
+        {
+          pfs: {
+            address: pfsAddress,
+            url: state.config.pfs!,
+            rtt: 3,
+            price: One as UInt<32>,
+            token: pfsTokenAddress,
+          },
+        },
+        { tokenNetwork, target, value },
+      ),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject(
       pathFind.success(
         {
           paths: [
@@ -291,18 +322,7 @@ describe('PFS: pathFindServiceEpic', () => {
   test('success request pfs from config', async () => {
     expect.assertions(1);
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork, target, value }),
-      );
+    const value = bigNumberify(100) as UInt<32>;
 
     fetch.mockResolvedValueOnce({
       ok: true,
@@ -321,13 +341,24 @@ describe('PFS: pathFindServiceEpic', () => {
     });
 
     let pfsSafetyMargin!: number;
-    depsMock.latest$
-      .pipe(first())
-      .subscribe(({ config }) => (pfsSafetyMargin = config.pfsSafetyMargin));
+    depsMock.config$.pipe(first()).subscribe(config => (pfsSafetyMargin = config.pfsSafetyMargin));
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock).toPromise(),
-    ).resolves.toMatchObject(
+    const promise = pathFindServiceEpic(action$, state$, depsMock).toPromise();
+
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork, target, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject(
       pathFind.success(
         {
           paths: [
@@ -346,27 +377,14 @@ describe('PFS: pathFindServiceEpic', () => {
 
   test('success request pfs from pfsList', async () => {
     expect.assertions(4);
-    // put config.pfs into auto mode
-    state$.next(raidenReducer(state$.value, raidenConfigUpdate({ pfs: undefined })));
 
     const value = bigNumberify(100) as UInt<32>,
       pfsAddress1 = '0x0800000000000000000000000000000000000091' as Address,
       pfsAddress2 = '0x0800000000000000000000000000000000000092' as Address,
-      pfsAddress3 = '0x0800000000000000000000000000000000000093' as Address,
-      action$ = of(
-        pfsListUpdated({
-          pfsList: [pfsAddress1, pfsAddress2, pfsAddress3, pfsAddress],
-        }),
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork, target, value }),
-      );
+      pfsAddress3 = '0x0800000000000000000000000000000000000093' as Address;
+
+    // put config.pfs into auto mode
+    action$.next(raidenConfigUpdate({ pfs: undefined }));
 
     // pfsAddress1 will be accepted with default https:// schema
     depsMock.serviceRegistryContract.functions.urls.mockResolvedValueOnce('domain.only.url');
@@ -423,15 +441,29 @@ describe('PFS: pathFindServiceEpic', () => {
     });
 
     let pfsSafetyMargin!: number;
-    depsMock.latest$
-      .pipe(first())
-      .subscribe(({ config }) => (pfsSafetyMargin = config.pfsSafetyMargin));
+    depsMock.config$.pipe(first()).subscribe(config => (pfsSafetyMargin = config.pfsSafetyMargin));
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock)
-        .pipe(toArray())
-        .toPromise(),
-    ).resolves.toMatchObject([
+    const promise = pathFindServiceEpic(action$, state$, depsMock)
+      .pipe(toArray())
+      .toPromise();
+
+    [
+      pfsListUpdated({
+        pfsList: [pfsAddress1, pfsAddress2, pfsAddress3, pfsAddress],
+      }),
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork, target, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 50);
+
+    await expect(promise).resolves.toMatchObject([
       iouPersist(
         {
           iou: expect.objectContaining({
@@ -468,23 +500,9 @@ describe('PFS: pathFindServiceEpic', () => {
   test('fail request pfs from pfsList, empty', async () => {
     expect.assertions(1);
     // put config.pfs into auto mode
-    state$.next(raidenReducer(state$.value, raidenConfigUpdate({ pfs: undefined })));
+    action$.next(raidenConfigUpdate({ pfs: undefined }));
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        pfsListUpdated({
-          pfsList: [pfsAddress, pfsAddress, pfsAddress],
-        }),
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork, target, value }),
-      );
+    const value = bigNumberify(100) as UInt<32>;
 
     // invalid url
     depsMock.serviceRegistryContract.functions.urls.mockResolvedValueOnce('""');
@@ -493,9 +511,25 @@ describe('PFS: pathFindServiceEpic', () => {
     // invalid schema
     depsMock.serviceRegistryContract.functions.urls.mockResolvedValueOnce('http://not.https.url');
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock).toPromise(),
-    ).resolves.toMatchObject(
+    const promise = pathFindServiceEpic(action$, state$, depsMock).toPromise();
+
+    [
+      pfsListUpdated({
+        pfsList: [pfsAddress, pfsAddress, pfsAddress],
+      }),
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork, target, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject(
       pathFind.failure(
         expect.objectContaining({
           message: ErrorCodes.PFS_INVALID_INFO,
@@ -508,18 +542,7 @@ describe('PFS: pathFindServiceEpic', () => {
   test('fail pfs request error', async () => {
     expect.assertions(1);
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork, target, value }),
-      );
+    const value = bigNumberify(100) as UInt<32>;
 
     fetch.mockResolvedValueOnce({
       ok: true,
@@ -544,9 +567,22 @@ describe('PFS: pathFindServiceEpic', () => {
       text: jest.fn(async () => '{ "error_code": 1337, "errors": "No route" }'),
     });
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock).toPromise(),
-    ).resolves.toMatchObject(
+    const promise = pathFindServiceEpic(action$, state$, depsMock).toPromise();
+
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork, target, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject(
       pathFind.failure(
         expect.objectContaining({
           message: ErrorCodes.PFS_ERROR_RESPONSE,
@@ -560,18 +596,7 @@ describe('PFS: pathFindServiceEpic', () => {
   test('fail pfs return success but invalid response format', async () => {
     expect.assertions(1);
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork, target, value }),
-      );
+    const value = bigNumberify(100) as UInt<32>;
 
     fetch.mockResolvedValueOnce({
       ok: true,
@@ -589,9 +614,21 @@ describe('PFS: pathFindServiceEpic', () => {
       text: jest.fn(async () => losslessStringify(paths)),
     });
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock).toPromise(),
-    ).resolves.toMatchObject(
+    const promise = pathFindServiceEpic(action$, state$, depsMock).toPromise();
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork, target, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject(
       pathFind.failure(
         expect.objectContaining({ message: expect.stringContaining('Invalid value') }),
         {
@@ -606,18 +643,7 @@ describe('PFS: pathFindServiceEpic', () => {
   test('success with free pfs and valid route', async () => {
     expect.assertions(1);
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork, target, value }),
-      );
+    const value = bigNumberify(100) as UInt<32>;
 
     const freePfsInfoResponse = { ...pfsInfoResponse, price_info: 0 };
 
@@ -642,9 +668,22 @@ describe('PFS: pathFindServiceEpic', () => {
       text: jest.fn(async () => losslessStringify(result)),
     });
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock).toPromise(),
-    ).resolves.toMatchObject(
+    const promise = pathFindServiceEpic(action$, state$, depsMock).toPromise();
+
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork, target, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject(
       pathFind.success(
         { paths: [{ path: [partner, target], fee: bigNumberify(1) as Int<32> }] },
         { tokenNetwork, target, value },
@@ -655,25 +694,9 @@ describe('PFS: pathFindServiceEpic', () => {
   test('success with cached iou and valid route', async () => {
     expect.assertions(1);
 
-    state$.next(
-      raidenReducer(
-        state$.value,
-        iouPersist({ iou }, { tokenNetwork, serviceAddress: iou.receiver }),
-      ),
-    );
+    action$.next(iouPersist({ iou }, { tokenNetwork, serviceAddress: iou.receiver }));
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork, target, value }),
-      );
+    const value = bigNumberify(100) as UInt<32>;
 
     fetch.mockResolvedValueOnce({
       ok: true,
@@ -696,11 +719,24 @@ describe('PFS: pathFindServiceEpic', () => {
       text: jest.fn(async () => losslessStringify(result)),
     });
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock)
-        .pipe(toArray())
-        .toPromise(),
-    ).resolves.toMatchObject([
+    const promise = pathFindServiceEpic(action$, state$, depsMock)
+      .pipe(toArray())
+      .toPromise();
+
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork, target, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject([
       iouPersist(
         {
           iou: expect.objectContaining({
@@ -719,18 +755,7 @@ describe('PFS: pathFindServiceEpic', () => {
   test('success from config but filter out invalid pfs result routes', async () => {
     expect.assertions(1);
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork, target, value }),
-      );
+    const value = bigNumberify(100) as UInt<32>;
 
     fetch.mockResolvedValueOnce({
       ok: true,
@@ -769,9 +794,21 @@ describe('PFS: pathFindServiceEpic', () => {
       text: jest.fn(async () => losslessStringify(result)),
     });
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock).toPromise(),
-    ).resolves.toMatchObject(
+    const promise = pathFindServiceEpic(action$, state$, depsMock).toPromise();
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork, target, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject(
       pathFind.success(
         { paths: [{ path: [partner, target], fee: bigNumberify(1) as Int<32> }] },
         { tokenNetwork, target, value },
@@ -782,26 +819,13 @@ describe('PFS: pathFindServiceEpic', () => {
   test('fail channel not open', async () => {
     expect.assertions(1);
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork, target, value }),
-      );
+    const value = bigNumberify(100) as UInt<32>;
 
-    state$.next(
-      [
-        channelClose.success(
-          { id: channelId, participant: partner, txHash, txBlock: 126, confirmed: true },
-          { tokenNetwork, partner },
-        ),
-      ].reduce(raidenReducer, state$.value),
+    action$.next(
+      channelClose.success(
+        { id: channelId, participant: partner, txHash, txBlock: 126, confirmed: true },
+        { tokenNetwork, partner },
+      ),
     );
 
     fetch.mockResolvedValueOnce({
@@ -828,9 +852,22 @@ describe('PFS: pathFindServiceEpic', () => {
       text: jest.fn(async () => losslessStringify(result)),
     });
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock).toPromise(),
-    ).resolves.toMatchObject(
+    const promise = pathFindServiceEpic(action$, state$, depsMock).toPromise();
+
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork, target, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject(
       pathFind.failure(expect.objectContaining({ message: ErrorCodes.PFS_NO_ROUTES_FOUND }), {
         tokenNetwork,
         target,
@@ -842,23 +879,26 @@ describe('PFS: pathFindServiceEpic', () => {
   test('fail provided route but not enough capacity', async () => {
     expect.assertions(1);
 
-    const value = bigNumberify(80000000) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request(
-          { paths: [{ path: [depsMock.address, partner, target], fee }] },
-          { tokenNetwork, target, value },
-        ),
-      );
+    const value = bigNumberify(80000000) as UInt<32>;
 
-    expect(pathFindServiceEpic(action$, state$, depsMock).toPromise()).resolves.toMatchObject(
+    const promise = pathFindServiceEpic(action$, state$, depsMock).toPromise();
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request(
+        { paths: [{ path: [depsMock.address, partner, target], fee }] },
+        { tokenNetwork, target, value },
+      ),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject(
       pathFind.failure(expect.objectContaining({ message: ErrorCodes.PFS_NO_ROUTES_FOUND }), {
         tokenNetwork,
         target,
@@ -870,18 +910,7 @@ describe('PFS: pathFindServiceEpic', () => {
   test('fail no route between nodes', async () => {
     expect.assertions(1);
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork, target, value }),
-      );
+    const value = bigNumberify(100) as UInt<32>;
 
     fetch.mockResolvedValueOnce({
       ok: true,
@@ -918,11 +947,24 @@ describe('PFS: pathFindServiceEpic', () => {
       text: jest.fn(async () => losslessStringify(errorResult)),
     });
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock)
-        .pipe(toArray())
-        .toPromise(),
-    ).resolves.toMatchObject([
+    const promise = pathFindServiceEpic(action$, state$, depsMock)
+      .pipe(toArray())
+      .toPromise();
+
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork, target, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject([
       iouPersist(
         {
           iou: expect.objectContaining({
@@ -944,18 +986,7 @@ describe('PFS: pathFindServiceEpic', () => {
   test('fail last iou server error', async () => {
     expect.assertions(1);
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork, target, value }),
-      );
+    const value = bigNumberify(100) as UInt<32>;
 
     fetch.mockResolvedValueOnce({
       ok: true,
@@ -973,11 +1004,24 @@ describe('PFS: pathFindServiceEpic', () => {
       text: jest.fn(async () => losslessStringify({})),
     });
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock)
-        .pipe(toArray())
-        .toPromise(),
-    ).resolves.toMatchObject([
+    const promise = pathFindServiceEpic(action$, state$, depsMock)
+      .pipe(toArray())
+      .toPromise();
+
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork, target, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject([
       pathFind.failure(
         expect.objectContaining({
           message: ErrorCodes.PFS_LAST_IOU_REQUEST_FAILED,
@@ -991,18 +1035,7 @@ describe('PFS: pathFindServiceEpic', () => {
   test('fail last iou invalid signature', async () => {
     expect.assertions(1);
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork, target, value }),
-      );
+    const value = bigNumberify(100) as UInt<32>;
 
     fetch.mockResolvedValueOnce({
       ok: true,
@@ -1028,11 +1061,24 @@ describe('PFS: pathFindServiceEpic', () => {
       text: jest.fn(async () => losslessStringify(lastIOUResult)),
     });
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock)
-        .pipe(toArray())
-        .toPromise(),
-    ).resolves.toMatchObject([
+    const promise = pathFindServiceEpic(action$, state$, depsMock)
+      .pipe(toArray())
+      .toPromise();
+
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork, target, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject([
       pathFind.failure(
         expect.objectContaining({
           message: ErrorCodes.PFS_IOU_SIGNATURE_MISMATCH,
@@ -1049,18 +1095,7 @@ describe('PFS: pathFindServiceEpic', () => {
   test('fail iou already claimed', async () => {
     expect.assertions(1);
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork, target, value }),
-      );
+    const value = bigNumberify(100) as UInt<32>;
 
     fetch.mockResolvedValueOnce({
       ok: true,
@@ -1098,11 +1133,24 @@ describe('PFS: pathFindServiceEpic', () => {
       text: jest.fn(async () => losslessStringify(result)),
     });
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock)
-        .pipe(toArray())
-        .toPromise(),
-    ).resolves.toMatchObject([
+    const promise = pathFindServiceEpic(action$, state$, depsMock)
+      .pipe(toArray())
+      .toPromise();
+
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork, target, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject([
       iouClear(undefined, { tokenNetwork, serviceAddress: iou.receiver }),
       pathFind.failure(
         expect.objectContaining({
@@ -1122,28 +1170,29 @@ describe('PFS: pathFindServiceEpic', () => {
     expect.assertions(2);
 
     // disable pfs
-    state$.next(raidenReducer(state$.value, raidenConfigUpdate({ pfs: null })));
+    action$.next(raidenConfigUpdate({ pfs: null }));
 
     await expect(
       depsMock.latest$.pipe(pluckDistinct('config', 'pfs'), first()).toPromise(),
     ).resolves.toBeNull();
 
-    const value = bigNumberify(100) as UInt<32>,
-      action$ = of(
-        matrixPresence.success(
-          { userId: partnerUserId, available: true, ts: Date.now() },
-          { address: partner },
-        ),
-        matrixPresence.success(
-          { userId: targetUserId, available: true, ts: Date.now() },
-          { address: target },
-        ),
-        pathFind.request({}, { tokenNetwork, target, value }),
-      );
+    const value = bigNumberify(100) as UInt<32>;
 
-    await expect(
-      pathFindServiceEpic(action$, state$, depsMock).toPromise(),
-    ).resolves.toMatchObject(
+    const promise = pathFindServiceEpic(action$, state$, depsMock).toPromise();
+    [
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+      matrixPresence.success(
+        { userId: targetUserId, available: true, ts: Date.now() },
+        { address: target },
+      ),
+      pathFind.request({}, { tokenNetwork, target, value }),
+    ].forEach(a => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject(
       pathFind.failure(expect.objectContaining({ message: ErrorCodes.PFS_DISABLED }), {
         tokenNetwork,
         target,
@@ -1154,27 +1203,35 @@ describe('PFS: pathFindServiceEpic', () => {
 });
 
 describe('PFS: pfsCapacityUpdateEpic', () => {
-  const depsMock = raidenEpicDeps();
-  const {
-    token,
-    tokenNetwork,
-    channelId,
-    partner,
-    settleTimeout,
-    isFirstParticipant,
-    txHash,
-    state,
-  } = epicFixtures(depsMock);
+  let depsMock: ReturnType<typeof raidenEpicDeps>,
+    token: ReturnType<typeof epicFixtures>['token'],
+    tokenNetwork: ReturnType<typeof epicFixtures>['tokenNetwork'],
+    channelId: ReturnType<typeof epicFixtures>['channelId'],
+    partner: ReturnType<typeof epicFixtures>['partner'],
+    settleTimeout: ReturnType<typeof epicFixtures>['settleTimeout'],
+    isFirstParticipant: ReturnType<typeof epicFixtures>['isFirstParticipant'],
+    txHash: ReturnType<typeof epicFixtures>['txHash'],
+    action$: ReturnType<typeof epicFixtures>['action$'],
+    state$: ReturnType<typeof epicFixtures>['state$'];
 
   const openBlock = 121;
-  let openedState: RaidenState;
 
-  /**
-   * this will leave/reset transferingState, signedTransfer as a state with a channel and pending
-   * transfer
-   */
   beforeEach(async () => {
-    openedState = [
+    depsMock = raidenEpicDeps();
+    ({
+      token,
+      tokenNetwork,
+      channelId,
+      partner,
+      settleTimeout,
+      isFirstParticipant,
+      txHash,
+      action$,
+      state$,
+    } = epicFixtures(depsMock));
+
+    // put an open channel in state
+    [
       tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
       channelOpen.success(
         {
@@ -1188,14 +1245,21 @@ describe('PFS: pfsCapacityUpdateEpic', () => {
         { tokenNetwork, partner },
       ),
       newBlock({ blockNumber: 125 }),
-    ].reduce(raidenReducer, state);
+    ].forEach(a => action$.next(a));
   });
 
   test('own channelDeposit.success triggers capacity update', async () => {
     expect.assertions(1);
 
-    const deposit = bigNumberify(500) as UInt<32>,
-      action = channelDeposit.success(
+    const deposit = bigNumberify(500) as UInt<32>;
+
+    let pfsRoom!: string;
+    depsMock.config$.pipe(first()).subscribe(config => (pfsRoom = config.pfsRoom!));
+
+    const promise = pfsCapacityUpdateEpic(action$, state$, depsMock).toPromise();
+
+    action$.next(
+      channelDeposit.success(
         {
           id: channelId,
           participant: depsMock.address,
@@ -1206,13 +1270,10 @@ describe('PFS: pfsCapacityUpdateEpic', () => {
         },
         { tokenNetwork, partner },
       ),
-      action$ = of(action),
-      state$ = new BehaviorSubject<RaidenState>([action].reduce(raidenReducer, openedState));
+    );
+    setTimeout(() => action$.complete(), 10);
 
-    let pfsRoom!: string;
-    depsMock.latest$.pipe(first()).subscribe(({ config }) => (pfsRoom = config.pfsRoom!));
-
-    await expect(pfsCapacityUpdateEpic(action$, state$, depsMock).toPromise()).resolves.toEqual(
+    await expect(promise).resolves.toEqual(
       messageGlobalSend(
         {
           message: expect.objectContaining({
@@ -1231,8 +1292,15 @@ describe('PFS: pfsCapacityUpdateEpic', () => {
   test("signature fail isn't fatal", async () => {
     expect.assertions(2);
 
-    const deposit = bigNumberify(500) as UInt<32>,
-      action = channelDeposit.success(
+    const deposit = bigNumberify(500) as UInt<32>;
+
+    const signerSpy = jest.spyOn(depsMock.signer, 'signMessage');
+    signerSpy.mockRejectedValueOnce(new Error('Signature rejected'));
+
+    const promise = pfsCapacityUpdateEpic(action$, state$, depsMock).toPromise();
+
+    action$.next(
+      channelDeposit.success(
         {
           id: channelId,
           participant: depsMock.address,
@@ -1243,15 +1311,10 @@ describe('PFS: pfsCapacityUpdateEpic', () => {
         },
         { tokenNetwork, partner },
       ),
-      action$ = of(action),
-      state$ = new BehaviorSubject<RaidenState>([action].reduce(raidenReducer, openedState));
+    );
+    setTimeout(() => action$.complete(), 10);
 
-    const signerSpy = jest.spyOn(depsMock.signer, 'signMessage');
-    signerSpy.mockRejectedValueOnce(new Error('Signature rejected'));
-
-    await expect(
-      pfsCapacityUpdateEpic(action$, state$, depsMock).toPromise(),
-    ).resolves.toBeUndefined();
+    await expect(promise).resolves.toBeUndefined();
 
     expect(signerSpy).toHaveBeenCalledTimes(1);
     signerSpy.mockRestore();
@@ -1259,23 +1322,28 @@ describe('PFS: pfsCapacityUpdateEpic', () => {
 });
 
 describe('PFS: pfsServiceRegistryMonitorEpic', () => {
-  const depsMock = raidenEpicDeps(),
-    { state, pfsAddress } = epicFixtures(depsMock),
-    state$ = new BehaviorSubject(state);
-
-  getLatest$(of(raidenConfigUpdate({})), state$, depsMock).subscribe(depsMock.latest$);
-
-  afterAll(() => state$.complete());
+  let depsMock: ReturnType<typeof raidenEpicDeps>,
+    pfsAddress: ReturnType<typeof epicFixtures>['pfsAddress'],
+    action$: ReturnType<typeof epicFixtures>['action$'],
+    state$: ReturnType<typeof epicFixtures>['state$'];
 
   beforeEach(() => {
-    state$.next(state); // reset state
+    depsMock = raidenEpicDeps();
+    ({ pfsAddress, action$, state$ } = epicFixtures(depsMock));
+  });
+
+  afterAll(() => {
+    jest.clearAllMocks();
+    action$.complete();
+    state$.complete();
+    depsMock.latest$.complete();
   });
 
   test('success', async () => {
     expect.assertions(2);
 
     // enable config.pfs auto (undefined)
-    state$.next(raidenReducer(state$.value, raidenConfigUpdate({ pfs: undefined })));
+    action$.next(raidenConfigUpdate({ pfs: undefined }));
 
     const validTill = bigNumberify(Math.floor(Date.now() / 1000) + 86400), // tomorrow
       registeredEncoded = defaultAbiCoder.encode(


### PR DESCRIPTION
Fix #1120 and other issues caused by PFS sending `fee=0` if it didn't get updated.
This PR also removes `publishReplay` on `path/epics`, turning properly to `latest$` usage, including epics tests conversion.
The downside is that, on interactive signing, users will need to sign at least one message per channel per session, to sent to PFS, but it's better than getting a wrong fee. On subkey, this issue is minimized, and when we're able to mediate, we may need to send PFSCapacityUpdate on every capacity update, so PFS knows how to properly calculate fees through us.