### PR TITLE
Enable faster channel opening & deposit by parallelizing them and their confirmations

### DIFF
--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -11,7 +11,6 @@ import { Web3Provider } from '@/services/web3-provider';
 import { BalanceUtils } from '@/utils/balance-utils';
 import { DeniedReason, Progress, Token, TokenModel } from '@/model/types';
 import { BigNumber, BigNumberish } from 'ethers/utils';
-import { Zero } from 'ethers/constants';
 import { exhaustMap, filter } from 'rxjs/operators';
 import asyncPool from 'tiny-async-pool';
 import { ConfigProvider } from './config-provider';
@@ -236,15 +235,11 @@ export default class RaidenService {
     progressUpdater(1, 3);
 
     try {
-      await raiden.openChannel(token, partner);
+      await raiden.openChannel(token, partner, { deposit: amount }, e =>
+        e.type === EventTypes.OPENED ? progressUpdater(2, 3) : ''
+      );
     } catch (e) {
       throw new ChannelOpenFailed(e);
-    }
-
-    progressUpdater(2, 3);
-
-    if (amount.gt(Zero)) {
-      await this.deposit(token, partner, amount);
     }
   }
 

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- [#1128] Enable faster channel opening & deposit by parallelizing them and their confirmations
+
 ### Fixed
 - [#1120] Ensure PFS is updated by sending a PFSCapacityUpdate every time our capacity changes
 - [#1116] Wait for confirmation blocks after mint & depositToUDC to resolve promise

--- a/raiden-ts/src/channels/actions.ts
+++ b/raiden-ts/src/channels/actions.ts
@@ -42,7 +42,7 @@ export const channelOpen = createAsyncAction(
   'channel/open/request',
   'channel/open/success',
   'channel/open/failed',
-  t.partial({ settleTimeout: t.number, subkey: t.boolean }),
+  t.partial({ settleTimeout: t.number, subkey: t.boolean, deposit: UInt(32) }),
   t.type({
     id: t.number,
     settleTimeout: t.number,

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -27,7 +27,7 @@ import { ContractsInfo, EventTypes, OnChange, RaidenEpicDeps } from './types';
 import { ShutdownReason } from './constants';
 import { RaidenState, getState } from './state';
 import { RaidenConfig, makeDefaultConfig, PartialRaidenConfig } from './config';
-import { RaidenChannels } from './channels/state';
+import { RaidenChannels, ChannelState } from './channels/state';
 import { RaidenTransfer } from './transfers/state';
 import { raidenReducer } from './reducer';
 import { raidenRootEpic } from './epics';
@@ -546,24 +546,47 @@ export class Raiden {
    * @param options - (optional) option parameter
    * @param options.settleTimeout - Custom, one-time settle timeout
    * @param options.subkey - Whether to use the subkey for on-chain tx or main account (default)
+   * @param onChange - Optional callback for status change notification
    * @returns txHash of channelOpen call, iff it succeeded
    */
   public async openChannel(
     token: string,
     partner: string,
-    options: { settleTimeout?: number; subkey?: boolean } = {},
+    options: { settleTimeout?: number; subkey?: boolean; deposit?: BigNumberish } = {},
+    onChange?: OnChange<EventTypes, { txHash: string }>,
   ): Promise<Hash> {
     assert(Address.is(token) && Address.is(partner), 'Invalid address');
     const tokenNetwork = await this.monitorToken(token);
     assert(!options.subkey || this.deps.main, "Can't send tx from subkey if not set");
+    const deposit = options.deposit === undefined ? undefined : decode(UInt(32), options.deposit);
 
     const meta = { tokenNetwork, partner };
     // wait for confirmation
-    const promise = asyncActionToPromise(channelOpen, meta, this.action$, true).then(
+    const openPromise = asyncActionToPromise(channelOpen, meta, this.action$, false).then(
       ({ txHash }) => txHash, // pluck txHash
     );
-    this.store.dispatch(channelOpen.request(options, meta));
-    return promise;
+
+    this.store.dispatch(channelOpen.request({ ...options, deposit }, meta));
+
+    const openTxHash = await openPromise;
+    onChange?.({ type: EventTypes.OPENED, payload: { txHash: openTxHash } });
+
+    await this.state$
+      .pipe(
+        pluckDistinct('channels', tokenNetwork, partner, 'state'),
+        first(state => state === ChannelState.open),
+      )
+      .toPromise();
+    onChange?.({ type: EventTypes.CONFIRMED, payload: { txHash: openTxHash } });
+
+    if (deposit) {
+      const depositTx = await asyncActionToPromise(channelDeposit, meta, this.action$, true).then(
+        ({ txHash }) => txHash, // pluck txHash
+      );
+      onChange?.({ type: EventTypes.DEPOSITED, payload: { txHash: depositTx } });
+    }
+
+    return openTxHash;
   }
 
   /**
@@ -954,7 +977,6 @@ export class Raiden {
     if (!receipt.status)
       throw new RaidenError(ErrorCodes.RDN_MINT_FAILED, { transactionHash: tx.hash! });
 
-    await waitConfirmation(receipt, this.deps);
     return tx.hash as Hash;
   }
 

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -63,6 +63,7 @@ export interface ChangeEvent<T extends string, P> {
 export type OnChange<T extends string, P> = (event: ChangeEvent<T, P>) => void;
 
 export enum EventTypes {
+  OPENED = 'OPENED',
   APPROVED = 'APPROVED',
   DEPOSITED = 'DEPOSITED',
   CONFIRMED = 'CONFIRMED',

--- a/raiden-ts/tests/e2e/provider.ts
+++ b/raiden-ts/tests/e2e/provider.ts
@@ -30,7 +30,7 @@ export class TestProvider extends Web3Provider {
           seed: 'testrpc_provider',
           network_id: 1338,
           db: memdown(),
-          // logger: console,
+          logger: console,
           ...opts,
         }),
     );

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -343,9 +343,9 @@ describe('Raiden', () => {
       ).rejects.toThrow();
     });
 
-    test('success with default settleTimeout=20', async () => {
+    test('success with default settleTimeout=20 & deposit', async () => {
       expect.assertions(2);
-      await expect(raiden.openChannel(token, partner)).resolves.toMatch(/^0x/);
+      await expect(raiden.openChannel(token, partner, { deposit: 117 })).resolves.toMatch(/^0x/);
       await expect(raiden.channels$.pipe(first()).toPromise()).resolves.toMatchObject({
         [token]: {
           [partner]: {
@@ -353,7 +353,7 @@ describe('Raiden', () => {
             tokenNetwork,
             partner,
             state: ChannelState.open,
-            ownDeposit: Zero,
+            ownDeposit: bigNumberify(117),
             partnerDeposit: Zero,
             settleTimeout: 20,
             balance: Zero,


### PR DESCRIPTION
Currently, channel open & deposit can take a very long time, since they're called separatelly from userspace and needs to be processed serially, as deposit can only be done after channel state is in place.
But the information needed for deposit is available while opening the channel (when the respective txs are sent and mined), and therefore, we can parallelize these operations (and specially their confirmation) to minimize the time needed to open a channel.
So, this PR:
- makes `channelOpen.request` accept an optional `deposit` param
- if requesting a deposit with said param, call `token.approve` in parallel with `openChannel`
- wait for both to be mined in parallel
- iff channel open was successful, wait for the `channelId` and right away call `setTotalDeposit` with it
- emits respective `channelDeposit.failure` if it doesn't succeed
- public `openChannel` method accepts `deposit`, waits for the respective events, and notify users through an `onChange` callback
- adapt dApp to use above param and callback instead of slow separate open + deposit calls

With this, open + deposit can complete and be confirmed as soon as N + 1 blocks, while the previous schema required `2 * (N + 1)` blocks, where N is the number of confirmation blocks.