### PR TITLE
Some improvements to bundle size

### DIFF
--- a/raiden-dapp/vue.config.js
+++ b/raiden-dapp/vue.config.js
@@ -17,14 +17,13 @@ module.exports = {
       .use('i18n')
       .loader('@kazupon/vue-i18n-loader')
       .end();
-    config.resolve.alias.set(
-      'ethers',
-      path.resolve(__dirname, 'node_modules/ethers')
-    );
-    config.resolve.alias.set(
-      'loglevel',
-      path.resolve(__dirname, 'node_modules/loglevel')
-    );
+    const commonModules = ['ethers', 'rxjs', 'lodash', 'loglevel'];
+    for (const mod of commonModules) {
+      config.resolve.alias.set(
+        mod,
+        path.resolve(__dirname, `node_modules/${mod}`)
+      );
+    }
   },
 
   pluginOptions: {

--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -27,7 +27,10 @@ import {
   publishReplay,
   ignoreElements,
 } from 'rxjs/operators';
-import { findKey, get, isEmpty, negate } from 'lodash';
+import findKey from 'lodash/findKey';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
+import negate from 'lodash/negate';
 
 import { BigNumber, hexlify, concat, defaultAbiCoder } from 'ethers/utils';
 import { Event } from 'ethers/contract';

--- a/raiden-ts/src/epics.ts
+++ b/raiden-ts/src/epics.ts
@@ -9,7 +9,7 @@ import {
   startWith,
   map,
 } from 'rxjs/operators';
-import { negate } from 'lodash';
+import negate from 'lodash/negate';
 
 import { RaidenState } from './state';
 import { RaidenEpicDeps } from './types';

--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -1,5 +1,6 @@
-import { Signer, Wallet, Contract } from 'ethers';
-import { ContractReceipt, ContractTransaction } from 'ethers/contract';
+import { Signer } from 'ethers/abstract-signer';
+import { Wallet } from 'ethers/wallet';
+import { Contract, ContractReceipt, ContractTransaction } from 'ethers/contract';
 import { Network, toUtf8Bytes, sha256 } from 'ethers/utils';
 import { JsonRpcProvider } from 'ethers/providers';
 import { Observable, from, defer } from 'rxjs';
@@ -13,7 +14,9 @@ import {
   first,
   exhaustMap,
 } from 'rxjs/operators';
-import { findKey, transform, pick } from 'lodash';
+import pick from 'lodash/pick';
+import transform from 'lodash/transform';
+import findKey from 'lodash/findKey';
 import logging from 'loglevel';
 
 import { RaidenState } from './state';

--- a/raiden-ts/src/messages/utils.ts
+++ b/raiden-ts/src/messages/utils.ts
@@ -1,5 +1,5 @@
 import * as t from 'io-ts';
-import { Signer } from 'ethers';
+import { Signer } from 'ethers/abstract-signer';
 import { keccak256, RLP, verifyMessage } from 'ethers/utils';
 import { arrayify, concat, hexlify } from 'ethers/utils/bytes';
 import { HashZero } from 'ethers/constants';

--- a/raiden-ts/src/path/epics.ts
+++ b/raiden-ts/src/path/epics.ts
@@ -20,11 +20,11 @@ import {
   withLatestFrom,
 } from 'rxjs/operators';
 import { fromFetch } from 'rxjs/fetch';
-import { Signer } from 'ethers';
+import { Signer } from 'ethers/abstract-signer';
 import { Event } from 'ethers/contract';
 import { BigNumber, bigNumberify, toUtf8Bytes, verifyMessage, concat } from 'ethers/utils';
 import { Two, Zero } from 'ethers/constants';
-import { memoize } from 'lodash';
+import memoize from 'lodash/memoize';
 
 import { UserDeposit } from '../contracts/UserDeposit';
 import { RaidenAction } from '../actions';

--- a/raiden-ts/src/path/utils.ts
+++ b/raiden-ts/src/path/utils.ts
@@ -3,7 +3,7 @@ import * as t from 'io-ts';
 import { Observable, from, of, EMPTY } from 'rxjs';
 import { mergeMap, map, timeout, withLatestFrom, catchError, toArray } from 'rxjs/operators';
 import { fromFetch } from 'rxjs/fetch';
-import { memoize } from 'lodash';
+import memoize from 'lodash/memoize';
 
 import { RaidenState } from '../state';
 import { RaidenEpicDeps } from '../types';

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -1,5 +1,5 @@
 import './polyfills';
-import { Signer } from 'ethers';
+import { Signer } from 'ethers/abstract-signer';
 import { AsyncSendable, Web3Provider, JsonRpcProvider } from 'ethers/providers';
 import { Network, BigNumber, BigNumberish, bigNumberify } from 'ethers/utils';
 import { Zero, AddressZero } from 'ethers/constants';
@@ -9,7 +9,8 @@ import { applyMiddleware, createStore, Store } from 'redux';
 import { createEpicMiddleware, EpicMiddleware } from 'redux-observable';
 import { createLogger } from 'redux-logger';
 
-import { constant, memoize } from 'lodash';
+import constant from 'lodash/constant';
+import memoize from 'lodash/memoize';
 import { Observable, AsyncSubject, merge, defer, EMPTY, ReplaySubject, of } from 'rxjs';
 import { first, filter, map, mergeMap, skip } from 'rxjs/operators';
 import logging from 'loglevel';

--- a/raiden-ts/src/state.ts
+++ b/raiden-ts/src/state.ts
@@ -3,7 +3,7 @@
 import * as t from 'io-ts';
 import { AddressZero } from 'ethers/constants';
 import { Network, getNetwork } from 'ethers/utils';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import logging from 'loglevel';
 
 import { PartialRaidenConfig } from './config';

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { One, Zero } from 'ethers/constants';
 import { bigNumberify } from 'ethers/utils';
-import { findKey, get, isMatchWith, pick } from 'lodash';
 import { combineLatest, EMPTY, from, Observable, of } from 'rxjs';
 import {
   catchError,
@@ -13,6 +12,10 @@ import {
   tap,
   withLatestFrom,
 } from 'rxjs/operators';
+import findKey from 'lodash/findKey';
+import get from 'lodash/get';
+import isMatchWith from 'lodash/isMatchWith';
+import pick from 'lodash/pick';
 
 import { RaidenAction } from '../../actions';
 import { Channel, ChannelState } from '../../channels/state';

--- a/raiden-ts/src/transfers/epics/refund.ts
+++ b/raiden-ts/src/transfers/epics/refund.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 import { filter, mergeMap, withLatestFrom } from 'rxjs/operators';
-import { isEqualWith } from 'lodash';
+import isEqualWith from 'lodash/isEqualWith';
 
 import { RaidenAction } from '../../actions';
 import { RefundTransfer } from '../../messages/types';

--- a/raiden-ts/src/transport/epics.ts
+++ b/raiden-ts/src/transport/epics.ts
@@ -42,7 +42,10 @@ import {
   retryWhen,
 } from 'rxjs/operators';
 import { fromFetch } from 'rxjs/fetch';
-import { find, minBy, sortBy, curry } from 'lodash';
+import find from 'lodash/find';
+import minBy from 'lodash/minBy';
+import sortBy from 'lodash/sortBy';
+import curry from 'lodash/curry';
 
 import { getAddress, verifyMessage } from 'ethers/utils';
 

--- a/raiden-ts/src/transport/utils.ts
+++ b/raiden-ts/src/transport/utils.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 import { filter, scan, startWith, share } from 'rxjs/operators';
-import { memoize } from 'lodash';
+import memoize from 'lodash/memoize';
 
 import { RaidenAction } from '../actions';
 import { Presences } from './types';

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -1,5 +1,5 @@
 import { AsyncSubject, Subject, Observable } from 'rxjs';
-import { Signer } from 'ethers';
+import { Signer } from 'ethers/abstract-signer';
 import { JsonRpcProvider } from 'ethers/providers';
 import { Network } from 'ethers/utils';
 import { MatrixClient } from 'matrix-js-sdk';

--- a/raiden-ts/src/utils/actions.ts
+++ b/raiden-ts/src/utils/actions.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/class-name-casing */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as t from 'io-ts';
-import { isMatchWith } from 'lodash';
+import isMatchWith from 'lodash/isMatchWith';
 import { Observable } from 'rxjs';
 import { first, map } from 'rxjs/operators';
 

--- a/raiden-ts/src/utils/error.ts
+++ b/raiden-ts/src/utils/error.ts
@@ -1,7 +1,7 @@
 import * as t from 'io-ts';
 import { map } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
-import { findKey } from 'lodash';
+import findKey from 'lodash/findKey';
 
 export enum ErrorCodes {
   // Path errors

--- a/raiden-ts/src/utils/ethers.ts
+++ b/raiden-ts/src/utils/ethers.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Contract, Event } from 'ethers';
+import { Contract, Event } from 'ethers/contract';
 import { Provider, JsonRpcProvider, Listener, EventType, Filter, Log } from 'ethers/providers';
 import { Network } from 'ethers/utils';
 import { getNetwork as parseNetwork } from 'ethers/utils/networks';
-import { flatten, sortBy } from 'lodash';
 import { Observable, fromEventPattern, merge, from, of, EMPTY, combineLatest, defer } from 'rxjs';
 import { filter, first, map, switchMap, mergeMap, share } from 'rxjs/operators';
+import flatten from 'lodash/flatten';
+import sortBy from 'lodash/sortBy';
 
 import { isntNil } from './types';
 

--- a/raiden-ts/src/utils/types.ts
+++ b/raiden-ts/src/utils/types.ts
@@ -2,9 +2,9 @@
 import * as t from 'io-ts';
 import { BigNumber, bigNumberify, getAddress, isHexString, hexDataLength } from 'ethers/utils';
 import { Two, Zero } from 'ethers/constants';
-import { memoize } from 'lodash';
 import { Either, Right } from 'fp-ts/lib/Either';
 import { ThrowReporter } from 'io-ts/lib/ThrowReporter';
+import memoize from 'lodash/memoize';
 
 /* A Subset of DOM's Storage/localStorage interface which supports async/await */
 export interface Storage {


### PR DESCRIPTION
- tree-shaking lodash & ethers import syntax in SDK
- common modules aliasing

Part of #744 , reduces ~1.5MB on my bundle, not much, but on the right direction.