### PR TITLE
defaultConfig and updateConfig improvements

### DIFF
--- a/raiden-ts/src/channels/reducer.ts
+++ b/raiden-ts/src/channels/reducer.ts
@@ -1,4 +1,7 @@
-import { get, set, unset, getOr } from 'lodash/fp';
+import get from 'lodash/fp/get';
+import set from 'lodash/fp/set';
+import unset from 'lodash/fp/unset';
+import getOr from 'lodash/fp/getOr';
 import { Zero } from 'ethers/constants';
 
 import { UInt } from '../utils/types';

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -6,8 +6,13 @@ import { Address } from './utils/types';
 import { getNetworkName } from './utils/ethers';
 
 /**
- * A Raiden configuration object with required parameters and
- * optional parameters from [[PartialRaidenConfig]].
+ * A Raiden configuration object with required and optional params from [[PartialRaidenConfig]].
+ *
+ * Notice partial/undefined values are special: when a raidenConfigUpdate is called with an
+ * undefined value, it won't be set, as they can't be [re]stored in the JSON state, but instead
+ * means it'll be *reset* to the default value; therefore, if a partial value has a defined
+ * default, it can't be unset; if you want to support "empty" values, use null, empty string or
+ * other falsy serializable types, and/or ensure it never gets a default
  *
  * - matrixServerLookup - Matrix server URL to fetch existing matrix servers from.
  *      After intializing a [[Raiden]] instance, the matrix server can't be changed later on.
@@ -16,17 +21,18 @@ import { getNetworkName } from './utils/ethers';
  * - httpTimeout - Used in http fetch requests
  * - discoveryRoom - Discovery Room to auto-join, use null to disable
  * - pfsRoom - PFS Room to auto-join and send PFSCapacityUpdate to, use null to disable
- * - pfsSafetyMargin - Safety margin to be added to fees received from PFS. Use `1.1` to add a 10% safety margin.
+ * - pfs - Path Finding Service URL or Address. Set to null to disable, or empty string to enable
+ *         automatic fetching from ServiceRegistry.
+ * - pfsSafetyMargin - Safety margin to be added to fees received from PFS. Use `1.1` to add a 10%
+ *                     safety margin.
  * - matrixExcessRooms - Keep this much rooms for a single user of interest (partner, target).
  *                       Leave LRU beyond this threshold.
  * - confirmationBlocks - How many blocks to wait before considering a transaction as confirmed
+ * - logger - String specifying the console log level of redux-logger. Use '' to silence.
+ * - caps - Own transport capabilities
  * - matrixServer? - Specify a matrix server to use.
- * - logger? - String specifying the console log level of redux-logger. Use '' to disable.
- *             Defaults to 'debug' if undefined and process.env.NODE_ENV === 'development'
- * - pfs? - Path Finding Service URL or Address. Set to null to disable, or leave undefined to
- *          enable automatic fetching from ServiceRegistry.
- * - subkey? - When using subkey, this sets the behavior when { subkey } option isn't explicitly set
- *             in on-chain method calls. false (default) = use main key; true = use subkey
+ * - subkey? - When using subkey, this sets the behavior when { subkey } option isn't explicitly
+ *             set in on-chain method calls. false (default) = use main key; true = use subkey
  */
 export const RaidenConfig = t.readonly(
   t.intersection([
@@ -37,6 +43,7 @@ export const RaidenConfig = t.readonly(
       httpTimeout: t.number,
       discoveryRoom: t.union([t.string, t.null]),
       pfsRoom: t.union([t.string, t.null]),
+      pfs: t.union([Address, t.string, t.null]),
       pfsSafetyMargin: t.number,
       matrixExcessRooms: t.number,
       confirmationBlocks: t.number,
@@ -48,12 +55,11 @@ export const RaidenConfig = t.readonly(
         warn: null,
         error: null,
       }),
+      caps: t.readonly(t.record(t.string /* Capabilities */, t.any)),
     }),
     t.partial({
       matrixServer: t.string,
-      pfs: t.union([Address, t.string, t.null]),
       subkey: t.boolean,
-      caps: t.readonly(t.record(t.string /* Capabilities */, t.any)),
     }),
   ]),
 );
@@ -84,6 +90,7 @@ export function makeDefaultConfig(
     httpTimeout: 30e3,
     discoveryRoom: `raiden_${getNetworkName(network)}_discovery`,
     pfsRoom: `raiden_${getNetworkName(network)}_path_finding`,
+    pfs: '', // empty string = auto mode
     matrixExcessRooms: 3,
     pfsSafetyMargin: 1.0,
     confirmationBlocks: 5,

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -69,9 +69,13 @@ export interface PartialRaidenConfig extends t.TypeOf<typeof PartialRaidenConfig
  *
  * @param obj - Object containing common parameters for config
  * @param obj.network - ether's Network object for the current blockchain
+ * @param overwrites - Overwrites values from default config
  * @returns A full config object
  */
-export function makeDefaultConfig({ network }: { network: Network }): RaidenConfig {
+export function makeDefaultConfig(
+  { network }: { network: Network },
+  overwrites?: PartialRaidenConfig,
+): RaidenConfig {
   return {
     matrixServerLookup:
       'https://raw.githubusercontent.com/raiden-network/raiden-transport/master/known_servers.test.yaml',
@@ -89,5 +93,6 @@ export function makeDefaultConfig({ network }: { network: Network }): RaidenConf
       [Capabilities.NO_RECEIVE]: true,
       [Capabilities.NO_MEDIATE]: true,
     },
+    ...overwrites,
   };
 }

--- a/raiden-ts/src/epics.ts
+++ b/raiden-ts/src/epics.ts
@@ -14,7 +14,7 @@ import negate from 'lodash/negate';
 import { RaidenState } from './state';
 import { RaidenEpicDeps } from './types';
 import { RaidenAction, raidenShutdown } from './actions';
-import { makeDefaultConfig, PartialRaidenConfig, RaidenConfig } from './config';
+import { PartialRaidenConfig, RaidenConfig } from './config';
 import { getPresences$ } from './transport/utils';
 import { pfsListUpdated } from './path/actions';
 import { Address } from './utils/types';
@@ -35,9 +35,8 @@ import * as PathFindEpics from './path/epics';
 export function getLatest$(
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-  { network }: { network: RaidenEpicDeps['network'] },
+  { defaultConfig }: Pick<RaidenEpicDeps, 'defaultConfig'>,
 ) {
-  const defaultConfig = makeDefaultConfig({ network });
   let lastConfig: [PartialRaidenConfig, RaidenConfig];
 
   return combineLatest([

--- a/raiden-ts/src/path/reducer.ts
+++ b/raiden-ts/src/path/reducer.ts
@@ -6,7 +6,8 @@
  * @param action - RaidenAction to handle
  * @returns New RaidenState['path'] slice
  */
-import { set, unset } from 'lodash/fp';
+import set from 'lodash/fp/set';
+import unset from 'lodash/fp/unset';
 
 import { initialState } from '../state';
 import { partialCombineReducers } from '../utils/redux';

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -27,7 +27,7 @@ import versions from './versions.json';
 import { ContractsInfo, EventTypes, OnChange, RaidenEpicDeps } from './types';
 import { ShutdownReason } from './constants';
 import { RaidenState, getState } from './state';
-import { RaidenConfig, makeDefaultConfig, PartialRaidenConfig } from './config';
+import { RaidenConfig, PartialRaidenConfig } from './config';
 import { RaidenChannels, ChannelState } from './channels/state';
 import { RaidenTransfer } from './transfers/state';
 import { raidenReducer } from './reducer';
@@ -138,10 +138,6 @@ export class Raiden {
     RaidenEpicDeps
   > | null;
 
-  private readonly defaultConfig: RaidenConfig;
-  // for a given partial config, "memoize-one" full config (merge of default & partial configs)
-  private lastConfig?: [PartialRaidenConfig, RaidenConfig];
-
   /** Instance's Logger, compatible with console's API */
   private readonly log: logging.Logger;
 
@@ -151,6 +147,7 @@ export class Raiden {
     signer: Signer,
     contractsInfo: ContractsInfo,
     state: RaidenState,
+    defaultConfig: RaidenConfig,
     main?: { address: Address; signer: Signer },
   ) {
     this.resolveName = provider.resolveName.bind(provider) as (name: string) => Promise<Address>;
@@ -169,7 +166,6 @@ export class Raiden {
     this.channels$ = this.state$.pipe(map(state => mapTokenToPartner(state)));
     this.transfers$ = initTransfers$(this.state$);
     this.events$ = this.action$.pipe(filter(isActionOf(RaidenEvents)));
-    this.defaultConfig = makeDefaultConfig({ network });
 
     this.getTokenInfo = memoize(async function(this: Raiden, token: string) {
       assert(Address.is(token), 'Invalid address');
@@ -194,6 +190,7 @@ export class Raiden {
       signer,
       address,
       log: this.log,
+      defaultConfig,
       contractsInfo,
       registryContract: TokenNetworkRegistryFactory.connect(
         contractsInfo.TokenNetworkRegistry.address,
@@ -317,7 +314,7 @@ export class Raiden {
     const { signer, address, main } = await getSigner(account, provider, subkey);
 
     // Build initial state or parse from storage
-    const { state, onState, onStateComplete } = await getState(
+    const { state, onState, onStateComplete, defaultConfig } = await getState(
       network,
       contracts,
       address,
@@ -335,7 +332,7 @@ export class Raiden {
       `Mismatch between network or registry address and loaded state`,
     );
 
-    const raiden = new Raiden(provider, network, signer, contracts, state, main);
+    const raiden = new Raiden(provider, network, signer, contracts, state, defaultConfig, main);
     if (onState) raiden.state$.subscribe(onState, onStateComplete, onStateComplete);
     return raiden;
   }
@@ -425,11 +422,9 @@ export class Raiden {
    * @returns Current Raiden config
    */
   public get config(): RaidenConfig {
-    // "memoize one" last merge of default and partial configs
-    const currentPartial = this.state.config;
-    if (this.lastConfig?.['0'] !== currentPartial)
-      this.lastConfig = [currentPartial, { ...this.defaultConfig, ...currentPartial }];
-    return this.lastConfig['1'];
+    let config!: RaidenConfig;
+    this.deps.config$.pipe(first()).subscribe(c => (config = c));
+    return config;
   }
 
   /**

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -319,7 +319,7 @@ export class Raiden {
       contracts,
       address,
       storageOrState,
-      config,
+      config && decode(PartialRaidenConfig, config),
     );
 
     assert(
@@ -344,6 +344,8 @@ export class Raiden {
    */
   public start(): void {
     assert(this.epicMiddleware, 'Already started or stopped!');
+    // on complete, sets epicMiddleware to null, so this.started === false
+    this.deps.latest$.subscribe(undefined, undefined, () => (this.epicMiddleware = null));
     this.epicMiddleware.run(raidenRootEpic);
     // prevent start from being called again, turns this.started to true
     this.epicMiddleware = undefined;
@@ -367,7 +369,7 @@ export class Raiden {
    */
   public stop(): void {
     // start still can't be called again, but turns this.started to false
-    this.epicMiddleware = null;
+    // this.epicMiddleware is set to null by latest$'s complete callback
     this.store.dispatch(raidenShutdown({ reason: ShutdownReason.STOP }));
   }
 
@@ -451,7 +453,7 @@ export class Raiden {
    * @param config - Partial object containing keys and values to update in config
    */
   public updateConfig(config: PartialRaidenConfig) {
-    this.store.dispatch(raidenConfigUpdate(config));
+    this.store.dispatch(raidenConfigUpdate(decode(PartialRaidenConfig, config)));
   }
 
   /**

--- a/raiden-ts/src/reducer.ts
+++ b/raiden-ts/src/reducer.ts
@@ -1,21 +1,29 @@
-import { isEmpty } from 'lodash/fp';
+import unset from 'lodash/fp/unset';
 
 import { channelsReducer } from './channels/reducer';
 import { pathReducer } from './path/reducer';
 import { transportReducer } from './transport/reducer';
 import { transfersReducer } from './transfers/reducer';
 
+import { PartialRaidenConfig } from './config';
 import { RaidenAction, raidenConfigUpdate } from './actions';
 import { RaidenState, initialState } from './state';
+import { createReducer } from './utils/actions';
 
 // update state.config on raidenConfigUpdate action
-const configReducer = (state: RaidenState = initialState, action: RaidenAction) => {
-  if (raidenConfigUpdate.is(action)) {
-    if (!isEmpty(action.payload))
-      return { ...state, config: { ...state.config, ...action.payload } };
-  }
-  return state;
-};
+// resets key to default value if value is undefined, otherwise overwrites it
+const configReducer = createReducer(initialState).handle(
+  raidenConfigUpdate,
+  (state, { payload }) => {
+    let config: PartialRaidenConfig = state.config;
+    for (const [k, v] of Object.entries(payload)) {
+      if (v !== undefined) config = { ...config, [k]: v };
+      else if (k in config) config = unset(k, config);
+    }
+    if (config === state.config) return state;
+    return { ...state, config };
+  },
+);
 
 const raidenReducers = {
   configReducer,

--- a/raiden-ts/src/state.ts
+++ b/raiden-ts/src/state.ts
@@ -6,7 +6,7 @@ import { Network, getNetwork } from 'ethers/utils';
 import debounce from 'lodash/debounce';
 import logging from 'loglevel';
 
-import { PartialRaidenConfig } from './config';
+import { PartialRaidenConfig, makeDefaultConfig, RaidenConfig } from './config';
 import { ContractsInfo } from './types';
 import { ConfirmableAction } from './actions';
 import migrateState from './migration';
@@ -193,6 +193,7 @@ export const getState = async (
   state: RaidenState;
   onState?: (state: RaidenState) => void;
   onStateComplete?: () => void;
+  defaultConfig: RaidenConfig;
 }> => {
   const log = logging.getLogger(`raiden:${address}`);
   let onState;
@@ -259,7 +260,8 @@ export const getState = async (
   }
 
   // if no provided nor stored state, initialize a pristine one
-  if (!state) state = makeInitialState({ network, address, contractsInfo: contracts }, { config });
+  if (!state) state = makeInitialState({ network, address, contractsInfo: contracts });
+  const defaultConfig = makeDefaultConfig({ network }, config);
 
-  return { state, onState, onStateComplete };
+  return { state, onState, onStateComplete, defaultConfig };
 };

--- a/raiden-ts/src/transfers/reducer.ts
+++ b/raiden-ts/src/transfers/reducer.ts
@@ -1,4 +1,6 @@
-import { get, set, unset } from 'lodash/fp';
+import get from 'lodash/fp/get';
+import set from 'lodash/fp/set';
+import unset from 'lodash/fp/unset';
 import { Zero, HashZero } from 'ethers/constants';
 import { hexlify } from 'ethers/utils';
 

--- a/raiden-ts/src/transport/epics.ts
+++ b/raiden-ts/src/transport/epics.ts
@@ -537,10 +537,10 @@ function setupMatrixClient$(
  */
 export const initMatrixEpic = (
   action$: Observable<RaidenAction>,
-  state$: Observable<RaidenState>,
-  { address, signer, matrix$, config$ }: RaidenEpicDeps,
+  {}: Observable<RaidenState>,
+  { address, signer, matrix$, latest$, config$ }: RaidenEpicDeps,
 ): Observable<matrixSetup> =>
-  combineLatest([state$, config$]).pipe(
+  combineLatest([latest$.pipe(pluck('state')), config$]).pipe(
     first(), // at startup
     mergeMap(([state, { matrixServer, matrixServerLookup, httpTimeout, caps }]) => {
       const server = state.transport.matrix?.server,

--- a/raiden-ts/src/transport/reducer.ts
+++ b/raiden-ts/src/transport/reducer.ts
@@ -1,4 +1,8 @@
-import { get, getOr, isEmpty, set, unset } from 'lodash/fp';
+import get from 'lodash/fp/get';
+import getOr from 'lodash/fp/getOr';
+import isEmpty from 'lodash/fp/isEmpty';
+import set from 'lodash/fp/set';
+import unset from 'lodash/fp/unset';
 
 import { partialCombineReducers } from '../utils/redux';
 import { createReducer } from '../utils/actions';

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -45,6 +45,7 @@ export interface RaidenEpicDeps {
   signer: Signer;
   address: Address;
   log: Logger;
+  defaultConfig: RaidenConfig;
   contractsInfo: ContractsInfo;
   registryContract: TokenNetworkRegistry;
   getTokenNetworkContract: (address: Address) => TokenNetwork;

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -281,7 +281,7 @@ describe('Raiden', () => {
       settleTimeout: 20,
       revealTimeout: 5,
     });
-    expect(raiden.config.pfs).toBeUndefined();
+    expect(raiden.config.pfs).toBe('');
     raiden.updateConfig({ revealTimeout: 8 });
     expect(raiden.config).toMatchObject({
       revealTimeout: 8,
@@ -854,7 +854,7 @@ describe('Raiden', () => {
         await new Promise(resolve => setTimeout(resolve, 100));
 
         // auto pfs mode
-        raiden.updateConfig({ pfs: undefined });
+        raiden.updateConfig({ pfs: '' });
 
         fetch.mockResolvedValueOnce({
           ok: true,
@@ -956,7 +956,7 @@ describe('Raiden', () => {
         text: jest.fn(async () => losslessStringify(pfsInfoResponse)),
       });
 
-      raiden.updateConfig({ pfs: undefined });
+      raiden.updateConfig({ pfs: '' });
       await expect(raiden.findPFS()).resolves.toEqual([
         {
           address: pfsAddress,
@@ -1073,7 +1073,7 @@ describe('Raiden', () => {
       });
 
       // config.pfs in auto mode
-      raiden.updateConfig({ pfs: undefined });
+      raiden.updateConfig({ pfs: '' });
 
       const pfss = await raiden.findPFS();
       expect(pfss).toEqual([

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -7,7 +7,7 @@ import { patchVerifyMessage } from '../patches';
 patchVerifyMessage();
 
 import { of, timer, EMPTY, Observable } from 'rxjs';
-import { first, tap, takeUntil, toArray, delay } from 'rxjs/operators';
+import { first, tap, takeUntil, toArray } from 'rxjs/operators';
 import { fakeSchedulers } from 'rxjs-marbles/jest';
 import { verifyMessage, BigNumber } from 'ethers/utils';
 
@@ -47,7 +47,6 @@ import { encodeJsonMessage, signMessage } from 'raiden-ts/messages/utils';
 
 import { epicFixtures } from '../fixtures';
 import { raidenEpicDeps, makeSignature } from '../mocks';
-import { pluckDistinct } from 'raiden-ts/utils/rx';
 import { ErrorCodes } from 'raiden-ts/utils/error';
 import { Signed } from 'raiden-ts/utils/types';
 import { Capabilities } from 'raiden-ts/constants';
@@ -115,27 +114,25 @@ describe('transport epic', () => {
 
   describe('initMatrixEpic', () => {
     test('matrix stored setup', async () => {
-      const action$ = EMPTY as Observable<RaidenAction>,
-        state$ = of(
-          raidenReducer(
-            state,
-            matrixSetup({
-              server: matrixServer,
-              setup: {
-                userId,
-                accessToken,
-                deviceId,
-                displayName,
-              },
-            }),
-          ),
-        );
+      action$.next(
+        matrixSetup({
+          server: matrixServer,
+          setup: {
+            userId,
+            accessToken,
+            deviceId,
+            displayName,
+          },
+        }),
+      );
 
-      await expect(
-        initMatrixEpic(action$, state$, depsMock)
-          .pipe(first())
-          .toPromise(),
-      ).resolves.toEqual(
+      const promise = initMatrixEpic(action$, state$, depsMock)
+        .pipe(first())
+        .toPromise();
+
+      setTimeout(() => action$.complete(), 10);
+
+      await expect(promise).resolves.toEqual(
         matrixSetup({
           server: matrixServer,
           setup: {
@@ -151,19 +148,13 @@ describe('transport epic', () => {
     });
 
     test('matrix server config set without stored setup', async () => {
-      const action$ = EMPTY as Observable<RaidenAction>,
-        state$ = depsMock.latest$.pipe(pluckDistinct('state'));
+      expect.assertions(2);
 
-      depsMock.latest$.pipe(first()).subscribe(l => {
-        const state = raidenReducer(l.state, raidenConfigUpdate({ matrixServer }));
-        depsMock.latest$.next({ ...l, state, config: { ...l.config, ...state.config } });
-      });
+      action$.next(raidenConfigUpdate({ matrixServer }));
+      const promise = initMatrixEpic(action$, state$, depsMock).toPromise();
+      setTimeout(() => action$.complete(), 10);
 
-      await expect(
-        initMatrixEpic(action$, state$, depsMock)
-          .pipe(first())
-          .toPromise(),
-      ).resolves.toEqual(
+      await expect(promise).resolves.toEqual(
         matrixSetup({
           server: matrixServer,
           setup: {
@@ -178,31 +169,26 @@ describe('transport epic', () => {
     });
 
     test('matrix server config set same as stored setup', async () => {
-      const action$ = EMPTY as Observable<RaidenAction>,
-        state$ = depsMock.latest$.pipe(pluckDistinct('state'));
+      [
+        matrixSetup({
+          server: matrixServer,
+          setup: {
+            userId,
+            accessToken,
+            deviceId,
+            displayName,
+          },
+        }),
+        raidenConfigUpdate({ matrixServer }),
+      ].forEach(a => action$.next(a));
 
-      // set config
-      depsMock.latest$.pipe(first()).subscribe(l => {
-        const state = [
-          matrixSetup({
-            server: matrixServer,
-            setup: {
-              userId,
-              accessToken,
-              deviceId,
-              displayName,
-            },
-          }),
-          raidenConfigUpdate({ matrixServer }),
-        ].reduce(raidenReducer, l.state);
-        depsMock.latest$.next({ ...l, state, config: { ...l.config, ...state.config } });
-      });
+      const promise = initMatrixEpic(action$, state$, depsMock)
+        .pipe(first())
+        .toPromise();
 
-      await expect(
-        initMatrixEpic(action$, state$, depsMock)
-          .pipe(first())
-          .toPromise(),
-      ).resolves.toEqual(
+      setTimeout(() => action$.complete(), 10);
+
+      await expect(promise).resolves.toEqual(
         matrixSetup({
           server: matrixServer,
           setup: {
@@ -314,38 +300,42 @@ describe('transport epic', () => {
   describe('matrixMonitorPresenceEpic', () => {
     test('fails when users does not have displayName', async () => {
       expect.assertions(1);
-      const action$ = of(matrixPresence.request(undefined, { address: partner })).pipe(delay(0)),
-        state$ = of(state);
 
       matrix.searchUserDirectory.mockImplementationOnce(async () => ({
         limited: false,
         results: [{ user_id: partnerUserId }],
       }));
 
-      await expect(
-        matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise(),
-      ).resolves.toEqual(matrixPresence.failure(expect.any(Error), { address: partner }));
+      const promise = matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise();
+
+      action$.next(matrixPresence.request(undefined, { address: partner }));
+      setTimeout(() => action$.complete(), 10);
+
+      await expect(promise).resolves.toEqual(
+        matrixPresence.failure(expect.any(Error), { address: partner }),
+      );
     });
 
     test('fails when users does not have valid addresses', async () => {
       expect.assertions(1);
-      const action$ = of(matrixPresence.request(undefined, { address: partner })).pipe(delay(0)),
-        state$ = of(state);
 
       matrix.searchUserDirectory.mockImplementationOnce(async () => ({
         limited: false,
         results: [{ user_id: `@invalidUser:${matrixServer}`, display_name: 'display_name' }],
       }));
 
-      await expect(
-        matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise(),
-      ).resolves.toEqual(matrixPresence.failure(expect.any(Error), { address: partner }));
+      const promise = matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise();
+
+      action$.next(matrixPresence.request(undefined, { address: partner }));
+      setTimeout(() => action$.complete(), 10);
+
+      await expect(promise).resolves.toEqual(
+        matrixPresence.failure(expect.any(Error), { address: partner }),
+      );
     });
 
     test('fails when users does not have presence or unknown address', async () => {
       expect.assertions(1);
-      const action$ = of(matrixPresence.request(undefined, { address: partner })).pipe(delay(0)),
-        state$ = of(state);
 
       (verifyMessage as jest.Mock).mockReturnValueOnce(token);
       matrix.searchUserDirectory.mockImplementationOnce(async () => ({
@@ -353,15 +343,19 @@ describe('transport epic', () => {
         results: [{ user_id: partnerUserId, display_name: 'display_name' }],
       }));
 
-      await expect(
-        matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise(),
-      ).resolves.toEqual(matrixPresence.failure(expect.any(Error), { address: partner }));
+      const promise = matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise();
+
+      action$.next(matrixPresence.request(undefined, { address: partner }));
+      setTimeout(() => action$.complete(), 10);
+
+      await expect(promise).resolves.toEqual(
+        matrixPresence.failure(expect.any(Error), { address: partner }),
+      );
     });
 
     test('fails when verifyMessage throws', async () => {
       expect.assertions(1);
-      const action$ = of(matrixPresence.request(undefined, { address: partner })).pipe(delay(0)),
-        state$ = of(state);
+
       matrix.searchUserDirectory.mockImplementationOnce(async () => ({
         limited: false,
         results: [{ user_id: partnerUserId, display_name: 'display_name' }],
@@ -370,9 +364,14 @@ describe('transport epic', () => {
         throw new Error('invalid signature');
       });
 
-      await expect(
-        matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise(),
-      ).resolves.toEqual(matrixPresence.failure(expect.any(Error), { address: partner }));
+      const promise = matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise();
+
+      action$.next(matrixPresence.request(undefined, { address: partner }));
+      setTimeout(() => action$.complete(), 10);
+
+      await expect(promise).resolves.toEqual(
+        matrixPresence.failure(expect.any(Error), { address: partner }),
+      );
     });
 
     test('success with previously monitored user', async () => {
@@ -381,22 +380,18 @@ describe('transport epic', () => {
         { userId: partnerUserId, available: false, ts: Date.now() },
         { address: partner },
       );
+      action$.next(presence);
 
       const promise = matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise();
 
-      action$.next(presence);
-      setTimeout(() => {
-        action$.next(matrixPresence.request(undefined, { address: partner }));
-        action$.complete();
-      }, 5);
+      action$.next(matrixPresence.request(undefined, { address: partner }));
+      setTimeout(() => action$.complete(), 10);
 
       await expect(promise).resolves.toBe(presence);
     });
 
     test('success with searchUserDirectory and getUserPresence', async () => {
       expect.assertions(1);
-      const action$ = of(matrixPresence.request(undefined, { address: partner })).pipe(delay(0)),
-        state$ = of(state);
 
       matrix.searchUserDirectory.mockImplementationOnce(async ({ term }) => ({
         results: [
@@ -408,9 +403,12 @@ describe('transport epic', () => {
         ],
       }));
 
-      await expect(
-        matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise(),
-      ).resolves.toEqual(
+      const promise = matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise();
+
+      action$.next(matrixPresence.request(undefined, { address: partner }));
+      setTimeout(() => action$.complete(), 10);
+
+      await expect(promise).resolves.toEqual(
         matrixPresence.success(
           {
             userId: partnerUserId,
@@ -425,8 +423,6 @@ describe('transport epic', () => {
 
     test('success even if some getUserPresence fails', async () => {
       expect.assertions(1);
-      const action$ = of(matrixPresence.request(undefined, { address: partner })).pipe(delay(0)),
-        state$ = of(state);
 
       matrix.searchUserDirectory.mockImplementationOnce(async () => ({
         limited: false,
@@ -437,9 +433,12 @@ describe('transport epic', () => {
       }));
       matrix._http.authedRequest.mockRejectedValueOnce(new Error('Could not fetch presence'));
 
-      await expect(
-        matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise(),
-      ).resolves.toEqual(
+      const promise = matrixMonitorPresenceEpic(action$, state$, depsMock).toPromise();
+
+      action$.next(matrixPresence.request(undefined, { address: partner }));
+      setTimeout(() => action$.complete(), 10);
+
+      await expect(promise).resolves.toEqual(
         matrixPresence.success(
           { userId: partnerUserId, available: true, ts: expect.any(Number) },
           { address: partner },
@@ -791,6 +790,8 @@ describe('transport epic', () => {
       'leave unknown rooms',
       fakeSchedulers(advance => {
         expect.assertions(3);
+
+        action$.next(raidenConfigUpdate({ httpTimeout: 30e3 }));
         const roomId = `!unknownRoomId:${matrixServer}`,
           state$ = of(state);
 

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -221,19 +221,16 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
         block_number: 102,
       },
     },
-    state = makeInitialState(
-      { network, address, contractsInfo },
+    state = makeInitialState({ network, address, contractsInfo }, { blockNumber }),
+    defaultConfig = makeDefaultConfig(
+      { network },
       {
-        blockNumber,
-        config: {
-          pfsSafetyMargin: 1.1,
-          pfs: 'https://pfs.raiden.test',
-          httpTimeout: 3e3,
-          confirmationBlocks: 2,
-        },
+        pfsSafetyMargin: 1.1,
+        pfs: 'https://pfs.raiden.test',
+        httpTimeout: 300,
+        confirmationBlocks: 2,
       },
-    ),
-    defaultConfig = makeDefaultConfig({ network });
+    );
 
   const latest$: RaidenEpicDeps['latest$'] = new BehaviorSubject({
       action: raidenConfigUpdate({}) as RaidenAction,
@@ -253,6 +250,7 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
     matrix$: new AsyncSubject<MatrixClient>(),
     address,
     log,
+    defaultConfig,
     network,
     contractsInfo,
     provider,

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -40,7 +40,6 @@ import { pluckDistinct } from 'raiden-ts/utils/rx';
 import { raidenConfigUpdate, RaidenAction } from 'raiden-ts/actions';
 import { Presences } from 'raiden-ts/transport/types';
 import { makeDefaultConfig } from 'raiden-ts/config';
-import { map } from 'rxjs/operators';
 
 export type MockedContract<T extends Contract> = jest.Mocked<T> & {
   functions: {
@@ -239,10 +238,7 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
       presences: {} as Presences,
       pfsList: [] as readonly Address[],
     }),
-    config$ = latest$.pipe(
-      pluckDistinct('state', 'config'),
-      map(config => ({ ...defaultConfig, ...config })),
-    );
+    config$ = latest$.pipe(pluckDistinct('config'));
 
   return {
     latest$,

--- a/raiden-ts/tests/unit/reducers.spec.ts
+++ b/raiden-ts/tests/unit/reducers.spec.ts
@@ -1,5 +1,5 @@
-import { get } from 'lodash';
-import { set } from 'lodash/fp';
+import get from 'lodash/get';
+import set from 'lodash/fp/set';
 
 import { Zero, One, AddressZero } from 'ethers/constants';
 import { bigNumberify, keccak256, getNetwork } from 'ethers/utils';


### PR DESCRIPTION
Fix #1233
See https://github.com/raiden-network/light-client/issues/1233#issuecomment-604776135

- updating config with an `undefined` value doesn't set it to undefined, but instead resets it to default
- configs that support empty must not be optional, but instead use some falsy values
- fix config.pfs which didn't conform to ^, by using `''` as `auto` indicator, instead of undefined
- `Raiden.create` config is used to change defaults, instead of being persisted [only] on initial state