### PR TITLE
Fixed SDK init in dApp

### DIFF
--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -118,7 +118,6 @@ export default class RaidenService {
 
         const account = await this.getAccount();
         this.store.commit('account', account);
-        this.store.commit('balance', await this.getBalance());
 
         this._userDepositTokenAddress = await raiden.userDepositTokenAddress();
 
@@ -168,6 +167,7 @@ export default class RaidenService {
 
         window.addEventListener('beforeunload', () => this.raiden.stop());
         raiden.start();
+        this.store.commit('balance', await this.getBalance());
       }
     } catch (e) {
       let deniedReason: DeniedReason;

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -431,7 +431,7 @@ describe('RaidenService', () => {
       expect(store.commit).toHaveBeenCalledTimes(4);
 
       expect(store.commit).toHaveBeenNthCalledWith(1, 'account', '123');
-      expect(store.commit).toHaveBeenNthCalledWith(2, 'balance', '0.0');
+      expect(store.commit).toHaveBeenNthCalledWith(3, 'balance', '0.0');
       expect(store.commit).toHaveBeenNthCalledWith(4, 'loadComplete');
 
       await raidenService.fetchTokenData(['0xtoken1']);


### PR DESCRIPTION
Fixes #1257 

Looks like this `getBalance()` method was called too early. Seemed to work prior to #1253. Moving the call to the end of the initialization  fixed it