### PR TITLE
Make gh-pages deploy script to use bash instead of sh

### DIFF
--- a/raiden-dapp/deploy.sh
+++ b/raiden-dapp/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ideas used from https://gist.github.com/motemen/8595451
 
 # Based on https://github.com/eldarlabs/ghpages-deploy-script/blob/master/scripts/deploy-ghpages.sh


### PR DESCRIPTION
Deploy failed because apparently `sh` doesn't support the `[[` check.