### PR TITLE
Fixes building integration image with raiden using 0.36.2 raiden-contracts package 

### DIFF
--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,4 +1,8 @@
-ARG CONTRACTS_VERSION="0.36.2"
+# The version of the raiden smart contracts that will be deployed on chain.
+ARG CONTRACTS_VERSION="0.36.0"
+# The version of the python package. It is always equal or greater than the CONTRACTS_VERSION
+# It is used only for the deployment of the smart-contracts.
+ARG CONTRACTS_PACKAGE_VERSION="0.37.0b3"
 ARG SERVICES_VERSION="100fecf0d8c21ee68d8afbea912b67167ec7aad3"
 ARG RAIDEN_VERSION="ea7025739b460f940c26616ca1fccdb739b218ed"
 ARG SYNAPSE_VERSION=1.10.0
@@ -35,6 +39,7 @@ ARG OS_NAME
 ARG GETH_URL_LINUX
 ARG GETH_MD5_LINUX
 ARG CONTRACTS_VERSION
+ARG CONTRACTS_PACKAGE_VERSION
 ARG GETH_VERSION
 
 RUN apt-get update \
@@ -108,8 +113,7 @@ ARG LOCAL_BASE=/usr/local
 ARG DATA_DIR=/opt/chain
 
 RUN download_geth.sh && deploy.sh \
-    && cp -R /opt/raiden/lib/python3.7/site-packages/raiden_contracts/data_${CONTRACTS_VERSION}/deployment_private_net.json /opt/deployment/ \
-    && cp -R /opt/raiden/lib/python3.7/site-packages/raiden_contracts/data_${CONTRACTS_VERSION}/deployment_services_private_net.json /opt/deployment/
+    && cp -R /opt/deployment/* ${VENV}/lib/python3.7/site-packages/raiden_contracts/data_${CONTRACTS_VERSION}/
 
 RUN mkdir -p /opt/synapse/config \
     && mkdir -p /opt/synapse/data_well_known \

--- a/integration/geth/deploy.sh
+++ b/integration/geth/deploy.sh
@@ -36,6 +36,17 @@ deploy_contracts.py --contract-version "${CONTRACTS_VERSION}" \
   --output "${SMARTCONTRACTS_ENV_FILE}" \
   --password "${PASSWORD}"
 
-chmod u+x "${SMARTCONTRACTS_ENV_FILE}"
+if [[ -f ${SMARTCONTRACTS_ENV_FILE} ]]; then
+  echo 'Deployment was successful'
+  chmod u+x "${SMARTCONTRACTS_ENV_FILE}"
+  kill -s TERM ${GETH_PID}
+  exit 0
+else
+  echo 'Deployment failed'
+  kill -s TERM ${GETH_PID}
+  exit 1
+fi
 
-kill -s TERM ${GETH_PID}
+
+
+

--- a/integration/geth/deploy.sh
+++ b/integration/geth/deploy.sh
@@ -2,7 +2,13 @@
 
 echo "Setting up private chain"
 
-source "${VENV}/bin/activate"
+# Setting up a virtual environment for the raiden contracts
+VENV=/tmp/deploy_venv
+python3 -m venv $VENV
+source $VENV/bin/activate
+pip install mypy_extensions
+pip install click>=7.0
+pip install raiden-contracts==${CONTRACTS_PACKAGE_VERSION}
 
 GETH_RESULT=$(geth --datadir "${DATA_DIR}" account new --password "${PASSWORD_FILE}")
 
@@ -37,9 +43,25 @@ deploy_contracts.py --contract-version "${CONTRACTS_VERSION}" \
   --password "${PASSWORD}"
 
 if [[ -f ${SMARTCONTRACTS_ENV_FILE} ]]; then
-  echo 'Deployment was successful'
+  cp ${VENV}/lib/python3.7/site-packages/raiden_contracts/data_${CONTRACTS_VERSION}/deployment_private_net.json /opt/deployment/
+  cp ${VENV}/lib/python3.7/site-packages/raiden_contracts/data_${CONTRACTS_VERSION}/deployment_services_private_net.json /opt/deployment/
+
+  if [[ ! -f /opt/deployment/deployment_private_net.json ]]; then
+    echo 'Could not find the deployment_private_net.json'
+    exit 1
+  fi
+
+  if [[ ! -f /opt/deployment/deployment_services_private_net.json ]]; then
+    echo 'Could not find the deployment_services_private_net.json'
+    exit 1
+  fi
+
   chmod u+x "${SMARTCONTRACTS_ENV_FILE}"
+  echo 'Deployment was successful'
   kill -s TERM ${GETH_PID}
+
+  # Cleanup the temporary virtual environment used during the deployment
+  rm -rf $VENV
   exit 0
 else
   echo 'Deployment failed'


### PR DESCRIPTION
The main reason that changing the version to 0.36.0 didn't work is the following issue https://github.com/raiden-network/raiden-contracts/commit/9984a498d1228580b936a4c248aa55092027c87e

- Uses a new virtual environment with a newer version of the `raiden-contracts` python package.
This way we can ensure that we can use newer versions of the deployer in case any bugs appear in the `raiden-contracts` package used with `raiden`.
- Adds a couple of checks for errors and failures to ensure that the image generation stops if for example contract deployment fails.

Closes #1307