### PR TITLE
Provide functionality to transfer all tokens & ETH on-chain

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## [Unreleased]
 ### Added
+- [#1392] Raiden on-chain methods provide easy ways to transfer entire token & ETH balances
 - [#1252] Mediate transfers (experimental)
 
+[#1392]: https://github.com/raiden-network/light-client/issues/1392
 [#1252]: https://github.com/raiden-network/light-client/issues/1252
 
 ## [0.6.0] - 2020-04-21

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -1236,7 +1236,7 @@ describe('Raiden', () => {
   });
 
   test('subkey', async () => {
-    expect.assertions(28);
+    expect.assertions(30);
     const sub = await createRaiden(0, storage, true);
 
     const subStarted = sub.action$.pipe(filter(isActionOf(matrixSetup)), first()).toPromise();
@@ -1323,9 +1323,13 @@ describe('Raiden', () => {
     expect((await sub.getTokenBalance(token, sub.address)).eq(200)).toBe(true);
 
     // transfer on chain from subkey to main account
-    await expect(sub.transferOnchainTokens(token, sub.mainAddress!, 200)).resolves.toMatch(/^0x/);
+    await expect(sub.transferOnchainTokens(token, sub.mainAddress!)).resolves.toMatch(/^0x/);
+    // config.subkey is true, transfering ETH to mainAddress without specifying value should transfer everything
+    await expect(sub.transferOnchainBalance(sub.mainAddress!)).resolves.toMatch(/^0x/);
     expect((await sub.getTokenBalance(token)).isZero()).toBe(true);
     expect((await sub.getTokenBalance(token, sub.mainAddress)).eq(mainTokenBalance)).toBe(true);
+    // subkey is emptied of ETH
+    expect((await sub.getBalance()).isZero()).toBe(true);
 
     sub.stop();
   });


### PR DESCRIPTION
Fix #1392

Now, `Raiden.transferOnchainTokens` and `Raiden.transferOnchainBalance` (ETH) have a default value for the `value` param, which is `MaxUint256`. 
If a value bigger than available is passed (e.g. the default/undefined), the entire balance is transferred. This is specially useful for emptying an account of ETH, since it requires calculating the transfer cost (according to gasPrice and limit), and transferring only the remaining.
Example:
```ts
// empty subkey's balance to main account
await raiden.transferOnchainBalance(raiden.mainAddress, undefined, { subkey: true });
```