### PR TITLE
Make Raiden subclassable

### DIFF
--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -98,8 +98,7 @@
     "ethers": "^4.0.46"
   },
   "files": [
-    "/dist*",
-    "/typings"
+    "/dist*"
   ],
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",
@@ -159,7 +158,6 @@
     "raiden-contracts/*",
     "scripts/*",
     "dist*/*",
-    "typings/*",
     "src/contracts/*"
   ],
   "prettier": {

--- a/raiden-ts/src/polyfills.ts
+++ b/raiden-ts/src/polyfills.ts
@@ -26,9 +26,8 @@ request((opts: object, cb: ReqCb) => {
   });
 });
 
-import wrtc from 'wrtc';
 if (!('RTCPeerConnection' in globalThis)) {
-  Object.assign(globalThis, wrtc);
+  Object.assign(globalThis, require('wrtc')); // eslint-disable-line @typescript-eslint/no-var-requires
 }
 
 // patch createNewMatrixCall to prevent matrix-js-sdk from hooking WebRTC events in browser;

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -258,6 +258,7 @@ export class Raiden {
    * An async factory is needed so we can do the needed async requests to construct the required
    * parameters ahead of construction time, and avoid partial initialization then
    *
+   * @param this - Raiden class or subclass
    * @param connection - A URL or provider to connect to, one of:
    *     <ul>
    *       <li>JsonRpcProvider instance,</li>
@@ -279,8 +280,9 @@ export class Raiden {
    * @param config - Raiden configuration
    * @param subkey - Whether to use a derived subkey or not
    * @returns Promise to Raiden SDK client instance
-   **/
-  public static async create(
+   */
+  public static async create<R extends typeof Raiden>(
+    this: R,
     connection: JsonRpcProvider | AsyncSendable | string,
     account: Signer | string | number,
     storageOrState?:
@@ -291,7 +293,7 @@ export class Raiden {
     contracts?: ContractsInfo,
     config?: PartialRaidenConfig,
     subkey?: true,
-  ): Promise<Raiden> {
+  ): Promise<InstanceType<R>> {
     let provider: JsonRpcProvider;
     if (typeof connection === 'string') {
       provider = new JsonRpcProvider(connection);
@@ -332,7 +334,15 @@ export class Raiden {
       `Mismatch between network or registry address and loaded state`,
     );
 
-    const raiden = new Raiden(provider, network, signer, contracts, state, defaultConfig, main);
+    const raiden = new this(
+      provider,
+      network,
+      signer,
+      contracts,
+      state,
+      defaultConfig,
+      main,
+    ) as InstanceType<R>;
     if (onState) raiden.state$.subscribe(onState, onStateComplete, onStateComplete);
     return raiden;
   }


### PR DESCRIPTION
Part of #1401 

Currently, if you try to subclass `Raiden`, `create` method return type is still inferred as resolving to an instance of the original Raiden class, instead of the expected subclass, as it's an async factory static method.
This changes uses `new this` to create the instance inside the static factory (at runtime), which there is the actual `klass`, and use [some generics magic](https://github.com/microsoft/TypeScript/issues/5863#issuecomment-528305043) to correctly hint the returned type as `InstanceType` of this klass.
Additionally, `wrtc` uses Node specific `require` for import, as it's only needed and available on non-browser environments.