### PR TITLE
Monitoring

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## [Unreleased]
 ### Added
 - [#1392] Raiden on-chain methods provide easy ways to transfer entire token & ETH balances
+- [#1368] Monitoring transfers (experimental)
 - [#1252] Mediate transfers (experimental)
 
 [#1392]: https://github.com/raiden-network/light-client/issues/1392
+[#1368]: https://github.com/raiden-network/light-client/issues/1368
 [#1252]: https://github.com/raiden-network/light-client/issues/1252
 
 ## [0.6.0] - 2020-04-21

--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -958,13 +958,21 @@ export const channelSettleEpic = (
       };
       let part1 = {
           address: partner,
-          ...(channel.partner.balanceProof || zeroBalanceProof),
+          ...zeroBalanceProof,
+          ...channel.partner.balanceProof,
         },
         part2 = {
           address,
-          ...(channel.own.balanceProof || zeroBalanceProof),
+          ...zeroBalanceProof,
+          ...channel.own.balanceProof,
         };
-      if (channel.isFirstParticipant) [part1, part2] = [part2, part1];
+
+      if (
+        part2.transferredAmount
+          .add(part2.lockedAmount)
+          .lt(part1.transferredAmount.add(part1.lockedAmount))
+      )
+        [part1, part2] = [part2, part1];
 
       // send settleChannel transaction
       return from(

--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -52,7 +52,7 @@ import { pluckDistinct } from '../utils/rx';
 import { fromEthersEvent, getEventsStream, getNetwork } from '../utils/ethers';
 import { encode } from '../utils/data';
 import { RaidenError, ErrorCodes } from '../utils/error';
-import { createBalanceHash } from '../messages/utils';
+import { createBalanceHash, MessageTypeId } from '../messages/utils';
 import {
   newBlock,
   tokenMonitored,
@@ -788,7 +788,7 @@ export const channelCloseEpic = (
       const closingMessage = concat([
         encode(tokenNetwork, 20),
         encode(network.chainId, 32),
-        encode(1, 32), // raiden_contracts.constants.MessageTypeId.BALANCE_PROOF
+        encode(MessageTypeId.BALANCE_PROOF, 32),
         encode(channel.id, 32),
         encode(balanceHash, 32),
         encode(nonce, 32),
@@ -877,7 +877,7 @@ export const channelUpdateEpic = (
       const nonClosingMessage = concat([
         encode(tokenNetwork, 20),
         encode(network.chainId, 32),
-        encode(2, 32), // raiden_contracts.constants.MessageTypeId.BALANCE_PROOF_UPDATE
+        encode(MessageTypeId.BALANCE_PROOF_UPDATE, 32),
         encode(channel.id, 32),
         encode(balanceHash, 32),
         encode(nonce, 32),

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -2,7 +2,7 @@ import * as t from 'io-ts';
 import { Network } from 'ethers/utils';
 
 import { Capabilities } from './constants';
-import { Address } from './utils/types';
+import { Address, UInt } from './utils/types';
 import { getNetworkName } from './utils/ethers';
 
 const RTCIceServer = t.type({ urls: t.union([t.string, t.array(t.string)]) });
@@ -23,6 +23,7 @@ const RTCIceServer = t.type({ urls: t.union([t.string, t.array(t.string)]) });
  * - httpTimeout - Used in http fetch requests
  * - discoveryRoom - Discovery Room to auto-join, use null to disable
  * - pfsRoom - PFS Room to auto-join and send PFSCapacityUpdate to, use null to disable
+ * - monitoringRoom - MS global room to auto-join and send RequestMonitoring messages, use null to disable
  * - pfs - Path Finding Service URL or Address. Set to null to disable, or empty string to enable
  *         automatic fetching from ServiceRegistry.
  * - pfsSafetyMargin - Safety margin to be added to fees received from PFS. Use `1.1` to add a 10%
@@ -30,6 +31,7 @@ const RTCIceServer = t.type({ urls: t.union([t.string, t.array(t.string)]) });
  * - matrixExcessRooms - Keep this much rooms for a single user of interest (partner, target).
  *                       Leave LRU beyond this threshold.
  * - confirmationBlocks - How many blocks to wait before considering a transaction as confirmed
+ * - monitoringReward - Reward to be paid to MS, in SVT/RDN; use Zero or null to disable
  * - logger - String specifying the console log level of redux-logger. Use '' to silence.
  * - caps - Own transport capabilities
  * - matrixServer? - Specify a matrix server to use.
@@ -45,10 +47,12 @@ export const RaidenConfig = t.readonly(
       httpTimeout: t.number,
       discoveryRoom: t.union([t.string, t.null]),
       pfsRoom: t.union([t.string, t.null]),
+      monitoringRoom: t.union([t.string, t.null]),
       pfs: t.union([Address, t.string, t.null]),
       pfsSafetyMargin: t.number,
       matrixExcessRooms: t.number,
       confirmationBlocks: t.number,
+      monitoringReward: t.union([t.null, UInt(32)]),
       logger: t.keyof({
         ['']: null, // silent/disabled
         trace: null,
@@ -93,10 +97,12 @@ export function makeDefaultConfig(
     httpTimeout: 30e3,
     discoveryRoom: `raiden_${getNetworkName(network)}_discovery`,
     pfsRoom: `raiden_${getNetworkName(network)}_path_finding`,
+    monitoringRoom: `raiden_${getNetworkName(network)}_monitoring`,
     pfs: '', // empty string = auto mode
     matrixExcessRooms: 3,
     pfsSafetyMargin: 1.0,
     confirmationBlocks: 5,
+    monitoringReward: null,
     logger: 'info',
     caps: {
       [Capabilities.NO_DELIVERY]: true,

--- a/raiden-ts/src/messages/types.ts
+++ b/raiden-ts/src/messages/types.ts
@@ -7,7 +7,7 @@
  */
 import * as t from 'io-ts';
 
-import { Address, Hash, Secret, UInt, Int } from '../utils/types';
+import { Address, Hash, Secret, UInt, Int, Signature } from '../utils/types';
 import { Lock } from '../channels/types';
 
 // types
@@ -25,6 +25,7 @@ export enum MessageType {
   WITHDRAW_EXPIRED = 'WithdrawExpired',
   PFS_CAPACITY_UPDATE = 'PFSCapacityUpdate',
   PFS_FEE_UPDATE = 'PFSFeeUpdate',
+  MONITOR_REQUEST = 'RequestMonitoring',
 }
 
 // Mixin of a message that contains an identifier and should be ack'ed with a respective Delivered
@@ -262,6 +263,26 @@ export const PFSFeeUpdate = t.readonly(
 );
 export interface PFSFeeUpdate extends t.TypeOf<typeof PFSFeeUpdate> {}
 
+export const MonitorRequest = t.readonly(
+  t.type({
+    type: t.literal(MessageType.MONITOR_REQUEST),
+    balance_proof: t.type({
+      chain_id: UInt(32),
+      token_network_address: Address,
+      channel_identifier: UInt(32),
+      nonce: UInt(8),
+      balance_hash: Hash,
+      additional_hash: Hash,
+      signature: Signature,
+    }),
+    monitoring_service_contract_address: Address,
+    non_closing_participant: Address,
+    non_closing_signature: Signature,
+    reward_amount: UInt(32),
+  }),
+);
+export interface MonitorRequest extends t.TypeOf<typeof MonitorRequest> {}
+
 export const Message = t.union([
   Delivered,
   Processed,
@@ -276,6 +297,7 @@ export const Message = t.union([
   WithdrawExpired,
   PFSCapacityUpdate,
   PFSFeeUpdate,
+  MonitorRequest,
 ]);
 // prefer an explicit union to have the union of the interfaces, instead of the union of t.TypeOf's
 export type Message =
@@ -291,5 +313,6 @@ export type Message =
   | WithdrawConfirmation
   | WithdrawExpired
   | PFSCapacityUpdate
-  | PFSFeeUpdate;
+  | PFSFeeUpdate
+  | MonitorRequest;
 export type EnvelopeMessage = LockedTransfer | RefundTransfer | Unlock | LockExpired;

--- a/raiden-ts/src/messages/utils.ts
+++ b/raiden-ts/src/messages/utils.ts
@@ -26,13 +26,17 @@ const CMDIDs: { readonly [T in MessageType]: number } = {
   [MessageType.WITHDRAW_EXPIRED]: 17,
   [MessageType.PFS_CAPACITY_UPDATE]: -1,
   [MessageType.PFS_FEE_UPDATE]: -1,
+  [MessageType.MONITOR_REQUEST]: -1,
 };
 
 // raiden_contracts.constants.MessageTypeId
 export enum MessageTypeId {
   BALANCE_PROOF = 1,
+  BALANCE_PROOF_UPDATE = 2,
   WITHDRAW = 3,
+  COOP_SETTLE = 4,
   IOU = 5,
+  MS_REWARD = 6,
 }
 
 /**
@@ -243,6 +247,18 @@ export function packMessage(message: Message) {
           encode(message.timestamp, 19),
         ]),
       ) as HexString; // variable size of fee_schedule.imbalance_penalty rlpEncoding, when not null
+    case MessageType.MONITOR_REQUEST:
+      return hexlify(
+        concat([
+          encode(message.monitoring_service_contract_address, 20),
+          encode(message.balance_proof.chain_id, 32),
+          encode(MessageTypeId.MS_REWARD, 32),
+          encode(message.balance_proof.token_network_address, 20),
+          encode(message.non_closing_participant, 20),
+          encode(message.non_closing_signature, 65),
+          encode(message.reward_amount, 32),
+        ]),
+      ) as HexString<221>;
   }
 }
 

--- a/raiden-ts/src/services/actions.ts
+++ b/raiden-ts/src/services/actions.ts
@@ -43,3 +43,6 @@ export interface iouPersist extends ActionType<typeof iouPersist> {}
 
 export const iouClear = createAction('iouClear', undefined, ServiceId);
 export interface iouClear extends ActionType<typeof iouClear> {}
+
+export const udcDeposited = createAction('udcDeposited', UInt(32));
+export interface udcDeposited extends ActionType<typeof udcDeposited> {}

--- a/raiden-ts/src/state.ts
+++ b/raiden-ts/src/state.ts
@@ -161,6 +161,7 @@ export const initialState = makeInitialState({
     ServiceRegistry: { address: AddressZero as Address, block_number: 0 },
     UserDeposit: { address: AddressZero as Address, block_number: 0 },
     SecretRegistry: { address: AddressZero as Address, block_number: 0 },
+    MonitoringService: { address: AddressZero as Address, block_number: 0 },
   },
 });
 

--- a/raiden-ts/src/transport/epics.ts
+++ b/raiden-ts/src/transport/epics.ts
@@ -116,7 +116,7 @@ type CapsMapping = { readonly [k: string]: any };
  * @returns Array of room names
  */
 function globalRoomNames(config: RaidenConfig) {
-  return [config.discoveryRoom, config.pfsRoom].filter(isntNil);
+  return [config.discoveryRoom, config.pfsRoom, config.monitoringRoom].filter(isntNil);
 }
 
 /**

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -14,7 +14,7 @@ import { SecretRegistry } from './contracts/SecretRegistry';
 
 import { RaidenAction } from './actions';
 import { RaidenState } from './state';
-import { Address } from './utils/types';
+import { Address, UInt } from './utils/types';
 import { RaidenConfig } from './config';
 import { Presences } from './transport/types';
 
@@ -28,6 +28,7 @@ export interface ContractsInfo {
   ServiceRegistry: Info;
   UserDeposit: Info;
   SecretRegistry: Info;
+  MonitoringService: Info;
 }
 
 export interface Latest {
@@ -37,6 +38,7 @@ export interface Latest {
   presences: Presences;
   pfsList: readonly Address[];
   rtc: { [address: string]: RTCDataChannel };
+  udcBalance: UInt<32>;
 }
 
 export interface RaidenEpicDeps {

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -216,14 +216,11 @@ describe('Raiden', () => {
             {
               network,
               contractsInfo: {
-                // eslint-disable-next-line @typescript-eslint/camelcase
                 TokenNetworkRegistry: { address: token as Address, block_number: 0 },
-                // eslint-disable-next-line @typescript-eslint/camelcase
                 ServiceRegistry: { address: partner as Address, block_number: 1 },
-                // eslint-disable-next-line @typescript-eslint/camelcase
                 UserDeposit: { address: partner as Address, block_number: 2 },
-                // eslint-disable-next-line @typescript-eslint/camelcase
                 SecretRegistry: { address: partner as Address, block_number: 3 },
+                MonitoringService: { address: partner as Address, block_number: 3 },
               },
               address: accounts[1] as Address,
             },

--- a/raiden-ts/tests/unit/epics/channels.spec.ts
+++ b/raiden-ts/tests/unit/epics/channels.spec.ts
@@ -1160,14 +1160,14 @@ describe('channels epic', () => {
       expect(tokenNetworkContract.functions.settleChannel).toHaveBeenCalledTimes(1);
       expect(tokenNetworkContract.functions.settleChannel).toHaveBeenCalledWith(
         channelId,
-        depsMock.address,
-        expect.anything(), // self transfered amount
-        expect.anything(), // self locked amount
-        expect.anything(), // self locksroot
         partner,
-        expect.anything(), // partner transfered amount
-        expect.anything(), // partner locked amount
-        expect.anything(), // partner locksroot
+        Zero, // self transfered amount
+        Zero, // self locked amount
+        HashZero, // self locksroot
+        depsMock.address,
+        Zero, // partner transfered amount
+        Zero, // partner locked amount
+        HashZero, // partner locksroot
       );
       expect(settleTx.wait).toHaveBeenCalledTimes(1);
     });

--- a/raiden-ts/tests/unit/epics/monitor.spec.ts
+++ b/raiden-ts/tests/unit/epics/monitor.spec.ts
@@ -1,0 +1,245 @@
+/* eslint-disable @typescript-eslint/no-explicit-any,@typescript-eslint/camelcase */
+import { bigNumberify, parseUnits, BigNumberish } from 'ethers/utils';
+import { Zero, One } from 'ethers/constants';
+import { of } from 'rxjs';
+import { first, toArray } from 'rxjs/operators';
+
+import { Capabilities } from 'raiden-ts/constants';
+import { raidenConfigUpdate } from 'raiden-ts/actions';
+import { MessageType, LockedTransfer } from 'raiden-ts/messages/types';
+import { signMessage } from 'raiden-ts/messages/utils';
+import { tokenMonitored, channelOpen, channelDeposit, newBlock } from 'raiden-ts/channels/actions';
+import { messageReceived, messageGlobalSend } from 'raiden-ts/messages/actions';
+import { transferGenerateAndSignEnvelopeMessageEpic } from 'raiden-ts/transfers/epics';
+import { UInt, decode } from 'raiden-ts/utils/types';
+import {
+  makeMessageId,
+  makeSecret,
+  getSecrethash,
+  makePaymentId,
+  getLocksroot,
+} from 'raiden-ts/transfers/utils';
+import { monitorRequestEpic, monitorUdcBalanceEpic } from 'raiden-ts/services/epics';
+import { udcDeposited } from 'raiden-ts/services/actions';
+
+import { epicFixtures } from '../fixtures';
+import { raidenEpicDeps } from '../mocks';
+
+test('monitorUdcBalanceEpic', async () => {
+  expect.assertions(2);
+
+  const depsMock = raidenEpicDeps();
+  const { action$, state$ } = epicFixtures(depsMock);
+  const deposit = bigNumberify(23) as UInt<32>;
+
+  depsMock.userDepositContract.functions.balances.mockResolvedValue(Zero);
+
+  const promise = monitorUdcBalanceEpic(action$, state$, depsMock).pipe(toArray()).toPromise();
+
+  setTimeout(() => {
+    depsMock.userDepositContract.functions.balances.mockResolvedValueOnce(deposit);
+    action$.next(newBlock({ blockNumber: 2 }));
+  }, 10);
+  setTimeout(() => action$.complete(), 500);
+
+  await expect(promise).resolves.toEqual([udcDeposited(Zero as UInt<32>), udcDeposited(deposit)]);
+  expect(depsMock.userDepositContract.functions.balances).toHaveBeenCalledTimes(2);
+});
+
+describe('monitorRequestEpic', () => {
+  let depsMock: ReturnType<typeof raidenEpicDeps>;
+  let token: ReturnType<typeof epicFixtures>['token'],
+    tokenNetwork: ReturnType<typeof epicFixtures>['tokenNetwork'],
+    channelId: ReturnType<typeof epicFixtures>['channelId'],
+    partner: ReturnType<typeof epicFixtures>['partner'],
+    settleTimeout: ReturnType<typeof epicFixtures>['settleTimeout'],
+    isFirstParticipant: ReturnType<typeof epicFixtures>['isFirstParticipant'],
+    txHash: ReturnType<typeof epicFixtures>['txHash'],
+    partnerSigner: ReturnType<typeof epicFixtures>['partnerSigner'],
+    action$: ReturnType<typeof epicFixtures>['action$'],
+    state$: ReturnType<typeof epicFixtures>['state$'];
+
+  const monitoringReward = parseUnits('5', 18) as UInt<32>;
+
+  beforeEach(async () => {
+    depsMock = raidenEpicDeps();
+    ({
+      token,
+      tokenNetwork,
+      channelId,
+      partner,
+      settleTimeout,
+      isFirstParticipant,
+      txHash,
+      partnerSigner,
+      action$,
+      state$,
+    } = epicFixtures(depsMock));
+
+    [
+      raidenConfigUpdate({
+        caps: {
+          [Capabilities.NO_DELIVERY]: true,
+          [Capabilities.NO_MEDIATE]: true,
+          // disable NO_RECEIVE
+        },
+        monitoringReward,
+        httpTimeout: 30,
+      }),
+      tokenMonitored({ token, tokenNetwork }),
+      channelOpen.success(
+        {
+          id: channelId,
+          settleTimeout,
+          isFirstParticipant,
+          txHash,
+          txBlock: 121,
+          confirmed: true,
+        },
+        { tokenNetwork, partner },
+      ),
+      channelDeposit.success(
+        {
+          id: channelId,
+          participant: depsMock.address,
+          totalDeposit: bigNumberify(500) as UInt<32>,
+          txHash,
+          txBlock: 122,
+          confirmed: true,
+        },
+        { tokenNetwork, partner },
+      ),
+      channelDeposit.success(
+        {
+          id: channelId,
+          participant: partner,
+          totalDeposit: bigNumberify(500) as UInt<32>,
+          txHash,
+          txBlock: 122,
+          confirmed: true,
+        },
+        { tokenNetwork, partner },
+      ),
+    ].forEach((a) => action$.next(a));
+  });
+
+  async function receiveTransfer(value: BigNumberish) {
+    const amount = decode(UInt(32), value);
+    const secret = makeSecret();
+    const secrethash = getSecrethash(secret);
+
+    const { state, config } = await depsMock.latest$.pipe(first()).toPromise();
+
+    const expiration = bigNumberify(state.blockNumber + config.revealTimeout * 2) as UInt<32>;
+    const lock = {
+      secrethash,
+      amount,
+      expiration,
+    };
+    const unsigned: LockedTransfer = {
+      type: MessageType.LOCKED_TRANSFER,
+      payment_identifier: makePaymentId(),
+      message_identifier: makeMessageId(),
+      chain_id: bigNumberify(depsMock.network.chainId) as UInt<32>,
+      token,
+      token_network_address: tokenNetwork,
+      recipient: depsMock.address,
+      target: partner, // lol
+      initiator: partner,
+      channel_identifier: bigNumberify(channelId) as UInt<32>,
+      metadata: { routes: [{ route: [depsMock.address, partner] }] },
+      lock,
+      locksroot: getLocksroot([
+        ...(state.channels[tokenNetwork][partner].partner.locks ?? []),
+        lock,
+      ]),
+      nonce: One as UInt<8>,
+      transferred_amount: Zero as UInt<32>,
+      locked_amount: (
+        state.channels[tokenNetwork][partner].partner.balanceProof?.lockedAmount ?? Zero
+      ).add(lock.amount) as UInt<32>,
+    };
+    const transf = await signMessage(partnerSigner, unsigned, depsMock);
+    transferGenerateAndSignEnvelopeMessageEpic(
+      of(messageReceived({ text: '', message: transf, ts: Date.now() }, { address: partner })),
+      state$,
+      depsMock,
+    ).subscribe((a) => action$.next(a));
+  }
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    action$.complete();
+    state$.complete();
+    depsMock.latest$.complete();
+  });
+
+  test('success: receiving a transfer triggers monitoring', async () => {
+    expect.assertions(2);
+
+    const signerSpy = jest.spyOn(depsMock.signer, 'signMessage');
+
+    const promise = monitorRequestEpic(action$, state$, depsMock).toPromise();
+    action$.next(udcDeposited(monitoringReward.mul(2) as UInt<32>));
+
+    await receiveTransfer(10);
+    setTimeout(() => action$.complete(), 500);
+
+    await expect(promise).resolves.toEqual(
+      messageGlobalSend(
+        expect.objectContaining({
+          message: expect.objectContaining({ type: MessageType.MONITOR_REQUEST }),
+        }),
+        { roomName: expect.stringMatching(/_monitoring$/) },
+      ),
+    );
+
+    expect(signerSpy).toHaveBeenCalledTimes(3);
+    signerSpy.mockRestore();
+  });
+
+  test('ignore: not enough udcBalance', async () => {
+    expect.assertions(1);
+
+    const promise = monitorRequestEpic(action$, state$, depsMock).toPromise();
+    action$.next(udcDeposited(monitoringReward.sub(1) as UInt<32>));
+
+    await receiveTransfer(10);
+    setTimeout(() => action$.complete(), 500);
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  test('ignore: config.monitoringReward unset', async () => {
+    expect.assertions(1);
+    action$.next(raidenConfigUpdate({ monitoringReward: null }));
+
+    const promise = monitorRequestEpic(action$, state$, depsMock).toPromise();
+    action$.next(udcDeposited(monitoringReward.mul(2) as UInt<32>));
+
+    await receiveTransfer(10);
+    setTimeout(() => action$.complete(), 500);
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  test('ignore: signing rejected not fatal', async () => {
+    expect.assertions(2);
+
+    const signerSpy = jest.spyOn(depsMock.signer, 'signMessage');
+
+    const promise = monitorRequestEpic(action$, state$, depsMock).toPromise();
+    action$.next(udcDeposited(monitoringReward.mul(2) as UInt<32>));
+
+    await receiveTransfer(10);
+
+    // to reject AFTER receiveTransfer signed Processed
+    signerSpy.mockRejectedValueOnce(new Error('Signature rejected'));
+    setTimeout(() => action$.complete(), 500);
+
+    await expect(promise).resolves.toBeUndefined();
+
+    expect(signerSpy).toHaveBeenCalledTimes(2);
+    signerSpy.mockRestore();
+  });
+});

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -11,9 +11,10 @@ import { memoize } from 'lodash';
 import logging from 'loglevel';
 
 jest.mock('ethers/providers');
+import { Zero } from 'ethers/constants';
 import { JsonRpcProvider, EventType, Listener } from 'ethers/providers';
 import { Log } from 'ethers/providers/abstract-provider';
-import { Network } from 'ethers/utils';
+import { Network, parseEther } from 'ethers/utils';
 import { Contract, EventFilter } from 'ethers/contract';
 import { Wallet } from 'ethers/wallet';
 
@@ -30,11 +31,13 @@ import { HumanStandardTokenFactory } from 'raiden-ts/contracts/HumanStandardToke
 import { ServiceRegistryFactory } from 'raiden-ts/contracts/ServiceRegistryFactory';
 import { UserDepositFactory } from 'raiden-ts/contracts/UserDepositFactory';
 import { SecretRegistryFactory } from 'raiden-ts/contracts/SecretRegistryFactory';
+import { MonitoringServiceFactory } from 'raiden-ts/contracts/MonitoringServiceFactory';
+import { MonitoringService } from 'raiden-ts/contracts/MonitoringService';
 
 import 'raiden-ts/polyfills';
 import { RaidenEpicDeps, ContractsInfo, Latest } from 'raiden-ts/types';
 import { makeInitialState } from 'raiden-ts/state';
-import { Address, Signature } from 'raiden-ts/utils/types';
+import { Address, Signature, UInt } from 'raiden-ts/utils/types';
 import { getServerName } from 'raiden-ts/utils/matrix';
 import { pluckDistinct } from 'raiden-ts/utils/rx';
 import { raidenConfigUpdate } from 'raiden-ts/actions';
@@ -193,6 +196,7 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
   userDepositContract.functions.one_to_n_address.mockResolvedValue(
     '0x0A0000000000000000000000000000000000000a',
   );
+  userDepositContract.functions.balances.mockResolvedValue(parseEther('5'));
 
   const secretRegistryContract = SecretRegistryFactory.connect(address, signer) as MockedContract<
     SecretRegistry
@@ -200,6 +204,15 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
 
   for (const func in secretRegistryContract.functions) {
     jest.spyOn(secretRegistryContract.functions, func as keyof SecretRegistry['functions']);
+  }
+
+  const monitoringServiceContract = MonitoringServiceFactory.connect(
+    address,
+    signer,
+  ) as MockedContract<MonitoringService>;
+
+  for (const func in monitoringServiceContract.functions) {
+    jest.spyOn(monitoringServiceContract.functions, func as keyof MonitoringService['functions']);
   }
 
   const contractsInfo: ContractsInfo = {
@@ -217,6 +230,10 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
       },
       SecretRegistry: {
         address: secretRegistryContract.address as Address,
+        block_number: 102,
+      },
+      MonitoringService: {
+        address: monitoringServiceContract.address as Address,
         block_number: 102,
       },
     },
@@ -238,6 +255,7 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
       presences: {},
       pfsList: [],
       rtc: {},
+      udcBalance: Zero as UInt<32>,
     }),
     config$ = latest$.pipe(pluckDistinct('config'));
 

--- a/raiden-ts/tests/unit/reducers.spec.ts
+++ b/raiden-ts/tests/unit/reducers.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/camelcase */
 import get from 'lodash/get';
 import set from 'lodash/fp/set';
 
@@ -80,14 +81,11 @@ describe('raidenReducer', () => {
         network: getNetwork('unspecified'),
         address,
         contractsInfo: {
-          // eslint-disable-next-line @typescript-eslint/camelcase
           TokenNetworkRegistry: { address: AddressZero as Address, block_number: 0 },
-          // eslint-disable-next-line @typescript-eslint/camelcase
           ServiceRegistry: { address: AddressZero as Address, block_number: 0 },
-          // eslint-disable-next-line @typescript-eslint/camelcase
           UserDeposit: { address: AddressZero as Address, block_number: 0 },
-          // eslint-disable-next-line @typescript-eslint/camelcase
           SecretRegistry: { address: AddressZero as Address, block_number: 0 },
+          MonitoringService: { address: AddressZero as Address, block_number: 0 },
         },
       },
       { blockNumber: 1337 },


### PR DESCRIPTION
Closes #1368
When receiving a transfer, if there's enough UDC deposit and `config.monitoringReward` is set, sign and send a `RequestMonitoring` message to the monitoring global room, so we can safely go offline.