### PR TITLE
Updates codecov bash uploader flag and nightly coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
           path: reports/junit
       - run:
           name: "Upload coverage"
-          command: cd .. && bash <(curl -s https://codecov.io/bash) -F sdk
+          command: cd .. && bash <(curl -s https://codecov.io/bash) -F sdk -C $CIRCLE_SHA1
 
   test_dapp:
     executor: base-executor
@@ -145,7 +145,7 @@ jobs:
           path: reports/junit
       - run:
           name: "Upload coverage"
-          command: cd .. && bash <(curl -s https://codecov.io/bash) -F dapp
+          command: cd .. && bash <(curl -s https://codecov.io/bash) -F dapp -C $CIRCLE_SHA1
 
   build_dapp:
     executor: base-executor
@@ -210,7 +210,7 @@ jobs:
           path: reports/junit
       - run:
           name: "Upload coverage"
-          command: cd .. && bash <(curl -s https://codecov.io/bash) -F sdk-integration
+          command: cd .. && bash <(curl -s https://codecov.io/bash) -F sdk_integration -C $CIRCLE_SHA1
 
 workflows:
   version: 2

--- a/codecov.yml
+++ b/codecov.yml
@@ -31,3 +31,7 @@ flags:
   sdk:
     paths:
       - raiden-ts/
+  sdk_integration:
+    carryforward: true
+    paths:
+      - raiden-ts/


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

**Short description**
Some times CI coverage upload will fail due to a bug in codecov bash utility.
```
==> Uploading reports 
    url: https://codecov.io
    query: branch=pull%2F1445&commit=024a44c5ccc4e0f6044c2d8d46a06e6ba962cb8a&build=28029&build_url=&name=&tag=&slug=raiden-network%2Flight-client&service=circleci&flags=dapp&pr=1445&job=0
    -> Pinging Codecov
https://codecov.io/upload/v4?package=bash-tbd&token=secret&branch=pull%2F1445&commit=024a44c5ccc4e0f6044c2d8d46a06e6ba962cb8a&build=28029&build_url=&name=&tag=&slug=raiden-network%2Flight-client&service=circleci&flags=dapp&pr=1445&job=0
HTTP 400
Commit sha does not match Circle build.
CircleCI received exit code 0 
```

Also fixes the name in the `sdk_integration` flag and adds it with a carry-forward flag:
https://docs.codecov.io/docs/flags#carryforward-flags 

```
https://codecov.io/upload/v4?package=bash-tbd&token=secret&branch=master&commit=6f68af80b4be9761356fcc09d9593fa025d66df2&build=27898&build_url=&name=&tag=&slug=raiden-network%2Flight-client&service=circleci&flags=sdk-integration&pr=&job=0
    -> Uploading
    X> Failed to upload
    -> Sleeping for 30s and trying again...
    -> Uploading to Codecov
    HTTP 400
flags must match pattern ^[\w\,]+$
```

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
