### PR TITLE
Light client 1458

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -17,6 +17,11 @@
 - [#1382] Better error handling when PFS can't find routes between nodes.
 - [#1427] Scroll bar issue in Channel List view.
 
+### Changed
+
+- [#1458] General screen has been renamed to account.
+
+[#1458]: https://github.com/raiden-network/light-client/issues/1458
 [#1402]: https://github.com/raiden-network/light-client/issues/1402
 [#1413]: https://github.com/raiden-network/light-client/issues/1413
 [#1395]: https://github.com/raiden-network/light-client/issues/1395

--- a/raiden-dapp/src/components/AppHeader.vue
+++ b/raiden-dapp/src/components/AppHeader.vue
@@ -13,7 +13,7 @@
               @click="onBackClicked()"
             >
               <v-img
-                :src="require('../assets/back_arrow.svg')"
+                :src="require('@/assets/back_arrow.svg')"
                 max-width="34px"
               />
             </v-btn>
@@ -37,7 +37,7 @@
           </v-col>
           <v-spacer />
           <span class="app-header__account-wrapper">
-            <header-identicon @click.native="navigateToGeneralHome()" />
+            <header-identicon @click.native="navigateToAccoount()" />
           </span>
         </div>
       </v-col>

--- a/raiden-dapp/src/components/account/AccountContent.vue
+++ b/raiden-dapp/src/components/account/AccountContent.vue
@@ -1,47 +1,47 @@
 <template>
-  <div class="general-screen-menu">
+  <div class="account-content">
     <div v-if="!loading && defaultAccount">
-      <v-row class="general-screen-menu__account-details" no-gutters>
+      <v-row class="account-content__account-details" no-gutters>
         <v-col cols="12">
-          <div class="general-screen-menu__account-details--title">
-            {{ $t('general-menu.account-details') }}
+          <div class="account-content__account-details--title">
+            {{ $t('account-content.account-details') }}
           </div>
         </v-col>
       </v-row>
       <v-row no-gutters>
         <v-col cols="2">
-          <span class="general-screen-menu__account-details--address">
-            {{ $t('general-menu.address') }}
+          <span class="account-content__account-details--address">
+            {{ $t('account-content.address') }}
           </span>
         </v-col>
         <v-col cols="10">
-          <span class="general-screen-menu__account-details--address">
+          <span class="account-content__account-details--address">
             <address-display :address="defaultAccount" full-address />
           </span>
         </v-col>
       </v-row>
-      <v-row class="general-screen-menu__account-details__eth" no-gutters>
+      <v-row class="account-content__account-details__eth" no-gutters>
         <v-col cols="2">
-          <span class="general-screen-menu__account-details__eth--currency">
-            {{ $t('general-menu.currency') }}
+          <span class="account-content__account-details__eth--currency">
+            {{ $t('account-content.currency') }}
           </span>
         </v-col>
         <v-col cols="10">
-          <span class="general-screen-menu__account-details__eth--balance">
+          <span class="account-content__account-details__eth--balance">
             {{ balance | decimals }}
           </span>
         </v-col>
       </v-row>
     </div>
-    <v-list two-line class="general-screen-menu__menu">
+    <v-list two-line class="account-content__menu">
       <v-list-item
         v-for="(menuItem, index) in menuItems"
         :key="index"
-        class="general-screen-menu__menu__list-items"
+        class="account-content__menu__list-items"
       >
-        <div class="general-screen-menu__menu__list-items__icon">
+        <div class="account-content__menu__list-items__icon">
           <v-img
-            :src="require(`../assets/${menuItem.icon}`)"
+            :src="require(`@/assets/${menuItem.icon}`)"
             max-width="40px"
             height="36px"
             contain
@@ -78,7 +78,7 @@ import AddressDisplay from '@/components/AddressDisplay.vue';
     ...mapGetters(['balance', 'isConnected'])
   }
 })
-export default class GeneralMenu extends Mixins(NavigationMixin) {
+export default class AccountContent extends Mixins(NavigationMixin) {
   menuItems: {}[] = [];
   loading!: boolean;
   defaultAccount!: string;
@@ -89,9 +89,11 @@ export default class GeneralMenu extends Mixins(NavigationMixin) {
     this.menuItems = [
       {
         icon: 'state.svg',
-        title: this.$t('general-menu.menu-items.backup-state-title') as string,
+        title: this.$t(
+          'account-content.menu-items.backup-state.title'
+        ) as string,
         subtitle: this.$t(
-          'general-menu.menu-items.backup-state-subtitle'
+          'account-content.menu-items.backup-state.subtitle'
         ) as string,
         route: () => {
           this.navigateToBackupState();
@@ -99,9 +101,11 @@ export default class GeneralMenu extends Mixins(NavigationMixin) {
       },
       {
         icon: 'bug.svg',
-        title: this.$t('general-menu.menu-items.report-bugs-title') as string,
+        title: this.$t(
+          'account-content.menu-items.report-bugs.title'
+        ) as string,
         subtitle: this.$t(
-          'general-menu.menu-items.report-bugs-subtitle'
+          'account-content.menu-items.report-bugs.subtitle'
         ) as string,
         route: () => {
           this.downloadLogs();
@@ -114,14 +118,19 @@ export default class GeneralMenu extends Mixins(NavigationMixin) {
       const mainAccount = await this.$raiden.getMainAccount();
       const raidenAccount = await this.$raiden.getAccount();
       if (mainAccount && raidenAccount) {
-        this.menuItems.unshift({
+        const raidenAccount = {
           icon: 'eth.svg',
-          title: 'Raiden Account',
-          subtitle: 'Transfer ETH between your main and Raiden account',
+          title: this.$t(
+            'account-content.menu-items.raiden-account.title'
+          ) as string,
+          subtitle: this.$t(
+            'account-content.menu-items.raiden-account.subtitle'
+          ) as string,
           route: () => {
             this.navigateToRaidenAccountTransfer();
           }
-        });
+        };
+        this.menuItems.unshift(raidenAccount);
       }
     }
   }
@@ -147,9 +156,9 @@ export default class GeneralMenu extends Mixins(NavigationMixin) {
 </script>
 
 <style scoped lang="scss">
-@import '../scss/colors';
+@import '../../scss/colors';
 
-.general-screen-menu {
+.account-content {
   margin: 0 64px 0 64px;
 
   &__account-details {

--- a/raiden-dapp/src/components/account/backup-state/DownloadStateDialog.vue
+++ b/raiden-dapp/src/components/account/backup-state/DownloadStateDialog.vue
@@ -9,7 +9,7 @@
         <v-col cols="6">
           <v-img
             class="download-state__warning"
-            :src="require('../assets/warning.svg')"
+            :src="require('@/assets/warning.svg')"
           ></v-img>
         </v-col>
         <v-col cols="12">
@@ -33,7 +33,7 @@
 import { Component, Prop, Emit, Mixins } from 'vue-property-decorator';
 import RaidenDialog from '@/components/RaidenDialog.vue';
 import ActionButton from '@/components/ActionButton.vue';
-import NavigationMixin from '../mixins/navigation-mixin';
+import NavigationMixin from '../../../mixins/navigation-mixin';
 
 @Component({
   components: {

--- a/raiden-dapp/src/components/account/backup-state/UploadStateDialog.vue
+++ b/raiden-dapp/src/components/account/backup-state/UploadStateDialog.vue
@@ -56,7 +56,7 @@
         <v-row class="upload-state__dropzone__button">
           <input ref="stateInput" type="file" hidden @change="onFileSelect" />
           <action-button
-            :enabled="!activeDropzone ? true : false"
+            :enabled="!activeDropzone"
             ghost
             :text="$t('backup-state.upload-button')"
             @click="$refs.stateInput.click()"
@@ -167,7 +167,7 @@ export default class UploadStateDialog extends Vue {
 </script>
 
 <style lang="scss" scoped>
-@import '../scss/colors';
+@import '../../../scss/colors';
 
 .upload-state {
   &__error {

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -30,15 +30,23 @@
     "raiden-account": "Raiden Account",
     "main-account": "Main Account"
   },
-  "general-menu": {
+  "account-content": {
     "account-details": "Account Details",
     "address": "Address:",
     "currency": "ETH:",
     "menu-items": {
-      "backup-state-title": "Backup state",
-      "backup-state-subtitle": "Download & upload your state",
-      "report-bugs-title": "Report bugs",
-      "report-bugs-subtitle": "Download logs"
+      "backup-state": {
+        "title": "Backup state",
+        "subtitle": "Download & upload your state"
+      },
+      "report-bugs": {
+        "title": "Report bugs",
+        "subtitle": "Download logs"
+      },
+      "raiden-account": {
+        "title": "Raiden Account",
+        "subtitle": "Transfer ETH between your main and Raiden account"
+      }
     }
   },
   "backup-state": {

--- a/raiden-dapp/src/mixins/navigation-mixin.ts
+++ b/raiden-dapp/src/mixins/navigation-mixin.ts
@@ -69,21 +69,21 @@ export default class NavigationMixin extends Vue {
     });
   }
 
-  navigateToGeneralHome() {
+  navigateToAccoount() {
     this.$router.push({
-      name: RouteNames.GENERAL_HOME
+      name: RouteNames.ACCOUNT_ROOT
     });
   }
 
   navigateToBackupState() {
     this.$router.push({
-      name: RouteNames.BACKUP_STATE
+      name: RouteNames.ACCOUNT_BACKUP
     });
   }
 
   navigateToRaidenAccountTransfer() {
     this.$router.push({
-      name: RouteNames.RAIDEN_ACCOUNT
+      name: RouteNames.ACCOUNT_RAIDEN
     });
   }
 

--- a/raiden-dapp/src/router/index.ts
+++ b/raiden-dapp/src/router/index.ts
@@ -72,8 +72,8 @@ const router = new Router({
       component: () => import('../views/ChannelsRoute.vue')
     },
     {
-      path: '/general',
-      name: RouteNames.GENERAL,
+      path: '/account',
+      name: RouteNames.ACCOUNT,
       beforeEnter: (to, from, next) => {
         // Remembers the route that was visited just before the General view is opened and
         // then loads the General view in a separate <router-view>. The last visited route
@@ -85,34 +85,34 @@ const router = new Router({
         } else if (to.matched.length) {
           to.matched[0].components.default = from.matched[0].components.default;
           to.matched[0].components.modal = () =>
-            import('../views/GeneralDialog.vue');
+            import('../views/AccountRoute.vue');
         }
         next();
       },
       children: [
         {
-          path: 'general-home',
-          name: RouteNames.GENERAL_HOME,
+          path: '/',
+          name: RouteNames.ACCOUNT_ROOT,
           meta: {
-            title: 'General'
+            title: 'Account'
           },
-          component: () => import('../views/GeneralHome.vue')
+          component: () => import('../views/account/AccountRoot.vue')
         },
         {
-          path: 'backup-state',
-          name: RouteNames.BACKUP_STATE,
+          path: 'backup',
+          name: RouteNames.ACCOUNT_BACKUP,
           meta: {
             title: 'Backup State'
           },
-          component: () => import('../views/BackupState.vue')
+          component: () => import('../views/account/BackupState.vue')
         },
         {
-          path: 'raiden-account',
-          name: RouteNames.RAIDEN_ACCOUNT,
+          path: 'raiden',
+          name: RouteNames.ACCOUNT_RAIDEN,
           meta: {
             title: 'Raiden Account'
           },
-          component: () => import('../views/RaidenAccount.vue')
+          component: () => import('../views/account/RaidenAccount.vue')
         }
       ]
     }

--- a/raiden-dapp/src/router/route-names.ts
+++ b/raiden-dapp/src/router/route-names.ts
@@ -6,8 +6,8 @@ export enum RouteNames {
   HOME = 'home',
   CHANNELS = 'channels',
   OPEN_CHANNEL = 'open-channel',
-  GENERAL = 'general',
-  GENERAL_HOME = 'general-home',
-  BACKUP_STATE = 'backup-state',
-  RAIDEN_ACCOUNT = 'raiden-account'
+  ACCOUNT = 'account',
+  ACCOUNT_ROOT = 'account-root',
+  ACCOUNT_BACKUP = 'account-backup',
+  ACCOUNT_RAIDEN = 'account-raiden'
 }

--- a/raiden-dapp/src/views/AccountRoute.vue
+++ b/raiden-dapp/src/views/AccountRoute.vue
@@ -1,9 +1,9 @@
 <template>
-  <div id="general-screen-wrapper">
-    <div class="general-screen">
-      <v-row class="general-screen__header" no-gutters>
-        <div class="general-screen__header__content">
-          <div class="general-screen__header__content__back">
+  <div id="account-route-wrapper">
+    <div class="account-route">
+      <v-row class="account-route__header" no-gutters>
+        <div class="account-route__header__content">
+          <div class="account-route__header__content__back">
             <v-btn
               height="40px"
               text
@@ -12,21 +12,21 @@
               @click="onGeneralBackClicked()"
             >
               <v-img
-                :src="require('../assets/back_arrow.svg')"
+                :src="require('@/assets/back_arrow.svg')"
                 max-width="34px"
               />
             </v-btn>
           </div>
-          <div class="general-screen__header__content__title">
+          <div class="account-route__header__content__title">
             {{ $route.meta.title }}
           </div>
         </div>
       </v-row>
       <router-view />
-      <v-row class="general-screen__footer" no-gutters>
+      <v-row class="account-route__footer" no-gutters>
         <div v-if="version">
           <span>{{ $t('versions.sdk', { version }) }}</span>
-          <span class="general-screen__footer__contracts-version">
+          <span class="account-route__footer__contracts-version">
             {{ $t('versions.contracts', { version: contractVersion }) }}
           </span>
         </div>
@@ -41,7 +41,7 @@ import { Raiden } from 'raiden-ts';
 import NavigationMixin from '@/mixins/navigation-mixin';
 
 @Component({})
-export default class GeneralDialog extends Mixins(NavigationMixin) {
+export default class AccountRoute extends Mixins(NavigationMixin) {
   get version() {
     return Raiden.version;
   }
@@ -57,7 +57,7 @@ export default class GeneralDialog extends Mixins(NavigationMixin) {
 @import '../scss/fonts';
 @import '../scss/colors';
 
-#general-screen-wrapper {
+#account-route-wrapper {
   align-items: center;
   display: flex;
   height: 100%;
@@ -70,7 +70,7 @@ export default class GeneralDialog extends Mixins(NavigationMixin) {
   }
 }
 
-.general-screen {
+.account-route {
   background-color: black;
   border-radius: 10px;
   display: flex;

--- a/raiden-dapp/src/views/account/AccountRoot.vue
+++ b/raiden-dapp/src/views/account/AccountRoot.vue
@@ -1,28 +1,28 @@
 <template>
-  <div class="general-screen-home">
-    <v-row class="general-screen-home__identicon" no-gutters>
+  <div class="account-root">
+    <v-row class="account-root__identicon" no-gutters>
       <header-identicon />
     </v-row>
-    <general-menu />
+    <account-content />
   </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import HeaderIdenticon from '@/components/HeaderIdenticon.vue';
-import GeneralMenu from '@/components/GeneralMenu.vue';
+import AccountContent from '@/components/account/AccountContent.vue';
 
 @Component({
   components: {
-    HeaderIdenticon,
-    GeneralMenu
+    AccountContent,
+    HeaderIdenticon
   }
 })
-export default class GeneralHome extends Vue {}
+export default class AccountRoot extends Vue {}
 </script>
 
 <style scoped lang="scss">
-.general-screen-home {
+.account-root {
   &__identicon {
     align-self: center;
     border-bottom: solid 1px #707070;

--- a/raiden-dapp/src/views/account/BackupState.vue
+++ b/raiden-dapp/src/views/account/BackupState.vue
@@ -17,10 +17,10 @@
               <div
                 class="backup-state__buttons__download-state__icon"
                 :class="{
-                  'backup-state__buttons__dowload-state__icon disabled-icon': !isConnected
+                  'backup-state__buttons__download-state__icon disabled-icon': !isConnected
                 }"
               >
-                <v-img :src="require('../assets/state_download.png')"></v-img>
+                <v-img :src="require('@/assets/state_download.png')"></v-img>
               </div>
               <v-list-item-content>
                 <div class="backup-state__buttons__download-state__title">
@@ -45,7 +45,7 @@
                   'backup-state__buttons__upload-state__icon disabled-icon': isConnected
                 }"
               >
-                <v-img :src="require('../assets/state_upload.png')"></v-img>
+                <v-img :src="require('@/assets/state_upload.png')"></v-img>
               </div>
               <v-list-item-content>
                 <div class="backup-state__buttons__upload-state__title">
@@ -72,8 +72,8 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import { mapGetters } from 'vuex';
-import DownloadStateDialog from '@/components/DownloadStateDialog.vue';
-import UploadStateDialog from '@/components/UploadStateDialog.vue';
+import DownloadStateDialog from '@/components/account/backup-state/DownloadStateDialog.vue';
+import UploadStateDialog from '@/components/account/backup-state/UploadStateDialog.vue';
 
 @Component({
   components: {
@@ -90,7 +90,7 @@ export default class BackupState extends Vue {
 </script>
 
 <style scoped lang="scss">
-@import '../scss/colors';
+@import '../../scss/colors';
 
 .backup-state {
   &__description {

--- a/raiden-dapp/src/views/account/RaidenAccount.vue
+++ b/raiden-dapp/src/views/account/RaidenAccount.vue
@@ -74,7 +74,7 @@ import { mapGetters, mapState } from 'vuex';
 import AmountInput from '@/components/AmountInput.vue';
 import ActionButton from '@/components/ActionButton.vue';
 import ErrorMessage from '@/components/ErrorMessage.vue';
-import { Token } from '../model/types';
+import { Token } from '@/model/types';
 import { bigNumberify, parseEther, BigNumber } from 'ethers/utils';
 
 @Component({
@@ -140,7 +140,7 @@ export default class RaidenAccount extends Vue {
 </script>
 
 <style scoped lang="scss">
-@import '../scss/colors';
+@import '../../scss/colors';
 
 .raiden-account {
   width: 100%;

--- a/raiden-dapp/tests/unit/components/account/account-content.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/account-content.spec.ts
@@ -1,3 +1,5 @@
+import AccountContent from '@/components/account/AccountContent.vue';
+
 jest.mock('vue-router');
 import Mocked = jest.Mocked;
 import { mount, Wrapper } from '@vue/test-utils';
@@ -5,13 +7,12 @@ import Vue from 'vue';
 import VueRouter from 'vue-router';
 import { RouteNames } from '@/router/route-names';
 import Vuetify from 'vuetify';
-import store from '@/store/index';
-import GeneralMenu from '@/components/GeneralMenu.vue';
+import store from '@/store';
 
 Vue.use(Vuetify);
 
-describe('GeneralMenu.vue', () => {
-  let wrapper: Wrapper<GeneralMenu>;
+describe('AccountContent.vue', () => {
+  let wrapper: Wrapper<AccountContent>;
   let router: Mocked<VueRouter>;
   let vuetify: typeof Vuetify;
   let $raiden = {
@@ -23,7 +24,7 @@ describe('GeneralMenu.vue', () => {
     router = new VueRouter() as Mocked<VueRouter>;
     store.commit('loadComplete');
     store.commit('account', 'testAccount');
-    wrapper = mount(GeneralMenu, {
+    wrapper = mount(AccountContent, {
       vuetify,
       store,
       mocks: {
@@ -38,23 +39,23 @@ describe('GeneralMenu.vue', () => {
 
   test('displays account details title', async () => {
     const accountDetailsTitle = wrapper.find(
-      '.general-screen-menu__account-details--title'
+      '.account-content__account-details--title'
     );
 
-    expect(accountDetailsTitle.text()).toBe('general-menu.account-details');
+    expect(accountDetailsTitle.text()).toBe('account-content.account-details');
   });
 
   test('displays address', async () => {
     store.commit('account', '0x31aA9D3E2bd38d22CA3Ae9be7aae1D518fe46043');
     await wrapper.vm.$nextTick();
     const addressTitle = wrapper
-      .findAll('.general-screen-menu__account-details--address')
+      .findAll('.account-content__account-details--address')
       .at(0);
     const address = wrapper
-      .findAll('.general-screen-menu__account-details--address')
+      .findAll('.account-content__account-details--address')
       .at(1);
 
-    expect(addressTitle.text()).toBe('general-menu.address');
+    expect(addressTitle.text()).toBe('account-content.address');
     expect(address.text()).toBe('0x31aA9D3E2bd38d22CA3Ae9be7aae1D518fe46043');
   });
 
@@ -62,25 +63,23 @@ describe('GeneralMenu.vue', () => {
     store.commit('balance', '12.0');
     await wrapper.vm.$nextTick();
     const ethTitle = wrapper.find(
-      '.general-screen-menu__account-details__eth--currency'
+      '.account-content__account-details__eth--currency'
     );
-    const eth = wrapper.find(
-      '.general-screen-menu__account-details__eth--balance'
-    );
+    const eth = wrapper.find('.account-content__account-details__eth--balance');
 
-    expect(ethTitle.text()).toBe('general-menu.currency');
+    expect(ethTitle.text()).toBe('account-content.currency');
     expect(eth.text()).toBe('12.000');
   });
 
   test('displays one menu item', () => {
-    const generalMenuItems = wrapper.findAll('.general-screen-menu__menu');
+    const menuItems = wrapper.findAll('.account-content__menu');
 
-    expect(generalMenuItems.length).toBe(1);
+    expect(menuItems.length).toBe(1);
   });
 
   test('backup state menu item', () => {
     const backupStateMenuItem = wrapper
-      .findAll('.general-screen-menu__menu__list-items')
+      .findAll('.account-content__menu__list-items')
       .at(0);
     const backupStateTitle = backupStateMenuItem.find('.v-list-item__title');
     const backupStateSubtitle = backupStateMenuItem.find(
@@ -90,22 +89,22 @@ describe('GeneralMenu.vue', () => {
     backupStateButton.trigger('click');
 
     expect(backupStateTitle.text()).toEqual(
-      'general-menu.menu-items.backup-state-title'
+      'account-content.menu-items.backup-state.title'
     );
     expect(backupStateSubtitle.text()).toEqual(
-      'general-menu.menu-items.backup-state-subtitle'
+      'account-content.menu-items.backup-state.subtitle'
     );
     expect(router.push).toHaveBeenCalledTimes(1);
     expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: RouteNames.BACKUP_STATE
+        name: RouteNames.ACCOUNT_BACKUP
       })
     );
   });
 
   test('report bugs menu item', () => {
     const reportBugsMenuItem = wrapper
-      .findAll('.general-screen-menu__menu__list-items')
+      .findAll('.account-content__menu__list-items')
       .at(1);
     const reportBugsTitle = reportBugsMenuItem.find('.v-list-item__title');
     const reportBugsSubtitle = reportBugsMenuItem.find(
@@ -113,22 +112,24 @@ describe('GeneralMenu.vue', () => {
     );
 
     expect(reportBugsTitle.text()).toEqual(
-      'general-menu.menu-items.report-bugs-title'
+      'account-content.menu-items.report-bugs.title'
     );
     expect(reportBugsSubtitle.text()).toBe(
-      'general-menu.menu-items.report-bugs-subtitle'
+      'account-content.menu-items.report-bugs.subtitle'
     );
   });
 
   test('show raiden account menu item, if connected via sub key', () => {
-    expect(wrapper.vm.$data.menuItems[0].title).toEqual('Raiden Account');
+    expect(wrapper.vm.$data.menuItems[0].title).toEqual(
+      'account-content.menu-items.raiden-account.title'
+    );
   });
 
   test('calls method for downloading logs', async () => {
     // @ts-ignore
     wrapper.vm.downloadLogs = jest.fn();
     const reportBugsMenuItem = wrapper
-      .findAll('.general-screen-menu__menu__list-items')
+      .findAll('.account-content__menu__list-items')
       .at(1);
     const reportBugsButton = reportBugsMenuItem.find('button');
     reportBugsButton.trigger('click');

--- a/raiden-dapp/tests/unit/components/account/backup-state/download-state-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/backup-state/download-state-dialog.spec.ts
@@ -1,7 +1,7 @@
 import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuetify from 'vuetify';
-import DownloadStateDialog from '@/components/DownloadStateDialog.vue';
+import DownloadStateDialog from '@/components/account/backup-state/DownloadStateDialog.vue';
 
 Vue.use(Vuetify);
 

--- a/raiden-dapp/tests/unit/components/account/backup-state/upload-state-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/backup-state/upload-state-dialog.spec.ts
@@ -2,7 +2,7 @@ jest.useFakeTimers();
 import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuetify from 'vuetify';
-import UploadStateDialog from '@/components/UploadStateDialog.vue';
+import UploadStateDialog from '@/components/account/backup-state/UploadStateDialog.vue';
 
 Vue.use(Vuetify);
 

--- a/raiden-dapp/tests/unit/components/mixins/navigation-mixin.spec.ts
+++ b/raiden-dapp/tests/unit/components/mixins/navigation-mixin.spec.ts
@@ -110,13 +110,13 @@ describe('NavigationMixin', () => {
     );
   });
 
-  test('navigate to general home', () => {
-    wrapper.vm.navigateToGeneralHome();
+  test('navigate to account', () => {
+    wrapper.vm.navigateToAccoount();
 
     expect(router.push).toHaveBeenCalledTimes(1);
     expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: RouteNames.GENERAL_HOME
+        name: RouteNames.ACCOUNT_ROOT
       })
     );
   });
@@ -127,7 +127,7 @@ describe('NavigationMixin', () => {
     expect(router.push).toHaveBeenCalledTimes(1);
     expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: RouteNames.BACKUP_STATE
+        name: RouteNames.ACCOUNT_BACKUP
       })
     );
   });
@@ -138,14 +138,14 @@ describe('NavigationMixin', () => {
     expect(router.push).toHaveBeenCalledTimes(1);
     expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: RouteNames.RAIDEN_ACCOUNT
+        name: RouteNames.ACCOUNT_RAIDEN
       })
     );
   });
 
   test('general modal back navigation', () => {
     wrapper.vm.$route.name = RouteNames.TRANSFER;
-    wrapper.vm.navigateToGeneralHome();
+    wrapper.vm.navigateToAccoount();
     wrapper.vm.onGeneralBackClicked();
 
     expect(router.push).toHaveBeenCalledTimes(1);

--- a/raiden-dapp/tests/unit/views/account-route.spec.ts
+++ b/raiden-dapp/tests/unit/views/account-route.spec.ts
@@ -1,3 +1,5 @@
+import AccountRoute from '@/views/AccountRoute.vue';
+
 jest.mock('vue-router');
 import Mocked = jest.Mocked;
 import { mount, Wrapper } from '@vue/test-utils';
@@ -5,12 +7,11 @@ import { TestData } from '../data/mock-data';
 import Vue from 'vue';
 import VueRouter from 'vue-router';
 import Vuetify from 'vuetify';
-import GeneralDialog from '@/views/GeneralDialog.vue';
 
 Vue.use(Vuetify);
 
-describe('GeneralDialog.vue', () => {
-  let wrapper: Wrapper<GeneralDialog>;
+describe('AccountRoute.vue', () => {
+  let wrapper: Wrapper<AccountRoute>;
   let router: Mocked<VueRouter>;
   let vuetify: typeof Vuetify;
 
@@ -18,7 +19,7 @@ describe('GeneralDialog.vue', () => {
     vuetify = new Vuetify();
     router = new VueRouter() as Mocked<VueRouter>;
 
-    wrapper = mount(GeneralDialog, {
+    wrapper = mount(AccountRoute, {
       vuetify,
       stubs: ['router-view'],
       mocks: {

--- a/raiden-dapp/tests/unit/views/account/account-root.spec.ts
+++ b/raiden-dapp/tests/unit/views/account/account-root.spec.ts
@@ -1,20 +1,20 @@
 import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuetify from 'vuetify';
-import store from '@/store/index';
-import { $identicon } from '../utils/mocks';
-import GeneralHome from '@/views/GeneralHome.vue';
+import store from '@/store';
+import { $identicon } from '../../utils/mocks';
+import AccountRoot from '@/views/account/AccountRoot.vue';
 
 Vue.use(Vuetify);
 
-describe('GeneralHome.vue', () => {
-  let wrapper: Wrapper<GeneralHome>;
+describe('AccountRoot.vue', () => {
+  let wrapper: Wrapper<AccountRoot>;
   let vuetify: typeof Vuetify;
 
   beforeEach(() => {
     vuetify = new Vuetify();
 
-    wrapper = mount(GeneralHome, {
+    wrapper = mount(AccountRoot, {
       vuetify,
       store,
       mocks: {

--- a/raiden-dapp/tests/unit/views/account/backup-state.spec.ts
+++ b/raiden-dapp/tests/unit/views/account/backup-state.spec.ts
@@ -3,8 +3,8 @@ import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuetify from 'vuetify';
 
-import store from '@/store/index';
-import BackupState from '@/views/BackupState.vue';
+import store from '@/store';
+import BackupState from '@/views/account/BackupState.vue';
 
 Vue.use(Vuetify);
 

--- a/raiden-dapp/tests/unit/views/account/raiden-account.spec.ts
+++ b/raiden-dapp/tests/unit/views/account/raiden-account.spec.ts
@@ -4,8 +4,8 @@ import Vue from 'vue';
 import Vuetify from 'vuetify';
 import flushPromises from 'flush-promises';
 
-import store from '@/store/index';
-import RaidenAccount from '@/views/RaidenAccount.vue';
+import store from '@/store';
+import RaidenAccount from '@/views/account/RaidenAccount.vue';
 
 Vue.use(Vuetify);
 

--- a/raiden-dapp/vue.config.js
+++ b/raiden-dapp/vue.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 
 module.exports = {
+  productionSourceMap: false,
   publicPath: process.env.DEPLOYMENT === 'staging' ? '/staging/' : '/',
   chainWebpack: config => {
     if (process.env.NODE_ENV !== 'production' && !process.env.CI) {


### PR DESCRIPTION
Fixes #1458  

**Short description**
Renames the former General Screen to Account. With this, it also updates the components/routes/CSS etc.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Go to the "general scree"
2. Verify that it has been renamed to Account
3. Routes are `/account/`, `/account/raiden`, `/account/backup` 
4. Everything works as before
