### PR TITLE
Retry without stored setup if auth fails with config.matrixServer

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -10,6 +10,11 @@
 [#1368]: https://github.com/raiden-network/light-client/issues/1368
 [#1252]: https://github.com/raiden-network/light-client/issues/1252
 
+### Fixed
+- [#1456] Retry without stored setup if auth fails
+
+[#1456]: https://github.com/raiden-network/light-client/issues/1456
+
 ## [0.6.0] - 2020-04-21
 ### Added
 - [#1338] Allow HTTP URLs for Path Finding Service (non-production)

--- a/raiden-ts/src/transport/epics.ts
+++ b/raiden-ts/src/transport/epics.ts
@@ -558,7 +558,8 @@ export const initMatrixEpic = (
         // if config.matrixServer is set, we must use it (possibly re-using stored credentials,
         // if matching), not fetch from lookup address
         if (matrixServer === server) servers$Array.push(of({ server, setup }));
-        else servers$Array.push(of({ server: matrixServer }));
+        // even if same server, also append without setup to retry if auth fails
+        servers$Array.push(of({ server: matrixServer }));
       } else {
         // previously used server
         if (server) servers$Array.push(of({ server, setup }));


### PR DESCRIPTION
Fixes #1456

**Short description**
Even if `config.matrixServer` is passed (currently done in dApp in testenv001), and stored `server` setup (auth) matches passed config, append a 2nd server option with same server but without setup to retry auth if stored one fails.

**Steps to manually test the change (dApp)**
1. Try connecting on testenv setup in a dApp with an auth error
