### PR TITLE
Fix per channel event monitoring and past events fetching

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -12,8 +12,10 @@
 
 ### Fixed
 - [#1456] Retry without stored setup if auth fails
+- [#1434] Ensure past channel events are correctly fetched
 
 [#1456]: https://github.com/raiden-network/light-client/issues/1456
+[#1434]: https://github.com/raiden-network/light-client/issues/1434
 
 ### Changed
 - [#1462] Refactor state schema and types to be simpler and safer

--- a/raiden-ts/src/channels/types.ts
+++ b/raiden-ts/src/channels/types.ts
@@ -2,9 +2,11 @@ import * as t from 'io-ts';
 
 import { Address, Hash, UInt } from '../utils/types';
 
-// should this become a brand?
+// should these become brands?
 export const ChannelKey = t.string;
 export type ChannelKey = string;
+export const ChannelUniqueKey = t.string;
+export type ChannelUniqueKey = string;
 
 // Represents a HashTime-Locked amount in a channel
 export const Lock = t.type(

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -12,7 +12,6 @@ import {
   tap,
   withLatestFrom,
 } from 'rxjs/operators';
-import findKey from 'lodash/findKey';
 import isMatchWith from 'lodash/isMatchWith';
 import pick from 'lodash/pick';
 
@@ -44,7 +43,7 @@ import { RaidenEpicDeps } from '../../types';
 import { isActionOf } from '../../utils/actions';
 import { LruCache } from '../../utils/lru';
 import { pluckDistinct } from '../../utils/rx';
-import { Address, assert, BigNumberC, Hash, Signed, UInt, Int } from '../../utils/types';
+import { assert, BigNumberC, Hash, Signed, UInt, Int } from '../../utils/types';
 import { RaidenError, ErrorCodes } from '../../utils/error';
 import { Capabilities } from '../../constants';
 import {
@@ -124,13 +123,12 @@ function makeAndSignTransfer$(
     secrethash: action.meta.secrethash,
   };
   const locksroot = getLocksroot([...channel.own.locks, lock]);
-  const token = findKey(state.tokens, (tn) => tn === action.payload.tokenNetwork)! as Address;
 
   log.info(
     'Signing transfer of value',
     action.payload.value.toString(),
     'of token',
-    token,
+    channel.token,
     ', to',
     action.payload.target,
     ', through routes',
@@ -151,7 +149,7 @@ function makeAndSignTransfer$(
     locked_amount: channel.own.balanceProof.lockedAmount.add(lock.amount) as UInt<32>,
     locksroot,
     payment_identifier: action.payload.paymentId,
-    token,
+    token: channel.token,
     recipient: partner,
     lock,
     target: action.payload.target,
@@ -545,13 +543,12 @@ function receiveTransferSigned(
       );
       const locksroot = getLocksroot([...channel.partner.locks, transfer.lock]);
       assert(transfer.locksroot === locksroot, 'locksroot mismatch');
-      const token = findKey(state.tokens, (tn) => tn === tokenNetwork)! as Address;
 
       log.info(
         'Receiving transfer of value',
         transfer.lock.amount.toString(),
         'of token',
-        token,
+        channel.token,
         ', from',
         transfer.initiator,
         ', through partner',

--- a/raiden-ts/src/utils/error.ts
+++ b/raiden-ts/src/utils/error.ts
@@ -20,7 +20,6 @@ export enum ErrorCodes {
 
   // Channel errors
   CNL_INVALID_STATE = 'Invalid channel state.',
-  CNL_TOKEN_NOT_FOUND = 'Could not find token for token network.',
   CNL_NO_OPEN_CHANNEL_FOUND = 'No open channel has been found.',
   CNL_NO_OPEN_OR_CLOSING_CHANNEL_FOUND = 'No open or closing channel has been found.',
   CNL_NO_SETTLEABLE_OR_SETTLING_CHANNEL_FOUND = 'No settleable or settling channel has been found.',

--- a/raiden-ts/tests/unit/epics/path.spec.ts
+++ b/raiden-ts/tests/unit/epics/path.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import { EMPTY, timer, Observable, of } from 'rxjs';
+import { EMPTY, timer, Observable } from 'rxjs';
 import { first, takeUntil, toArray, pluck } from 'rxjs/operators';
 import { bigNumberify, defaultAbiCoder } from 'ethers/utils';
 import { Zero, AddressZero, One } from 'ethers/constants';
@@ -1377,7 +1377,13 @@ describe('PFS: pfsFeeUpdateEpic', () => {
   test('success: send PFSFeeUpdate to global pfsRoom on channelMonitor', async () => {
     expect.assertions(1);
 
-    await expect(pfsFeeUpdateEpic(of(action), state$, depsMock).toPromise()).resolves.toEqual(
+    const promise = pfsFeeUpdateEpic(action$, state$, depsMock).toPromise();
+    setTimeout(() => {
+      action$.next(action);
+      action$.complete();
+    }, 10);
+
+    await expect(promise).resolves.toEqual(
       messageGlobalSend(
         {
           message: expect.objectContaining({
@@ -1396,9 +1402,13 @@ describe('PFS: pfsFeeUpdateEpic', () => {
     const signerSpy = jest.spyOn(depsMock.signer, 'signMessage');
     signerSpy.mockRejectedValueOnce(new Error('Signature rejected'));
 
-    await expect(
-      pfsFeeUpdateEpic(of(action), state$, depsMock).toPromise(),
-    ).resolves.toBeUndefined();
+    const promise = pfsFeeUpdateEpic(action$, state$, depsMock).toPromise();
+    setTimeout(() => {
+      action$.next(action);
+      action$.complete();
+    }, 10);
+
+    await expect(promise).resolves.toBeUndefined();
 
     expect(signerSpy).toHaveBeenCalledTimes(1);
     signerSpy.mockRestore();
@@ -1410,9 +1420,13 @@ describe('PFS: pfsFeeUpdateEpic', () => {
     // put channel in 'closing' state
     action$.next(channelClose.request(undefined, { tokenNetwork, partner }));
 
-    await expect(
-      pfsFeeUpdateEpic(of(action), state$, depsMock).toPromise(),
-    ).resolves.toBeUndefined();
+    const promise = pfsFeeUpdateEpic(action$, state$, depsMock).toPromise();
+    setTimeout(() => {
+      action$.next(action);
+      action$.complete();
+    }, 10);
+
+    await expect(promise).resolves.toBeUndefined();
   });
 
   test('skip: NO_MEDIATE', async () => {
@@ -1428,9 +1442,13 @@ describe('PFS: pfsFeeUpdateEpic', () => {
       }),
     );
 
-    await expect(
-      pfsFeeUpdateEpic(of(action), state$, depsMock).toPromise(),
-    ).resolves.toBeUndefined();
+    const promise = pfsFeeUpdateEpic(action$, state$, depsMock).toPromise();
+    setTimeout(() => {
+      action$.next(action);
+      action$.complete();
+    }, 10);
+
+    await expect(promise).resolves.toBeUndefined();
   });
 });
 

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -11,7 +11,7 @@ import { memoize } from 'lodash';
 import logging from 'loglevel';
 
 jest.mock('ethers/providers');
-import { Zero } from 'ethers/constants';
+import { Zero, HashZero } from 'ethers/constants';
 import { JsonRpcProvider, EventType, Listener } from 'ethers/providers';
 import { Log } from 'ethers/providers/abstract-provider';
 import { Network, parseEther } from 'ethers/utils';
@@ -157,6 +157,15 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
       for (const func in tokenNetworkContract.functions) {
         jest.spyOn(tokenNetworkContract.functions, func as keyof TokenNetwork['functions']);
       }
+      tokenNetworkContract.functions.getChannelParticipantInfo.mockResolvedValue([
+        Zero,
+        Zero,
+        false,
+        HashZero,
+        Zero,
+        HashZero,
+        Zero,
+      ]);
       return tokenNetworkContract;
     },
   );

--- a/raiden-ts/tests/unit/reducers.spec.ts
+++ b/raiden-ts/tests/unit/reducers.spec.ts
@@ -53,7 +53,7 @@ import {
 } from 'raiden-ts/transfers/utils';
 import { RaidenError, ErrorCodes } from 'raiden-ts/utils/error';
 import { Direction } from 'raiden-ts/transfers/state';
-import { channelKey } from 'raiden-ts/channels/utils';
+import { channelKey, channelUniqueKey } from 'raiden-ts/channels/utils';
 
 import { makeSignature } from './mocks';
 
@@ -785,7 +785,9 @@ describe('raidenReducer', () => {
         ),
       ].reduce(raidenReducer, state);
       expect(newState.channels[key]).toBeUndefined();
-      expect(newState.oldChannels[`${channelId}#${key}`]).toMatchObject({
+      expect(
+        newState.oldChannels[channelUniqueKey({ id: channelId, tokenNetwork, partner })],
+      ).toMatchObject({
         state: ChannelState.settled,
         id: channelId,
         settleBlock,
@@ -807,7 +809,9 @@ describe('raidenReducer', () => {
         ),
       ].reduce(raidenReducer, state);
       expect(newState.channels[key]).toBeUndefined();
-      expect(newState.oldChannels[`${channelId}#${key}`]).toMatchObject({
+      expect(
+        newState.oldChannels[channelUniqueKey({ id: channelId, tokenNetwork, partner })],
+      ).toMatchObject({
         state: ChannelState.settled,
         id: channelId,
         settleBlock: settleBlock + 1,
@@ -831,7 +835,9 @@ describe('raidenReducer', () => {
         ),
       ].reduce(raidenReducer, state);
       expect(newState.channels[key]).toBeUndefined();
-      expect(newState.oldChannels[`${channelId}#${key}`]).toMatchObject({
+      expect(
+        newState.oldChannels[channelUniqueKey({ id: channelId, tokenNetwork, partner })],
+      ).toMatchObject({
         state: ChannelState.settled,
         id: channelId,
         settleBlock: settleBlock + 2,


### PR DESCRIPTION
Fixes #1434 

**Short description**
Refactors the channel monitoring logic, which became more complex than it should. With little logs to investigate, and after some real life observation of some events being lost in very specific cases, this became the main target for thsi issue.
I did test by opening ~9 channels with hub, and this issue was not experienced.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [x] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Open and close a lot of channels with other nodes, with deposits, and check if any event is lost in the process
2. It helps by reducing the default timeouts. It was discovered that hub's raiden-py still accepts transfers with channels at `{ settleTimeout: 60 }` (passed directly to `Raiden.openChannel` method), which is a huge improvement on waiting time over default=500.