### PR TITLE
Update profile's caps on config.caps change and react on peers updates

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
-## [0.7.0] - 2020-05-08
+## [Unreleased]
+### Changed
+- [#1480] Update profile's caps on config.caps change and react on peers updates
 
+[#1480]: https://github.com/raiden-network/light-client/pull/1480
+
+## [0.7.0] - 2020-05-08
 ### Added
 - [#1392] Raiden on-chain methods provide easy ways to transfer entire token & ETH balances
 - [#1368] Monitoring transfers (experimental)
@@ -174,7 +179,7 @@
 - Add protocol message implementation.
 
 
-[unreleased]: https://github.com/raiden-network/light-client/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v0.7.0...HEAD
 [0.7.0]: https://github.com/raiden-network/light-client/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/raiden-network/light-client/compare/v0.5.2...v0.6.0
 [0.5.2]: https://github.com/raiden-network/light-client/compare/v0.5.1...v0.5.2

--- a/raiden-ts/src/transport/epics/init.ts
+++ b/raiden-ts/src/transport/epics/init.ts
@@ -281,10 +281,9 @@ function setupMatrixClient$(
   }).pipe(
     // the APIs below are authenticated, and therefore also act as validator
     mergeMap(({ matrix, server, setup }) =>
-      // ensure displayName is set even on restarts
+      // set these properties before starting sync
       merge(
         from(matrix.setDisplayName(setup.displayName)),
-        from(matrix.setPresence({ presence: 'online', status_msg: '' })),
         caps ? from(matrix.setAvatarUrl(stringifyCaps(caps))) : EMPTY,
       ).pipe(
         mapTo({ matrix, server, setup }), // return triplet again
@@ -390,10 +389,10 @@ export const matrixShutdownEpic = (
     mergeMap((matrix) =>
       action$.pipe(
         finalize(() => {
+          matrix.stopClient();
           matrix.setPresence({ presence: 'offline', status_msg: '' }).catch(() => {
             /* stopping, ignore exceptions */
           });
-          matrix.stopClient();
         }),
       ),
     ),


### PR DESCRIPTION
Part of #1369

**Short description**
So far, caps were reflected on `avatar_url` on Matrix only on initial (startup's) config, and also peers would not have our presence's caps reflected upon avatar's change.
This PR:
- Updates our profile's avatar_url when `config.caps` is updated
- avatar_url's updates are monitored by peers and a new matrix presence update is emitted reflecting these new capabilities

This is a non-breaking change, which just improves on a feature only useful between light-clients, and fully backwards compatible

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [x] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Have two light clients monitoring each other's presence (e.g. by calling `raiden.getAvailability` with other's address)
2. On one of them, update caps with e.g `raiden.updateConfig({ caps: { noDelivery: true, test: true } })
3. See the other detect it and emit a new `matrix/presence/success` action with updated `action.payload.caps` object