### PR TITLE
Channel balance-based Monitoring threshold

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- [#1369] Monitoring based on channel's balance
+
+[#1369]: https://github.com/raiden-network/light-client/issues/1369
+
 ### Changed
 - [#1480] Update profile's caps on config.caps change and react on peers updates
 

--- a/raiden-ts/src/channels/types.ts
+++ b/raiden-ts/src/channels/types.ts
@@ -9,15 +9,18 @@ export const ChannelUniqueKey = t.string;
 export type ChannelUniqueKey = string;
 
 // Represents a HashTime-Locked amount in a channel
-export const Lock = t.type(
-  {
-    amount: UInt(32),
-    expiration: UInt(32),
-    secrethash: Hash,
-  },
+export const Lock = t.intersection(
+  [
+    t.type({
+      amount: UInt(32),
+      expiration: UInt(32),
+      secrethash: Hash,
+    }),
+    t.partial({ registered: t.literal(true) }),
+  ],
   'Lock',
 );
-export type Lock = t.TypeOf<typeof Lock>;
+export interface Lock extends t.TypeOf<typeof Lock> {}
 
 /**
  * Balance Proof constructed from an EnvelopeMessage

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -1,9 +1,10 @@
 import * as t from 'io-ts';
-import { Network } from 'ethers/utils';
+import { Network, parseUnits } from 'ethers/utils';
 
 import { Capabilities } from './constants';
 import { Address, UInt } from './utils/types';
 import { getNetworkName } from './utils/ethers';
+import { Caps } from './transport/types';
 
 const RTCIceServer = t.type({ urls: t.union([t.string, t.array(t.string)]) });
 
@@ -33,7 +34,7 @@ const RTCIceServer = t.type({ urls: t.union([t.string, t.array(t.string)]) });
  * - confirmationBlocks - How many blocks to wait before considering a transaction as confirmed
  * - monitoringReward - Reward to be paid to MS, in SVT/RDN; use Zero or null to disable
  * - logger - String specifying the console log level of redux-logger. Use '' to silence.
- * - caps - Own transport capabilities
+ * - caps - Own transport capabilities overrides. Set to null to disable all, including defaults
  * - matrixServer? - Specify a matrix server to use.
  * - subkey? - When using subkey, this sets the behavior when { subkey } option isn't explicitly
  *             set in on-chain method calls. false (default) = use main key; true = use subkey
@@ -61,7 +62,7 @@ export const RaidenConfig = t.readonly(
         warn: null,
         error: null,
       }),
-      caps: t.readonly(t.record(t.string /* Capabilities */, t.any)),
+      caps: t.union([t.null, Caps]),
       fallbackIceServers: t.array(RTCIceServer),
     }),
     t.partial({
@@ -102,11 +103,10 @@ export function makeDefaultConfig(
     matrixExcessRooms: 3,
     pfsSafetyMargin: 1.0,
     confirmationBlocks: 5,
-    monitoringReward: null,
+    monitoringReward: parseUnits('5', 18) as UInt<32>,
     logger: 'info',
     caps: {
       [Capabilities.NO_DELIVERY]: true,
-      [Capabilities.NO_RECEIVE]: true,
       [Capabilities.NO_MEDIATE]: true,
       [Capabilities.WEBRTC]: true,
     },

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -1,5 +1,5 @@
 import * as t from 'io-ts';
-import { Network, parseUnits } from 'ethers/utils';
+import { Network, parseEther } from 'ethers/utils';
 
 import { Capabilities } from './constants';
 import { Address, UInt } from './utils/types';
@@ -35,6 +35,8 @@ const RTCIceServer = t.type({ urls: t.union([t.string, t.array(t.string)]) });
  * - monitoringReward - Reward to be paid to MS, in SVT/RDN; use Zero or null to disable
  * - logger - String specifying the console log level of redux-logger. Use '' to silence.
  * - caps - Own transport capabilities overrides. Set to null to disable all, including defaults
+ * - fallbackIceServers - STUN servers to be used as a fallback for WebRTC
+ * - rateToSvt - Exchange rate between tokens and SVT, in wei: e.g. rate[TKN]=2e18 => 1TKN = 2SVT
  * - matrixServer? - Specify a matrix server to use.
  * - subkey? - When using subkey, this sets the behavior when { subkey } option isn't explicitly
  *             set in on-chain method calls. false (default) = use main key; true = use subkey
@@ -64,6 +66,7 @@ export const RaidenConfig = t.readonly(
       }),
       caps: t.union([t.null, Caps]),
       fallbackIceServers: t.array(RTCIceServer),
+      rateToSvt: t.record(t.string, UInt(32)),
     }),
     t.partial({
       matrixServer: t.string,
@@ -103,7 +106,8 @@ export function makeDefaultConfig(
     matrixExcessRooms: 3,
     pfsSafetyMargin: 1.0,
     confirmationBlocks: 5,
-    monitoringReward: parseUnits('5', 18) as UInt<32>,
+    // SVT also uses 18 decimals, like Ether, so parseEther works
+    monitoringReward: parseEther('5') as UInt<32>,
     logger: 'info',
     caps: {
       [Capabilities.NO_DELIVERY]: true,
@@ -111,6 +115,7 @@ export function makeDefaultConfig(
       [Capabilities.WEBRTC]: true,
     },
     fallbackIceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
+    rateToSvt: {},
     ...overwrites,
   };
 }

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -456,15 +456,15 @@ export const pfsCapacityUpdateEpic = (
 export const pfsFeeUpdateEpic = (
   {}: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-  { log, address, network, signer, config$ }: RaidenEpicDeps,
+  { log, address, network, signer, config$, latest$ }: RaidenEpicDeps,
 ): Observable<messageGlobalSend> =>
   state$.pipe(
     groupChannel$,
     // get only first state per channel
     mergeMap((grouped$) => grouped$.pipe(first())),
-    withLatestFrom(config$),
+    withLatestFrom(config$, latest$),
     // ignore actions while/if mediating not enabled
-    filter(([, { pfsRoom, caps }]) => !!pfsRoom && !caps?.[Capabilities.NO_MEDIATE]),
+    filter(([, { pfsRoom }, { caps }]) => !!pfsRoom && !caps[Capabilities.NO_MEDIATE]),
     mergeMap(([channel, { pfsRoom }]) => {
       if (channel.state !== ChannelState.open) return EMPTY;
 

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import * as t from 'io-ts';
-import { defer, EMPTY, from, merge, Observable, of } from 'rxjs';
+import { defer, EMPTY, from, merge, Observable, of, combineLatest } from 'rxjs';
 import {
   catchError,
   concatMap,
@@ -26,20 +26,19 @@ import { fromFetch } from 'rxjs/fetch';
 import { Signer } from 'ethers/abstract-signer';
 import { Event } from 'ethers/contract';
 import { BigNumber, bigNumberify, toUtf8Bytes, verifyMessage, concat } from 'ethers/utils';
-import { Two, Zero } from 'ethers/constants';
+import { Two, Zero, WeiPerEther } from 'ethers/constants';
 import memoize from 'lodash/memoize';
 
 import { UserDeposit } from '../contracts/UserDeposit';
 import { RaidenAction } from '../actions';
 import { RaidenState } from '../state';
 import { RaidenEpicDeps } from '../types';
-import { RaidenConfig } from '../config';
 import { messageGlobalSend } from '../messages/actions';
 import { MessageType, PFSCapacityUpdate, PFSFeeUpdate, MonitorRequest } from '../messages/types';
 import { MessageTypeId, signMessage, createBalanceHash } from '../messages/utils';
 import { ChannelState, Channel } from '../channels/state';
 import { channelAmounts, groupChannel$ } from '../channels/utils';
-import { Address, decode, Int, Signature, Signed, UInt, assert } from '../utils/types';
+import { Address, decode, Int, Signature, Signed, UInt } from '../utils/types';
 import { isActionOf } from '../utils/actions';
 import { encode, losslessParse, losslessStringify } from '../utils/data';
 import { getEventsStream } from '../utils/ethers';
@@ -593,59 +592,76 @@ function makeMonitoringRequest$({
   signer,
   contractsInfo,
   latest$,
+  config$,
 }: RaidenEpicDeps) {
-  return ([channel, { monitoringRoom, monitoringReward }]: [Channel, RaidenConfig]) => {
-    // asserts never fail because of filter, here just to narrow types
-    assert(monitoringReward);
+  return (channel: Channel) => {
+    const { partnerUnlocked } = channelAmounts(channel);
+    if (!partnerUnlocked.gt(Zero)) return EMPTY; // give up early if nothing to lose
 
-    const balanceProof = channel.partner.balanceProof;
-    const balanceHash = createBalanceHash(
-      balanceProof.transferredAmount,
-      balanceProof.lockedAmount,
-      balanceProof.locksroot,
-    );
-
-    const nonClosingMessage = concat([
-      encode(channel.tokenNetwork, 20),
-      encode(network.chainId, 32),
-      encode(MessageTypeId.BALANCE_PROOF_UPDATE, 32),
-      encode(channel.id, 32),
-      encode(balanceHash, 32),
-      encode(balanceProof.nonce, 32),
-      encode(balanceProof.additionalHash, 32),
-      encode(balanceProof.signature, 65), // partner's signature for this balance proof
-    ]); // UInt8Array of 277 bytes
-
-    return latest$.pipe(
-      pluckDistinct('udcBalance'),
-      // wait for udcBalance >= monitoringReward, fires immediately if already
-      filter((udcBalance) => udcBalance.gte(monitoringReward)),
-      take(1),
-      // first sign the nonClosing signature, then the actual message
-      mergeMap(() => signer.signMessage(nonClosingMessage) as Promise<Signature>),
-      mergeMap((nonClosingSignature) =>
-        signMessage<MonitorRequest>(
-          signer,
-          {
-            type: MessageType.MONITOR_REQUEST,
-            balance_proof: {
-              chain_id: balanceProof.chainId,
-              token_network_address: balanceProof.tokenNetworkAddress,
-              channel_identifier: bigNumberify(channel.id) as UInt<32>,
-              nonce: balanceProof.nonce,
-              balance_hash: balanceHash,
-              additional_hash: balanceProof.additionalHash,
-              signature: balanceProof.signature,
-            },
-            non_closing_participant: address,
-            non_closing_signature: nonClosingSignature,
-            monitoring_service_contract_address: contractsInfo.MonitoringService.address,
-            reward_amount: monitoringReward,
-          },
-          { log },
-        ),
+    return combineLatest([latest$, config$]).pipe(
+      // combineLatest + filter ensures it'll pass if anything here changes
+      filter(
+        ([{ udcBalance }, { monitoringRoom, monitoringReward, rateToSvt }]) =>
+          // ignore actions while/if config.monitoringRoom isn't set
+          !!monitoringRoom &&
+          !!monitoringReward?.gt?.(Zero) &&
+          // wait for udcBalance >= monitoringReward, fires immediately if already
+          udcBalance.gte(monitoringReward) &&
+          // use partner's total off & on-chain unlocked, total we'd lose if don't update BP
+          partnerUnlocked
+            // use rateToSvt to convert to equivalent SVT, and pass only if > monitoringReward;
+            // default rate=0 means it'll NEVER monitor if no rate is set for token
+            .mul(rateToSvt[channel.token] ?? Zero)
+            .div(WeiPerEther)
+            .gt(monitoringReward),
       ),
-      map((message) => messageGlobalSend({ message }, { roomName: monitoringRoom! })),
+      take(1), // take/act on first time all conditions above pass
+      mergeMap(([, { monitoringReward, monitoringRoom }]) => {
+        const balanceProof = channel.partner.balanceProof;
+        const balanceHash = createBalanceHash(
+          balanceProof.transferredAmount,
+          balanceProof.lockedAmount,
+          balanceProof.locksroot,
+        );
+
+        const nonClosingMessage = concat([
+          encode(channel.tokenNetwork, 20),
+          encode(network.chainId, 32),
+          encode(MessageTypeId.BALANCE_PROOF_UPDATE, 32),
+          encode(channel.id, 32),
+          encode(balanceHash, 32),
+          encode(balanceProof.nonce, 32),
+          encode(balanceProof.additionalHash, 32),
+          encode(balanceProof.signature, 65), // partner's signature for this balance proof
+        ]); // UInt8Array of 277 bytes
+
+        // first sign the nonClosing signature, then the actual message
+        return from(signer.signMessage(nonClosingMessage) as Promise<Signature>).pipe(
+          mergeMap((nonClosingSignature) =>
+            signMessage<MonitorRequest>(
+              signer,
+              {
+                type: MessageType.MONITOR_REQUEST,
+                balance_proof: {
+                  chain_id: balanceProof.chainId,
+                  token_network_address: balanceProof.tokenNetworkAddress,
+                  channel_identifier: bigNumberify(channel.id) as UInt<32>,
+                  nonce: balanceProof.nonce,
+                  balance_hash: balanceHash,
+                  additional_hash: balanceProof.additionalHash,
+                  signature: balanceProof.signature,
+                },
+                non_closing_participant: address,
+                non_closing_signature: nonClosingSignature,
+                monitoring_service_contract_address: contractsInfo.MonitoringService.address,
+                reward_amount: monitoringReward!,
+              },
+              { log },
+            ),
+          ),
+          map((message) => messageGlobalSend({ message }, { roomName: monitoringRoom! })),
+        );
+      }),
       catchError((err) => {
         log.error('Error trying to generate & sign MonitorRequest', err);
         return EMPTY;
@@ -678,23 +694,11 @@ export const monitorRequestEpic = (
           (x, y) =>
             y.partner.balanceProof.transferredAmount.eq(
               x.partner.balanceProof.transferredAmount,
-            ) && y.partner.balanceProof.lockedAmount.eq(x.partner.balanceProof.lockedAmount),
+            ) &&
+            y.partner.balanceProof.lockedAmount.eq(x.partner.balanceProof.lockedAmount) &&
+            y.partner.locks === x.partner.locks,
         ),
         skip(1), // distinctUntilChanged allows first, we want to skip and act only on changes
-        withLatestFrom(deps.config$),
-        filter(
-          ([channel, { monitoringRoom, monitoringReward }]) =>
-            // ignore actions while/if config.monitoringRoom isn't set
-            !!monitoringRoom &&
-            !!monitoringReward?.gt?.(Zero) &&
-            channel.state === ChannelState.open &&
-            !!channel.partner.balanceProof &&
-            // ignore if partner's balanceProof isn't defined
-            channel.partner.balanceProof.transferredAmount
-              .add(channel.partner.balanceProof.lockedAmount)
-              .gt(Zero),
-        ),
-        // TODO: filter/continue only if economically viable
         debounceTime(httpTimeout / 2), // default: 15s
         // switchMap may unsubscribe from previous udcBalance wait/signature prompts if partner's
         // balanceProof balance changes in the meantime

--- a/raiden-ts/src/transfers/epics/init.ts
+++ b/raiden-ts/src/transfers/epics/init.ts
@@ -66,7 +66,7 @@ export const initQueuePendingEnvelopeMessagesEpic = (
 export const initQueuePendingReceivedEpic = (
   {}: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-  { config$ }: RaidenEpicDeps,
+  { latest$ }: RaidenEpicDeps,
 ) =>
   state$.pipe(
     first(),
@@ -80,7 +80,7 @@ export const initQueuePendingReceivedEpic = (
         !received.secret?.[1]?.registerBlock &&
         !received.channelClosed,
     ),
-    withLatestFrom(config$),
+    withLatestFrom(latest$),
     mergeMap(function* ([[secrethash, received], { caps }]) {
       // loop over all pending transfers
       const meta = { secrethash, direction: Direction.RECEIVED };
@@ -94,7 +94,7 @@ export const initQueuePendingReceivedEpic = (
         yield transferSecretReveal({ message: received.secretReveal[1] }, meta);
       // secret not yet known; request iff receiving is enabled
       // secretRequest should always be defined as we sign it when receiving transfer
-      if (!caps?.[Capabilities.NO_RECEIVE] && !received.secret && received.secretRequest) {
+      if (!caps[Capabilities.NO_RECEIVE] && !received.secret && received.secretRequest) {
         yield matrixPresence.request(undefined, { address: received.transfer[1].initiator });
         yield transferSecretRequest({ message: received.secretRequest[1] }, meta);
       }

--- a/raiden-ts/src/transfers/epics/mediate.ts
+++ b/raiden-ts/src/transfers/epics/mediate.ts
@@ -27,7 +27,7 @@ import { Direction } from '../state';
 export const transferMediateEpic = (
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-  { address, config$ }: RaidenEpicDeps,
+  { address, latest$ }: RaidenEpicDeps,
 ) =>
   action$.pipe(
     filter(transferSigned.is),
@@ -36,11 +36,11 @@ export const transferMediateEpic = (
       (action) =>
         action.meta.direction === Direction.RECEIVED && action.payload.message.target !== address,
     ),
-    withLatestFrom(state$, config$),
+    withLatestFrom(state$, latest$),
     // filter when mediating is enabled and outgoing transfer isn't set
     filter(
       ([action, { sent }, { caps }]) =>
-        !caps?.[Capabilities.NO_MEDIATE] && !(action.meta.secrethash in sent),
+        !caps[Capabilities.NO_MEDIATE] && !(action.meta.secrethash in sent),
     ),
     map(([{ payload: { message: transf }, meta: { secrethash } }]) =>
       // request an outbound transfer to target

--- a/raiden-ts/src/transfers/epics/secret.ts
+++ b/raiden-ts/src/transfers/epics/secret.ts
@@ -364,10 +364,14 @@ export const transferAutoRegisterEpic = (
     mergeMap((secrethash) =>
       action$.pipe(
         filter(newBlock.is),
-        withLatestFrom(latest$.pipe(pluck('state', Direction.RECEIVED, secrethash)), config$),
+        withLatestFrom(
+          latest$.pipe(pluck('state', Direction.RECEIVED, secrethash)),
+          config$,
+          latest$,
+        ),
         filter(
-          ([action, received, { caps, revealTimeout }]) =>
-            !caps?.[Capabilities.NO_RECEIVE] && // ignore if receiving is disabled
+          ([action, received, { revealTimeout }, { caps }]) =>
+            !caps[Capabilities.NO_RECEIVE] && // ignore if receiving is disabled
             !!received.secret && // register only if we know the secret
             received.transfer[1].lock.expiration
               .sub(revealTimeout)

--- a/raiden-ts/src/transfers/state.ts
+++ b/raiden-ts/src/transfers/state.ts
@@ -34,7 +34,7 @@ export const TransferState = t.readonly(
       /**
        * Transfer secret, if known
        * registerBlock is 0 if not yet registered on-chain
-       * */
+       */
       secret: Timed(t.type({ value: Secret, registerBlock: t.number })),
       /** <- incoming processed for locked transfer */
       transferProcessed: Timed(Signed(Processed)),

--- a/raiden-ts/src/transport/epics/helpers.ts
+++ b/raiden-ts/src/transport/epics/helpers.ts
@@ -21,41 +21,6 @@ import { RaidenError, ErrorCodes } from '../../utils/error';
 import { Message } from '../../messages/types';
 import { decodeJsonMessage, getMessageSigner } from '../../messages/utils';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type CapsMapping = { readonly [k: string]: any };
-
-/**
- * Stringify a caps mapping
- *
- * @param caps - Capabilities object/mapping
- * @returns stringified version of caps
- */
-export function stringifyCaps(caps: CapsMapping): string {
-  return Object.entries(caps)
-    .filter(([, v]) => typeof v !== 'boolean' || v)
-    .map(([k, v]) => (typeof v === 'boolean' ? k : `${k}="${v}"`))
-    .join(',');
-}
-
-/**
- * Parse a caps string in the format 'k1,k2=v2,k3="v3"' to { k1: true, k2: v2, k3: v3 } object
- *
- * @param caps - caps string
- * @returns Caps mapping object
- */
-export function parseCaps(caps?: string | null): CapsMapping | undefined {
-  if (!caps) return;
-  const result: { [k: string]: string | boolean } = {};
-  try {
-    // this regex splits by comma, but respecting strings inside double-quotes
-    for (const cap of caps.split(/,(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/g)) {
-      const match = cap.match(/^\s*([^=]+)(?: ?= ?"?(.*?)"?\s*)?$/);
-      if (match) result[match[1]] = match[2] ?? true;
-    }
-    return result;
-  } catch (err) {}
-}
-
 /**
  * Return the array of configured global rooms
  *

--- a/raiden-ts/src/transport/epics/init.ts
+++ b/raiden-ts/src/transport/epics/init.ts
@@ -32,6 +32,7 @@ import {
 } from 'rxjs/operators';
 import { fromFetch } from 'rxjs/fetch';
 import sortBy from 'lodash/sortBy';
+import isEmpty from 'lodash/isEmpty';
 
 import { createClient, MatrixClient, MatrixEvent, Filter } from 'matrix-js-sdk';
 import { logger as matrixLogger } from 'matrix-js-sdk/lib/logger';
@@ -46,7 +47,9 @@ import { getServerName } from '../../utils/matrix';
 import { pluckDistinct } from '../../utils/rx';
 import { matrixSetup } from '../actions';
 import { RaidenMatrixSetup } from '../state';
-import { CapsMapping, stringifyCaps, globalRoomNames } from './helpers';
+import { Caps } from '../types';
+import { stringifyCaps } from '../utils';
+import { globalRoomNames } from './helpers';
 
 const DEVICE_ID = 'RAIDEN';
 
@@ -226,7 +229,7 @@ function setupMatrixClient$(
   server: string,
   setup: RaidenMatrixSetup | undefined,
   { address, signer }: Pick<RaidenEpicDeps, 'address' | 'signer'>,
-  caps?: CapsMapping,
+  caps: Caps,
 ) {
   const serverName = getServerName(server);
   if (!serverName) throw new RaidenError(ErrorCodes.TRNS_NO_SERVERNAME, { server });
@@ -284,7 +287,7 @@ function setupMatrixClient$(
       // set these properties before starting sync
       merge(
         from(matrix.setDisplayName(setup.displayName)),
-        caps ? from(matrix.setAvatarUrl(stringifyCaps(caps))) : EMPTY,
+        from(matrix.setAvatarUrl(caps && !isEmpty(caps) ? stringifyCaps(caps) : '')),
       ).pipe(
         mapTo({ matrix, server, setup }), // return triplet again
       ),
@@ -307,9 +310,9 @@ export const initMatrixEpic = (
   {}: Observable<RaidenState>,
   { address, signer, matrix$, latest$, config$ }: RaidenEpicDeps,
 ): Observable<matrixSetup> =>
-  combineLatest([latest$.pipe(pluck('state')), config$]).pipe(
+  combineLatest([latest$, config$]).pipe(
     first(), // at startup
-    mergeMap(([state, { matrixServer, matrixServerLookup, httpTimeout, caps }]) => {
+    mergeMap(([{ state, caps }, { matrixServer, matrixServerLookup, httpTimeout }]) => {
       const server = state.transport.server,
         setup = state.transport.setup;
 

--- a/raiden-ts/src/transport/epics/presence.ts
+++ b/raiden-ts/src/transport/epics/presence.ts
@@ -31,7 +31,7 @@ import { getUserPresence } from '../../utils/matrix';
 import { pluckDistinct } from '../../utils/rx';
 import { matrixPresence } from '../actions';
 import { channelMonitor } from '../../channels/actions';
-import { parseCaps, stringifyCaps } from './helpers';
+import { parseCaps, stringifyCaps } from '../utils';
 
 // unavailable just means the user didn't do anything over a certain amount of time, but they're
 // still there, so we consider the user as available/online then
@@ -262,9 +262,9 @@ export const matrixMonitorChannelPresenceEpic = (
 export const matrixUpdateCapsEpic = (
   {}: Observable<RaidenAction>,
   {}: Observable<RaidenState>,
-  { matrix$, config$ }: RaidenEpicDeps,
+  { matrix$, latest$ }: RaidenEpicDeps,
 ): Observable<never> =>
-  config$.pipe(
+  latest$.pipe(
     pluckDistinct('caps'),
     skip(1), // skip replay(1) and act only on changes
     mergeMap((caps) => matrix$.pipe(map((matrix) => [caps, matrix] as const))),

--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -352,10 +352,10 @@ function handlePresenceChange$(
       (a, b) =>
         a.payload.userId === b.payload.userId && a.payload.available === b.payload.available,
     ),
-    withLatestFrom(matrix$, config$),
+    withLatestFrom(matrix$, config$, latest$),
     filter(
-      ([action, , { caps }]) =>
-        !!action.payload.caps?.[Capabilities.WEBRTC] && !!caps?.[Capabilities.WEBRTC],
+      ([action, , , { caps }]) =>
+        !!action.payload.caps?.[Capabilities.WEBRTC] && !!caps[Capabilities.WEBRTC],
     ),
     switchMap(([action, matrix, config]) => {
       // if peer goes offline in Matrix, reset dataChannel & unsubscribe defer to close dataChannel

--- a/raiden-ts/src/transport/types.ts
+++ b/raiden-ts/src/transport/types.ts
@@ -1,5 +1,10 @@
+import * as t from 'io-ts';
 import { matrixPresence } from './actions';
 
 export interface Presences {
   [address: string]: matrixPresence.success;
 }
+
+export const Caps = t.readonly(t.record(t.string /* Capabilities */, t.any));
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Caps = { readonly [k: string]: any };

--- a/raiden-ts/src/transport/utils.ts
+++ b/raiden-ts/src/transport/utils.ts
@@ -1,12 +1,13 @@
 import { Observable, combineLatest } from 'rxjs';
-import { filter, scan, startWith, share, map } from 'rxjs/operators';
+import { filter, scan, startWith, share, map, distinctUntilChanged } from 'rxjs/operators';
 import memoize from 'lodash/memoize';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
 
 import { Latest } from '../types';
 import { RaidenAction } from '../actions';
 import { Capabilities } from '../constants';
 import { RaidenConfig } from '../config';
-import { pluckDistinct } from '../utils/rx';
 import { Presences, Caps } from './types';
 import { matrixPresence } from './actions';
 
@@ -80,16 +81,17 @@ export function getCaps$(
   config$: Observable<RaidenConfig>,
   udcBalance$: Observable<Latest['udcBalance']>,
 ): Observable<Caps> {
-  return combineLatest([
-    config$.pipe(pluckDistinct('caps')),
-    config$.pipe(pluckDistinct('monitoringReward')),
-    udcBalance$,
-  ]).pipe(
-    map(([caps, monitoringReward, udcBalance]) => ({
+  return combineLatest([config$, udcBalance$]).pipe(
+    map(([{ caps, monitoringReward, rateToSvt }, udcBalance]) => ({
       // 'noReceive' is false (i.e. receiving enabled) iff (0 < monitoringReward <= udcBalance)
       // TODO: set per token?
-      [Capabilities.NO_RECEIVE]: !(monitoringReward?.gt(0) && monitoringReward.lte(udcBalance)),
+      [Capabilities.NO_RECEIVE]: !(
+        monitoringReward?.gt(0) &&
+        monitoringReward.lte(udcBalance) &&
+        !isEmpty(rateToSvt)
+      ),
       ...caps, // default & user's config.caps has priority over keys above, but unset by default
     })),
+    distinctUntilChanged(isEqual),
   );
 }

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -16,7 +16,7 @@ import { RaidenAction } from './actions';
 import { RaidenState } from './state';
 import { Address, UInt } from './utils/types';
 import { RaidenConfig } from './config';
-import { Presences } from './transport/types';
+import { Presences, Caps } from './transport/types';
 
 interface Info {
   address: Address;
@@ -39,6 +39,7 @@ export interface Latest {
   pfsList: readonly Address[];
   rtc: { [address: string]: RTCDataChannel };
   udcBalance: UInt<32>;
+  caps: Caps;
 }
 
 export interface RaidenEpicDeps {

--- a/raiden-ts/tests/unit/epics/receive.spec.ts
+++ b/raiden-ts/tests/unit/epics/receive.spec.ts
@@ -95,7 +95,7 @@ describe('receive transfers', () => {
     [
       raidenConfigUpdate({
         caps: {
-          // disable NO_RECEIVE
+          [Capabilities.NO_RECEIVE]: false, // disable NO_RECEIVE
           [Capabilities.NO_MEDIATE]: true,
           [Capabilities.NO_DELIVERY]: true,
         },

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -533,7 +533,8 @@ describe('transport epic', () => {
     );
     await expect(promise).resolves.toBeUndefined();
     expect(matrix.setAvatarUrl).toHaveBeenCalledTimes(1);
-    expect(matrix.setAvatarUrl).toHaveBeenCalledWith(`noDelivery,webRTC`);
+    // noReceive is dynamic
+    expect(matrix.setAvatarUrl).toHaveBeenCalledWith('noReceive,noDelivery,webRTC');
 
     promise = matrixUpdateCapsEpic(action$, state$, depsMock).toPromise();
     action$.next(
@@ -544,7 +545,7 @@ describe('transport epic', () => {
     setTimeout(() => action$.complete(), 10);
     await expect(promise).resolves.toBeUndefined();
     expect(matrix.setAvatarUrl).toHaveBeenCalledTimes(2);
-    expect(matrix.setAvatarUrl).toHaveBeenCalledWith(`noDelivery,customCap="abc"`);
+    expect(matrix.setAvatarUrl).toHaveBeenCalledWith('noReceive,noDelivery,customCap="abc"');
   });
 
   describe('matrixCreateRoomEpic', () => {

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -255,16 +255,18 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
         httpTimeout: 300,
         confirmationBlocks: 2,
       },
-    );
+    ),
+    config = { ...defaultConfig, ...state.config };
 
   const latest$ = new BehaviorSubject<Latest>({
       action: raidenConfigUpdate({}),
       state,
-      config: { ...defaultConfig, ...state.config },
+      config,
       presences: {},
       pfsList: [],
       rtc: {},
       udcBalance: Zero as UInt<32>,
+      caps: config.caps ?? {},
     }),
     config$ = latest$.pipe(pluckDistinct('config'));
 


### PR DESCRIPTION
Fixes #1369 

**Short description**
Implements a new config value for the SDK: `rateToSvt`, which holds a `token => wei` mapping. Only tokens present on this mapping will have monitoring enabled, and monitoring will be requested (i.e. paid to MS as rewards) only after channel's received total (off and on-chain unlocked sum), normalized through this rate, surpasses `monitoringReward` config, which default now is set to `5 SVT` (same as raiden-py,  hopefully enough for a MS to pick up our request, may be tweaked if needed). The `rateToSvt` config is empty by default, meaning receiving is still disabled by default and therefore no monitoring is applied.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. In served dApp, set the rate:
```ts
// rate=5e18 means 1e18wei of TKN (1TKN if decimals=18) is worth 5SVT, so 1+TKN is needed to trigger monitoring
raiden.updateConfig({ rateToSvt: { "<token_addr>": "5000000000000000000" } });
```
2. Receiving gets enabled
3. In another dApp account, transfer 0.9TKN to first client. Transfer should be received, but no monitoring signatures are requested
4. Make new transfer, worth 0.11TKN; threshold cross value of default monitoringReward of 5SVT, monitoring prompt happens 15s later and is sent to global rooms: `messageGlobalSend` actions to `meta: { roomName: "raiden_goerli_monitoring" }` containing the `type: "RequestMonitoring"` messages.
