### PR TITLE
Fixes scrollbar displaying in channels screen without many items

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -8,6 +8,11 @@
 - [#1380] Allow the user to withdraw tokens from the Raiden Account.
 - [#1371] Mint and deposit utility token to pay Monitoring Service.
 
+### Fixed
+
+- [#1490] Fixes scrollbar always showing up in channels screen.
+
+[#1490]: https://github.com/raiden-network/light-client/issues/1490
 [#1212]: https://github.com/raiden-network/light-client/issues/1212
 [#1380]: https://github.com/raiden-network/light-client/issues/1380
 [#1371]: https://github.com/raiden-network/light-client/issues/1371

--- a/raiden-dapp/src/components/navigation/Channels.vue
+++ b/raiden-dapp/src/components/navigation/Channels.vue
@@ -164,8 +164,6 @@ export default class Channels extends Mixins(NavigationMixin) {
 .channels {
   width: 100%;
   height: 100%;
-  overflow-y: scroll;
-  @extend .themed-scrollbar;
 
   &:first-child {
     padding-top: 50px;
@@ -182,9 +180,10 @@ export default class Channels extends Mixins(NavigationMixin) {
   }
 
   &__wrapper {
-    height: 100%;
+    height: calc(100% - 60px);
     width: 100%;
-    overflow-y: visible;
+    overflow-y: auto;
+    @extend .themed-scrollbar;
   }
 
   &__header {


### PR DESCRIPTION
Fixes #1490  

**Short description**
Makes sure that scrollbar is not shown unless there are enough items to need a scrollbar

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [x] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Go to channels.
2. If you have one or two channels, no scrollbar should display.
