### PR TITLE
Fix received transfers not showing up on history

### DIFF
--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -83,14 +83,14 @@ async function raidenTransfer(
   let unlockAt: number;
   await raiden.getAvailability(target);
   const { identifier: paymentId, ...rest } = opts;
-  const transferId = await raiden.transfer(token, target, amount, {
+  const key = await raiden.transfer(token, target, amount, {
     paymentId,
     ...rest,
   });
 
   const transfer = await new Promise<RaidenTransfer>((resolve, reject) => {
     const sub = raiden.transfers$.subscribe((t) => {
-      if (t.secrethash !== transferId) return;
+      if (t.key !== key) return;
       log.debug('Transfer:', t);
       if (!revealAt && t.success !== undefined) revealAt = t.changedAt.getTime();
       if (!unlockAt && t.status.startsWith('UNLOCK')) unlockAt = t.changedAt.getTime();

--- a/raiden-dapp/src/components/transaction-history/Transaction.vue
+++ b/raiden-dapp/src/components/transaction-history/Transaction.vue
@@ -24,7 +24,11 @@
           }}
           <address-display
             class="transaction__item__details-left__address"
-            :address="transfer.partner"
+            :address="
+              transfer.direction === 'sent'
+                ? transfer.target
+                : transfer.initiator
+            "
           />
         </v-row>
         <v-row class="transaction__item__details-left__time-stamp" no-gutters>

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -174,9 +174,7 @@ export default class RaidenService {
 
         // Subscribe to our pending transfers
         raiden.transfers$.subscribe(transfer => {
-          if (transfer.initiator === account) {
-            this.store.commit('updateTransfers', transfer);
-          }
+          this.store.commit('updateTransfers', transfer);
         });
 
         this.store.commit('network', raiden.network);
@@ -318,13 +316,13 @@ export default class RaidenService {
     paymentId: BigNumber
   ) {
     try {
-      const secretHash = await this.raiden.transfer(token, target, amount, {
+      const key = await this.raiden.transfer(token, target, amount, {
         paymentId,
         paths
       });
 
       // Wait for transaction to be completed
-      await this.raiden.waitTransfer(secretHash);
+      await this.raiden.waitTransfer(key);
     } catch (e) {
       throw new TransferFailed(e);
     }

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -98,7 +98,7 @@ const store: StoreOptions<RootState> = {
       Object.assign(state, defaultState());
     },
     updateTransfers(state: RootState, transfer: RaidenTransfer) {
-      state.transfers = { ...state.transfers, [transfer.secrethash]: transfer };
+      state.transfers = { ...state.transfers, [transfer.key]: transfer };
     },
     backupState(state: RootState, uploadedState: string) {
       state.stateBackup = uploadedState;
@@ -165,23 +165,23 @@ const store: StoreOptions<RootState> = {
     },
     pendingTransfers: ({ transfers }: RootState) =>
       Object.keys(transfers)
-        .filter(secretHash => {
-          const { completed } = transfers[secretHash];
+        .filter(key => {
+          const { completed } = transfers[key];
 
           // return whether transfer is pending or not
           return !completed;
         })
-        .reduce((pendingTransfers: Transfers, secretHash: string) => {
-          pendingTransfers[secretHash] = transfers[secretHash];
+        .reduce((pendingTransfers: Transfers, key: string) => {
+          pendingTransfers[key] = transfers[key];
           return pendingTransfers;
         }, {}),
     transfer: (state: RootState) => (paymentId: BigNumber) => {
-      const secretHash = Object.keys(state.transfers).find(
-        secretHash => state.transfers[secretHash].paymentId === paymentId
+      const key = Object.keys(state.transfers).find(
+        key => state.transfers[key].paymentId === paymentId
       );
 
-      if (secretHash) {
-        return state.transfers[secretHash];
+      if (key) {
+        return state.transfers[key];
       }
 
       return undefined;

--- a/raiden-dapp/src/types.d.ts
+++ b/raiden-dapp/src/types.d.ts
@@ -4,7 +4,7 @@ import { DeniedReason, Token, Presences } from '@/model/types';
 import { Network } from 'ethers/utils';
 
 export type Tokens = { [token: string]: Token };
-export type Transfers = { [secretHash: string]: RaidenTransfer };
+export type Transfers = { [key: string]: RaidenTransfer };
 export type ChannelAction = 'close' | 'deposit' | 'settle';
 
 export interface ConnectOptions {

--- a/raiden-dapp/tests/unit/components/transaction.spec.ts
+++ b/raiden-dapp/tests/unit/components/transaction.spec.ts
@@ -26,6 +26,8 @@ describe('Transaction.vue', () => {
           changedAt: new Date('June 5, 1986 23:59:59'),
           direction: transferDirection,
           partner: '0x123',
+          initiator: '0x123',
+          target: '0x456',
           success: successStatus,
           token: '0xtoken'
         }

--- a/raiden-dapp/tests/unit/components/transfer-progress-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/transfer-progress-dialog.spec.ts
@@ -11,12 +11,12 @@ describe('TransferProgressDialog.vue', () => {
   let wrapper: Wrapper<TransferProgressDialog>;
   let vuetify: typeof Vuetify;
   const transferPending = {
-    secrethash: '0x1',
+    key: 'sent:0x1',
     paymentId: '0x1',
     status: 'PENDING'
   };
   const transferRequested = {
-    secrethash: '0x1',
+    key: 'sent:0x1',
     paymentId: '0x1',
     status: 'REQUESTED'
   };

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -302,8 +302,9 @@ describe('RaidenService', () => {
     describe('settleChannel', () => {
       test('resolves when settle is successful', async () => {
         raiden.settleChannel = jest.fn().mockResolvedValue('txhash' as Hash);
-        await expect(raidenService.settleChannel('0xtoken', '0xpartner'))
-          .resolves;
+        await expect(
+          raidenService.settleChannel('0xtoken', '0xpartner')
+        ).resolves.toBeUndefined();
         expect(raiden.settleChannel).toHaveBeenCalledTimes(1);
         expect(raiden.settleChannel).toHaveBeenCalledWith(
           '0xtoken',
@@ -329,7 +330,7 @@ describe('RaidenService', () => {
 
         await expect(
           raidenService.transfer('0xtoken', '0xpartner', One, path, paymentId)
-        ).resolves;
+        ).resolves.toBeUndefined();
         expect(raiden.transfer).toHaveBeenCalledTimes(1);
         expect(raiden.transfer).toHaveBeenCalledWith(
           '0xtoken',
@@ -435,7 +436,7 @@ describe('RaidenService', () => {
       test('save transfers in store', async () => {
         const dummyTransfer = {
           initiator: '123',
-          secrethash: '0x1',
+          key: 'sent:0x1',
           completed: false
         };
         (raiden as any).transfers$ = new BehaviorSubject(dummyTransfer);

--- a/raiden-dapp/tests/unit/store.spec.ts
+++ b/raiden-dapp/tests/unit/store.spec.ts
@@ -310,8 +310,8 @@ describe('store', () => {
 
   test('return only pending transfers', () => {
     [
-      { secrethash: '0x1', completed: true },
-      { secrethash: '0x2', completed: false }
+      { key: 'sent:0x1', completed: true },
+      { key: 'sent:0x2', completed: false }
     ].forEach(transfer => store.commit('updateTransfers', transfer));
     const { pendingTransfers } = store.getters;
     expect(Object.keys(pendingTransfers).length).toEqual(1);
@@ -319,11 +319,11 @@ describe('store', () => {
 
   test('return transfer with specific identifier ', () => {
     [
-      { secrethash: '0x1', paymentId: '0x1' },
-      { secrethash: '0x2', paymentId: '0x2' }
+      { key: 'sent:0x1', paymentId: '0x1' },
+      { key: 'sent:0x2', paymentId: '0x2' }
     ].forEach(transfer => store.commit('updateTransfers', transfer));
     const transfer = store.getters.transfer('0x1');
-    expect(transfer.secrethash).toEqual('0x1');
+    expect(transfer.key).toEqual('sent:0x1');
   });
 
   test('isConnected should be false if loading', () => {

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -8,8 +8,10 @@
 
 ### Changed
 - [#1480] Update profile's caps on config.caps change and react on peers updates
+- [#1503] Expose received transfers through transfers$ observable
 
 [#1480]: https://github.com/raiden-network/light-client/pull/1480
+[#1503]: https://github.com/raiden-network/light-client/issues/1503
 
 ## [0.7.0] - 2020-05-08
 ### Added

--- a/raiden-ts/src/transfers/actions.ts
+++ b/raiden-ts/src/transfers/actions.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 /* eslint-disable @typescript-eslint/class-name-casing */
 import * as t from 'io-ts';
+import invert from 'lodash/invert';
 
 import { Address, UInt, Int, Secret, Hash, Signed } from '../utils/types';
 import { createAction, ActionType, createAsyncAction } from '../utils/actions';
@@ -17,10 +18,11 @@ import {
   WithdrawConfirmation,
 } from '../messages/types';
 import { Paths } from '../services/types';
+import { Direction } from './state';
 
 const TransferId = t.type({
   secrethash: Hash,
-  direction: t.keyof({ sent: null, received: null }),
+  direction: t.keyof(invert(Direction) as Record<Direction, string>),
 });
 
 /**

--- a/raiden-ts/src/transfers/state.ts
+++ b/raiden-ts/src/transfers/state.ts
@@ -13,10 +13,12 @@ import {
 } from '../messages/types';
 import { Address, Timed, Hash, Int, Signed, Secret } from '../utils/types';
 
-export enum Direction {
-  SENT = 'sent',
-  RECEIVED = 'received',
-}
+// it's like an enum, but with literals
+export const Direction = {
+  SENT: 'sent',
+  RECEIVED: 'received',
+} as const;
+export type Direction = typeof Direction[keyof typeof Direction];
 
 /**
  * This struct holds the relevant messages exchanged in a transfer
@@ -117,6 +119,7 @@ export enum RaidenTransferStatus {
  * This should be only used as a public view of the internal transfer state
  */
 export interface RaidenTransfer {
+  key: string; // some key which uniquely identifies this transfer
   secrethash: Hash; // used as transfer identifier
   direction: 'sent' | 'received';
   status: RaidenTransferStatus;

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -803,14 +803,14 @@ describe('Raiden', () => {
       test('success: direct route', async () => {
         expect.assertions(4);
 
-        const transfers: { [h: string]: RaidenTransfer } = {};
-        raiden.transfers$.subscribe((t) => (transfers[t.secrethash] = t));
+        const transfers: { [k: string]: RaidenTransfer } = {};
+        raiden.transfers$.subscribe((t) => (transfers[t.key] = t));
 
-        const secrethash = await raiden.transfer(token, partner, 23);
-        expect(secrethash).toMatch(/^0x[0-9a-fA-F]{64}$/);
+        const key = await raiden.transfer(token, partner, 23);
+        expect(key).toMatch(/^sent:0x[0-9a-fA-F]{64}$/);
 
-        expect(secrethash in transfers).toBe(true);
-        expect(transfers[secrethash].status).toBe(RaidenTransferStatus.pending);
+        expect(key in transfers).toBe(true);
+        expect(transfers[key].status).toBe(RaidenTransferStatus.pending);
       });
 
       test('success: auto pfs route', async () => {
@@ -873,17 +873,17 @@ describe('Raiden', () => {
           text: jest.fn(async () => losslessStringify(result)),
         });
 
-        const transfers: { [h: string]: RaidenTransfer } = {};
-        raiden.transfers$.subscribe((t) => (transfers[t.secrethash] = t));
+        const transfers: { [k: string]: RaidenTransfer } = {};
+        raiden.transfers$.subscribe((t) => (transfers[t.key] = t));
 
-        const secrethash = await raiden.transfer(token, target, 23);
-        expect(secrethash).toMatch(/^0x[0-9a-fA-F]{64}$/);
+        const key = await raiden.transfer(token, target, 23);
+        expect(key).toMatch(/^sent:0x[0-9a-fA-F]{64}$/);
 
-        expect(secrethash in transfers).toBe(true);
-        expect(transfers[secrethash].status).toBe(RaidenTransferStatus.pending);
+        expect(key in transfers).toBe(true);
+        expect(transfers[key].status).toBe(RaidenTransferStatus.pending);
 
         // transfer metadata contains the actual used routes (removing invalid ones)
-        expect(transfers[secrethash].metadata).toEqual({
+        expect(transfers[key].metadata).toEqual({
           routes: [{ route: [partner, target] }],
         });
 


### PR DESCRIPTION
Fixes #1503 

**Short description**
Exposes received transfers through `transfers$` observable, define `RaidenTransfer.key` as a unique string key, to be used instead of `secrethash`.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Try repro at linked issue
2. See it works for received transfers:
![image](https://user-images.githubusercontent.com/587021/81729575-91ad9700-9462-11ea-96fd-bd9c0985d502.png)


