### PR TITLE
Fixed token list sorting

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- [#1485] Fixed token list sorting.
+
+[#1485]: https://github.com/raiden-network/light-client/issues/1485
+
 ## [0.8.0] - 2020-05-14
 
 ### Added

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -151,7 +151,7 @@ const store: StoreOptions<RootState> = {
     allTokens: (state: RootState): Token[] =>
       Object.values(state.tokens).sort((a: Token, b: Token) => {
         if (hasNonZeroBalance(a, b)) {
-          return a.balance! < b.balance! ? 1 : -1;
+          return (b.balance! as BigNumber).gt(a.balance! as BigNumber) ? 1 : -1;
         }
 
         return a.symbol && b.symbol ? a.symbol.localeCompare(b.symbol) : 0;


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #1485

**Short description**

<img width="698" alt="Screenshot 2020-05-15 at 09 16 26" src="https://user-images.githubusercontent.com/3169205/82022315-c9982280-968c-11ea-9294-829595c99537.png">


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect dapp
2. Mint ETHCC3 and TTT
3. Open channel with hub with one of the tokens, so you have an odd amount left like 0.89475680745
4. On transfer screen click on token
5. In transfer list check the sorting
