### PR TITLE
Fixes handling of tokens with zero decimals

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### Fixed
 
+- [#1493] Properly handles tokens with zero decimals, fixes transaction history token display.
 - [#1485] Fixed token list sorting.
 
+[#1493]: https://github.com/raiden-network/light-client/issues/1493
 [#1485]: https://github.com/raiden-network/light-client/issues/1485
 
 ## [0.8.0] - 2020-05-14

--- a/raiden-dapp/src/components/AmountInput.vue
+++ b/raiden-dapp/src/components/AmountInput.vue
@@ -23,7 +23,7 @@
 <script lang="ts">
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import { Token } from '@/model/types';
-import { BalanceUtils } from '@/utils/balance-utils';
+import { BalanceUtils, getDecimals } from '@/utils/balance-utils';
 import { BigNumber } from 'ethers/utils';
 import { Zero } from 'ethers/constants';
 
@@ -33,13 +33,13 @@ export default class AmountInput extends Vue {
   label?: string;
   @Prop({})
   disabled!: boolean;
-  @Prop({ default: '0.00' })
+  @Prop({ required: true })
   value!: string;
   @Prop()
   token?: Token;
   @Prop({ default: false, type: Boolean })
   limit!: boolean;
-  @Prop({ default: '0.0', type: String })
+  @Prop({ default: '', type: String })
   placeholder!: string;
   @Prop({ required: false, default: () => Zero })
   max!: BigNumber;
@@ -73,7 +73,10 @@ export default class AmountInput extends Vue {
       !this.limit ||
       (v && this.hasEnoughBalance(v, this.max)) ||
       this.$parent.$t('amount-input.error.not-enough-funds', {
-        funds: BalanceUtils.toUnits(this.max, this.token!.decimals || 18),
+        funds: BalanceUtils.toUnits(
+          this.max,
+          getDecimals(this.token!.decimals)
+        ),
         symbol: this.token!.symbol
       })
   ];
@@ -81,7 +84,7 @@ export default class AmountInput extends Vue {
   private noDecimalOverflow(v: string) {
     return (
       AmountInput.numericRegex.test(v) &&
-      !BalanceUtils.decimalsOverflow(v, this.token!.decimals || 18)
+      !BalanceUtils.decimalsOverflow(v, getDecimals(this.token!.decimals))
     );
   }
 

--- a/raiden-dapp/src/components/AmountInput.vue
+++ b/raiden-dapp/src/components/AmountInput.vue
@@ -23,7 +23,7 @@
 <script lang="ts">
 import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import { Token } from '@/model/types';
-import { BalanceUtils, getDecimals } from '@/utils/balance-utils';
+import { BalanceUtils } from '@/utils/balance-utils';
 import { BigNumber } from 'ethers/utils';
 import { Zero } from 'ethers/constants';
 
@@ -73,10 +73,7 @@ export default class AmountInput extends Vue {
       !this.limit ||
       (v && this.hasEnoughBalance(v, this.max)) ||
       this.$parent.$t('amount-input.error.not-enough-funds', {
-        funds: BalanceUtils.toUnits(
-          this.max,
-          getDecimals(this.token!.decimals)
-        ),
+        funds: BalanceUtils.toUnits(this.max, this.token!.decimals ?? 18),
         symbol: this.token!.symbol
       })
   ];
@@ -84,7 +81,7 @@ export default class AmountInput extends Vue {
   private noDecimalOverflow(v: string) {
     return (
       AmountInput.numericRegex.test(v) &&
-      !BalanceUtils.decimalsOverflow(v, getDecimals(this.token!.decimals))
+      !BalanceUtils.decimalsOverflow(v, this.token!.decimals ?? 18)
     );
   }
 

--- a/raiden-dapp/src/components/dialogs/ChannelDepositDialog.vue
+++ b/raiden-dapp/src/components/dialogs/ChannelDepositDialog.vue
@@ -72,12 +72,12 @@
 </template>
 
 <script lang="ts">
-import { Component, Emit, Prop, Vue } from 'vue-property-decorator';
+import { Component, Emit, Prop, Vue, Watch } from 'vue-property-decorator';
 import { Token } from '@/model/types';
 import AmountInput from '@/components/AmountInput.vue';
 import ActionButton from '@/components/ActionButton.vue';
 import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
-import { BalanceUtils } from '@/utils/balance-utils';
+import { BalanceUtils, getDecimals } from '@/utils/balance-utils';
 
 @Component({
   components: {
@@ -98,8 +98,24 @@ export default class ChannelDepositDialog extends Vue {
   @Prop({ required: false, default: false })
   done?: boolean;
 
-  deposit: string = '0.0';
+  deposit: string = '';
   valid: boolean = false;
+
+  @Watch('visible')
+  onVisibilityChanged(visible: boolean) {
+    if (!visible) {
+      return;
+    }
+    this.updateDeposit();
+  }
+
+  mounted() {
+    this.updateDeposit();
+  }
+
+  private updateDeposit() {
+    this.deposit = getDecimals(this.token.decimals) === 0 ? '0' : '0.0';
+  }
 
   @Emit()
   cancel() {}

--- a/raiden-dapp/src/components/dialogs/ChannelDepositDialog.vue
+++ b/raiden-dapp/src/components/dialogs/ChannelDepositDialog.vue
@@ -77,7 +77,7 @@ import { Token } from '@/model/types';
 import AmountInput from '@/components/AmountInput.vue';
 import ActionButton from '@/components/ActionButton.vue';
 import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
-import { BalanceUtils, getDecimals } from '@/utils/balance-utils';
+import { BalanceUtils } from '@/utils/balance-utils';
 
 @Component({
   components: {
@@ -114,7 +114,7 @@ export default class ChannelDepositDialog extends Vue {
   }
 
   private updateDeposit() {
-    this.deposit = getDecimals(this.token.decimals) === 0 ? '0' : '0.0';
+    this.deposit = (this.token.decimals ?? 18) === 0 ? '0' : '0.0';
   }
 
   @Emit()

--- a/raiden-dapp/src/components/navigation/OpenChannel.vue
+++ b/raiden-dapp/src/components/navigation/OpenChannel.vue
@@ -178,6 +178,10 @@ export default class OpenChannel extends Mixins(NavigationMixin) {
       this.navigateToHome();
     }
 
+    if (this.token.decimals === 0 && this.deposit.indexOf('.') > -1) {
+      this.deposit = this.deposit.split('.')[0];
+    }
+
     if (!AddressUtils.checkAddressChecksum(partner)) {
       this.navigateToTokenSelect();
       return;

--- a/raiden-dapp/src/components/navigation/Transfer.vue
+++ b/raiden-dapp/src/components/navigation/Transfer.vue
@@ -52,6 +52,7 @@
     </v-row>
     <div class="transfer__form-container">
       <v-form
+        ref="transfer"
         v-model="valid"
         autocomplete="off"
         novalidate
@@ -99,7 +100,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins } from 'vue-property-decorator';
+import { Component, Mixins, Watch } from 'vue-property-decorator';
 import AddressInput from '@/components/AddressInput.vue';
 import AmountInput from '@/components/AmountInput.vue';
 import { Token } from '@/model/types';
@@ -158,6 +159,11 @@ export default class Transfer extends Mixins(BlockieMixin, NavigationMixin) {
     tokenAddress: string
   ) => RaidenChannel | undefined;
 
+  @Watch('$route', { immediate: true, deep: true })
+  onRouteChange() {
+    (this.$refs?.transfer as any)?.reset();
+  }
+
   get token(): Token {
     const { token: address } = this.$route.params;
     return this.$store.getters.token(address) || ({ address } as Token);
@@ -196,6 +202,10 @@ export default class Transfer extends Mixins(BlockieMixin, NavigationMixin) {
 
     if (typeof this.token.decimals !== 'number') {
       this.navigateToHome();
+    }
+
+    if (this.token.decimals === 0 && this.amount.indexOf('.') > -1) {
+      this.amount = this.amount.split('.')[0];
     }
   }
 

--- a/raiden-dapp/src/components/transaction-history/Transaction.vue
+++ b/raiden-dapp/src/components/transaction-history/Transaction.vue
@@ -49,7 +49,7 @@
               class="transaction__item__details-right__amount--sum"
               exact-amount
               :amount="transfer.amount"
-              :token="transfer.token"
+              :token="tokens[transfer.token]"
             />
           </div>
         </v-row>
@@ -83,19 +83,24 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
-import { Transfers } from '../../types';
+import { Tokens, Transfers } from '@/types';
 import AddressDisplay from '@/components/AddressDisplay.vue';
 import AmountDisplay from '@/components/AmountDisplay.vue';
+import { mapState } from 'vuex';
 
 @Component({
   components: {
     AddressDisplay,
     AmountDisplay
+  },
+  computed: {
+    ...mapState(['tokens'])
   }
 })
 export default class Transaction extends Vue {
   @Prop({ required: true })
   transfer!: Transfers;
+  tokens!: Tokens;
 }
 </script>
 

--- a/raiden-dapp/src/filters.ts
+++ b/raiden-dapp/src/filters.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import { BigNumber } from 'ethers/utils';
-import { BalanceUtils, getDecimals } from '@/utils/balance-utils';
+import { BalanceUtils } from '@/utils/balance-utils';
 import split from 'lodash/split';
 import capitalize from 'lodash/capitalize';
 
@@ -31,22 +31,25 @@ export default class Filters {
   }
 
   static displayFormat(amount: BigNumber, decimals?: number): string {
-    const numberOfDecimals = getDecimals(decimals);
-    const units = BalanceUtils.toUnits(amount, numberOfDecimals);
+    const units = BalanceUtils.toUnits(amount, decimals ?? 18);
     const deposit = parseFloat(units);
     if (deposit === 0) {
-      return numberOfDecimals === 0 ? '0' : '0.0';
+      return decimals === 0 ? '0' : '0.0';
     } else if (deposit < 0.000001) {
       return '<0.000001';
     } else {
-      const [integerPart, decimalPart] = split(units, '.');
+      return Filters.formatValue(units, decimals);
+    }
+  }
 
-      if (decimalPart && decimalPart.length > 6) {
-        let newDecimal = decimalPart.substring(0, 6);
-        return `≈${integerPart}.${newDecimal}`;
-      } else {
-        return decimals === 0 ? integerPart : units;
-      }
+  private static formatValue(units: string, decimals: number | undefined) {
+    const [integerPart, decimalPart] = split(units, '.');
+
+    if (decimalPart && decimalPart.length > 6) {
+      let newDecimal = decimalPart.substring(0, 6);
+      return `≈${integerPart}.${newDecimal}`;
+    } else {
+      return decimals === 0 ? integerPart : units;
     }
   }
 
@@ -55,7 +58,7 @@ export default class Filters {
   }
 
   static toUnits = (wei: BigNumber, decimals?: number) =>
-    BalanceUtils.toUnits(wei, getDecimals(decimals));
+    BalanceUtils.toUnits(wei, decimals ?? 18);
 
   static formatDate = (value: Date): string => {
     return `${new Intl.DateTimeFormat('en-US').format(

--- a/raiden-dapp/src/filters.ts
+++ b/raiden-dapp/src/filters.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import { BigNumber } from 'ethers/utils';
-import { BalanceUtils } from '@/utils/balance-utils';
+import { BalanceUtils, getDecimals } from '@/utils/balance-utils';
 import split from 'lodash/split';
 import capitalize from 'lodash/capitalize';
 
@@ -31,10 +31,11 @@ export default class Filters {
   }
 
   static displayFormat(amount: BigNumber, decimals?: number): string {
-    const units = BalanceUtils.toUnits(amount, decimals || 18);
+    const numberOfDecimals = getDecimals(decimals);
+    const units = BalanceUtils.toUnits(amount, numberOfDecimals);
     const deposit = parseFloat(units);
     if (deposit === 0) {
-      return '0.0';
+      return numberOfDecimals === 0 ? '0' : '0.0';
     } else if (deposit < 0.000001) {
       return '<0.000001';
     } else {
@@ -44,7 +45,7 @@ export default class Filters {
         let newDecimal = decimalPart.substring(0, 6);
         return `≈${integerPart}.${newDecimal}`;
       } else {
-        return units;
+        return decimals === 0 ? integerPart : units;
       }
     }
   }
@@ -54,7 +55,7 @@ export default class Filters {
   }
 
   static toUnits = (wei: BigNumber, decimals?: number) =>
-    BalanceUtils.toUnits(wei, decimals || 18);
+    BalanceUtils.toUnits(wei, getDecimals(decimals));
 
   static formatDate = (value: Date): string => {
     return `${new Intl.DateTimeFormat('en-US').format(

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -64,7 +64,7 @@ const hasNonZeroBalance = (a: Token, b: Token) =>
 const settingsLocalStorage = new VuexPersistence<RootState>({
   storage: window.localStorage,
   reducer: state => ({ settings: state.settings }),
-  filter: mutation => mutation.type == 'updateSettings',
+  filter: mutation => mutation.type == 'updateSettinSyugs',
   key: 'raiden_dapp_settings'
 });
 

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -64,7 +64,7 @@ const hasNonZeroBalance = (a: Token, b: Token) =>
 const settingsLocalStorage = new VuexPersistence<RootState>({
   storage: window.localStorage,
   reducer: state => ({ settings: state.settings }),
-  filter: mutation => mutation.type == 'updateSettinSyugs',
+  filter: mutation => mutation.type == 'updateSettings',
   key: 'raiden_dapp_settings'
 });
 

--- a/raiden-dapp/src/utils/balance-utils.ts
+++ b/raiden-dapp/src/utils/balance-utils.ts
@@ -6,7 +6,11 @@ export class BalanceUtils {
   }
 
   static toUnits(wei: BigNumber, decimals: number): string {
-    return formatUnits(wei, decimals);
+    const units = formatUnits(wei, decimals);
+    if (decimals === 0) {
+      return units.split('.')[0];
+    }
+    return units;
   }
 
   static decimalsOverflow(depositTokens: string, decimals: number): boolean {
@@ -20,6 +24,18 @@ export class BalanceUtils {
   }
 
   static parse(deposit: string, decimals: number) {
-    return parseUnits(deposit, decimals);
+    return parseUnits(
+      deposit.endsWith('.')
+        ? deposit.substring(0, deposit.length - 1)
+        : deposit,
+      decimals
+    );
   }
+}
+
+export function getDecimals(decimals?: number) {
+  if (decimals === undefined) {
+    return 18;
+  }
+  return decimals;
 }

--- a/raiden-dapp/src/utils/balance-utils.ts
+++ b/raiden-dapp/src/utils/balance-utils.ts
@@ -32,10 +32,3 @@ export class BalanceUtils {
     );
   }
 }
-
-export function getDecimals(decimals?: number) {
-  if (decimals === undefined) {
-    return 18;
-  }
-  return decimals;
-}

--- a/raiden-dapp/tests/unit/balance-utils.spec.ts
+++ b/raiden-dapp/tests/unit/balance-utils.spec.ts
@@ -47,4 +47,8 @@ describe('BalanceUtils', () => {
   test('return only integer part if decimals are 0', () => {
     expect(BalanceUtils.toUnits(One, 0)).toBe('1');
   });
+
+  test('parse ignores trailing dot', () => {
+    expect(BalanceUtils.parse('1.', 0)).toEqual(One);
+  });
 });

--- a/raiden-dapp/tests/unit/balance-utils.spec.ts
+++ b/raiden-dapp/tests/unit/balance-utils.spec.ts
@@ -1,6 +1,7 @@
 import { BalanceUtils } from '@/utils/balance-utils';
 import { BigNumber } from 'ethers/utils';
 import { Token } from '@/model/types';
+import { One } from 'ethers/constants';
 
 describe('BalanceUtils', () => {
   let token: Token = {
@@ -41,5 +42,9 @@ describe('BalanceUtils', () => {
 
   test('return false when the number is zero', () => {
     expect(BalanceUtils.decimalsOverflow('0', token.decimals!)).toBe(false);
+  });
+
+  test('return only integer part if decimals are 0', () => {
+    expect(BalanceUtils.toUnits(One, 0)).toBe('1');
   });
 });

--- a/raiden-dapp/tests/unit/components/amount-input.spec.ts
+++ b/raiden-dapp/tests/unit/components/amount-input.spec.ts
@@ -19,6 +19,7 @@ describe('AmountInput.vue', () => {
       propsData: {
         label: 'Has Label',
         token: TestData.token,
+        value: '0.00',
         ...params
       },
       mocks: {

--- a/raiden-dapp/tests/unit/components/channel-deposit.spec.ts
+++ b/raiden-dapp/tests/unit/components/channel-deposit.spec.ts
@@ -13,7 +13,7 @@ describe('ChannelDeposit.vue', () => {
   let wrapper: Wrapper<ChannelDepositDialog>;
   let vuetify: typeof Vuetify;
 
-  beforeAll(() => {
+  beforeEach(() => {
     vuetify = new Vuetify();
     wrapper = mount(ChannelDepositDialog, {
       vuetify,
@@ -42,5 +42,19 @@ describe('ChannelDeposit.vue', () => {
     const events = depositTokensEvent?.shift();
     const deposit: BigNumber = events?.shift() as BigNumber;
     expect(new BigNumber(0.5 * 10 ** 5).eq(deposit)).toBeTruthy();
+  });
+
+  test('do not update the deposit placeholder if dialog hides', async () => {
+    wrapper.setProps({ token: { ...TestData.token, decimals: 0 } });
+    expect(wrapper.vm.$data.deposit).toBe('0.0');
+    (wrapper.vm as any).onVisibilityChanged(false);
+    expect(wrapper.vm.$data.deposit).toBe('0.0');
+  });
+
+  test('update the deposit placeholder if dialog shows', async () => {
+    wrapper.setProps({ token: { ...TestData.token, decimals: 0 } });
+    expect(wrapper.vm.$data.deposit).toBe('0.0');
+    (wrapper.vm as any).onVisibilityChanged(true);
+    expect(wrapper.vm.$data.deposit).toBe('0');
   });
 });

--- a/raiden-dapp/tests/unit/components/transaction.spec.ts
+++ b/raiden-dapp/tests/unit/components/transaction.spec.ts
@@ -3,6 +3,8 @@ import Vue from 'vue';
 import Vuetify from 'vuetify';
 import { BigNumber } from 'ethers/utils';
 import Transaction from '@/components/transaction-history/Transaction.vue';
+import store from '@/store';
+import { Zero } from 'ethers/constants';
 
 Vue.use(Vuetify);
 
@@ -16,6 +18,7 @@ describe('Transaction.vue', () => {
   ) => {
     vuetify = new Vuetify();
     return mount(Transaction, {
+      store,
       vuetify,
       mocks: {
         $t: (msg: string) => msg
@@ -34,6 +37,18 @@ describe('Transaction.vue', () => {
       }
     });
   };
+
+  beforeEach(() => {
+    store.commit('updateTokens', {
+      '0xtoken': {
+        address: '0xtoken',
+        decimals: 18,
+        name: 'TestToken',
+        symbol: 'TTT',
+        balance: Zero
+      }
+    });
+  });
 
   test('transactions are prefixed with "sent to" for sent transfers', () => {
     wrapper = createWrapper('sent', true);

--- a/raiden-dapp/tests/unit/filters.spec.ts
+++ b/raiden-dapp/tests/unit/filters.spec.ts
@@ -1,6 +1,6 @@
 import Filters from '@/filters';
 import { BigNumber } from 'ethers/utils';
-import { Zero } from 'ethers/constants';
+import { One, Zero } from 'ethers/constants';
 
 describe('filters', () => {
   describe('truncate', () => {
@@ -32,6 +32,14 @@ describe('filters', () => {
   });
 
   describe('displayFormat', () => {
+    test('displays 0 if 0 is passed without decimals', () => {
+      expect(Filters.displayFormat(Zero, 0)).toEqual('0');
+    });
+
+    test('displays 1 if 1 is passed without decimals', () => {
+      expect(Filters.displayFormat(One, 0)).toEqual('1');
+    });
+
     test('return the number prefixed with "<" when the number is less than 0.000001', () => {
       expect(Filters.displayFormat(new BigNumber(10 ** 3), 18)).toEqual(
         '<0.000001'


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #1493 

**Short description**
Properly handles the display of tokens that contain 0 decimals. Previously 0 would fall into the same category as `undefined` and `18` decimals would be assumed which was wrong.

- Also fixes the token display on the transfer history

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Try to create a new channel with one of the scenario player tokens. 
2. For the scenario player tokens the amounts should be integer everywhere. 
3. The amount input for the scenario player should inform you if you have any decimals, and should consider valid any integer input up to `max`. I
4. Switching between `TTT` and the scenario token should switch between displaying decimals and not displaying.
5. Change between 0 and 0.00 as a place holder should also appear in the deposit screen.
6. When opening a channel on the scenario player token, you get a message about 0 decimals if you input any decimals.
