### PR TITLE
Truncates Account screen address on mobile

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 ### Fixed
 
+- [#1516] Fixed truncation of address on Account screen
 - [#1506] Fixed error label display on transfer screen for amount input.
 - [#1493] Properly handles tokens with zero decimals, fixes transaction history token display.
 - [#1485] Fixed token list sorting.
 
+[#1516]: https://github.com/raiden-network/light-client/issues/1516
 [#1506]: https://github.com/raiden-network/light-client/issues/1506
 [#1493]: https://github.com/raiden-network/light-client/issues/1493
 [#1485]: https://github.com/raiden-network/light-client/issues/1485
@@ -285,7 +287,7 @@
 - Add link to privacy policy.
 - Add basic transfer screen.
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v0.8.0...HEAD
+[unreleased]: https://github.com/raiden-network/light-client/compare/v0.8.0...HEAD
 [0.8.0]: https://github.com/raiden-network/light-client/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/raiden-network/light-client/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/raiden-network/light-client/compare/v0.5.2...v0.6.0

--- a/raiden-dapp/src/components/account/AccountContent.vue
+++ b/raiden-dapp/src/components/account/AccountContent.vue
@@ -23,12 +23,12 @@
       </v-row>
       <v-row class="account-content__account-details__eth" no-gutters>
         <v-col cols="2">
-          <span class="account-content__account-details__eth--currency">
+          <span class="account-content__account-details__eth__currency">
             {{ $t('account-content.currency') }}
           </span>
         </v-col>
         <v-col cols="10">
-          <span class="account-content__account-details__eth--balance">
+          <span class="account-content__account-details__eth__balance">
             {{ balance | decimals }}
           </span>
         </v-col>
@@ -225,7 +225,7 @@ export default class AccountContent extends Mixins(NavigationMixin) {
     &__eth {
       margin-bottom: 66px;
 
-      &--balance {
+      &__balance {
         @include respond-to(handhelds) {
           margin-left: 30px;
         }

--- a/raiden-dapp/src/components/account/AccountContent.vue
+++ b/raiden-dapp/src/components/account/AccountContent.vue
@@ -2,13 +2,6 @@
   <div class="account-content">
     <div v-if="!loading && defaultAccount">
       <v-row class="account-content__account-details" no-gutters>
-        <v-col cols="12">
-          <div class="account-content__account-details--title">
-            {{ $t('account-content.account-details') }}
-          </div>
-        </v-col>
-      </v-row>
-      <v-row no-gutters>
         <v-col cols="2">
           <span class="account-content__account-details--address">
             {{ $t('account-content.address') }}
@@ -16,7 +9,15 @@
         </v-col>
         <v-col cols="10">
           <span class="account-content__account-details--address">
-            <address-display :address="defaultAccount" full-address />
+            <address-display
+              class="account-content__account-details--address__desktop"
+              :address="defaultAccount"
+              full-address
+            />
+            <address-display
+              class="account-content__account-details--address__mobile"
+              :address="defaultAccount"
+            />
           </span>
         </v-col>
       </v-row>
@@ -45,8 +46,7 @@
             max-width="40px"
             height="36px"
             contain
-          >
-          </v-img>
+          ></v-img>
         </div>
         <v-list-item-content>
           <v-list-item-title>{{ menuItem.title }}</v-list-item-title>
@@ -187,6 +187,7 @@ export default class AccountContent extends Mixins(NavigationMixin) {
 </script>
 
 <style scoped lang="scss">
+@import '../../scss/mixins';
 @import '../../scss/colors';
 
 .account-content {
@@ -201,8 +202,23 @@ export default class AccountContent extends Mixins(NavigationMixin) {
       padding-bottom: 15px;
     }
 
-    &__address {
+    &--address {
       font-size: 16px;
+
+      &__desktop {
+        margin-top: 2px;
+        @include respond-to(handhelds) {
+          display: none;
+        }
+      }
+
+      &__mobile {
+        display: none;
+        margin-top: 2px;
+        @include respond-to(handhelds) {
+          display: flex;
+        }
+      }
     }
 
     &__eth {

--- a/raiden-dapp/src/components/account/AccountContent.vue
+++ b/raiden-dapp/src/components/account/AccountContent.vue
@@ -10,12 +10,12 @@
         <v-col cols="10">
           <span class="account-content__account-details--address">
             <address-display
-              class="account-content__account-details--address__desktop"
+              class="account-content__account-details--address--desktop"
               :address="defaultAccount"
               full-address
             />
             <address-display
-              class="account-content__account-details--address__mobile"
+              class="account-content__account-details--address--mobile"
               :address="defaultAccount"
             />
           </span>
@@ -205,24 +205,31 @@ export default class AccountContent extends Mixins(NavigationMixin) {
     &--address {
       font-size: 16px;
 
-      &__desktop {
+      &--desktop {
         margin-top: 2px;
         @include respond-to(handhelds) {
           display: none;
         }
       }
 
-      &__mobile {
+      &--mobile {
         display: none;
         margin-top: 2px;
         @include respond-to(handhelds) {
           display: flex;
+          margin-left: 30px;
         }
       }
     }
 
     &__eth {
       margin-bottom: 66px;
+
+      &--balance {
+        @include respond-to(handhelds) {
+          margin-left: 30px;
+        }
+      }
 
       &__currency,
       &__balance {

--- a/raiden-dapp/src/components/account/AccountContent.vue
+++ b/raiden-dapp/src/components/account/AccountContent.vue
@@ -3,19 +3,19 @@
     <div v-if="!loading && defaultAccount">
       <v-row class="account-content__account-details" no-gutters>
         <v-col cols="2">
-          <span class="account-content__account-details--address">
+          <span class="account-content__account-details__address">
             {{ $t('account-content.address') }}
           </span>
         </v-col>
         <v-col cols="10">
-          <span class="account-content__account-details--address">
+          <span class="account-content__account-details__address">
             <address-display
-              class="account-content__account-details--address--desktop"
+              class="account-content__account-details__address__desktop"
               :address="defaultAccount"
               full-address
             />
             <address-display
-              class="account-content__account-details--address--mobile"
+              class="account-content__account-details__address__mobile"
               :address="defaultAccount"
             />
           </span>
@@ -202,17 +202,17 @@ export default class AccountContent extends Mixins(NavigationMixin) {
       padding-bottom: 15px;
     }
 
-    &--address {
+    &__address {
       font-size: 16px;
 
-      &--desktop {
+      &__desktop {
         margin-top: 2px;
         @include respond-to(handhelds) {
           display: none;
         }
       }
 
-      &--mobile {
+      &__mobile {
         display: none;
         margin-top: 2px;
         @include respond-to(handhelds) {

--- a/raiden-dapp/tests/unit/components/account/account-content.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/account-content.spec.ts
@@ -62,9 +62,9 @@ describe('AccountContent.vue', () => {
     store.commit('balance', '12.0');
     await wrapper.vm.$nextTick();
     const ethTitle = wrapper.find(
-      '.account-content__account-details__eth--currency'
+      '.account-content__account-details__eth__currency'
     );
-    const eth = wrapper.find('.account-content__account-details__eth--balance');
+    const eth = wrapper.find('.account-content__account-details__eth__balance');
 
     expect(ethTitle.text()).toBe('account-content.currency');
     expect(eth.text()).toBe('12.000');

--- a/raiden-dapp/tests/unit/components/account/account-content.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/account-content.spec.ts
@@ -38,26 +38,24 @@ describe('AccountContent.vue', () => {
     await wrapper.vm.$nextTick();
   });
 
-  test('displays account details title', async () => {
-    const accountDetailsTitle = wrapper.find(
-      '.account-content__account-details--title'
-    );
-
-    expect(accountDetailsTitle.text()).toBe('account-content.account-details');
-  });
-
   test('displays address', async () => {
     store.commit('account', '0x31aA9D3E2bd38d22CA3Ae9be7aae1D518fe46043');
     await wrapper.vm.$nextTick();
     const addressTitle = wrapper
       .findAll('.account-content__account-details--address')
       .at(0);
-    const address = wrapper
-      .findAll('.account-content__account-details--address')
-      .at(1);
+    const addressDesktop = wrapper.find(
+      '.account-content__account-details--address__desktop'
+    );
+    const addressMobile = wrapper.find(
+      '.account-content__account-details--address__mobile'
+    );
 
     expect(addressTitle.text()).toBe('account-content.address');
-    expect(address.text()).toBe('0x31aA9D3E2bd38d22CA3Ae9be7aae1D518fe46043');
+    expect(addressDesktop.text()).toBe(
+      '0x31aA9D3E2bd38d22CA3Ae9be7aae1D518fe46043'
+    );
+    expect(addressMobile.text()).toBe('0x31...6043');
   });
 
   test('displays eth', async () => {

--- a/raiden-dapp/tests/unit/components/account/account-content.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/account-content.spec.ts
@@ -42,13 +42,13 @@ describe('AccountContent.vue', () => {
     store.commit('account', '0x31aA9D3E2bd38d22CA3Ae9be7aae1D518fe46043');
     await wrapper.vm.$nextTick();
     const addressTitle = wrapper
-      .findAll('.account-content__account-details--address')
+      .findAll('.account-content__account-details__address')
       .at(0);
     const addressDesktop = wrapper.find(
-      '.account-content__account-details--address--desktop'
+      '.account-content__account-details__address__desktop'
     );
     const addressMobile = wrapper.find(
-      '.account-content__account-details--address--mobile'
+      '.account-content__account-details__address__mobile'
     );
 
     expect(addressTitle.text()).toBe('account-content.address');

--- a/raiden-dapp/tests/unit/components/account/account-content.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/account-content.spec.ts
@@ -45,10 +45,10 @@ describe('AccountContent.vue', () => {
       .findAll('.account-content__account-details--address')
       .at(0);
     const addressDesktop = wrapper.find(
-      '.account-content__account-details--address__desktop'
+      '.account-content__account-details--address--desktop'
     );
     const addressMobile = wrapper.find(
-      '.account-content__account-details--address__mobile'
+      '.account-content__account-details--address--mobile'
     );
 
     expect(addressTitle.text()).toBe('account-content.address');


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes # 

**Short description**
Truncates Account screen address on mobile. I spent some time trying to find a way to change the prop via the CSS but could not. This was the most straight forward solution I could come up with.


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to the dApp and pop open the Account screen.
2. Reduce browser window to mobile size and the full address should truncate.
