### PR TITLE
Notify when receiving transfers gets disabled

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- [#1473] Notify when receiving transfers get disabled (e.g. by low UDC balance)
+
 ### Fixed
 
 - [#1516] Fixed truncation of address on Account screen
@@ -12,6 +16,7 @@
 ### Changed
 - [#842] Disable mainnet w/ environment variable.
 
+[#1473]: https://github.com/raiden-network/light-client/issues/1473
 [#1516]: https://github.com/raiden-network/light-client/issues/1516
 [#1506]: https://github.com/raiden-network/light-client/issues/1506
 [#1493]: https://github.com/raiden-network/light-client/issues/1493

--- a/raiden-dapp/src/App.vue
+++ b/raiden-dapp/src/App.vue
@@ -18,26 +18,44 @@
     </div>
     <offline-snackbar />
     <update-snackbar />
+    <receiving-disabled-dialog
+      :visible="showReceivingDisabled"
+      @dismiss="showReceivingDisabled = false"
+    />
   </v-app>
 </template>
 
 <script lang="ts">
-import { Component, Mixins } from 'vue-property-decorator';
+import { Component, Mixins, Watch } from 'vue-property-decorator';
+import { mapGetters } from 'vuex';
 import NavigationMixin from './mixins/navigation-mixin';
 import AppHeader from '@/components/AppHeader.vue';
 import OfflineSnackbar from '@/components/OfflineSnackbar.vue';
 import UpdateSnackbar from '@/components/UpdateSnackbar.vue';
+import ReceivingDisabledDialog from '@/components/dialogs/ReceivingDisabledDialog.vue';
 
 @Component({
+  computed: {
+    ...mapGetters(['canReceive'])
+  },
   components: {
     AppHeader,
     OfflineSnackbar,
-    UpdateSnackbar
+    UpdateSnackbar,
+    ReceivingDisabledDialog
   }
 })
 export default class App extends Mixins(NavigationMixin) {
+  canReceive!: boolean;
+  showReceivingDisabled = false;
+
   destroyed() {
     this.$raiden.disconnect();
+  }
+
+  @Watch('canReceive')
+  onCanReceiveChanged(canReceive: boolean | undefined) {
+    this.showReceivingDisabled = canReceive === false;
   }
 }
 </script>

--- a/raiden-dapp/src/components/dialogs/ReceivingDisabledDialog.vue
+++ b/raiden-dapp/src/components/dialogs/ReceivingDisabledDialog.vue
@@ -1,0 +1,77 @@
+<template>
+  <raiden-dialog
+    :visible="visible"
+    class="receiving-disabled-dialog"
+    @close="dismiss"
+  >
+    <v-card-title class="receiving-disabled-dialog__title">
+      {{ $t('receiving-disabled-dialog.title') }}
+    </v-card-title>
+
+    <v-card-text>
+      <v-row align="center" justify="center" no-gutters>
+        <v-col cols="6">
+          <v-img
+            class="receiving-disabled-dialog__icon"
+            :src="require('@/assets/warning.svg')"
+          ></v-img>
+        </v-col>
+        <v-col cols="12">
+          <div class="receiving-disabled-dialog__description">
+            <span>
+              {{ $t('receiving-disabled-dialog.body') }}
+            </span>
+          </div>
+        </v-col>
+      </v-row>
+    </v-card-text>
+  </raiden-dialog>
+</template>
+
+<script lang="ts">
+import { Component, Emit, Prop, Vue } from 'vue-property-decorator';
+
+import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
+
+@Component({
+  components: { RaidenDialog }
+})
+export default class ReceivingDisabledDialog extends Vue {
+  @Prop({ required: true, type: Boolean })
+  visible!: boolean;
+
+  @Emit()
+  dismiss() {}
+}
+</script>
+
+<style scoped lang="scss">
+@import '@/scss/colors';
+
+.receiving-disabled-dialog {
+  &__title {
+    padding-bottom: 32px !important;
+  }
+
+  &__icon {
+    ::v-deep {
+      .v-image {
+        &__image {
+          /* blue to red */
+          filter: hue-rotate(165deg);
+        }
+      }
+    }
+  }
+
+  &__description {
+    text-align: center;
+    font-size: 14px;
+    font-weight: 400;
+    letter-spacing: 0;
+    color: #ffffff;
+    opacity: 1;
+    padding-top: 32px;
+  }
+}
+</style>

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -423,6 +423,10 @@
     "problem": "Problem:",
     "solution": "Solution:"
   },
+  "receiving-disabled-dialog": {
+    "title": "Receiving transfers is disabled",
+    "body": "This may be due to configuration or UDC deposit being too low. If your client can receive, ensure you have enough UDC balance to pay for Monitoring Service (on Account menu) to enable receiving again."
+  },
   "errors": {
     "RDN_GENERAL_ERROR": {
       "title": "An error occured",

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -4,7 +4,6 @@ import {
   Raiden,
   RaidenPaths,
   RaidenPFS,
-  UInt,
   ErrorCodes,
   RaidenError
 } from 'raiden-ts';
@@ -13,7 +12,7 @@ import { RootState, Tokens } from '@/types';
 import { Web3Provider } from '@/services/web3-provider';
 import { BalanceUtils } from '@/utils/balance-utils';
 import { DeniedReason, Progress, Token, TokenModel } from '@/model/types';
-import { BigNumber, BigNumberish, parseEther, parseUnits } from 'ethers/utils';
+import { BigNumber, BigNumberish, parseEther } from 'ethers/utils';
 import { exhaustMap, filter } from 'rxjs/operators';
 import asyncPool from 'tiny-async-pool';
 import { ConfigProvider } from './config-provider';
@@ -42,8 +41,7 @@ export default class RaidenService {
         {
           pfsSafetyMargin: 1.1,
           pfs: process.env.VUE_APP_PFS,
-          matrixServer: process.env.VUE_APP_TRANSPORT,
-          monitoringReward: parseUnits('5', 18) as UInt<32>
+          matrixServer: process.env.VUE_APP_TRANSPORT
         },
         subkey
       );
@@ -172,6 +170,10 @@ export default class RaidenService {
         raiden.events$
           .pipe(filter(value => value.type === 'raidenShutdown'))
           .subscribe(() => this.store.commit('reset'));
+
+        raiden.config$.subscribe(config =>
+          this.store.commit('updateConfig', config)
+        );
 
         raiden.events$.subscribe(value => {
           if (value.type === 'tokenMonitored') {

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -6,7 +6,9 @@ import {
   ChannelState,
   RaidenChannel,
   RaidenChannels,
-  RaidenTransfer
+  RaidenTransfer,
+  RaidenConfig,
+  Capabilities
 } from 'raiden-ts';
 import {
   AccTokenModel,
@@ -45,7 +47,8 @@ const _defaultState: RootState = {
   settings: {
     isFirstTimeConnect: true,
     useRaidenAccount: true
-  }
+  },
+  config: {}
 };
 
 export function defaultState(): RootState {
@@ -120,6 +123,9 @@ const store: StoreOptions<RootState> = {
     },
     updateSettings(state: RootState, settings: Settings) {
       state.settings = settings;
+    },
+    updateConfig(state: RootState, config: Partial<RaidenConfig>) {
+      state.config = config;
     }
   },
   actions: {},
@@ -214,6 +220,9 @@ const store: StoreOptions<RootState> = {
       return state.raidenAccountBalance
         ? state.raidenAccountBalance
         : state.accountBalance;
+    },
+    canReceive: (state: RootState): boolean => {
+      return !state.config.caps?.[Capabilities.NO_RECEIVE];
     }
   },
   plugins: [settingsLocalStorage.plugin]

--- a/raiden-dapp/src/types.d.ts
+++ b/raiden-dapp/src/types.d.ts
@@ -1,5 +1,5 @@
 import RaidenService from '@/services/raiden-service';
-import { RaidenChannels, RaidenTransfer } from 'raiden-ts';
+import { RaidenChannels, RaidenTransfer, RaidenConfig } from 'raiden-ts';
 import { DeniedReason, Token, Presences } from '@/model/types';
 import { Network } from 'ethers/utils';
 
@@ -22,6 +22,7 @@ export interface RootState {
   transfers: Transfers;
   stateBackup: string;
   settings: Settings;
+  config: Partial<RaidenConfig>;
 }
 
 declare global {

--- a/raiden-dapp/tests/unit/app.spec.ts
+++ b/raiden-dapp/tests/unit/app.spec.ts
@@ -9,6 +9,7 @@ import store from '@/store/index';
 import Vuetify from 'vuetify';
 import RaidenService from '@/services/raiden-service';
 import App from '@/App.vue';
+import { Capabilities } from 'raiden-ts';
 
 Vue.use(VueRouter);
 Vue.use(Vuex);
@@ -30,7 +31,7 @@ describe('App.vue', () => {
     wrapper = shallowMount(App, {
       vuetify,
       store,
-      stubs: ['router-view'],
+      stubs: ['router-view', 'v-dialog'],
       mocks: {
         $router: router,
         $raiden: $raiden,
@@ -49,5 +50,21 @@ describe('App.vue', () => {
     wrapper.vm.$destroy();
 
     expect($raiden.disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  test("show ReceivingDiabled dialog if can't receive", async () => {
+    expect.assertions(2);
+
+    store.commit('updateConfig', {
+      caps: { [Capabilities.NO_RECEIVE]: false }
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.$data.showReceivingDisabled).toBe(false);
+
+    store.commit('updateConfig', {
+      caps: { [Capabilities.NO_RECEIVE]: true }
+    });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.$data.showReceivingDisabled).toBe(true);
   });
 });

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -19,7 +19,8 @@ import {
   Hash,
   Raiden,
   RaidenError,
-  RaidenTransfer
+  RaidenTransfer,
+  Capabilities
 } from 'raiden-ts';
 import { BigNumber, bigNumberify } from 'ethers/utils';
 import { BehaviorSubject, EMPTY, of } from 'rxjs';
@@ -58,6 +59,7 @@ describe('RaidenService', () => {
     raidenMock.address = '123';
     raidenMock.channels$ = EMPTY;
     raidenMock.events$ = EMPTY;
+    raidenMock.config$ = EMPTY;
     // Emit a dummy transfer event every time raiden is mocked
     raidenMock.transfers$ = of({}).pipe(delay(1000));
   };
@@ -714,5 +716,17 @@ describe('RaidenService', () => {
       DeniedReason.INITIALIZATION_FAILED
     );
     expect(store.commit).toBeCalledWith('loadComplete');
+  });
+
+  test('commit config$ updates', async () => {
+    expect.assertions(1);
+
+    const subject = new BehaviorSubject({});
+    (raiden as any).config$ = subject;
+    await setupSDK();
+    const config = { caps: { [Capabilities.NO_RECEIVE]: true } };
+    subject.next(config);
+
+    expect(store.commit).toHaveBeenLastCalledWith('updateConfig', config);
   });
 });

--- a/raiden-dapp/tests/unit/store.spec.ts
+++ b/raiden-dapp/tests/unit/store.spec.ts
@@ -4,6 +4,7 @@ import { DeniedReason, emptyTokenModel, Token } from '@/model/types';
 import { Tokens } from '@/types';
 import { Zero } from 'ethers/constants';
 import { BigNumber, bigNumberify } from 'ethers/utils';
+import { Capabilities } from 'raiden-ts';
 
 describe('store', () => {
   const testTokens = (token: string, name?: string, symbol?: string) => {
@@ -329,5 +330,13 @@ describe('store', () => {
   test('isConnected should be false if loading', () => {
     store.commit('account', '0x0000000000000000000000000000000000020001');
     expect(store.getters.isConnected).toBe(false);
+  });
+
+  test('canReceive should reflect config.caps', () => {
+    store.commit('updateConfig', { caps: { [Capabilities.NO_RECEIVE]: true } });
+    expect(store.getters.canReceive).toBe(false);
+    // no 'noReceive' canReceive
+    store.commit('updateConfig', { caps: {} });
+    expect(store.getters.canReceive).toBe(true);
   });
 });

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- [#1473] Expose config$ observable
+
+[#1473]: https://github.com/raiden-network/light-client/issues/1473
+
 ### Changed
 - [#842] Don't enforce test nets.
 

--- a/raiden-ts/src/index.ts
+++ b/raiden-ts/src/index.ts
@@ -2,11 +2,11 @@
 export { Raiden } from './raiden';
 export { RaidenState, encodeRaidenState } from './state';
 export { RaidenEvent, RaidenAction } from './actions';
-export { ShutdownReason } from './constants';
 export { RaidenTransfer, RaidenTransferStatus } from './transfers/state';
 export { ChannelState, RaidenChannel, RaidenChannels } from './channels/state';
 export { RaidenPaths, RaidenPFS } from './services/types';
 export { RaidenConfig } from './config';
+export * from './constants';
 export * from './types';
 export * from './utils/types';
 export * from './utils/error';

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -79,7 +79,6 @@ import { RaidenError, ErrorCodes } from './utils/error';
 export class Raiden {
   private readonly store: Store<RaidenState, RaidenAction>;
   private readonly deps: RaidenEpicDeps;
-  public config!: RaidenConfig;
 
   /**
    * action$ exposes the internal events pipeline. It's intended for debugging, and its interface
@@ -110,6 +109,11 @@ export class Raiden {
    * may be used as identifier to know which transfer got updated.
    */
   public readonly transfers$: Observable<RaidenTransfer>;
+
+  /** RaidenConfig object */
+  public config!: RaidenConfig;
+  /** RaidenConfig observable (for reactive use)  */
+  public config$: Observable<RaidenConfig>;
 
   /**
    * Expose ether's Provider.resolveName for ENS support
@@ -241,9 +245,10 @@ export class Raiden {
       },
     });
 
-    this.deps.config$.subscribe((config) => (this.config = config));
+    this.config$ = this.deps.config$;
+    this.config$.subscribe((config) => (this.config = config));
 
-    this.deps.config$
+    this.config$
       .pipe(pluckDistinct('logger'))
       .subscribe((logger) => this.log.setLevel(logger || 'silent', false));
 

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -462,21 +462,20 @@ export const pfsCapacityUpdateEpic = (
  * @param deps.network - Current network
  * @param deps.signer - Signer instance
  * @param deps.config$ - Config observable
- * @param deps.latest$ - Latest observable
  * @returns Observable of messageGlobalSend actions
  */
 export const pfsFeeUpdateEpic = (
   {}: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-  { log, address, network, signer, config$, latest$ }: RaidenEpicDeps,
+  { log, address, network, signer, config$ }: RaidenEpicDeps,
 ): Observable<messageGlobalSend> =>
   state$.pipe(
     groupChannel$,
     // get only first state per channel
     mergeMap((grouped$) => grouped$.pipe(first())),
-    withLatestFrom(config$, latest$),
+    withLatestFrom(config$),
     // ignore actions while/if mediating not enabled
-    filter(([, { pfsRoom }, { caps }]) => !!pfsRoom && !caps[Capabilities.NO_MEDIATE]),
+    filter(([, { pfsRoom, caps }]) => !!pfsRoom && !caps?.[Capabilities.NO_MEDIATE]),
     mergeMap(([channel, { pfsRoom }]) => {
       if (channel.state !== ChannelState.open) return EMPTY;
 

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -496,7 +496,7 @@ function makeAndSignWithdrawConfirmation(
 function receiveTransferSigned(
   state$: Observable<RaidenState>,
   action: messageReceivedTyped<Signed<LockedTransfer>>,
-  { address, log, network, signer, config$, latest$ }: RaidenEpicDeps,
+  { address, log, network, signer, config$ }: RaidenEpicDeps,
 ): Observable<
   | transferSigned
   | transfer.failure
@@ -506,9 +506,9 @@ function receiveTransferSigned(
 > {
   const secrethash = action.payload.message.lock.secrethash;
   const meta = { secrethash, direction: Direction.RECEIVED };
-  return combineLatest([state$, config$, latest$]).pipe(
+  return combineLatest([state$, config$]).pipe(
     first(),
-    mergeMap(([state, { revealTimeout }, { caps }]) => {
+    mergeMap(([state, { revealTimeout, caps }]) => {
       const transfer: Signed<LockedTransfer> = action.payload.message;
       if (secrethash in state.received) {
         log.warn('transfer already present', action.meta);
@@ -571,7 +571,7 @@ function receiveTransferSigned(
       );
 
       let request$: Observable<Signed<SecretRequest> | undefined> = of(undefined);
-      if (!caps[Capabilities.NO_RECEIVE] && transfer.target === address)
+      if (!caps?.[Capabilities.NO_RECEIVE] && transfer.target === address)
         request$ = defer(() => {
           const request: SecretRequest = {
             type: MessageType.SECRET_REQUEST,

--- a/raiden-ts/src/transfers/epics/mediate.ts
+++ b/raiden-ts/src/transfers/epics/mediate.ts
@@ -23,13 +23,13 @@ import { Direction } from '../state';
  * @param state$ - Observable of RaidenStates
  * @param deps - Raiden epic deps
  * @param deps.address - Our address
- * @param deps.latest$ - Latest observable
+ * @param deps.config$ - Latest observable
  * @returns Observable of outbound transfer.request actions
  */
 export const transferMediateEpic = (
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-  { address, latest$ }: RaidenEpicDeps,
+  { address, config$ }: RaidenEpicDeps,
 ) =>
   action$.pipe(
     filter(transferSigned.is),
@@ -38,11 +38,11 @@ export const transferMediateEpic = (
       (action) =>
         action.meta.direction === Direction.RECEIVED && action.payload.message.target !== address,
     ),
-    withLatestFrom(state$, latest$),
+    withLatestFrom(state$, config$),
     // filter when mediating is enabled and outgoing transfer isn't set
     filter(
       ([action, { sent }, { caps }]) =>
-        !caps[Capabilities.NO_MEDIATE] && !(action.meta.secrethash in sent),
+        !caps?.[Capabilities.NO_MEDIATE] && !(action.meta.secrethash in sent),
     ),
     map(([{ payload: { message: transf }, meta: { secrethash } }]) =>
       // request an outbound transfer to target

--- a/raiden-ts/src/transfers/epics/secret.ts
+++ b/raiden-ts/src/transfers/epics/secret.ts
@@ -378,14 +378,10 @@ export const transferAutoRegisterEpic = (
     mergeMap((secrethash) =>
       action$.pipe(
         filter(newBlock.is),
-        withLatestFrom(
-          latest$.pipe(pluck('state', Direction.RECEIVED, secrethash)),
-          config$,
-          latest$,
-        ),
+        withLatestFrom(latest$.pipe(pluck('state', Direction.RECEIVED, secrethash)), config$),
         filter(
-          ([action, received, { revealTimeout }, { caps }]) =>
-            !caps[Capabilities.NO_RECEIVE] && // ignore if receiving is disabled
+          ([action, received, { revealTimeout, caps }]) =>
+            !caps?.[Capabilities.NO_RECEIVE] && // ignore if receiving is disabled
             !!received.secret && // register only if we know the secret
             received.transfer[1].lock.expiration
               .sub(revealTimeout)

--- a/raiden-ts/src/transport/epics/init.ts
+++ b/raiden-ts/src/transport/epics/init.ts
@@ -229,7 +229,7 @@ function setupMatrixClient$(
   server: string,
   setup: RaidenMatrixSetup | undefined,
   { address, signer }: Pick<RaidenEpicDeps, 'address' | 'signer'>,
-  caps: Caps,
+  caps: Caps | null,
 ) {
   const serverName = getServerName(server);
   if (!serverName) throw new RaidenError(ErrorCodes.TRNS_NO_SERVERNAME, { server });
@@ -317,7 +317,7 @@ export const initMatrixEpic = (
 ): Observable<matrixSetup> =>
   combineLatest([latest$, config$]).pipe(
     first(), // at startup
-    mergeMap(([{ state, caps }, { matrixServer, matrixServerLookup, httpTimeout }]) => {
+    mergeMap(([{ state }, { matrixServer, matrixServerLookup, httpTimeout, caps }]) => {
       const server = state.transport.server,
         setup = state.transport.setup;
 

--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -352,10 +352,10 @@ function handlePresenceChange$(
       (a, b) =>
         a.payload.userId === b.payload.userId && a.payload.available === b.payload.available,
     ),
-    withLatestFrom(matrix$, config$, latest$),
+    withLatestFrom(matrix$, config$),
     filter(
-      ([action, , , { caps }]) =>
-        !!action.payload.caps?.[Capabilities.WEBRTC] && !!caps[Capabilities.WEBRTC],
+      ([action, , { caps }]) =>
+        !!action.payload.caps?.[Capabilities.WEBRTC] && !!caps?.[Capabilities.WEBRTC],
     ),
     switchMap(([action, matrix, config]) => {
       // if peer goes offline in Matrix, reset dataChannel & unsubscribe defer to close dataChannel

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -16,7 +16,7 @@ import { RaidenAction } from './actions';
 import { RaidenState } from './state';
 import { Address, UInt } from './utils/types';
 import { RaidenConfig } from './config';
-import { Presences, Caps } from './transport/types';
+import { Presences } from './transport/types';
 
 interface Info {
   address: Address;
@@ -39,7 +39,6 @@ export interface Latest {
   pfsList: readonly Address[];
   rtc: { [address: string]: RTCDataChannel };
   udcBalance: UInt<32>;
-  caps: Caps;
 }
 
 export interface RaidenEpicDeps {

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { timer } from 'rxjs';
 import { first, filter, takeUntil } from 'rxjs/operators';
-import { Zero } from 'ethers/constants';
+import { Zero, MaxUint256 } from 'ethers/constants';
 import { parseEther, parseUnits, bigNumberify, BigNumber, keccak256, Network } from 'ethers/utils';
 
 import { TestProvider } from './provider';
@@ -312,7 +312,11 @@ describe('Raiden', () => {
 
   describe('getUDCCapacity', () => {
     test('no balance', async () => {
-      expect.assertions(1);
+      expect.assertions(3);
+      // initial high, to avoid it interferring with caps[Capabilities.NO_RECEIVE]
+      await expect(raiden.getUDCCapacity()).resolves.toEqual(MaxUint256);
+      await expect(raiden.userDepositTokenAddress()).resolves.toMatch(/^0x/);
+      // should be updated soonish
       await expect(raiden.getUDCCapacity()).resolves.toEqual(Zero);
     });
 

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -266,7 +266,6 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
       pfsList: [],
       rtc: {},
       udcBalance: Zero as UInt<32>,
-      caps: config.caps ?? {},
     }),
     config$ = latest$.pipe(pluckDistinct('config'));
 


### PR DESCRIPTION
Fixes #1473 

TODO: tests, changelog

**Short description**
A dialog is shown on any screen on dApp when/if SDK has Receiving transfers disabled. This can happen on startup or during runtime, for mainly a couple of reasons:
- `rateToSvt` config mapping is empty (it is by default, so receiving is disabled until it gets populated)
- `monitoringReward` config isn't set (it is by default, as 5SVT)
- `udcBalance` is not enough to pay monitoring reward (which can happen at startup or at runtime by a withdraw from service or user #1421).
- explictly disabled in user config with `Raiden.updateConfig({ caps: { noReceive: true } })`, which has priority

![image](https://user-images.githubusercontent.com/587021/82388249-884a9e80-9a0f-11ea-9554-d117bf626c6c.png)


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. On dApp, acquire `raiden` SDK instance and enable receiving with:
```ts
raiden.updateConfig({
  rateToSvt: { '<token_addr>': '100000000000000000000' },
  caps: { noReceive: false },
 })
```
2. Reload, check no dialog is shown
3. Disable receiving explicity while connected:
```ts
raiden.updateConfig({ caps: { noReceive: true } })
```
4. See dialog shown which says receiving is disabled
5. One can also trigger dialog shown, even if `caps['noReceive']` is unset (auto), if UDC balance is emptied, if one sets `monitoringReward` config to something higher than UDC desposit or `rateToSvt` is emptied
