### PR TITLE
Fix mainnet network name

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ## [Unreleased]
-
 ### Changed
 - [#842] Don't enforce test nets.
 

--- a/raiden-ts/src/utils/ethers.ts
+++ b/raiden-ts/src/utils/ethers.ts
@@ -162,5 +162,9 @@ export function patchSignSend(provider: JsonRpcProvider): void {
  * @returns name or chainId as string
  */
 export function getNetworkName(network: Network) {
-  return network.name !== 'unknown' ? network.name : network.chainId.toString();
+  return network.name === 'unknown'
+    ? network.chainId.toString()
+    : network.name === 'homestead'
+    ? 'mainnet'
+    : network.name;
 }

--- a/raiden-ts/tests/unit/utils.spec.ts
+++ b/raiden-ts/tests/unit/utils.spec.ts
@@ -10,7 +10,12 @@ import { Event } from 'ethers/contract';
 import { BigNumber, bigNumberify, keccak256, hexDataLength } from 'ethers/utils';
 import { LosslessNumber } from 'lossless-json';
 
-import { fromEthersEvent, getEventsStream, patchSignSend } from 'raiden-ts/utils/ethers';
+import {
+  fromEthersEvent,
+  getEventsStream,
+  patchSignSend,
+  getNetworkName,
+} from 'raiden-ts/utils/ethers';
 import {
   Address,
   BigNumberC,
@@ -431,4 +436,10 @@ describe('RaidenError', () => {
       expect(err.details).toStrictEqual({ value: 'bar', key: 'foo' });
     }
   });
+});
+
+test('getNetworkName', () => {
+  expect(getNetworkName({ name: 'unknown', chainId: 1337 })).toBe('1337');
+  expect(getNetworkName({ name: 'homestead', chainId: 1 })).toBe('mainnet');
+  expect(getNetworkName({ name: 'goerli', chainId: 5 })).toBe('goerli');
 });


### PR DESCRIPTION
Fixes #1547

**Short description**
Fix network name for mainnet, instead of homestead, `mainnet`, to be compatible with matrix rooms created for raiden.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [x] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**
1. On issue
