### PR TITLE
Fixes truncation of long token names

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- [#1541] Truncates long token names in the transfer screen.
 - [#1516] Fixed truncation of address on Account screen
 - [#1506] Fixed error label display on transfer screen for amount input.
 - [#1493] Properly handles tokens with zero decimals, fixes transaction history token display.
@@ -18,6 +19,7 @@
 - [#1443] Eth transfer screen redesign
 - [#842] Disable mainnet w/ environment variable.
 
+[#1541]: https://github.com/raiden-network/light-client/issues/1541
 [#1443]: https://github.com/raiden-network/light-client/issues/1443
 [#1473]: https://github.com/raiden-network/light-client/issues/1473
 [#1516]: https://github.com/raiden-network/light-client/issues/1516

--- a/raiden-dapp/src/components/navigation/Transfer.vue
+++ b/raiden-dapp/src/components/navigation/Transfer.vue
@@ -24,7 +24,7 @@
       </v-col>
       <v-col class="transfer__actions__token-button">
         <action-button
-          :text="token.name"
+          :text="token.name | truncate(22)"
           ghost
           enabled
           full-width


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #1541  

**Short description**

Truncates overly long token names to 22 characters.
![image](https://user-images.githubusercontent.com/2269732/82807761-b7866300-9e88-11ea-9333-603eab544c2e.png)


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 


**Steps to manually test the change (dApp)**

1. Open the dApp
2. Go to transfers screen
