### PR TITLE
Refactor tests and fixtures

### DIFF
--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -126,8 +126,7 @@
     },
     "parserOptions": {
       "ecmaVersion": 2018,
-      "sourceType": "module",
-      "project": "./tsconfig.json"
+      "sourceType": "module"
     },
     "rules": {
       "import/order": [

--- a/raiden-ts/tests/unit/epics/channels.spec.ts
+++ b/raiden-ts/tests/unit/epics/channels.spec.ts
@@ -1,21 +1,32 @@
-import { epicFixtures } from '../fixtures';
-import { raidenEpicDeps, makeLog } from '../mocks';
-
-import { marbles } from 'rxjs-marbles/jest';
-import { of, from, timer, concat } from 'rxjs';
-import { first, toArray, pluck, tap, ignoreElements } from 'rxjs/operators';
-import { ContractTransaction } from 'ethers/contract';
-import { bigNumberify, BigNumber } from 'ethers/utils';
-import { Zero, HashZero, One } from 'ethers/constants';
-import { defaultAbiCoder } from 'ethers/utils/abi-coder';
-import { range } from 'lodash';
-
-import { UInt, Int } from 'raiden-ts/utils/types';
-import { RaidenAction, raidenConfigUpdate } from 'raiden-ts/actions';
-import { RaidenState } from 'raiden-ts/state';
+import { makeLog, makeRaidens, makeHash, waitBlock, makeTransaction } from '../mocks';
 import {
-  newBlock,
-  tokenMonitored,
+  token,
+  tokenNetwork,
+  id,
+  openBlock,
+  closeBlock,
+  settleBlock,
+  settleTimeout,
+  txHash,
+  ensureChannelIsClosed,
+  ensureChannelIsOpen,
+  ensureTokenIsMonitored,
+  deposit,
+  confirmationBlocks,
+  ensureChannelIsDeposited,
+  ensureTransferReceivedUnlocked,
+  ensureTransferReceivedPending,
+  secrethash,
+  secret,
+  ensureChannelIsSettled,
+} from '../fixtures';
+
+import { bigNumberify, BigNumber } from 'ethers/utils';
+import { Zero, HashZero } from 'ethers/constants';
+import { defaultAbiCoder } from 'ethers/utils/abi-coder';
+
+import { UInt } from 'raiden-ts/utils/types';
+import {
   channelMonitor,
   channelOpen,
   channelDeposit,
@@ -24,1276 +35,700 @@ import {
   channelSettle,
   channelWithdrawn,
 } from 'raiden-ts/channels/actions';
-import {
-  channelOpenEpic,
-  channelOpenedEpic,
-  channelDepositEpic,
-  channelCloseEpic,
-  channelSettleEpic,
-  channelMonitoredEpic,
-  channelSettleableEpic,
-  channelUpdateEpic,
-  channelUnlockEpic,
-} from 'raiden-ts/channels/epics';
-import { raidenReducer } from 'raiden-ts/reducer';
-import { getLatest$ } from 'raiden-ts/epics';
-import {
-  makeSecret,
-  getSecrethash,
-  makePaymentId,
-  makeMessageId,
-  getLocksroot,
-} from 'raiden-ts/transfers/utils';
-import { Direction } from 'raiden-ts/transfers/state';
-import { MessageType } from 'raiden-ts/messages/types';
-import { signMessage } from 'raiden-ts/messages/utils';
-import { transferSigned, transferUnlock } from 'raiden-ts/transfers/actions';
+import { channelKey, channelUniqueKey } from 'raiden-ts/channels/utils';
+import { ChannelState } from 'raiden-ts/channels';
+import { TokenNetwork } from 'raiden-ts/contracts/TokenNetwork';
+import { Filter } from 'ethers/providers';
 
-describe('channels epic', () => {
-  const depsMock = raidenEpicDeps();
-  const {
-    token,
-    tokenContract,
-    tokenNetworkContract,
-    tokenNetwork,
-    channelId,
-    partner,
-    settleTimeout,
-    isFirstParticipant,
-    txHash,
-    state,
-  } = epicFixtures(depsMock);
+test('channelSettleableEpic', async () => {
+  expect.assertions(3);
 
-  beforeEach(async () => {
-    // reset depsMock.latest$ to state
-    await getLatest$(of(raidenConfigUpdate({})), of(state), depsMock)
-      .pipe(tap((latest) => depsMock.latest$.next(latest)))
-      .toPromise();
-  });
+  const [raiden, partner] = await makeRaidens(2);
+  await ensureChannelIsClosed([raiden, partner]);
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+  const key = channelKey({ tokenNetwork, partner });
 
-  test(
-    'channelSettleableEpic',
-    marbles((m) => {
-      const closeBlock = 125;
-      // state contains one channel in closed state
-      const newState = [
-        tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant,
-            token,
-            txHash,
-            txBlock: 121,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-        channelClose.success(
-          {
-            id: channelId,
-            participant: depsMock.address,
-            txHash,
-            txBlock: closeBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-      ].reduce(raidenReducer, state);
-      /* first newBlock bigger than settleTimeout causes a channelSettleable to be emitted */
-      const action$ = m.cold('---b-B-|', {
-          b: newBlock({ blockNumber: closeBlock + settleTimeout - 1 }),
-          B: newBlock({ blockNumber: closeBlock + settleTimeout + 4 }),
-        }),
-        state$ = m.cold('--s-|', { s: newState });
-      m.expect(channelSettleableEpic(action$, state$)).toBeObservable(
-        m.cold('-----S-|', {
-          S: channelSettleable(
-            { settleableBlock: closeBlock + settleTimeout + 4 },
-            { tokenNetwork, partner },
-          ),
-        }),
-      );
-    }),
+  await waitBlock(closeBlock + settleTimeout - 1);
+  expect(raiden.store.getState().channels[key].state).toBe(ChannelState.closed);
+
+  await waitBlock(closeBlock + settleTimeout + 7);
+  expect(raiden.store.getState().channels[key].state).toBe(ChannelState.settleable);
+  expect(raiden.output).toContainEqual(
+    channelSettleable(
+      { settleableBlock: closeBlock + settleTimeout + 7 },
+      { tokenNetwork, partner: partner.address },
+    ),
   );
+});
 
-  describe('channelOpenEpic', () => {
-    test('fails if channel.state !== opening', async () => {
-      // there's a channel already opened in state
-      const action = channelOpen.request({ settleTimeout }, { tokenNetwork, partner }),
-        curState = [
-          tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-          channelOpen.success(
-            {
-              id: channelId,
-              settleTimeout,
-              isFirstParticipant,
-              token,
-              txHash,
-              txBlock: 125,
-              confirmed: true,
-            },
-            { tokenNetwork, partner },
-          ),
-        ].reduce(raidenReducer, state);
-      const action$ = of<RaidenAction>(action),
-        state$ = of<RaidenState>(curState);
+describe('channelOpenEpic', () => {
+  test('fails if channel exists', async () => {
+    expect.assertions(2);
 
-      await expect(channelOpenEpic(action$, state$, depsMock).toPromise()).resolves.toEqual(
-        channelOpen.failure(expect.any(Error), { tokenNetwork, partner }),
-      );
-    });
+    const [raiden, partner] = await makeRaidens(2);
+    await ensureChannelIsOpen([raiden, partner]);
 
-    test('tx fails', async () => {
-      const action = channelOpen.request({ settleTimeout }, { tokenNetwork, partner }),
-        curState = [tokenMonitored({ token, tokenNetwork, fromBlock: 1 }), action].reduce(
-          raidenReducer,
-          state,
-        );
-      const action$ = of<RaidenAction>(action),
-        state$ = of<RaidenState>(curState);
-
-      const tx: ContractTransaction = {
-        hash: txHash,
-        confirmations: 1,
-        nonce: 1,
-        gasLimit: bigNumberify(1e6),
-        gasPrice: bigNumberify(2e10),
-        value: Zero,
-        data: '0x',
-        chainId: depsMock.network.chainId,
-        from: depsMock.address,
-        wait: jest.fn().mockResolvedValue({ byzantium: true, status: 0 }),
-      };
-      tokenNetworkContract.functions.openChannel.mockResolvedValueOnce(tx);
-
-      await expect(channelOpenEpic(action$, state$, depsMock).toPromise()).resolves.toEqual(
-        channelOpen.failure(expect.any(Error), { tokenNetwork, partner }),
-      );
-    });
-
-    test('success', async () => {
-      // there's a channel already opened in state
-      const action = channelOpen.request({ settleTimeout }, { tokenNetwork, partner }),
-        curState = [tokenMonitored({ token, tokenNetwork, fromBlock: 1 }), action].reduce(
-          raidenReducer,
-          state,
-        );
-      const action$ = of<RaidenAction>(action),
-        state$ = of<RaidenState>(curState);
-
-      const tx: ContractTransaction = {
-        hash: txHash,
-        confirmations: 1,
-        nonce: 1,
-        gasLimit: bigNumberify(1e6),
-        gasPrice: bigNumberify(2e10),
-        value: Zero,
-        data: '0x',
-        chainId: depsMock.network.chainId,
-        from: depsMock.address,
-        wait: jest.fn().mockResolvedValue({ byzantium: true, status: 1 }),
-      };
-      tokenNetworkContract.functions.openChannel.mockResolvedValueOnce(tx);
-
-      // result is undefined on success as the respective channelOpen.success is emitted by the
-      // tokenMonitoredEpic, which monitors the blockchain for ChannelOpened events
-      await expect(
-        channelOpenEpic(action$, state$, depsMock).toPromise(),
-      ).resolves.toBeUndefined();
-      expect(tokenNetworkContract.functions.openChannel).toHaveBeenCalledTimes(1);
-      expect(tx.wait).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  test('channelOpenedEpic', async () => {
-    const {
-      tokenNetwork,
-      channelId,
-      partner,
-      settleTimeout,
-      isFirstParticipant,
-      txHash,
-    } = epicFixtures(depsMock);
-
-    const action = channelOpen.success(
-      {
-        id: channelId,
-        settleTimeout,
-        isFirstParticipant,
-        token,
-        txHash,
-        txBlock: 125,
-        confirmed: true,
-      },
-      { tokenNetwork, partner },
+    raiden.store.dispatch(
+      channelOpen.request({ settleTimeout }, { tokenNetwork, partner: partner.address }),
     );
-    const action$ = of<RaidenAction>(action);
-
-    await expect(channelOpenedEpic(action$).toPromise()).resolves.toMatchObject(
-      channelMonitor({ id: channelId, fromBlock: 125 }, { tokenNetwork, partner }),
+    expect(raiden.store.getState().channels[channelKey({ tokenNetwork, partner })].state).toBe(
+      ChannelState.open,
+    );
+    expect(raiden.output).toContainEqual(
+      channelOpen.failure(expect.any(Error), { tokenNetwork, partner: partner.address }),
     );
   });
 
-  describe('channelMonitoredEpic', () => {
-    const deposit = bigNumberify(1023) as UInt<32>,
-      depositEncoded = defaultAbiCoder.encode(['uint256'], [deposit]),
-      withdraw = bigNumberify(100) as UInt<32>,
-      withdrawEncoded = defaultAbiCoder.encode(['uint256'], [withdraw]),
-      openBlock = 121,
-      closeBlock = 124,
-      settleBlock = closeBlock + settleTimeout + 1,
-      settleDataEncoded = defaultAbiCoder.encode(
-        ['uint256', 'bytes32', 'uint256', 'bytes32'],
-        [Zero, HashZero, Zero, HashZero],
+  test('tx fails', async () => {
+    expect.assertions(2);
+
+    const [raiden, partner] = await makeRaidens(2);
+    await ensureTokenIsMonitored(raiden);
+
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+    const openTx = makeTransaction(0);
+    tokenNetworkContract.functions.openChannel.mockResolvedValue(openTx);
+
+    await waitBlock(openBlock);
+    raiden.store.dispatch(
+      channelOpen.request({ settleTimeout }, { tokenNetwork, partner: partner.address }),
+    );
+    await waitBlock();
+    expect(tokenNetworkContract.functions.openChannel).toHaveBeenCalled();
+    expect(raiden.output).toContainEqual(
+      channelOpen.failure(expect.any(Error), { tokenNetwork, partner: partner.address }),
+    );
+  });
+
+  test('success', async () => {
+    expect.assertions(2);
+
+    const [raiden, partner] = await makeRaidens(2);
+    await ensureTokenIsMonitored(raiden);
+
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+    const openTx = makeTransaction();
+    tokenNetworkContract.functions.openChannel.mockResolvedValue(openTx);
+
+    raiden.store.dispatch(
+      channelOpen.request({ settleTimeout }, { tokenNetwork, partner: partner.address }),
+    );
+    await waitBlock();
+
+    // result is undefined on success as the respective channelOpen.success is emitted by the
+    // tokenMonitoredEpic, which monitors the blockchain for ChannelOpened events
+    expect(tokenNetworkContract.functions.openChannel).toHaveBeenCalledTimes(1);
+    expect(openTx.wait).toHaveBeenCalledTimes(1);
+  });
+});
+
+test('channelOpenedEpic', async () => {
+  expect.assertions(1);
+
+  const [raiden, partner] = await makeRaidens(2);
+  await ensureChannelIsOpen([raiden, partner]);
+
+  expect(raiden.output).toContainEqual(
+    channelMonitor(
+      { id, fromBlock: expect.any(Number) },
+      { tokenNetwork, partner: partner.address },
+    ),
+  );
+});
+
+describe('channelMonitoredEpic', () => {
+  const idEncoded = defaultAbiCoder.encode(['uint256'], [id]);
+  const depositEncoded = defaultAbiCoder.encode(['uint256'], [deposit]);
+
+  function getMonitoredFilter(tokenNetworkContract: TokenNetwork): Filter {
+    return {
+      address: tokenNetworkContract.address,
+      topics: [
+        [
+          tokenNetworkContract.interface.events.ChannelNewDeposit.topic,
+          tokenNetworkContract.interface.events.ChannelWithdraw.topic,
+          tokenNetworkContract.interface.events.ChannelClosed.topic,
+          tokenNetworkContract.interface.events.ChannelSettled.topic,
+        ],
+        [idEncoded],
+      ],
+    };
+  }
+
+  test('initial monitor with past$ own ChannelNewDeposit event', async () => {
+    expect.assertions(1);
+
+    const [raiden, partner] = await makeRaidens(2);
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+
+    raiden.deps.provider.getLogs.mockResolvedValue([
+      makeLog({
+        blockNumber: openBlock + 1,
+        filter: tokenNetworkContract.filters.ChannelNewDeposit(id, raiden.address, null),
+        data: depositEncoded, // non-indexed total_deposit = 1023 goes in data
+      }),
+    ]);
+    await ensureChannelIsOpen([raiden, partner]);
+    raiden.store.dispatch(
+      channelMonitor({ id, fromBlock: openBlock }, { tokenNetwork, partner: partner.address }),
+    );
+    await waitBlock();
+
+    expect(raiden.output).toContainEqual(
+      channelDeposit.success(
+        {
+          id,
+          participant: raiden.address,
+          totalDeposit: deposit,
+          txHash: expect.any(String),
+          txBlock: openBlock + 1,
+          confirmed: undefined,
+        },
+        { tokenNetwork, partner: partner.address },
       ),
-      delayEnd$ = timer(10).pipe(ignoreElements());
-
-    test('first channelMonitor with past$ own ChannelNewDeposit event', async () => {
-      const curState = [
-        tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant,
-            token,
-            txHash,
-            txBlock: openBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-      ].reduce(raidenReducer, state);
-      const action$ = of<RaidenAction>(
-          channelMonitor({ id: channelId, fromBlock: openBlock }, { tokenNetwork, partner }),
-        ),
-        // give some time so takeUntil doesn't unsubscribe ahead of time
-        state$ = concat(of<RaidenState>(curState), delayEnd$);
-      getLatest$(action$, state$, depsMock).subscribe((latest) => depsMock.latest$.next(latest));
-
-      depsMock.provider.getLogs.mockResolvedValueOnce([
-        makeLog({
-          blockNumber: 123,
-          filter: tokenNetworkContract.filters.ChannelNewDeposit(
-            channelId,
-            depsMock.address,
-            null,
-          ),
-          data: depositEncoded, // non-indexed total_deposit = 1023 goes in data
-        }),
-      ]);
-
-      await expect(channelMonitoredEpic(action$, state$, depsMock).toPromise()).resolves.toEqual(
-        channelDeposit.success(
-          {
-            id: channelId,
-            participant: depsMock.address,
-            totalDeposit: deposit,
-            txHash: expect.any(String),
-            txBlock: 123,
-            confirmed: undefined,
-          },
-          { tokenNetwork, partner },
-        ),
-      );
-    });
-
-    test('already channelMonitor with new$ partner ChannelNewDeposit event', async () => {
-      const action = channelMonitor({ id: channelId }, { tokenNetwork, partner }),
-        curState = [
-          tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-          channelOpen.success(
-            {
-              id: channelId,
-              settleTimeout,
-              isFirstParticipant,
-              token,
-              txHash,
-              txBlock: openBlock,
-              confirmed: true,
-            },
-            { tokenNetwork, partner },
-          ),
-        ].reduce(raidenReducer, state);
-      const action$ = of<RaidenAction>(action),
-        state$ = concat(of<RaidenState>(curState), delayEnd$);
-      getLatest$(action$, state$, depsMock).subscribe((latest) => depsMock.latest$.next(latest));
-
-      const promise = channelMonitoredEpic(action$, state$, depsMock).toPromise();
-
-      depsMock.provider.emit(
-        '*',
-        makeLog({
-          blockNumber: 125,
-          filter: tokenNetworkContract.filters.ChannelNewDeposit(channelId, partner, null),
-          data: depositEncoded, // non-indexed total_deposit = 1023 goes in data
-        }),
-      );
-
-      await expect(promise).resolves.toEqual(
-        channelDeposit.success(
-          {
-            id: channelId,
-            participant: partner,
-            totalDeposit: deposit,
-            txHash: expect.any(String),
-            txBlock: 125,
-            confirmed: undefined,
-          },
-          { tokenNetwork, partner },
-        ),
-      );
-    });
-
-    test("ensure multiple channelMonitor don't produce duplicated events", async () => {
-      const multiple = 16;
-      const curState = [
-        tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant,
-            token,
-            txHash,
-            txBlock: openBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-      ].reduce(raidenReducer, state);
-      const action$ = from(
-          range(multiple).map(() => channelMonitor({ id: channelId }, { tokenNetwork, partner })),
-        ),
-        state$ = concat(of<RaidenState>(curState), delayEnd$);
-      getLatest$(action$, state$, depsMock).subscribe((latest) => depsMock.latest$.next(latest));
-
-      const promise = channelMonitoredEpic(action$, state$, depsMock)
-        .pipe(toArray()) // aggregate all emitted values in this period in a single array
-        .toPromise();
-
-      // even though multiple channelMonitor events were fired, blockchain fires a single event
-      depsMock.provider.emit(
-        '*',
-        makeLog({
-          blockNumber: 125,
-          filter: tokenNetworkContract.filters.ChannelNewDeposit(
-            channelId,
-            depsMock.address,
-            null,
-          ),
-          data: depositEncoded, // non-indexed total_deposit = 1023 goes in data
-        }),
-      );
-
-      const result = await promise;
-      expect(result).toHaveLength(1);
-      expect(result[0]).toEqual(
-        channelDeposit.success(
-          {
-            id: channelId,
-            participant: depsMock.address,
-            totalDeposit: deposit,
-            txHash: expect.any(String),
-            txBlock: 125,
-            confirmed: undefined,
-          },
-          { tokenNetwork, partner },
-        ),
-      );
-
-      expect(depsMock.provider.on).toHaveBeenCalledTimes(1); // mergedFilter
-    });
-
-    test('new$ partner ChannelWithdraw event', async () => {
-      const curState = [
-        tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant,
-            token,
-            txHash,
-            txBlock: openBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-        channelDeposit.success(
-          {
-            id: channelId,
-            participant: partner,
-            totalDeposit: bigNumberify(410) as UInt<32>,
-            txHash,
-            txBlock: openBlock + 1,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-      ].reduce(raidenReducer, state);
-      const action$ = of<RaidenAction>(
-          channelMonitor({ id: channelId }, { tokenNetwork, partner }),
-        ),
-        state$ = concat(of<RaidenState>(curState), delayEnd$);
-      getLatest$(action$, state$, depsMock).subscribe((latest) => depsMock.latest$.next(latest));
-
-      const promise = channelMonitoredEpic(action$, state$, depsMock).toPromise();
-
-      depsMock.provider.emit(
-        '*',
-        makeLog({
-          blockNumber: closeBlock,
-          transactionHash: txHash,
-          filter: tokenNetworkContract.filters.ChannelWithdraw(channelId, partner, null),
-          data: withdrawEncoded, // non-indexed totalWithdraw
-        }),
-      );
-
-      await expect(promise).resolves.toEqual(
-        channelWithdrawn(
-          {
-            id: channelId,
-            participant: partner,
-            totalWithdraw: withdraw,
-            txHash,
-            txBlock: closeBlock,
-            confirmed: undefined,
-          },
-          { tokenNetwork, partner },
-        ),
-      );
-    });
-
-    test('new$ partner ChannelClosed event', async () => {
-      const curState = [
-        tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant,
-            token,
-            txHash,
-            txBlock: openBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-      ].reduce(raidenReducer, state);
-      const action$ = of<RaidenAction>(
-          channelMonitor({ id: channelId }, { tokenNetwork, partner }),
-        ),
-        state$ = concat(of<RaidenState>(curState), delayEnd$);
-      getLatest$(action$, state$, depsMock).subscribe((latest) => depsMock.latest$.next(latest));
-
-      const promise = channelMonitoredEpic(action$, state$, depsMock).toPromise();
-
-      depsMock.provider.emit(
-        '*',
-        makeLog({
-          blockNumber: closeBlock,
-          transactionHash: txHash,
-          filter: tokenNetworkContract.filters.ChannelClosed(channelId, partner, 11, null),
-          data: HashZero, // non-indexed balance_hash
-        }),
-      );
-
-      await expect(promise).resolves.toEqual(
-        channelClose.success(
-          {
-            id: channelId,
-            participant: partner,
-            txHash,
-            txBlock: closeBlock,
-            confirmed: undefined,
-          },
-          { tokenNetwork, partner },
-        ),
-      );
-    });
-
-    test('new$ ChannelSettled event', async () => {
-      const curState = [
-        tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant,
-            token,
-            txHash,
-            txBlock: openBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-        channelClose.success(
-          {
-            id: channelId,
-            participant: depsMock.address,
-            txHash,
-            txBlock: closeBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ), // channel is in "closed" state already
-      ].reduce(raidenReducer, state);
-      const action$ = of<RaidenAction>(
-          channelMonitor({ id: channelId }, { tokenNetwork, partner }),
-        ),
-        state$ = concat(of<RaidenState>(curState), delayEnd$);
-      getLatest$(action$, state$, depsMock).subscribe((latest) => depsMock.latest$.next(latest));
-
-      expect(depsMock.provider.removeListener).not.toHaveBeenCalled();
-      const promise = channelMonitoredEpic(action$, state$, depsMock).toPromise();
-
-      expect(depsMock.provider.listenerCount()).toBe(1);
-
-      depsMock.provider.emit(
-        '*',
-        makeLog({
-          blockNumber: settleBlock,
-          transactionHash: txHash,
-          filter: tokenNetworkContract.filters.ChannelSettled(channelId, null, null, null, null),
-          data: settleDataEncoded, // participants amounts aren't indexed, so they go in data
-        }),
-      );
-
-      await expect(promise).resolves.toEqual(
-        channelSettle.success(
-          { id: channelId, txHash, txBlock: settleBlock, confirmed: undefined, locks: [] },
-          { tokenNetwork, partner },
-        ),
-      );
-
-      // ensure ChannelSettledAction completed channel monitoring and unsubscribed from events
-      expect(depsMock.provider.removeListener).toHaveBeenCalledTimes(1);
-      expect(depsMock.provider.listenerCount()).toBe(0);
-    });
+    );
   });
 
-  describe('channelDepositEpic', () => {
-    const deposit = bigNumberify(1023) as UInt<32>,
-      openBlock = 121;
+  test('already monitored with new$ partner ChannelNewDeposit event', async () => {
+    expect.assertions(1);
 
-    test('fails if there is no token for tokenNetwork', async () => {
-      // there's a channel already opened in state
-      const action$ = of<RaidenAction>(
-          channelDeposit.request({ deposit }, { tokenNetwork, partner }),
-        ),
-        state$ = of<RaidenState>(state);
+    const [raiden, partner] = await makeRaidens(2);
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
 
-      await expect(channelDepositEpic(action$, state$, depsMock).toPromise()).resolves.toEqual(
-        channelDeposit.failure(expect.any(Error), { tokenNetwork, partner }),
-      );
-    });
+    await ensureChannelIsOpen([raiden, partner]);
+    raiden.store.dispatch(
+      channelMonitor({ id, fromBlock: openBlock }, { tokenNetwork, partner: partner.address }),
+    );
+    await waitBlock(openBlock + 2);
+    raiden.deps.provider.emit(
+      getMonitoredFilter(tokenNetworkContract),
+      makeLog({
+        blockNumber: openBlock + 2,
+        filter: tokenNetworkContract.filters.ChannelNewDeposit(id, partner.address, null),
+        data: depositEncoded, // non-indexed total_deposit = 1023 goes in data
+      }),
+    );
+    await waitBlock();
 
-    test('fails if channel.state !== "open"', async () => {
-      // there's a channel already opened in state
-      const action = channelDeposit.request({ deposit }, { tokenNetwork, partner }),
-        // channel is in 'opening' state
-        curState = [
-          tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-          channelOpen.request({ settleTimeout }, { tokenNetwork, partner }),
-        ].reduce(raidenReducer, state);
-      const action$ = of<RaidenAction>(action),
-        state$ = of<RaidenState>(curState);
-
-      await expect(channelDepositEpic(action$, state$, depsMock).toPromise()).resolves.toEqual(
-        channelDeposit.failure(expect.any(Error), { tokenNetwork, partner }),
-      );
-    });
-
-    test('approve tx fails', async () => {
-      expect.assertions(3);
-      // there's a channel already opened in state
-      const curState = [
-        tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant,
-            token,
-            txHash,
-            txBlock: openBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-      ].reduce(raidenReducer, state);
-      const action$ = of<RaidenAction>(
-          channelDeposit.request({ deposit }, { tokenNetwork, partner }),
-        ),
-        state$ = of<RaidenState>(curState);
-
-      const approveTx: ContractTransaction = {
-        hash: txHash,
-        confirmations: 1,
-        nonce: 1,
-        gasLimit: bigNumberify(1e6),
-        gasPrice: bigNumberify(2e10),
-        value: Zero,
-        data: '0x',
-        chainId: depsMock.network.chainId,
-        from: depsMock.address,
-        wait: jest.fn().mockResolvedValue({ byzantium: true, status: 0 }),
-      };
-      tokenContract.functions.approve.mockResolvedValueOnce(approveTx);
-
-      await expect(channelDepositEpic(action$, state$, depsMock).toPromise()).resolves.toEqual(
-        channelDeposit.failure(expect.any(Error), { tokenNetwork, partner }),
-      );
-      expect(tokenContract.functions.approve).toHaveBeenCalledTimes(1);
-      expect(tokenContract.functions.approve).toHaveBeenCalledWith(tokenNetwork, deposit);
-    });
-
-    test('setTotalDeposit tx fails', async () => {
-      // there's a channel already opened in state
-      const curState = [
-        tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant,
-            token,
-            txHash,
-            txBlock: openBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-      ].reduce(raidenReducer, state);
-      const action$ = of<RaidenAction>(
-          channelDeposit.request({ deposit }, { tokenNetwork, partner }),
-        ),
-        state$ = of<RaidenState>(curState);
-
-      const approveTx: ContractTransaction = {
-        hash: txHash,
-        confirmations: 1,
-        nonce: 1,
-        gasLimit: bigNumberify(1e6),
-        gasPrice: bigNumberify(2e10),
-        value: Zero,
-        data: '0x',
-        chainId: depsMock.network.chainId,
-        from: depsMock.address,
-        wait: jest.fn().mockResolvedValue({ byzantium: true, status: 1 }),
-      };
-      tokenContract.functions.approve.mockResolvedValueOnce(approveTx);
-
-      const setTotalDeposiTx: ContractTransaction = {
-        hash: txHash,
-        confirmations: 1,
-        nonce: 2,
-        gasLimit: bigNumberify(1e6),
-        gasPrice: bigNumberify(2e10),
-        value: Zero,
-        data: '0x',
-        chainId: depsMock.network.chainId,
-        from: depsMock.address,
-        wait: jest.fn().mockResolvedValue({ byzantium: true, status: 0 }),
-      };
-      tokenNetworkContract.functions.setTotalDeposit.mockResolvedValueOnce(setTotalDeposiTx);
-
-      await expect(channelDepositEpic(action$, state$, depsMock).toPromise()).resolves.toEqual(
-        channelDeposit.failure(expect.any(Error), { tokenNetwork, partner }),
-      );
-    });
-
-    test('success', async () => {
-      // there's a channel already opened in state
-      const prevDeposit = bigNumberify(330) as UInt<32>;
-      const curState = [
-        tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant,
-            token,
-            txHash,
-            txBlock: openBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-        // own initial deposit of 330
-        channelDeposit.success(
-          {
-            id: channelId,
-            participant: depsMock.address,
-            totalDeposit: prevDeposit,
-            txHash,
-            txBlock: openBlock + 1,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-      ].reduce(raidenReducer, state);
-      const action$ = of<RaidenAction>(
-          channelDeposit.request({ deposit }, { tokenNetwork, partner }),
-        ),
-        state$ = of<RaidenState>(curState);
-
-      const approveTx: ContractTransaction = {
-        hash: txHash,
-        confirmations: 1,
-        nonce: 1,
-        gasLimit: bigNumberify(1e6),
-        gasPrice: bigNumberify(2e10),
-        value: Zero,
-        data: '0x',
-        chainId: depsMock.network.chainId,
-        from: depsMock.address,
-        wait: jest.fn().mockResolvedValue({ byzantium: true, status: 1 }),
-      };
-      tokenContract.functions.approve.mockResolvedValueOnce(approveTx);
-
-      const setTotalDepositTx: ContractTransaction = {
-        hash: txHash,
-        confirmations: 1,
-        nonce: 2,
-        gasLimit: bigNumberify(1e6),
-        gasPrice: bigNumberify(2e10),
-        value: Zero,
-        data: '0x',
-        chainId: depsMock.network.chainId,
-        from: depsMock.address,
-        wait: jest.fn().mockResolvedValue({ byzantium: true, status: 1 }),
-      };
-      tokenNetworkContract.functions.setTotalDeposit.mockResolvedValueOnce(setTotalDepositTx);
-      tokenNetworkContract.functions.getChannelParticipantInfo.mockResolvedValueOnce([
-        prevDeposit,
-        Zero,
-        true,
-        '',
-        Zero,
-        '',
-        Zero,
-      ]);
-
-      // result is undefined on success as the respective channelDeposit.success is emitted by the
-      // channelMonitoredEpic, which monitors the blockchain for ChannelNewDeposit events
-      await expect(
-        channelDepositEpic(action$, state$, depsMock).toPromise(),
-      ).resolves.toBeUndefined();
-      expect(tokenContract.functions.approve).toHaveBeenCalledTimes(1);
-      expect(approveTx.wait).toHaveBeenCalledTimes(1);
-      expect(tokenNetworkContract.functions.setTotalDeposit).toHaveBeenCalledTimes(1);
-      expect(tokenNetworkContract.functions.setTotalDeposit).toHaveBeenCalledWith(
-        channelId,
-        depsMock.address,
-        deposit.add(prevDeposit),
-        partner,
-      );
-      expect(setTotalDepositTx.wait).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('channelCloseEpic', () => {
-    let depsMock: ReturnType<typeof raidenEpicDeps>;
-    let token: ReturnType<typeof epicFixtures>['token'],
-      tokenNetworkContract: ReturnType<typeof epicFixtures>['tokenNetworkContract'],
-      tokenNetwork: ReturnType<typeof epicFixtures>['tokenNetwork'],
-      channelId: ReturnType<typeof epicFixtures>['channelId'],
-      partner: ReturnType<typeof epicFixtures>['partner'],
-      partnerSigner: ReturnType<typeof epicFixtures>['partnerSigner'],
-      settleTimeout: ReturnType<typeof epicFixtures>['settleTimeout'],
-      isFirstParticipant: ReturnType<typeof epicFixtures>['isFirstParticipant'],
-      txHash: ReturnType<typeof epicFixtures>['txHash'],
-      action$: ReturnType<typeof epicFixtures>['action$'],
-      state$: ReturnType<typeof epicFixtures>['state$'];
-    const openBlock = 121;
-    const closeBlock = 125;
-
-    beforeEach(async () => {
-      depsMock = raidenEpicDeps();
-      ({
-        token,
-        tokenNetworkContract,
-        tokenNetwork,
-        channelId,
-        partner,
-        partnerSigner,
-        settleTimeout,
-        isFirstParticipant,
-        txHash,
-        action$,
-        state$,
-      } = epicFixtures(depsMock));
-
-      [
-        tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant,
-            token,
-            txHash,
-            txBlock: openBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-        newBlock({ blockNumber: closeBlock }),
-      ].forEach((a) => action$.next(a));
-
-      // put a received & unlocked transfer from partner in state
-      const { state, config } = await depsMock.latest$.pipe(first()).toPromise();
-      const secret = makeSecret();
-      const secrethash = getSecrethash(secret);
-      const amount = bigNumberify(10) as UInt<32>;
-      const direction = Direction.RECEIVED;
-      const expiration = bigNumberify(state.blockNumber + config.revealTimeout * 2) as UInt<32>;
-      const lock = {
-        secrethash,
-        amount,
-        expiration,
-      };
-      const transf = await signMessage(
-        partnerSigner,
+    expect(raiden.output).toContainEqual(
+      channelDeposit.success(
         {
-          type: MessageType.LOCKED_TRANSFER,
-          payment_identifier: makePaymentId(),
-          message_identifier: makeMessageId(),
-          chain_id: bigNumberify(depsMock.network.chainId) as UInt<32>,
-          token,
-          token_network_address: tokenNetwork,
-          recipient: depsMock.address,
-          target: depsMock.address,
-          initiator: partner,
-          channel_identifier: bigNumberify(channelId) as UInt<32>,
-          metadata: { routes: [{ route: [depsMock.address] }] },
-          lock,
-          locksroot: getLocksroot([lock]),
-          nonce: One as UInt<8>,
-          transferred_amount: Zero as UInt<32>,
-          locked_amount: lock.amount,
+          id,
+          participant: partner.address,
+          totalDeposit: deposit,
+          txHash: expect.any(String),
+          txBlock: openBlock + 2,
+          confirmed: undefined,
         },
-        depsMock,
-      );
+        { tokenNetwork, partner: partner.address },
+      ),
+    );
+  });
 
-      const unlock = await signMessage(
-        partnerSigner,
+  test('new$ partner ChannelWithdraw event', async () => {
+    expect.assertions(1);
+    const withdraw = bigNumberify(300) as UInt<32>;
+    const withdrawEncoded = defaultAbiCoder.encode(['uint256'], [withdraw]);
+
+    const [raiden, partner] = await makeRaidens(2);
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+
+    await ensureChannelIsOpen([raiden, partner]);
+    raiden.store.dispatch(
+      channelMonitor({ id, fromBlock: openBlock }, { tokenNetwork, partner: partner.address }),
+    );
+    await waitBlock(closeBlock - 1);
+    raiden.deps.provider.emit(
+      getMonitoredFilter(tokenNetworkContract),
+      makeLog({
+        blockNumber: closeBlock - 1,
+        transactionHash: txHash,
+        filter: tokenNetworkContract.filters.ChannelWithdraw(id, partner.address, null),
+        data: withdrawEncoded, // non-indexed totalWithdraw
+      }),
+    );
+    await waitBlock();
+
+    expect(raiden.output).toContainEqual(
+      channelWithdrawn(
         {
-          type: MessageType.UNLOCK,
-          payment_identifier: transf.payment_identifier,
-          message_identifier: makeMessageId(),
-          chain_id: transf.chain_id,
-          token_network_address: tokenNetwork,
-          channel_identifier: transf.channel_identifier,
-          nonce: transf.nonce.add(1) as UInt<8>,
-          transferred_amount: transf.transferred_amount.add(amount) as UInt<32>,
-          locked_amount: transf.locked_amount.sub(amount) as UInt<32>,
-          locksroot: getLocksroot([]),
-          secret,
+          id,
+          participant: partner.address,
+          totalWithdraw: withdraw,
+          txHash,
+          txBlock: closeBlock - 1,
+          confirmed: undefined,
         },
-        depsMock,
-      );
-
-      [
-        transferSigned(
-          {
-            message: transf,
-            fee: Zero as Int<32>,
-          },
-          { secrethash, direction },
-        ),
-        transferUnlock.success({ message: unlock }, { secrethash, direction }),
-      ].forEach((a) => action$.next(a));
-    });
-
-    afterEach(() => {
-      jest.clearAllMocks();
-      action$.complete();
-      state$.complete();
-      depsMock.latest$.complete();
-    });
-
-    test('fails if there is no open channel with partner on tokenNetwork', async () => {
-      // there's a channel already opened in state
-      const action$ = of<RaidenAction>(channelClose.request(undefined, { tokenNetwork, partner })),
-        state$ = of<RaidenState>(state);
-
-      await expect(channelCloseEpic(action$, state$, depsMock).toPromise()).resolves.toEqual(
-        channelClose.failure(expect.any(Error), { tokenNetwork, partner }),
-      );
-    });
-
-    test('fails if channel.state !== "open"|"closing"', async () => {
-      // there's a channel already opened in state
-      const curState = [
-        tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        // channel is in 'opening' state
-        channelOpen.request({ settleTimeout }, { tokenNetwork, partner }),
-      ].reduce(raidenReducer, state);
-      const action$ = of<RaidenAction>(channelClose.request(undefined, { tokenNetwork, partner })),
-        state$ = of<RaidenState>(curState);
-
-      await expect(channelCloseEpic(action$, state$, depsMock).toPromise()).resolves.toEqual(
-        channelClose.failure(expect.any(Error), { tokenNetwork, partner }),
-      );
-    });
-
-    test('closeChannel tx fails', async () => {
-      const closeTx: ContractTransaction = {
-        hash: txHash,
-        confirmations: 1,
-        nonce: 2,
-        gasLimit: bigNumberify(1e6),
-        gasPrice: bigNumberify(2e10),
-        value: Zero,
-        data: '0x',
-        chainId: depsMock.network.chainId,
-        from: depsMock.address,
-        wait: jest.fn().mockResolvedValue({ byzantium: true, status: 0 }),
-      };
-      tokenNetworkContract.functions.closeChannel.mockResolvedValueOnce(closeTx);
-
-      const promise = channelCloseEpic(action$, state$, depsMock).toPromise();
-      action$.next(channelClose.request(undefined, { tokenNetwork, partner }));
-      action$.complete();
-
-      await expect(promise).resolves.toEqual(
-        channelClose.failure(expect.any(Error), { tokenNetwork, partner }),
-      );
-    });
-
-    test('success', async () => {
-      const closeTx: ContractTransaction = {
-        hash: txHash,
-        confirmations: 1,
-        nonce: 3,
-        gasLimit: bigNumberify(1e6),
-        gasPrice: bigNumberify(2e10),
-        value: Zero,
-        data: '0x',
-        chainId: depsMock.network.chainId,
-        from: depsMock.address,
-        wait: jest.fn().mockResolvedValue({ byzantium: true, status: 1 }),
-      };
-      tokenNetworkContract.functions.closeChannel.mockResolvedValueOnce(closeTx);
-
-      const promise = channelCloseEpic(action$, state$, depsMock).toPromise();
-      action$.next(channelClose.request(undefined, { tokenNetwork, partner }));
-      action$.complete();
-
-      // result is undefined on success as the respective channelClose.success is emitted by the
-      // channelMonitoredEpic, which monitors the blockchain for channel events
-      await expect(promise).resolves.toBeUndefined();
-      expect(tokenNetworkContract.functions.closeChannel).toHaveBeenCalledTimes(1);
-      expect(tokenNetworkContract.functions.closeChannel).toHaveBeenCalledWith(
-        channelId,
-        partner,
-        depsMock.address,
-        expect.any(String), // balance_hash
-        expect.any(BigNumber), // nonce
-        expect.any(String), // additional_hash
-        expect.any(String), // non_closing_signature
-        expect.any(String), // closing_signature
-      );
-      expect(closeTx.wait).toHaveBeenCalledTimes(1);
-    });
-
-    test('channelUpdateEpic', async () => {
-      const promise = channelUpdateEpic(action$, state$, depsMock).toPromise();
-      [
-        channelClose.success(
-          {
-            id: channelId,
-            participant: partner,
-            txHash,
-            txBlock: closeBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-        newBlock({ blockNumber: closeBlock + 1 }),
-        newBlock({ blockNumber: closeBlock + 2 }),
-      ].forEach((a) => action$.next(a));
-
-      setTimeout(() => action$.complete(), 10);
-      await expect(promise).resolves.toBeUndefined();
-
-      expect(tokenNetworkContract.functions.updateNonClosingBalanceProof).toHaveBeenCalledTimes(1);
-    });
+        { tokenNetwork, partner: partner.address },
+      ),
+    );
   });
 
-  describe('channelSettleEpic', () => {
-    const openBlock = 121,
-      closeBlock = 125,
-      settleBlock = closeBlock + settleTimeout + 1;
+  test('new$ partner ChannelClosed event', async () => {
+    expect.assertions(2);
 
-    test('fails if there is no channel with partner on tokenNetwork', async () => {
-      // there's a channel already opened in state
-      const action$ = of<RaidenAction>(
-          channelSettle.request(undefined, { tokenNetwork, partner }),
-        ),
-        state$ = of<RaidenState>(state);
+    const [raiden, partner] = await makeRaidens(2);
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
 
-      await expect(channelSettleEpic(action$, state$, depsMock).toPromise()).resolves.toEqual(
-        channelSettle.failure(expect.any(Error), { tokenNetwork, partner }),
-      );
-    });
+    await ensureChannelIsOpen([raiden, partner]);
+    raiden.store.dispatch(
+      channelMonitor({ id, fromBlock: openBlock }, { tokenNetwork, partner: partner.address }),
+    );
+    await waitBlock(closeBlock);
+    raiden.deps.provider.emit(
+      getMonitoredFilter(tokenNetworkContract),
+      makeLog({
+        blockNumber: closeBlock,
+        transactionHash: txHash,
+        filter: tokenNetworkContract.filters.ChannelClosed(id, partner.address, 11, null),
+        data: HashZero, // non-indexed balance_hash
+      }),
+    );
+    await waitBlock();
 
-    test('fails if channel.state !== "settleable|settling"', async () => {
-      // there's a channel in closed state, but not yet settleable
-      const curState = [
-        tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant,
-            token,
-            txHash,
-            txBlock: openBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-        newBlock({ blockNumber: closeBlock }),
-        channelClose.success(
-          {
-            id: channelId,
-            participant: depsMock.address,
-            txHash,
-            txBlock: closeBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-      ].reduce(raidenReducer, state);
-      const action$ = of<RaidenAction>(
-          channelSettle.request(undefined, { tokenNetwork, partner }),
-        ),
-        state$ = of<RaidenState>(curState);
-
-      await expect(channelSettleEpic(action$, state$, depsMock).toPromise()).resolves.toEqual(
-        channelSettle.failure(expect.any(Error), { tokenNetwork, partner }),
-      );
-    });
-
-    test('settleChannel tx fails', async () => {
-      // there's a channel with partner in closed state and current block >= settleBlock
-      const curState = [
-        tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant,
-            token,
-            txHash,
-            txBlock: openBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-        newBlock({ blockNumber: closeBlock }),
-        channelClose.success(
-          {
-            id: channelId,
-            participant: depsMock.address,
-            txHash,
-            txBlock: closeBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-        newBlock({ blockNumber: settleBlock }),
-        channelSettleable({ settleableBlock: settleBlock }, { tokenNetwork, partner }),
-      ].reduce(raidenReducer, state);
-      const action$ = of<RaidenAction>(
-          channelSettle.request(undefined, { tokenNetwork, partner }),
-        ),
-        state$ = of<RaidenState>(curState);
-
-      const settleTx: ContractTransaction = {
-        hash: txHash,
-        confirmations: 1,
-        nonce: 2,
-        gasLimit: bigNumberify(1e6),
-        gasPrice: bigNumberify(2e10),
-        value: Zero,
-        data: '0x',
-        chainId: depsMock.network.chainId,
-        from: depsMock.address,
-        wait: jest.fn().mockResolvedValue({ byzantium: true, status: 0 }),
-      };
-      tokenNetworkContract.functions.settleChannel.mockResolvedValueOnce(settleTx);
-
-      await expect(channelSettleEpic(action$, state$, depsMock).toPromise()).resolves.toEqual(
-        channelSettle.failure(expect.any(Error), { tokenNetwork, partner }),
-      );
-    });
-
-    test('success', async () => {
-      // there's a channel with partner in closed state and current block >= settleBlock
-      const curState = [
-        tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant,
-            token,
-            txHash,
-            txBlock: openBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-        newBlock({ blockNumber: closeBlock }),
-        channelClose.success(
-          {
-            id: channelId,
-            participant: depsMock.address,
-            txHash,
-            txBlock: closeBlock,
-            confirmed: true,
-          },
-          { tokenNetwork, partner },
-        ),
-        newBlock({ blockNumber: settleBlock }),
-        channelSettleable({ settleableBlock: settleBlock }, { tokenNetwork, partner }),
-      ].reduce(raidenReducer, state);
-      const action$ = of<RaidenAction>(
-          channelSettle.request(undefined, { tokenNetwork, partner }),
-        ),
-        state$ = of<RaidenState>(curState);
-
-      const settleTx: ContractTransaction = {
-        hash: txHash,
-        confirmations: 1,
-        nonce: 2,
-        gasLimit: bigNumberify(1e6),
-        gasPrice: bigNumberify(2e10),
-        value: Zero,
-        data: '0x',
-        chainId: depsMock.network.chainId,
-        from: depsMock.address,
-        wait: jest.fn().mockResolvedValue({ byzantium: true, status: 1 }),
-      };
-      tokenNetworkContract.functions.settleChannel.mockResolvedValueOnce(settleTx);
-
-      // result is undefined on success as the respective ChannelSettledAction is emitted by the
-      // channelMonitoredEpic, which monitors the blockchain for channel events
-      await expect(
-        channelSettleEpic(action$, state$, depsMock).toPromise(),
-      ).resolves.toBeUndefined();
-      expect(tokenNetworkContract.functions.settleChannel).toHaveBeenCalledTimes(1);
-      expect(tokenNetworkContract.functions.settleChannel).toHaveBeenCalledWith(
-        channelId,
-        depsMock.address,
-        Zero, // self transfered amount
-        Zero, // self locked amount
-        HashZero, // self locksroot
-        partner,
-        Zero, // partner transfered amount
-        Zero, // partner locked amount
-        HashZero, // partner locksroot
-      );
-      expect(settleTx.wait).toHaveBeenCalledTimes(1);
-    });
+    expect(raiden.output).toContainEqual(
+      channelClose.success(
+        {
+          id,
+          participant: partner.address,
+          txHash,
+          txBlock: closeBlock,
+          confirmed: undefined,
+        },
+        { tokenNetwork, partner: partner.address },
+      ),
+    );
+    expect(raiden.store.getState().channels[channelKey({ tokenNetwork, partner })].state).toBe(
+      ChannelState.closing,
+    );
   });
 
-  test('channelUnlockEpic', async () => {
+  test('new$ ChannelSettled event', async () => {
+    expect.assertions(9);
+    const settleDataEncoded = defaultAbiCoder.encode(
+      ['uint256', 'bytes32', 'uint256', 'bytes32'],
+      [Zero, HashZero, Zero, HashZero],
+    );
+
+    const [raiden, partner] = await makeRaidens(2);
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+
+    await ensureChannelIsClosed([raiden, partner]);
+    raiden.store.dispatch(
+      channelMonitor({ id, fromBlock: openBlock }, { tokenNetwork, partner: partner.address }),
+    );
+    await waitBlock(settleBlock);
+
+    const filter = getMonitoredFilter(tokenNetworkContract);
+    expect(raiden.deps.provider.on).toHaveBeenCalledWith(filter, expect.any(Function));
+    expect(raiden.deps.provider.removeListener).not.toHaveBeenCalledWith(
+      filter,
+      expect.any(Function),
+    );
+    expect(raiden.deps.provider.listenerCount(filter)).toBe(1);
+
+    const settleHash = makeHash();
+    raiden.deps.provider.emit(
+      filter,
+      makeLog({
+        blockNumber: settleBlock,
+        transactionHash: settleHash,
+        filter: tokenNetworkContract.filters.ChannelSettled(id, null, null, null, null),
+        data: settleDataEncoded, // participants amounts aren't indexed, so they go in data
+      }),
+    );
+    await waitBlock();
+
+    expect(raiden.output).toContainEqual(
+      channelSettle.success(
+        { id, txHash: settleHash, txBlock: settleBlock, confirmed: undefined, locks: [] },
+        { tokenNetwork, partner: partner.address },
+      ),
+    );
+
+    await waitBlock(settleBlock + 2 * confirmationBlocks);
+    expect(raiden.output).toContainEqual(
+      channelSettle.success(
+        { id, txHash: settleHash, txBlock: expect.any(Number), confirmed: true, locks: [] },
+        { tokenNetwork, partner: partner.address },
+      ),
+    );
+
+    // ensure ChannelSettledAction completed channel monitoring and unsubscribed from events
+    expect(raiden.deps.provider.removeListener).toHaveBeenCalledWith(filter, expect.any(Function));
+    expect(raiden.deps.provider.listenerCount(filter)).toBe(0);
+
+    // ensure channel state is moved from 'channels' to 'oldChannels'
+    expect(channelKey({ tokenNetwork, partner }) in raiden.store.getState().channels).toBe(false);
+    expect(
+      channelUniqueKey({ id, tokenNetwork, partner }) in raiden.store.getState().oldChannels,
+    ).toBe(true);
+  });
+});
+
+describe('channelDepositEpic', () => {
+  test('fails if channel.state !== "open" or missing', async () => {
+    expect.assertions(1);
+
+    const [raiden, partner] = await makeRaidens(2);
+    raiden.store.dispatch(
+      channelDeposit.request({ deposit }, { tokenNetwork, partner: partner.address }),
+    );
+    await waitBlock();
+
+    expect(raiden.output).toContainEqual(
+      channelDeposit.failure(expect.any(Error), { tokenNetwork, partner: partner.address }),
+    );
+  });
+
+  test('approve tx fails', async () => {
+    expect.assertions(3);
+
+    const [raiden, partner] = await makeRaidens(2);
+    await ensureChannelIsOpen([raiden, partner]);
+
+    const tokenContract = raiden.deps.getTokenContract(token);
+    const approveTx = makeTransaction(0);
+    tokenContract.functions.approve.mockResolvedValue(approveTx);
+
+    raiden.store.dispatch(
+      channelDeposit.request({ deposit }, { tokenNetwork, partner: partner.address }),
+    );
+    await waitBlock();
+
+    expect(raiden.output).toContainEqual(
+      channelDeposit.failure(expect.any(Error), { tokenNetwork, partner: partner.address }),
+    );
+    expect(tokenContract.functions.approve).toHaveBeenCalledTimes(1);
+    expect(tokenContract.functions.approve).toHaveBeenCalledWith(tokenNetwork, deposit);
+  });
+
+  test('setTotalDeposit tx fails', async () => {
+    expect.assertions(1);
+
+    const [raiden, partner] = await makeRaidens(2);
+    await ensureChannelIsOpen([raiden, partner]);
+
+    const tokenContract = raiden.deps.getTokenContract(token);
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+
+    const approveTx = makeTransaction();
+    tokenContract.functions.approve.mockResolvedValue(approveTx);
+
+    const setTotalDepositTx = makeTransaction(0);
+    tokenNetworkContract.functions.setTotalDeposit.mockResolvedValue(setTotalDepositTx);
+
+    raiden.store.dispatch(
+      channelDeposit.request({ deposit }, { tokenNetwork, partner: partner.address }),
+    );
+    await waitBlock();
+
+    expect(raiden.output).toContainEqual(
+      channelDeposit.failure(expect.any(Error), { tokenNetwork, partner: partner.address }),
+    );
+  });
+
+  test('success', async () => {
+    expect.assertions(6);
+
+    const prevDeposit = bigNumberify(330) as UInt<32>;
+    const [raiden, partner] = await makeRaidens(2);
+    await ensureChannelIsDeposited([raiden, partner], prevDeposit);
+
+    const tokenContract = raiden.deps.getTokenContract(token);
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+
+    const approveTx = makeTransaction();
+    tokenContract.functions.approve.mockResolvedValue(approveTx);
+
+    const setTotalDepositTx = makeTransaction();
+    tokenNetworkContract.functions.setTotalDeposit.mockResolvedValue(setTotalDepositTx);
+    tokenNetworkContract.functions.getChannelParticipantInfo.mockResolvedValue([
+      prevDeposit,
+      Zero,
+      true,
+      '',
+      Zero,
+      '',
+      Zero,
+    ]);
+
+    raiden.store.dispatch(
+      channelDeposit.request({ deposit }, { tokenNetwork, partner: partner.address }),
+    );
+    await waitBlock();
+
+    // result is undefined on success as the respective channelDeposit.success is emitted by the
+    // channelMonitoredEpic, which monitors the blockchain for ChannelNewDeposit events
+    expect(raiden.output).not.toContainEqual(
+      channelDeposit.failure(expect.any(Error), { tokenNetwork, partner: partner.address }),
+    );
+    expect(tokenContract.functions.approve).toHaveBeenCalledTimes(1);
+    expect(approveTx.wait).toHaveBeenCalledTimes(1);
+    expect(tokenNetworkContract.functions.setTotalDeposit).toHaveBeenCalledTimes(1);
+    expect(tokenNetworkContract.functions.setTotalDeposit).toHaveBeenCalledWith(
+      id,
+      raiden.address,
+      deposit.add(prevDeposit),
+      partner.address,
+    );
+    expect(setTotalDepositTx.wait).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('channelCloseEpic', () => {
+  test('fails if there is no open channel with partner on tokenNetwork', async () => {
+    expect.assertions(1);
+
+    const [raiden, partner] = await makeRaidens(2);
+    await ensureTokenIsMonitored(raiden);
+
+    raiden.store.dispatch(
+      channelClose.request(undefined, { tokenNetwork, partner: partner.address }),
+    );
+    expect(raiden.output).toContainEqual(
+      channelClose.failure(expect.any(Error), { tokenNetwork, partner: partner.address }),
+    );
+  });
+
+  test('fails if channel.state !== "open"|"closing"', async () => {
+    expect.assertions(1);
+
+    const [raiden, partner] = await makeRaidens(2);
+    await ensureChannelIsClosed([raiden, partner]);
+
+    raiden.store.dispatch(
+      channelClose.request(undefined, { tokenNetwork, partner: partner.address }),
+    );
+    expect(raiden.output).toContainEqual(
+      channelClose.failure(expect.any(Error), { tokenNetwork, partner: partner.address }),
+    );
+  });
+
+  test('closeChannel tx fails', async () => {
+    expect.assertions(1);
+
+    const [raiden, partner] = await makeRaidens(2);
+    await ensureChannelIsOpen([raiden, partner]);
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+
+    const closeTx = makeTransaction(0);
+    tokenNetworkContract.functions.closeChannel.mockResolvedValue(closeTx);
+
+    raiden.store.dispatch(
+      channelClose.request(undefined, { tokenNetwork, partner: partner.address }),
+    );
+    await waitBlock();
+    expect(raiden.output).toContainEqual(
+      channelClose.failure(expect.any(Error), { tokenNetwork, partner: partner.address }),
+    );
+  });
+
+  test('success', async () => {
     expect.assertions(4);
-    const tokenNetworkContract = depsMock.getTokenNetworkContract(tokenNetwork);
 
-    tokenNetworkContract.functions.unlock.mockResolvedValueOnce({
-      hash: txHash,
-      confirmations: 1,
-      nonce: 2,
-      gasLimit: bigNumberify(1e6),
-      gasPrice: bigNumberify(2e10),
-      value: Zero,
-      data: '0x',
-      chainId: depsMock.network.chainId,
-      from: depsMock.address,
-      wait: jest.fn().mockResolvedValue({ byzantium: true, status: 0 }),
-    });
+    const [raiden, partner] = await makeRaidens(2);
+    await ensureChannelIsOpen([raiden, partner]);
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+    const closeTx = makeTransaction();
+    tokenNetworkContract.functions.closeChannel.mockResolvedValue(closeTx);
 
-    await expect(
-      channelUnlockEpic(
-        of(
-          channelSettle.success(
-            {
-              id: channelId,
-              txHash,
-              txBlock: 129,
-              confirmed: true,
-              locks: [
-                {
-                  amount: bigNumberify(10) as UInt<32>,
-                  expiration: bigNumberify(128) as UInt<32>,
-                  secrethash: getSecrethash(makeSecret()),
-                },
-              ],
-            },
-            { tokenNetwork, partner },
-          ),
-        ),
-        depsMock.latest$.pipe(pluck('state')),
-        depsMock,
-      ).toPromise(),
-    ).resolves.toBeUndefined();
+    raiden.store.dispatch(
+      channelClose.request(undefined, { tokenNetwork, partner: partner.address }),
+    );
+    await waitBlock();
 
-    tokenNetworkContract.functions.unlock.mockResolvedValueOnce({
-      hash: txHash,
-      confirmations: 1,
-      nonce: 2,
-      gasLimit: bigNumberify(1e6),
-      gasPrice: bigNumberify(2e10),
-      value: Zero,
-      data: '0x',
-      chainId: depsMock.network.chainId,
-      from: depsMock.address,
-      wait: jest.fn().mockResolvedValue({ byzantium: true, status: 1 }),
-    });
+    // result is undefined on success as the respective channelClose.success is emitted by the
+    // channelMonitoredEpic, which monitors the blockchain for channel events
+    expect(raiden.output).not.toContainEqual(
+      channelClose.failure(expect.any(Error), { tokenNetwork, partner: partner.address }),
+    );
 
-    await expect(
-      channelUnlockEpic(
-        of(
-          channelSettle.success(
-            {
-              id: channelId,
-              txHash,
-              txBlock: 129,
-              confirmed: true,
-              locks: [
-                {
-                  amount: bigNumberify(10) as UInt<32>,
-                  expiration: bigNumberify(128) as UInt<32>,
-                  secrethash: getSecrethash(makeSecret()),
-                },
-              ],
-            },
-            { tokenNetwork, partner },
-          ),
-        ),
-        depsMock.latest$.pipe(pluck('state')),
-        depsMock,
-      ).toPromise(),
-    ).resolves.toBeUndefined();
+    expect(tokenNetworkContract.functions.closeChannel).toHaveBeenCalledTimes(1);
+    expect(tokenNetworkContract.functions.closeChannel).toHaveBeenCalledWith(
+      id,
+      partner.address,
+      raiden.address,
+      expect.any(String), // balance_hash
+      expect.any(BigNumber), // nonce
+      expect.any(String), // additional_hash
+      expect.any(String), // non_closing_signature
+      expect.any(String), // closing_signature
+    );
+    expect(closeTx.wait).toHaveBeenCalledTimes(1);
+  });
+});
 
-    expect(tokenNetworkContract.functions.unlock).toHaveBeenCalledTimes(2);
+test('channelUpdateEpic', async () => {
+  expect.assertions(1);
+
+  const [raiden, partner] = await makeRaidens(2);
+  const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+
+  await ensureChannelIsOpen([raiden, partner]);
+  await ensureTransferReceivedUnlocked([raiden, partner]);
+  await ensureChannelIsClosed([partner, raiden]); // partner closes
+  await waitBlock();
+  await waitBlock();
+
+  expect(tokenNetworkContract.functions.updateNonClosingBalanceProof).toHaveBeenCalledTimes(1);
+});
+
+describe('channelSettleEpic', () => {
+  test('fails if there is no channel with partner on tokenNetwork', async () => {
+    expect.assertions(1);
+
+    const [raiden, partner] = await makeRaidens(2);
+    await ensureTokenIsMonitored(raiden);
+
+    raiden.store.dispatch(
+      channelSettle.request(undefined, { tokenNetwork, partner: partner.address }),
+    );
+    expect(raiden.output).toContainEqual(
+      channelSettle.failure(expect.any(Error), { tokenNetwork, partner: partner.address }),
+    );
+  });
+
+  test('fails if channel.state !== "settleable|settling"', async () => {
+    expect.assertions(1);
+
+    const [raiden, partner] = await makeRaidens(2);
+    await ensureChannelIsClosed([raiden, partner]);
+
+    raiden.store.dispatch(
+      channelSettle.request(undefined, { tokenNetwork, partner: partner.address }),
+    );
+    expect(raiden.output).toContainEqual(
+      channelSettle.failure(expect.any(Error), { tokenNetwork, partner: partner.address }),
+    );
+  });
+
+  test('settleChannel tx fails', async () => {
+    expect.assertions(1);
+
+    const [raiden, partner] = await makeRaidens(2);
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+
+    await ensureChannelIsClosed([raiden, partner]);
+    await waitBlock(settleBlock);
+
+    const settleTx = makeTransaction(0);
+    tokenNetworkContract.functions.settleChannel.mockResolvedValue(settleTx);
+
+    raiden.store.dispatch(
+      channelSettle.request(undefined, { tokenNetwork, partner: partner.address }),
+    );
+    await waitBlock();
+    expect(raiden.output).toContainEqual(
+      channelSettle.failure(expect.any(Error), { tokenNetwork, partner: partner.address }),
+    );
+  });
+
+  test('success', async () => {
+    expect.assertions(6);
+
+    const [raiden, partner] = await makeRaidens(2);
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+
+    await ensureChannelIsClosed([raiden, partner]);
+    await waitBlock(settleBlock + confirmationBlocks + 1);
+
+    const settleTx = makeTransaction();
+    tokenNetworkContract.functions.settleChannel.mockResolvedValue(settleTx);
+
+    raiden.store.dispatch(
+      channelSettle.request(undefined, { tokenNetwork, partner: partner.address }),
+    );
+    await ensureChannelIsSettled([raiden, partner]);
+    await waitBlock();
+
+    // result is undefined on success as the respective channelSettle.success is emitted by the
+    // channelMonitoredEpic, which monitors the blockchain for channel events
+    expect(raiden.output).not.toContainEqual(
+      channelSettle.failure(expect.any(Error), { tokenNetwork, partner: partner.address }),
+    );
+    expect(
+      raiden.store.getState().channels[channelKey({ tokenNetwork, partner })],
+    ).toBeUndefined();
+    expect(
+      raiden.store.getState().oldChannels[channelUniqueKey({ tokenNetwork, partner, id })],
+    ).toBeDefined();
+
+    expect(tokenNetworkContract.functions.settleChannel).toHaveBeenCalledTimes(1);
+    expect(tokenNetworkContract.functions.settleChannel).toHaveBeenCalledWith(
+      id,
+      raiden.address,
+      Zero, // self transfered amount
+      Zero, // self locked amount
+      HashZero, // self locksroot
+      partner.address,
+      Zero, // partner transfered amount
+      Zero, // partner locked amount
+      HashZero, // partner locksroot
+    );
+    expect(settleTx.wait).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('channelUnlockEpic', () => {
+  test('tx fails', async () => {
+    expect.assertions(2);
+    const [raiden, partner] = await makeRaidens(2);
+    const { secretRegistryContract } = raiden.deps;
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+
+    await ensureChannelIsOpen([raiden, partner]);
+    await ensureTransferReceivedPending([raiden, partner]);
+
+    raiden.deps.provider.emit(
+      secretRegistryContract.filters.SecretRevealed(null, null),
+      makeLog({
+        blockNumber: raiden.deps.provider.blockNumber + 1,
+        filter: secretRegistryContract.filters.SecretRevealed(secrethash, null),
+        data: defaultAbiCoder.encode(['bytes32'], [secret]),
+      }),
+    );
+    await waitBlock();
+    await ensureChannelIsClosed([raiden, partner]); // partner closes
+    tokenNetworkContract.functions.unlock.mockResolvedValue(makeTransaction(0));
+
+    await waitBlock(settleBlock);
+    await ensureChannelIsSettled([raiden, partner]);
+
+    expect(tokenNetworkContract.functions.unlock).toHaveBeenCalledTimes(1);
     expect(tokenNetworkContract.functions.unlock).toHaveBeenCalledWith(
-      channelId,
-      depsMock.address,
-      partner,
+      id,
+      raiden.address,
+      partner.address,
+      expect.any(Uint8Array),
+    );
+  });
+
+  test('success', async () => {
+    expect.assertions(2);
+    const [raiden, partner] = await makeRaidens(2);
+    const { secretRegistryContract } = raiden.deps;
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+
+    await ensureChannelIsOpen([raiden, partner]);
+    await ensureTransferReceivedPending([raiden, partner]);
+
+    raiden.deps.provider.emit(
+      secretRegistryContract.filters.SecretRevealed(null, null),
+      makeLog({
+        blockNumber: raiden.deps.provider.blockNumber + 1,
+        filter: secretRegistryContract.filters.SecretRevealed(secrethash, null),
+        data: defaultAbiCoder.encode(['bytes32'], [secret]),
+      }),
+    );
+    await waitBlock();
+    await ensureChannelIsSettled([raiden, partner]);
+
+    expect(tokenNetworkContract.functions.unlock).toHaveBeenCalledTimes(1);
+    expect(tokenNetworkContract.functions.unlock).toHaveBeenCalledWith(
+      id,
+      raiden.address,
+      partner.address,
       expect.any(Uint8Array),
     );
   });

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -1,11 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-jest.mock('matrix-js-sdk');
+
+import { raidenEpicDeps, makeSignature, mockRTC } from '../mocks';
+import { epicFixtures } from '../fixtures';
 
 import { createClient } from 'matrix-js-sdk';
-
-import { patchVerifyMessage } from '../patches';
-patchVerifyMessage();
-
 import { of, timer, EMPTY, Observable } from 'rxjs';
 import { first, tap, takeUntil, toArray } from 'rxjs/operators';
 import { fakeSchedulers } from 'rxjs-marbles/jest';
@@ -50,9 +48,6 @@ import { encodeJsonMessage, signMessage } from 'raiden-ts/messages/utils';
 import { ErrorCodes } from 'raiden-ts/utils/error';
 import { Signed, Address } from 'raiden-ts/utils/types';
 import { Capabilities } from 'raiden-ts/constants';
-
-import { epicFixtures } from '../fixtures';
-import { raidenEpicDeps, makeSignature, mockRTC } from '../mocks';
 
 describe('transport epic', () => {
   let depsMock: ReturnType<typeof raidenEpicDeps>,

--- a/raiden-ts/tests/unit/fixtures.ts
+++ b/raiden-ts/tests/unit/fixtures.ts
@@ -4,14 +4,19 @@ import { patchEthersDefineReadOnly } from './patches';
 patchEthersDefineReadOnly();
 
 import { Subject } from 'rxjs';
-import { first, scan } from 'rxjs/operators';
+import { first, scan, pluck } from 'rxjs/operators';
 import { Wallet } from 'ethers';
-import { AddressZero } from 'ethers/constants';
-import { bigNumberify } from 'ethers/utils';
+import { AddressZero, Zero, HashZero } from 'ethers/constants';
+import { bigNumberify, defaultAbiCoder } from 'ethers/utils';
 
 import { Address, Hash, Int, UInt } from 'raiden-ts/utils/types';
 import { Processed, MessageType } from 'raiden-ts/messages/types';
-import { makeMessageId, makePaymentId } from 'raiden-ts/transfers/utils';
+import {
+  makeMessageId,
+  makePaymentId,
+  makeSecret,
+  getSecrethash,
+} from 'raiden-ts/transfers/utils';
 import { IOU } from 'raiden-ts/services/types';
 import { RaidenState } from 'raiden-ts/state';
 import { pluckDistinct } from 'raiden-ts/utils/rx';
@@ -19,8 +24,23 @@ import { RaidenAction } from 'raiden-ts/actions';
 import { raidenReducer } from 'raiden-ts/reducer';
 import { getLatest$ } from 'raiden-ts/epics';
 import { channelKey } from 'raiden-ts/channels/utils';
+import { tokenMonitored } from 'raiden-ts/channels/actions';
+import { ChannelState } from 'raiden-ts/channels';
+import { Direction } from 'raiden-ts/transfers/state';
+import { transfer, transferUnlock } from 'raiden-ts/transfers/actions';
+import { messageReceived } from 'raiden-ts/messages/actions';
 
-import { makeMatrix, MockRaidenEpicDeps } from './mocks';
+import {
+  makeMatrix,
+  MockRaidenEpicDeps,
+  MockedRaiden,
+  makeAddress,
+  makeHash,
+  waitBlock,
+  providersEmit,
+  makeLog,
+} from './mocks';
+import { Filter } from 'ethers/providers';
 
 /**
  * Composes several constants used across epics
@@ -124,4 +144,283 @@ export function epicFixtures(depsMock: MockRaidenEpicDeps) {
     action$,
     state$,
   };
+}
+
+// fixture constants
+export const token = makeAddress();
+export const tokenNetwork = makeAddress();
+export const settleTimeout = 60;
+export const revealTimeout = 50;
+export const confirmationBlocks = 5;
+export const id = 17; // channelId
+export const isFirstParticipant = true;
+export const openBlock = 121;
+export const closeBlock = openBlock + 10;
+export const settleBlock = closeBlock + settleTimeout + 1;
+export const txHash = makeHash();
+export const deposit = bigNumberify(1000) as UInt<32>;
+export const matrixServer = 'matrix.raiden.test';
+export const secret = makeSecret();
+export const secrethash = getSecrethash(secret);
+export const amount = bigNumberify(10) as UInt<32>;
+
+/**
+ * Ensure token is monitored on raiden's state
+ *
+ * @param raiden - Client instance
+ */
+export async function ensureTokenIsMonitored(raiden: MockedRaiden): Promise<void> {
+  if (token in raiden.store.getState().tokens) return;
+  raiden.store.dispatch(tokenMonitored({ token, tokenNetwork }));
+}
+
+/**
+ * Ensure there's a channel open with partner
+ *
+ * @param clients - Clients tuple
+ * @param clients.0 - Own raiden
+ * @param clients.1 - Partner raiden to open channel with
+ */
+export async function ensureChannelIsOpen([raiden, partner]: [
+  MockedRaiden,
+  MockedRaiden,
+]): Promise<void> {
+  await ensureTokenIsMonitored(raiden);
+  const key = channelKey({ tokenNetwork, partner: partner.address });
+  if (key in raiden.store.getState().channels) return;
+
+  const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+  providersEmit(
+    tokenNetworkContract.filters.ChannelOpened(null, null, null, null),
+    makeLog({
+      transactionHash: makeHash(),
+      blockNumber: openBlock,
+      filter: tokenNetworkContract.filters.ChannelOpened(
+        id,
+        raiden.address,
+        partner.address,
+        null,
+      ),
+      data: defaultAbiCoder.encode(['uint256'], [settleTimeout]),
+    }),
+  );
+  await waitBlock(openBlock);
+  await waitBlock(openBlock + confirmationBlocks + 1); // confirmation
+}
+
+/**
+ * Ensure there's a channel open with partner and it's funded
+ *
+ * @param clients - Clients tuple
+ * @param clients.0 - Own raiden
+ * @param clients.1 - Partner raiden to open channel with
+ * @param totalDeposit - Deposit to perform
+ */
+export async function ensureChannelIsDeposited(
+  [raiden, partner]: [MockedRaiden, MockedRaiden],
+  totalDeposit: UInt<32> = deposit,
+): Promise<void> {
+  await ensureChannelIsOpen([raiden, partner]);
+  const key = channelKey({ tokenNetwork, partner: partner.address });
+  if (raiden.store.getState().channels[key].own.deposit.gte(totalDeposit)) return;
+  const txHash = makeHash();
+  const txBlock = openBlock + 1;
+  const participant = raiden.address;
+
+  const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+  const events = tokenNetworkContract.interface.events;
+  const monitorFilter: Filter = {
+    address: tokenNetwork,
+    topics: [
+      [
+        events.ChannelNewDeposit.topic,
+        events.ChannelWithdraw.topic,
+        events.ChannelClosed.topic,
+        events.ChannelSettled.topic,
+      ],
+      [defaultAbiCoder.encode(['uint256'], [id])],
+    ],
+  };
+  providersEmit(
+    monitorFilter,
+    makeLog({
+      transactionHash: txHash,
+      blockNumber: txBlock,
+      filter: tokenNetworkContract.filters.ChannelNewDeposit(id, participant, null),
+      data: defaultAbiCoder.encode(['uint256'], [totalDeposit]),
+    }),
+  );
+  await waitBlock();
+  await waitBlock(); // confirmation
+}
+
+/**
+ * Ensure there's a channel open with partner
+ *
+ * @param clients - Clients tuple
+ * @param clients.0 - Own raiden
+ * @param clients.1 - Partner raiden to open channel with
+ */
+export async function ensureChannelIsClosed([raiden, partner]: [
+  MockedRaiden,
+  MockedRaiden,
+]): Promise<void> {
+  await ensureChannelIsOpen([raiden, partner]);
+  const key = channelKey({ tokenNetwork, partner: partner.address });
+  if (raiden.store.getState().channels[key].state === ChannelState.closed) return;
+  const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+  const events = tokenNetworkContract.interface.events;
+  const monitorFilter: Filter = {
+    address: tokenNetwork,
+    topics: [
+      [
+        events.ChannelNewDeposit.topic,
+        events.ChannelWithdraw.topic,
+        events.ChannelClosed.topic,
+        events.ChannelSettled.topic,
+      ],
+      [defaultAbiCoder.encode(['uint256'], [id])],
+    ],
+  };
+  providersEmit(
+    monitorFilter,
+    makeLog({
+      transactionHash: makeHash(),
+      blockNumber: closeBlock,
+      filter: tokenNetworkContract.filters.ChannelClosed(id, raiden.address, 0, null),
+      data: HashZero,
+    }),
+  );
+  await waitBlock(closeBlock);
+  await waitBlock(closeBlock + confirmationBlocks + 1); // confirmation
+}
+
+/**
+ * Ensure there's a channel open with partner
+ *
+ * @param clients - Clients tuple
+ * @param clients.0 - Own raiden
+ * @param clients.1 - Partner raiden to open channel with
+ */
+export async function ensureChannelIsSettled([raiden, partner]: [
+  MockedRaiden,
+  MockedRaiden,
+]): Promise<void> {
+  await ensureChannelIsClosed([raiden, partner]);
+  const key = channelKey({ tokenNetwork, partner: partner.address });
+  if (!(key in raiden.store.getState().channels)) return;
+  const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+  const events = tokenNetworkContract.interface.events;
+  const monitorFilter: Filter = {
+    address: tokenNetwork,
+    topics: [
+      [
+        events.ChannelNewDeposit.topic,
+        events.ChannelWithdraw.topic,
+        events.ChannelClosed.topic,
+        events.ChannelSettled.topic,
+      ],
+      [defaultAbiCoder.encode(['uint256'], [id])],
+    ],
+  };
+  providersEmit(
+    monitorFilter,
+    makeLog({
+      transactionHash: makeHash(),
+      blockNumber: settleBlock,
+      filter: tokenNetworkContract.filters.ChannelSettled(id, null, null, null, null),
+      data: defaultAbiCoder.encode(
+        ['uint256', 'bytes32', 'uint256', 'bytes32'],
+        [Zero, HashZero, Zero, HashZero],
+      ),
+    }),
+  );
+  await waitBlock(settleBlock);
+  await waitBlock(settleBlock + confirmationBlocks + 1); // confirmation
+}
+
+/**
+ * Ensure there's a pending received transfer from partner
+ *
+ * @param clients - Clients tuple
+ * @param clients.0 - Own raiden
+ * @param clients.1 - Partner raiden to send transfer from
+ * @param value - Amount to transfer
+ */
+export async function ensureTransferReceivedPending(
+  [raiden, partner]: [MockedRaiden, MockedRaiden],
+  value = amount,
+): Promise<void> {
+  await ensureChannelIsDeposited([partner, raiden]); // from partner to raiden
+  if (secrethash in raiden.store.getState().received) return;
+
+  const paymentId = makePaymentId();
+  const sentPromise = partner.deps.latest$
+    .pipe(
+      first(({ state }) => secrethash in state.sent),
+      pluck('state', 'sent', secrethash),
+    )
+    .toPromise();
+  partner.store.dispatch(
+    transfer.request(
+      {
+        tokenNetwork,
+        target: raiden.address,
+        value,
+        paths: [{ path: [raiden.address], fee: Zero as Int<32> }],
+        paymentId,
+        secret,
+      },
+      { secrethash, direction: Direction.SENT },
+    ),
+  );
+  const sent = await sentPromise;
+
+  const receivedPromise = raiden.deps.latest$
+    .pipe(first(({ state }) => secrethash in state.received))
+    .toPromise();
+  raiden.store.dispatch(
+    messageReceived(
+      { text: '', message: sent.transfer[1], ts: Date.now() },
+      { address: partner.address },
+    ),
+  );
+  await receivedPromise;
+}
+
+/**
+ * Ensure there's an unlocked transfer received from partner
+ *
+ * @param clients - Clients tuple
+ * @param clients.0 - Own raiden
+ * @param clients.1 - Partner raiden to send transfer from
+ */
+export async function ensureTransferReceivedUnlocked([raiden, partner]: [
+  MockedRaiden,
+  MockedRaiden,
+]): Promise<void> {
+  await ensureTransferReceivedPending([raiden, partner]); // from partner to raiden
+  if (raiden.store.getState().received[secrethash]?.unlock) return;
+
+  const sentPromise = partner.deps.latest$
+    .pipe(
+      first(({ state }) => !!state.sent[secrethash]?.unlock),
+      pluck('state', 'sent', secrethash),
+    )
+    .toPromise();
+  partner.store.dispatch(
+    transferUnlock.request(undefined, { secrethash, direction: Direction.SENT }),
+  );
+  const sent = await sentPromise;
+
+  const receivedPromise = raiden.deps.latest$
+    .pipe(first(({ state }) => !!state.received[secrethash]?.unlock))
+    .toPromise();
+  raiden.store.dispatch(
+    messageReceived(
+      { text: '', message: sent.unlock![1], ts: Date.now() },
+      { address: partner.address },
+    ),
+  );
+  await receivedPromise;
 }

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -1,21 +1,31 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { patchEthersDefineReadOnly, patchMatrixGetNetwork } from './patches';
+import { patchEthersDefineReadOnly, patchEthersGetNetwork } from './patches';
 patchEthersDefineReadOnly();
-patchMatrixGetNetwork();
+patchEthersGetNetwork();
 
-import { AsyncSubject, of, BehaviorSubject, Subject } from 'rxjs';
+import { AsyncSubject, of, BehaviorSubject, ReplaySubject } from 'rxjs';
 import { MatrixClient } from 'matrix-js-sdk';
 import { EventEmitter } from 'events';
 import { memoize } from 'lodash';
 import logging from 'loglevel';
+import { Store, createStore, applyMiddleware } from 'redux';
 
 jest.mock('ethers/providers');
 import { JsonRpcProvider, EventType, Listener } from 'ethers/providers';
 import { Zero, HashZero } from 'ethers/constants';
 import { Log } from 'ethers/providers/abstract-provider';
-import { Network, parseEther } from 'ethers/utils';
-import { Contract, EventFilter } from 'ethers/contract';
+import {
+  Network,
+  parseEther,
+  getAddress,
+  hexlify,
+  randomBytes,
+  keccak256,
+  verifyMessage,
+  bigNumberify,
+} from 'ethers/utils';
+import { Contract, EventFilter, ContractTransaction } from 'ethers/contract';
 import { Wallet } from 'ethers/wallet';
 
 import { TokenNetworkRegistry } from 'raiden-ts/contracts/TokenNetworkRegistry';
@@ -36,23 +46,37 @@ import { MonitoringService } from 'raiden-ts/contracts/MonitoringService';
 
 import { RaidenEpicDeps, ContractsInfo, Latest } from 'raiden-ts/types';
 import { makeInitialState, RaidenState } from 'raiden-ts/state';
-import { Address, Signature, UInt } from 'raiden-ts/utils/types';
+import { Address, Signature, UInt, Hash, assert } from 'raiden-ts/utils/types';
 import { getServerName } from 'raiden-ts/utils/matrix';
 import { pluckDistinct } from 'raiden-ts/utils/rx';
-import { raidenConfigUpdate, RaidenAction } from 'raiden-ts/actions';
+import { raidenConfigUpdate, RaidenAction, raidenShutdown } from 'raiden-ts/actions';
 import { makeDefaultConfig } from 'raiden-ts/config';
 import { makeSecret } from 'raiden-ts/transfers/utils';
+import { raidenReducer } from 'raiden-ts/reducer';
+import { ShutdownReason } from 'raiden-ts/constants';
+import { createEpicMiddleware } from 'redux-observable';
+import { raidenRootEpic } from 'raiden-ts/epics';
+import { filter, take } from 'rxjs/operators';
+
+logging.setLevel(logging.levels.DEBUG);
+
+export type MockedTransaction = ContractTransaction & {
+  wait: jest.MockedFunction<ContractTransaction['wait']>;
+};
 
 export type MockedContract<T extends Contract> = jest.Mocked<T> & {
   functions: {
     [K in keyof T['functions']]: jest.MockInstance<
-      ReturnType<T['functions'][K]>,
+      ReturnType<T['functions'][K]> extends Promise<ContractTransaction>
+        ? Promise<MockedTransaction>
+        : ReturnType<T['functions'][K]>,
       Parameters<T['functions'][K]>
     >;
   };
 };
 
 export interface MockRaidenEpicDeps extends RaidenEpicDeps {
+  signer: Wallet;
   provider: jest.Mocked<JsonRpcProvider>;
   registryContract: MockedContract<TokenNetworkRegistry>;
   getTokenNetworkContract: (address: string) => MockedContract<TokenNetwork>;
@@ -62,7 +86,32 @@ export interface MockRaidenEpicDeps extends RaidenEpicDeps {
   secretRegistryContract: MockedContract<SecretRegistry>;
 }
 
-export type MockedEpicClient = [Subject<RaidenAction>, Subject<RaidenState>, MockRaidenEpicDeps];
+/**
+ * Returns some valid signature
+ *
+ * @returns Some arbitrary valid signature hex string
+ */
+export function makeSignature(): Signature {
+  return '0x5770d597b270ad9d1225c901b1ef6bfd8782b15d7541379619c5dae02c5c03c1196291b042a4fea9dbddcb1c6bcd2a5ee19180e8dc881c2e9298757e84ad190b1c' as Signature;
+}
+
+/**
+ * Generate a random address
+ *
+ * @returns address
+ */
+export function makeAddress() {
+  return getAddress(hexlify(randomBytes(20))) as Address;
+}
+
+/**
+ * Generate a random hash
+ *
+ * @returns hash
+ */
+export function makeHash() {
+  return keccak256(randomBytes(32)) as Hash;
+}
 
 /**
  * Create a mocked ethers Log object
@@ -75,16 +124,40 @@ export function makeLog({ filter, ...opts }: { filter: EventFilter } & Partial<L
   const blockNumber = opts.blockNumber || 1337;
   return {
     blockNumber: blockNumber,
-    blockHash: `0xblockHash${blockNumber}`,
+    blockHash: makeHash(),
     transactionIndex: 1,
     removed: false,
     transactionLogIndex: 1,
     data: '0x',
-    transactionHash: `0xtxHash${blockNumber}`,
+    transactionHash: makeHash(),
     logIndex: 1,
     ...opts,
     address: filter.address!,
     topics: filter.topics!,
+  };
+}
+
+/**
+ * @param status - Status of the transaction (default=succeed)
+ * @param overrides - Properties to override on returned transaction
+ * @returns Mocked ContractTransaction
+ */
+export function makeTransaction(
+  status = 1,
+  overrides?: Partial<MockedTransaction>,
+): MockedTransaction {
+  return {
+    hash: makeHash(),
+    confirmations: 1,
+    nonce: 0,
+    gasLimit: bigNumberify(1e5),
+    gasPrice: bigNumberify(1e9),
+    value: Zero,
+    data: '0x',
+    chainId: 1337,
+    from: makeAddress(),
+    wait: jest.fn().mockResolvedValue({ byzantium: true, status }),
+    ...overrides,
   };
 }
 
@@ -156,15 +229,6 @@ export function makeMatrix(userId: string, server: string): jest.Mocked<MatrixCl
 }
 
 /**
- * Returns some valid signature
- *
- * @returns Some arbitrary valid signature hex string
- */
-export function makeSignature(): Signature {
-  return '0x5770d597b270ad9d1225c901b1ef6bfd8782b15d7541379619c5dae02c5c03c1196291b042a4fea9dbddcb1c6bcd2a5ee19180e8dc881c2e9298757e84ad190b1c' as Signature;
-}
-
-/**
  * Spies and mocks classes constructors on globalThis
  *
  * @returns Mocked spies
@@ -194,6 +258,72 @@ export function mockRTC() {
   return { rtcDataChannel, rtcConnection, RTCPeerConnection };
 }
 
+// array of cleanup functions registered on current test
+const mockedCleanups: (() => void)[] = [];
+
+afterEach(() => {
+  let clean;
+  while ((clean = mockedCleanups.pop())) clean();
+});
+
+// spyOn .on, .removeListener & .emit methods and replace with a synchronous simplified logic
+function mockEthersEventEmitter(target: JsonRpcProvider | Contract): void {
+  let listeners: Map<EventType, Set<Listener>> | null = new Map();
+
+  function getEventTag(event: EventType): string {
+    if (typeof event === 'string') return event;
+    else if (Array.isArray(event)) return `filter::${event.join('|')}`;
+    else return `filter:${event.address}:${(event.topics ?? []).join('|')}`;
+  }
+
+  const onSpy = jest
+    .spyOn(target, 'on')
+    .mockImplementation((event: EventType, callback: Listener) => {
+      if (!listeners) return target;
+      event = getEventTag(event);
+      let cbs = listeners.get(event);
+      if (!cbs) listeners.set(event, (cbs = new Set()));
+      cbs.add(callback);
+      return target;
+    });
+  const removeSpy = jest
+    .spyOn(target, 'removeListener')
+    .mockImplementation((event: EventType, callback: Listener) => {
+      if (!listeners) return target;
+      event = getEventTag(event);
+      const cbs = listeners.get(event);
+      if (cbs) cbs.delete(callback);
+      return target;
+    });
+  const countSpy = jest
+    .spyOn(target, 'listenerCount')
+    .mockImplementation((event?: EventType): number => {
+      if (!listeners) return 0;
+      if (event) return listeners.get(getEventTag(event))?.size ?? 0;
+      return Array.from(listeners.values()).reduce((acc, cbs) => acc + cbs.size, 0);
+    });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const emitSpy = jest
+    .spyOn(target, 'emit')
+    .mockImplementation((event: EventType, ...args: any[]) => {
+      if (!listeners) return false;
+      event = getEventTag(event);
+      if (event === '*') {
+        for (const cbs of listeners.values()) for (const cb of cbs) cb(...args);
+      } else if (listeners.has(event)) listeners.get(event)!.forEach((cb) => cb(...args));
+      return true;
+    });
+
+  mockedCleanups.push(() => {
+    listeners?.clear();
+    listeners = null;
+    onSpy.mockRestore();
+    removeSpy.mockRestore();
+    countSpy.mockRestore();
+    emitSpy.mockRestore();
+  });
+}
+
 /**
  * Create a mock of RaidenEpicDeps
  *
@@ -203,46 +333,6 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
   const network: Network = { name: 'testnet', chainId: 1337 };
 
   const provider = new JsonRpcProvider() as jest.Mocked<JsonRpcProvider>;
-
-  // spyOn .on, .removeListener & .emit methods and replace with a synchronous simplified logic
-  const mockEthersEventEmitter = (target: JsonRpcProvider | Contract): void => {
-    const listeners = new Map<EventType, Set<Listener>>();
-    function getEventTag(event: EventType): string {
-      if (typeof event === 'string') return event;
-      else if (Array.isArray(event)) return `filter::${event.join('|')}`;
-      else return `filter:${event.address}:${(event.topics || []).join('|')}`;
-    }
-    jest.spyOn(target, 'on').mockImplementation((event: EventType, callback: Listener) => {
-      event = getEventTag(event);
-      let cbs = listeners.get(event);
-      if (!cbs) listeners.set(event, (cbs = new Set()));
-      cbs.add(callback);
-      return target;
-    });
-    jest
-      .spyOn(target, 'removeListener')
-      .mockImplementation((event: EventType, callback: Listener) => {
-        event = getEventTag(event);
-        const cbs = listeners.get(event);
-        if (cbs) cbs.delete(callback);
-        return target;
-      });
-    jest.spyOn(target, 'listenerCount').mockImplementation((event?: EventType): number => {
-      if (event && listeners.has(event)) return listeners.get(getEventTag(event))!.size;
-      else if (event) return 0;
-      let count = 0;
-      for (const cbs of listeners.values()) count += cbs.size;
-      return count;
-    });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    jest.spyOn(target, 'emit').mockImplementation((event: EventType, ...args: any[]) => {
-      event = getEventTag(event);
-      if (event === '*') {
-        for (const cbs of listeners.values()) for (const cb of cbs) cb(...args);
-      } else if (listeners.has(event)) listeners.get(event)!.forEach((cb) => cb(...args));
-      return true;
-    });
-  };
 
   let blockNumber = 125;
   Object.assign(provider, { network });
@@ -261,7 +351,6 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
 
   const signer = new Wallet(makeSecret(), provider);
   const address = signer.address as Address;
-  logging.setLevel(logging.levels.DEBUG);
   const log = logging.getLogger(`raiden:${address}`);
 
   const registryAddress = '0xregistry';
@@ -377,6 +466,7 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
     defaultConfig = makeDefaultConfig(
       { network },
       {
+        matrixServerLookup: 'https://matrixLookup.raiden.test',
         pfsSafetyMargin: 1.1,
         pfs: 'pfs.raiden.test',
         httpTimeout: 300,
@@ -414,4 +504,433 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
     userDepositContract,
     secretRegistryContract,
   };
+}
+
+const mockedMatrixUsers: {
+  [userId: string]: {
+    userId: string;
+    presence: string;
+    displayName?: string;
+    avatarUrl?: string;
+  };
+} = {};
+
+function mockedMatrixCreateClient({ baseUrl }: { baseUrl: string }): jest.Mocked<MatrixClient> {
+  const server = getServerName(baseUrl)!;
+  let userId: string;
+  let address: string;
+  return (Object.assign(new EventEmitter(), {
+    startClient: jest.fn(async () => (mockedMatrixUsers[userId].presence = 'online')),
+    stopClient: jest.fn(() => {
+      delete mockedMatrixUsers[userId];
+    }),
+    joinRoom: jest.fn(async (alias) => ({
+      roomId: `!${alias}_room_id:${server}`,
+      currentState: { setStateEvents: jest.fn() },
+    })),
+    // reject to test register
+    login: jest.fn().mockRejectedValue(new Error('invalid password')),
+    register: jest.fn(async (user, password) => {
+      address = getAddress(user);
+      assert(verifyMessage(server, password) === address, 'wrong password');
+      userId = `@${user}:${server}`;
+      mockedMatrixUsers[userId] = {
+        userId,
+        presence: 'offline',
+      };
+      return {
+        user_id: userId,
+        device_id: `${user}_device_id`,
+        access_token: `${user}_access_token`,
+      };
+    }),
+    searchUserDirectory: jest.fn(async ({ term }) => ({
+      results: Object.values(mockedMatrixUsers)
+        .filter((u) => u.userId.includes(term))
+        .map((u) => ({ user_id: u.userId, display_name: u.displayName })),
+    })),
+    getUserId: jest.fn(() => userId),
+    getUsers: jest.fn(() => Object.values(mockedMatrixUsers)),
+    getUser: jest.fn((userId) => mockedMatrixUsers[userId] ?? null),
+    getProfileInfo: jest.fn(async (userId) => {
+      if (!(userId in mockedMatrixUsers)) return null;
+      return {
+        displayname: mockedMatrixUsers[userId].displayName,
+        avatar_url: mockedMatrixUsers[userId].avatarUrl,
+      };
+    }),
+    setDisplayName: jest.fn(async (displayname) => {
+      assert(userId in mockedMatrixUsers);
+      assert(verifyMessage(userId, displayname) === address);
+      mockedMatrixUsers[userId].displayName = displayname;
+    }),
+    setAvatarUrl: jest.fn(async (avatarUrl) => {
+      assert(userId in mockedMatrixUsers);
+      mockedMatrixUsers[userId].avatarUrl = avatarUrl;
+    }),
+    setPresence: jest.fn(async ({ presence }: { presence: string }) => {
+      assert(userId in mockedMatrixUsers);
+      mockedMatrixUsers[userId].presence = presence;
+    }),
+    createRoom: jest.fn(async ({ visibility, invite }) => ({
+      room_id: `!roomId_${visibility || 'public'}_with_${(invite || []).join('_')}:${server}`,
+      getMember: jest.fn(),
+      getCanonicalAlias: jest.fn(() => null),
+      getAliases: jest.fn(() => []),
+    })),
+    getRoom: jest.fn((roomId) => ({
+      roomId,
+      getMember: jest.fn(),
+      getCanonicalAlias: jest.fn(() => null),
+      getAliases: jest.fn(() => []),
+    })),
+    getRooms: jest.fn(() => []),
+    getHomeserverUrl: jest.fn(() => server),
+    invite: jest.fn(async () => true),
+    leave: jest.fn(async () => true),
+    sendEvent: jest.fn(async () => true),
+    _http: {
+      opts: {},
+      // mock request done by raiden/utils::getUserPresence
+      authedRequest: jest.fn(async () => ({
+        user_id: 'user_id',
+        last_active_ago: 1,
+        presence: 'online',
+      })),
+    },
+    turnServer: jest.fn(async () => ({
+      uris: 'https://turn.raiden.test',
+      ttl: 86400,
+      username: 'user',
+      password: 'password',
+    })),
+    store: {
+      storeRoom: jest.fn(),
+    },
+    createFilter: jest.fn(async () => true),
+  }) as unknown) as jest.Mocked<MatrixClient>;
+}
+
+jest.mock('matrix-js-sdk', () => ({
+  ...jest.requireActual<any>('matrix-js-sdk'),
+  createClient: mockedMatrixCreateClient,
+}));
+
+export interface MockedRaiden {
+  address: Address;
+  store: Store<RaidenState, RaidenAction>;
+  deps: MockRaidenEpicDeps;
+  output: RaidenAction[];
+}
+
+const mockedClients: MockedRaiden[] = [];
+const registryAddress = makeAddress();
+const svtAddress = makeAddress();
+const oneToNAddress = makeAddress();
+
+/**
+ * Stop a client and complete its observables
+ *
+ * @param raiden - Client to stop
+ */
+export function stopRaiden(raiden: MockedRaiden) {
+  raiden.store.dispatch(raidenShutdown({ reason: ShutdownReason.STOP }));
+}
+
+/**
+ * Create a mock of a Raiden client for epics
+ *
+ * @returns Mocked Raiden Epics params
+ */
+export async function makeRaiden(): Promise<MockedRaiden> {
+  const network: Network = { name: 'testnet', chainId: 1337 };
+  const { JsonRpcProvider } = jest.requireActual('ethers/providers');
+  const provider = new JsonRpcProvider() as jest.Mocked<JsonRpcProvider>;
+  provider.pollingInterval = 10;
+  const signer = new Wallet(makeSecret(), provider);
+  const address = signer.address as Address;
+  const log = logging.getLogger(`raiden:${address}`);
+
+  Object.assign(provider, { _network: network });
+  jest.spyOn(provider, 'on');
+  jest.spyOn(provider as any, '_doPoll').mockImplementation(() => undefined);
+  jest.spyOn(provider, 'removeListener');
+  jest.spyOn(provider, 'listenerCount');
+  jest.spyOn(provider, 'getNetwork').mockImplementation(async () => provider.network);
+  jest.spyOn(provider, 'resolveName').mockImplementation(async (addressOrName) => addressOrName);
+  jest.spyOn(provider, 'send').mockImplementation(async (method) => {
+    if (method === 'net_version') return network.chainId;
+    throw new Error('provider.send called');
+  });
+  jest.spyOn(provider, 'getLogs').mockResolvedValue([]);
+  jest.spyOn(provider, 'getBlock');
+  jest.spyOn(provider, 'getTransaction');
+  jest.spyOn(provider, 'listAccounts').mockResolvedValue([address]);
+  // See: https://github.com/cartant/rxjs-marbles/issues/11
+  jest.spyOn(provider, 'getBlockNumber').mockImplementation(async () => provider.blockNumber);
+  jest
+    .spyOn(provider, 'getTransactionReceipt')
+    .mockImplementation(
+      async (txHash: string) =>
+        ({ txHash, confirmations: 6, blockNumber: provider.blockNumber } as any),
+    );
+  // use provider.resetEventsBlock used to set current block number for provider
+  jest
+    .spyOn(provider, 'resetEventsBlock')
+    .mockImplementation((n: number) => Object.assign(provider, { _fastBlockNumber: n }));
+  // mockEthersEventEmitter(provider);
+  provider.on('block', (n: number) => provider.resetEventsBlock(n));
+  provider.resetEventsBlock(100);
+
+  const registryContract = TokenNetworkRegistryFactory.connect(
+    registryAddress,
+    signer,
+  ) as MockedContract<TokenNetworkRegistry>;
+  for (const func in registryContract.functions) {
+    jest.spyOn(registryContract.functions, func as keyof TokenNetworkRegistry['functions']);
+  }
+  registryContract.functions.token_to_token_networks.mockImplementation(async () => makeAddress());
+
+  const getTokenNetworkContract = memoize(
+    (address: string): MockedContract<TokenNetwork> => {
+      const tokenNetworkContract = TokenNetworkFactory.connect(address, signer) as MockedContract<
+        TokenNetwork
+      >;
+      for (const func in tokenNetworkContract.functions) {
+        jest.spyOn(tokenNetworkContract.functions, func as keyof TokenNetwork['functions']);
+      }
+      tokenNetworkContract.functions.getChannelParticipantInfo.mockResolvedValue([
+        Zero,
+        Zero,
+        false,
+        HashZero,
+        Zero,
+        HashZero,
+        Zero,
+      ]);
+      tokenNetworkContract.functions.openChannel.mockResolvedValue(makeTransaction());
+      tokenNetworkContract.functions.setTotalDeposit.mockResolvedValue(makeTransaction());
+      tokenNetworkContract.functions.closeChannel.mockResolvedValue(makeTransaction());
+      tokenNetworkContract.functions.updateNonClosingBalanceProof.mockResolvedValue(
+        makeTransaction(),
+      );
+      tokenNetworkContract.functions.settleChannel.mockResolvedValue(makeTransaction());
+      tokenNetworkContract.functions.unlock.mockResolvedValue(makeTransaction());
+      return tokenNetworkContract;
+    },
+  );
+
+  const getTokenContract = memoize(
+    (address: string): MockedContract<HumanStandardToken> => {
+      const tokenContract = HumanStandardTokenFactory.connect(address, signer) as MockedContract<
+        HumanStandardToken
+      >;
+      for (const func in tokenContract.functions) {
+        jest.spyOn(tokenContract.functions, func as keyof HumanStandardToken['functions']);
+      }
+      tokenContract.functions.approve.mockResolvedValue(makeTransaction());
+      return tokenContract;
+    },
+  );
+
+  const serviceRegistryContract = ServiceRegistryFactory.connect(
+    registryAddress,
+    signer,
+  ) as MockedContract<ServiceRegistry>;
+  for (const func in serviceRegistryContract.functions) {
+    jest.spyOn(serviceRegistryContract.functions, func as keyof ServiceRegistry['functions']);
+  }
+  serviceRegistryContract.functions.token.mockResolvedValue(svtAddress);
+  serviceRegistryContract.functions.urls.mockImplementation(async () => 'https://pfs.raiden.test');
+
+  const userDepositContract = UserDepositFactory.connect(address, signer) as MockedContract<
+    UserDeposit
+  >;
+
+  for (const func in userDepositContract.functions) {
+    jest.spyOn(userDepositContract.functions, func as keyof UserDeposit['functions']);
+  }
+
+  userDepositContract.functions.one_to_n_address.mockResolvedValue(oneToNAddress);
+  userDepositContract.functions.balances.mockResolvedValue(parseEther('5'));
+
+  const secretRegistryContract = SecretRegistryFactory.connect(address, signer) as MockedContract<
+    SecretRegistry
+  >;
+
+  for (const func in secretRegistryContract.functions) {
+    jest.spyOn(secretRegistryContract.functions, func as keyof SecretRegistry['functions']);
+  }
+
+  const monitoringServiceContract = MonitoringServiceFactory.connect(
+    address,
+    signer,
+  ) as MockedContract<MonitoringService>;
+
+  for (const func in monitoringServiceContract.functions) {
+    jest.spyOn(monitoringServiceContract.functions, func as keyof MonitoringService['functions']);
+  }
+
+  const contractsInfo: ContractsInfo = {
+    TokenNetworkRegistry: {
+      address: registryContract.address as Address,
+      block_number: 100,
+    },
+    ServiceRegistry: {
+      address: serviceRegistryContract.address as Address,
+      block_number: 101,
+    },
+    UserDeposit: {
+      address: userDepositContract.address as Address,
+      block_number: 102,
+    },
+    SecretRegistry: {
+      address: secretRegistryContract.address as Address,
+      block_number: 102,
+    },
+    MonitoringService: {
+      address: monitoringServiceContract.address as Address,
+      block_number: 102,
+    },
+  };
+
+  const defaultConfig = makeDefaultConfig(
+    { network },
+    {
+      // matrixServerLookup: 'https://matrixLookup.raiden.test',
+      matrixServer: 'matrix.raiden.test',
+      pfsSafetyMargin: 1.1,
+      pfs: 'pfs.raiden.test',
+      httpTimeout: 300,
+      settleTimeout: 60,
+      revealTimeout: 50,
+      confirmationBlocks: 5,
+    },
+  );
+  const latest$ = new ReplaySubject<Latest>(1);
+  const config$ = latest$.pipe(pluckDistinct('config'));
+
+  const deps = {
+    latest$,
+    config$,
+    matrix$: new AsyncSubject<MatrixClient>(),
+    address,
+    log,
+    defaultConfig,
+    network,
+    contractsInfo,
+    provider,
+    signer,
+    registryContract,
+    getTokenNetworkContract,
+    getTokenContract,
+    serviceRegistryContract,
+    userDepositContract,
+    secretRegistryContract,
+  };
+
+  const initialState = makeInitialState(
+    { network, address, contractsInfo },
+    { blockNumber: provider.blockNumber },
+  );
+
+  const epicMiddleware = createEpicMiddleware<
+    RaidenAction,
+    RaidenAction,
+    RaidenState,
+    RaidenEpicDeps
+  >({ dependencies: deps });
+  const output: RaidenAction[] = [];
+  const store = createStore(
+    raidenReducer,
+    initialState as any,
+    applyMiddleware(epicMiddleware, () => (next) => (action) => {
+      log.debug('action$', action);
+      output.push(action);
+      return next(action);
+    }),
+  );
+
+  const raiden: MockedRaiden = {
+    address,
+    store,
+    deps,
+    output,
+  };
+  mockedClients.push(raiden);
+  mockedCleanups.push(() => {
+    raiden.deps.provider.removeAllListeners();
+    stopRaiden(raiden);
+    const idx = mockedClients.indexOf(raiden);
+    if (idx >= 0) mockedClients.splice(idx, 1);
+  });
+
+  epicMiddleware.run(raidenRootEpic);
+  await raiden.deps.latest$
+    .pipe(
+      filter(({ state }) => state.blockNumber >= raiden.deps.provider.blockNumber),
+      take(1),
+    )
+    .toPromise();
+  // raiden.store.dispatch(newBlock({ blockNumber: provider.blockNumber }));
+  return raiden;
+}
+
+/**
+ * Create multiple mocked clients
+ *
+ * @param length - Number of clients to create
+ * @returns Array of mocked clients
+ */
+export async function makeRaidens(length: number): Promise<MockedRaiden[]> {
+  return Promise.all(Array.from({ length }, makeRaiden));
+}
+
+/**
+ * Asynchronously wait for some time
+ *
+ * @param ms - milliseconds to wait
+ * @returns Promise to void
+ */
+export async function sleep(ms = 10): Promise<void> {
+  return new Promise((resolve) => setTimeout(() => process.nextTick(resolve), ms));
+}
+
+/**
+ * Emit an event to all currently mocked providers
+ *
+ * @param eventName - event name or filter
+ * @param args - event args
+ * @returns Promise which resolves when we detect these providers detected event
+ */
+export async function providersEmit(eventName: EventType, ...args: any[]): Promise<void> {
+  const promise = Promise.all(
+    mockedClients.map(
+      (r) => new Promise((resolve) => r.deps.provider.once(eventName, () => resolve())),
+    ),
+  );
+  mockedClients.forEach((r) => r.deps.provider.emit(eventName, ...args));
+  await promise;
+}
+
+/**
+ * Emit blocks to all connected providers
+ *
+ * @param block - block number to be emitted, or else increment by one
+ * @returns Promise resolved after all mockedClients fetch block
+ */
+export async function waitBlock(block?: number): Promise<void> {
+  if (!block) block = mockedClients[0].deps.provider.blockNumber + 1;
+  const promise = Promise.all(
+    mockedClients.map((r) =>
+      r.deps.latest$
+        .pipe(
+          filter(({ state }) => state.blockNumber >= block!),
+          take(1),
+        )
+        .toPromise(),
+    ),
+  );
+  await providersEmit('block', block);
+  await promise;
 }

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
-import { patchEthersDefineReadOnly, patchEthersGetNetwork } from './patches';
+import { patchEthersDefineReadOnly, patchEthersGetNetwork, patchVerifyMessage } from './patches';
+patchVerifyMessage();
 patchEthersDefineReadOnly();
 patchEthersGetNetwork();
 
@@ -11,6 +11,7 @@ import { memoize } from 'lodash';
 import logging from 'loglevel';
 import { Store, createStore, applyMiddleware } from 'redux';
 
+// TODO: remove this mock
 jest.mock('ethers/providers');
 import { JsonRpcProvider, EventType, Listener } from 'ethers/providers';
 import { Zero, HashZero } from 'ethers/constants';

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -348,7 +348,7 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
   const provider = new JsonRpcProvider() as jest.Mocked<JsonRpcProvider>;
 
   let blockNumber = 125;
-  Object.assign(provider, { network });
+  Object.assign(provider, { network, _ethersType: 'Provider' });
   Object.defineProperty(provider, 'blockNumber', { get: () => blockNumber });
   jest.spyOn(provider, 'getNetwork').mockImplementation(async () => network);
   jest.spyOn(provider, 'resolveName').mockImplementation(async (addressOrName) => addressOrName);
@@ -626,7 +626,7 @@ function mockedMatrixCreateClient({ baseUrl }: { baseUrl: string }): jest.Mocked
 
 jest.mock('matrix-js-sdk', () => ({
   ...jest.requireActual<any>('matrix-js-sdk'),
-  createClient: mockedMatrixCreateClient,
+  createClient: jest.fn(mockedMatrixCreateClient),
 }));
 
 export interface MockedRaiden {

--- a/raiden-ts/tests/unit/patches.ts
+++ b/raiden-ts/tests/unit/patches.ts
@@ -28,9 +28,12 @@ export const patchVerifyMessage = () => {
       ...origSepc256k1,
       __esModule: true,
       KeyPair: MockedKeyPair,
-      verifyMessage: jest.fn(({}: string, sig: string): string =>
-        getAddress('0x' + sig.substr(-44, 40)),
-      ),
+      verifyMessage: jest.fn((msg: string, sig: string): string => {
+        // TODO: remove userId special case after mockedMatrixCreateClient is used
+        const match = /^@(0x[0-9a-f]{40})[.:]/i.exec(msg);
+        if (match?.[1]) return getAddress(match[1]);
+        return getAddress('0x' + sig.substr(-44, 40));
+      }),
     };
   });
 };

--- a/raiden-ts/tests/unit/patches.ts
+++ b/raiden-ts/tests/unit/patches.ts
@@ -1,26 +1,47 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { JsonRpcProvider } from 'ethers/providers';
-import { Network } from 'ethers/utils';
+import type { JsonRpcProvider } from 'ethers/providers';
+import type { Network, Arrayish, Signature } from 'ethers/utils';
+import { getAddress } from 'ethers/utils/address';
+import { HashZero } from 'ethers/constants';
 
-// ethers utils mock to always validate matrix userIds/displayName
-export const patchVerifyMessage = () =>
-  jest.mock('ethers/utils', () => ({
-    ...jest.requireActual<any>('ethers/utils'),
-    verifyMessage: jest.fn((msg: string, sig: string): string => {
-      const { getAddress, verifyMessage: origVerifyMessage } = jest.requireActual('ethers/utils');
-      const match = /^@(0x[0-9a-f]{40})[.:]/i.exec(msg);
-      if (match && match[1]) return getAddress(match[1]);
-      return origVerifyMessage(msg, sig);
-    }),
-  }));
+// ethers utils mock to skip slow elliptic sign/verify
+export const patchVerifyMessage = () => {
+  jest.mock('ethers/utils/secp256k1', () => {
+    const origSepc256k1 = jest.requireActual<typeof import('ethers/utils/secp256k1')>(
+      'ethers/utils/secp256k1',
+    );
+    const { KeyPair, computeAddress } = origSepc256k1;
+    class MockedKeyPair extends KeyPair {
+      private _address?: string;
+      sign({}: Arrayish | string): Signature {
+        if (!this._address) this._address = computeAddress(this.publicKey);
+        return {
+          r: HashZero,
+          s: HashZero.substr(0, 24) + this._address!.substr(2) + '00',
+          recoveryParam: 0,
+          v: 27,
+        };
+      }
+    }
+    return {
+      ...origSepc256k1,
+      __esModule: true,
+      KeyPair: MockedKeyPair,
+      verifyMessage: jest.fn(({}: string, sig: string): string =>
+        getAddress('0x' + sig.substr(-44, 40)),
+      ),
+    };
+  });
+};
 
 // raiden-ts/utils.getNetwork has the same functionality as provider.getNetwork
 // but fetches everytime instead of just returning a cached property
 // On mocked tests, we unify both again, so we can just mock provider.getNetwork in-place
 export const patchEthersGetNetwork = () =>
   jest.mock('raiden-ts/utils/ethers', () => ({
-    ...jest.requireActual<any>('raiden-ts/utils/ethers'),
+    ...jest.requireActual<typeof import('raiden-ts/utils/ethers')>('raiden-ts/utils/ethers'),
+    __esModule: true,
     getNetwork: jest.fn((provider: JsonRpcProvider): Promise<Network> => provider.getNetwork()),
   }));
 
@@ -28,7 +49,8 @@ export const patchEthersGetNetwork = () =>
 // functions and properties. Mock it here so we can mock later
 export const patchEthersDefineReadOnly = () =>
   jest.mock('ethers/utils/properties', () => ({
-    ...jest.requireActual<any>('ethers/utils/properties'),
+    ...jest.requireActual<typeof import('ethers/utils/properties')>('ethers/utils/properties'),
+    __esModule: true,
     defineReadOnly: jest.fn(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (object: any, name: string, value: any): void =>

--- a/raiden-ts/tests/unit/patches.ts
+++ b/raiden-ts/tests/unit/patches.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-jest.mock('ethers/providers');
 import { JsonRpcProvider } from 'ethers/providers';
 import { Network } from 'ethers/utils';
 
@@ -19,9 +18,9 @@ export const patchVerifyMessage = () =>
 // raiden-ts/utils.getNetwork has the same functionality as provider.getNetwork
 // but fetches everytime instead of just returning a cached property
 // On mocked tests, we unify both again, so we can just mock provider.getNetwork in-place
-export const patchMatrixGetNetwork = () =>
-  jest.mock('raiden-ts/utils/matrix', () => ({
-    ...jest.requireActual<any>('raiden-ts/utils/matrix'),
+export const patchEthersGetNetwork = () =>
+  jest.mock('raiden-ts/utils/ethers', () => ({
+    ...jest.requireActual<any>('raiden-ts/utils/ethers'),
     getNetwork: jest.fn((provider: JsonRpcProvider): Promise<Network> => provider.getNetwork()),
   }));
 

--- a/raiden-ts/tests/unit/utils.spec.ts
+++ b/raiden-ts/tests/unit/utils.spec.ts
@@ -1,10 +1,13 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
+import { makeLog, makeRaiden, waitBlock, makeAddress } from './mocks';
+import { token, tokenNetwork } from './fixtures';
+
 import * as t from 'io-ts';
 import { fold, isRight } from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/pipeable';
 import { isError } from 'util';
 import { of } from 'rxjs';
-import { first, take, toArray } from 'rxjs/operators';
+import { first } from 'rxjs/operators';
 
 import { Event } from 'ethers/contract';
 import { BigNumber, bigNumberify, keccak256, hexDataLength } from 'ethers/utils';
@@ -31,110 +34,112 @@ import { LruCache } from 'raiden-ts/utils/lru';
 import { encode, losslessParse, losslessStringify } from 'raiden-ts/utils/data';
 import { getLocksroot, makeSecret, getSecrethash } from 'raiden-ts/transfers/utils';
 import { Lock } from 'raiden-ts/channels';
-import { makeLog, raidenEpicDeps } from './mocks';
 
-describe('fromEthersEvent', () => {
-  const { provider } = raidenEpicDeps();
+const { JsonRpcProvider } = jest.requireActual('ethers/providers');
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+test('fromEthersEvent', async () => {
+  expect.assertions(3);
 
-  test('event registered and emitted', async () => {
-    const promise = fromEthersEvent<number>(provider, 'block').pipe(first()).toPromise();
-    provider.emit('block', 1337);
+  const provider = new JsonRpcProvider();
+  const onSpy = jest.spyOn(provider, 'on');
+  const removeListenerSpy = jest.spyOn(provider, 'removeListener');
 
-    const blockNumber = await promise;
+  const promise = fromEthersEvent<number>(provider, 'block').pipe(first()).toPromise();
+  provider.emit('block', 1337);
+  const blockNumber = await promise;
 
-    expect(blockNumber).toBe(1337);
-    expect(provider.on).toHaveBeenCalledTimes(1);
-    expect(provider.removeListener).toHaveBeenCalledTimes(1);
-  });
+  expect(blockNumber).toBe(1337);
+  expect(onSpy).toHaveBeenCalledTimes(1);
+  expect(removeListenerSpy).toHaveBeenCalledTimes(1);
 });
 
 describe('getEventsStream', () => {
-  const { provider, registryContract } = raidenEpicDeps();
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
   type TokenNetworkCreatedEvent = [string, string, Event];
 
   test('newEvents$ only', async () => {
+    expect.assertions(4);
+    const raiden = await makeRaiden();
+    const { provider, registryContract } = raiden.deps;
     const filter = registryContract.filters.TokenNetworkCreated(null, null);
 
-    const promise = getEventsStream<TokenNetworkCreatedEvent>(registryContract, [filter])
-      .pipe(first())
-      .toPromise();
+    const output: TokenNetworkCreatedEvent[] = [];
+    const sub = getEventsStream<TokenNetworkCreatedEvent>(registryContract, [
+      filter,
+    ]).subscribe((e) => output.push(e));
 
-    const tokenAddr = '0x0000000000000000000000000000000000000001',
-      tokenNetworkAddr = '0x0000000000000000000000000000000000000002';
     const log = makeLog({
-      filter: registryContract.filters.TokenNetworkCreated(tokenAddr, tokenNetworkAddr),
+      filter: registryContract.filters.TokenNetworkCreated(token, tokenNetwork),
     });
     provider.emit(filter, log);
 
-    const event = await promise;
+    await waitBlock();
 
-    expect(event).toBeDefined();
-    expect(event[0]).toBe(tokenAddr);
-    expect(event[1]).toBe(tokenNetworkAddr);
+    expect(output).toHaveLength(1);
+    const event = output[0];
+    expect(event[0]).toBe(token);
+    expect(event[1]).toBe(tokenNetwork);
     expect(event[2]).toMatchObject({
       address: registryContract.address,
       blockNumber: 1337,
-      args: { '0': tokenAddr, '1': tokenNetworkAddr, length: 2 },
+      args: { '0': token, '1': tokenNetwork, length: 2 },
     });
+
+    sub.unsubscribe();
   });
 
   test('pastEvents$ and newEvents$', async () => {
+    expect.assertions(10);
+    const raiden = await makeRaiden();
+    const { provider, registryContract } = raiden.deps;
     const filter = registryContract.filters.TokenNetworkCreated(null, null);
 
-    const pastTokenAddr = '0x0000000000000000000000000000000000000003',
-      pastTokenNetworkAddr = '0x0000000000000000000000000000000000000004';
+    const pastToken = makeAddress();
+    const pastTokenNetwork = makeAddress();
 
     const pastLog = makeLog({
       blockNumber: 999,
-      filter: registryContract.filters.TokenNetworkCreated(pastTokenAddr, pastTokenNetworkAddr),
+      filter: registryContract.filters.TokenNetworkCreated(pastToken, pastTokenNetwork),
     });
 
     // ensure getEventsStream will need to wait for next block
-    provider.resetEventsBlock((undefined as unknown) as number);
+    provider.resetEventsBlock(0);
     provider.getLogs.mockResolvedValueOnce([pastLog]);
 
-    const promise = getEventsStream<TokenNetworkCreatedEvent>(registryContract, [filter], of(1))
-      .pipe(take(2), toArray())
-      .toPromise();
+    const output: TokenNetworkCreatedEvent[] = [];
+    const sub = getEventsStream<TokenNetworkCreatedEvent>(
+      registryContract,
+      [filter],
+      of(1),
+    ).subscribe((e) => output.push(e));
 
-    provider.emit('block', 1336);
+    await waitBlock();
+    await waitBlock(1336);
 
-    const tokenAddr = '0x0000000000000000000000000000000000000001',
-      tokenNetworkAddr = '0x0000000000000000000000000000000000000002';
     const log = makeLog({
-      filter: registryContract.filters.TokenNetworkCreated(tokenAddr, tokenNetworkAddr),
+      filter: registryContract.filters.TokenNetworkCreated(token, tokenNetwork),
     });
-    setTimeout(() => provider.emit(filter, log), 10);
+    provider.emit(filter, log);
 
-    const events = await promise;
+    await waitBlock();
 
-    expect(events).toBeDefined();
-    expect(events).toHaveLength(2);
+    expect(output).toHaveLength(2);
 
-    expect(events[1][0]).toBe(tokenAddr);
-    expect(events[1][1]).toBe(tokenNetworkAddr);
-    expect(events[1][2]).toMatchObject({
+    expect(output[1][0]).toBe(token);
+    expect(output[1][1]).toBe(tokenNetwork);
+    expect(output[1][2]).toMatchObject({
       address: registryContract.address,
       blockNumber: 1337,
-      args: { '0': tokenAddr, '1': tokenNetworkAddr, length: 2 },
+      args: { '0': token, '1': tokenNetwork, length: 2 },
     });
 
-    expect(events[0][0]).toBe(pastTokenAddr);
-    expect(events[0][1]).toBe(pastTokenNetworkAddr);
-    const pastEvent = events[0][2];
+    expect(output[0][0]).toBe(pastToken);
+    expect(output[0][1]).toBe(pastTokenNetwork);
+
+    const pastEvent = output[0][2];
     expect(pastEvent).toMatchObject({
       address: registryContract.address,
       blockNumber: 999,
-      args: { '0': pastTokenAddr, '1': pastTokenNetworkAddr, length: 2 },
+      args: { '0': pastToken, '1': pastTokenNetwork, length: 2 },
     });
     pastEvent.removeListener();
 
@@ -145,11 +150,13 @@ describe('getEventsStream', () => {
     expect(provider.getBlock).toHaveBeenCalledWith(pastLog.blockHash);
     expect(provider.getTransaction).toHaveBeenCalledWith(pastLog.transactionHash);
     expect(provider.getTransactionReceipt).toHaveBeenCalledWith(pastLog.transactionHash);
+
+    sub.unsubscribe();
   });
 });
 
 test('patchSignSend', async () => {
-  const { provider } = raidenEpicDeps();
+  const provider = new JsonRpcProvider();
 
   const sendSpy = jest.spyOn(provider, 'send');
   sendSpy.mockImplementation(async (method, params) => [method, params]);


### PR DESCRIPTION
Fixes #1377 

**Short description**
Refactor unit mocks, fixtures and tests. For now, the new pattern was only applied to `utils.spec.ts` and `channels.spec.ts` (this was one of the oldest tests suites, and therefore, one of the most outdated).

The new testing paradigm involves a `makeRaiden` mocked function, which initializes a mocked Raiden client (actually, just a small subset of its functionality), including full epics subscription and `await` for first block actions to be synced. A `makeRaidens(n)` utility is also provided to generate `n` clients in parallel (including some pure caching, like wallets), which can then be destructured into e.g. `[raiden, partner]` pairs. These functions also queue cleanup functions to stop/unsubscribe from generated observables. For waits, `setTimeout`s for completes can be replaced by `await waitBlock`, which emits the next block and also ensures it's picked by registered clients.

For fixtures, there're now a few `ensure*` async utility functions, which should emit events and actions to the clients passed as parameter and `await` them to catch up a given state. Example: `ensureChannelIsOpen([raiden, partner])` will emit contracts events and only resolve after both us and partner fetch those events and persist them in state. Constant fixtures are also moved to `fixtures` and can be imported directly.

With this, these tests are self-contained, properly cleaned up `afterEach`, hopefully not leaking to other tests in the suite, and after we finish migrating and remove the previous mocks, we can even enable `restoreMocks` jest config option safely.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Just run SDK's unit test and ensure everything pass
