### PR TITLE
Refactor signIOU and fetchLastIou$

### DIFF
--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -539,13 +539,13 @@ describe('transport epic', () => {
     promise = matrixUpdateCapsEpic(action$, state$, depsMock).toPromise();
     action$.next(
       raidenConfigUpdate({
-        caps: { [Capabilities.NO_DELIVERY]: true, customCap: 'abc' },
+        caps: { [Capabilities.NO_RECEIVE]: true, customCap: 'abc' },
       }),
     );
     setTimeout(() => action$.complete(), 10);
     await expect(promise).resolves.toBeUndefined();
     expect(matrix.setAvatarUrl).toHaveBeenCalledTimes(2);
-    expect(matrix.setAvatarUrl).toHaveBeenCalledWith('noReceive,noDelivery,customCap="abc"');
+    expect(matrix.setAvatarUrl).toHaveBeenCalledWith('noReceive,customCap="abc"');
   });
 
   describe('matrixCreateRoomEpic', () => {
@@ -1619,6 +1619,10 @@ describe('transport epic', () => {
 
     test('success caller & candidates', async () => {
       expect.assertions(4);
+
+      // change partner to one with higher address, to be the callee
+      partner = '0xFffFfFFF00000000000000000000000000000088' as Address;
+      partnerUserId = `@${partner.toLowerCase()}:${matrixServer}`;
 
       const promise = rtcConnectEpic(action$, state$, depsMock)
         .pipe(takeUntil(timer(200)), toArray())

--- a/raiden-ts/tests/unit/fixtures.ts
+++ b/raiden-ts/tests/unit/fixtures.ts
@@ -10,7 +10,7 @@ import { Wallet } from 'ethers';
 import { AddressZero } from 'ethers/constants';
 import { bigNumberify } from 'ethers/utils';
 
-import { Address, Hash, Int, Signature, Signed, UInt } from 'raiden-ts/utils/types';
+import { Address, Hash, Int, UInt } from 'raiden-ts/utils/types';
 import { Processed, MessageType } from 'raiden-ts/messages/types';
 import { makeMessageId, makePaymentId } from 'raiden-ts/transfers/utils';
 import { IOU } from 'raiden-ts/services/types';
@@ -75,8 +75,7 @@ export function epicFixtures(depsMock: MockRaidenEpicDeps) {
       chain_id: bigNumberify(depsMock.network.chainId) as UInt<32>,
       expiration_block: bigNumberify(3232341) as UInt<32>,
       amount: bigNumberify(100) as UInt<32>,
-      signature: '0x87ea2a9c6834513dcabfca011c4422eb02a824b8bbbfc8f555d6a6dd2ebbbe953e1a47ad27b9715d8c8cf2da833f7b7d6c8f9bdb997591b7234999901f042caf1b' as Signature,
-    } as Signed<IOU>,
+    } as IOU,
     key = channelKey({ tokenNetwork, partner }),
     action$ = new Subject<RaidenAction>(),
     state$ = new Subject<RaidenState>();


### PR DESCRIPTION
Part of #1377 

**Short description**
Refactor `fetchLastIou$` and split `packIOU` & `signIOU` on `services/utils.ts`, so it can be used on tests to sign an unsigned IOU into its signed form.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. This is a purely internal change, shouldn't impact behavior at all
