### PR TITLE
Fixes typing that causes integration test to fail

### DIFF
--- a/raiden-ts/tests/integration/integration.spec.ts
+++ b/raiden-ts/tests/integration/integration.spec.ts
@@ -1,7 +1,7 @@
 import { RaidenState } from 'raiden-ts/state';
 import { assert, Storage } from 'raiden-ts/utils/types';
 import { Raiden } from 'raiden-ts/raiden';
-import { promises as fs } from 'fs';
+import { OpenMode, promises as fs } from 'fs';
 import { ContractsInfo } from 'raiden-ts/types';
 import { bigNumberify } from 'ethers/utils';
 import { MockStorage } from '../e2e/mocks';
@@ -30,7 +30,7 @@ async function createRaiden(
   assert(await fs.stat(deploymentInfoFile));
   assert(await fs.stat(deploymentServiceInfoFile));
 
-  const options = { encoding: 'utf8', flag: 'r' };
+  const options: { encoding: BufferEncoding; flag?: OpenMode } = { encoding: 'utf8', flag: 'r' };
 
   const deployFile = (await fs.readFile(deploymentInfoFile, options)) as string;
   const servicesDeployFile = (await fs.readFile(deploymentServiceInfoFile, options)) as string;


### PR DESCRIPTION
**Short description**

Last night the integration tests failed due to a typing issued:

https://app.circleci.com/pipelines/github/raiden-network/light-client/5129/workflows/e32c7464-0073-4633-a4a0-8598e7181a9e/jobs/31489/steps

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Get the integration image locally
2. Run ./integration/run-integration.sh
