### PR TITLE
Clarifies that channels for a specific token display

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -6,12 +6,16 @@
 
 - [#168] Notification panel
 
+
 ### Fixed
 
 - [#1579] Removes minting references when detected network is mainnet.
 
 ### Changed
 
+- [#1540] Adds title to channels list to clarify that only channels for the selected token display.
+
+[#1540]: https://github.com/raiden-network/light-client/issues/1540
 [#1579]: https://github.com/raiden-network/light-client/issues/1579
 [#168]: https://github.com/raiden-network/light-client/issues/168
 

--- a/raiden-dapp/src/components/navigation/Channels.vue
+++ b/raiden-dapp/src/components/navigation/Channels.vue
@@ -1,5 +1,25 @@
 <template>
   <div class="channels">
+    <v-row class="ml-5 mr-5" no-gutters>
+      <v-col>
+        <span class="font-weight-light mr-1">
+          {{ $t('channels.title') }}
+        </span>
+        <v-tooltip top>
+          <template #activator="{ on }">
+            <span class="font-weight-medium" v-on="on">
+              {{
+                $t('channels.token-info', {
+                  name: truncate(token.name, 22),
+                  symbol: truncate(token.symbol, 8)
+                })
+              }}
+            </span>
+          </template>
+          <span> {{ token.address }} </span>
+        </v-tooltip>
+      </v-col>
+    </v-row>
     <list-header
       v-if="open.length > 0"
       :header="$t('channels.open.header')"
@@ -68,6 +88,7 @@ import NavigationMixin from '@/mixins/navigation-mixin';
 import ChannelList from '@/components/channels/ChannelList.vue';
 import ChannelDialogs from '@/components/channels/ChannelDialogs.vue';
 import { ChannelAction } from '@/types';
+import Filters from '@/filters';
 
 @Component({
   components: { ChannelDialogs, ListHeader, ChannelList },
@@ -83,6 +104,7 @@ export default class Channels extends Mixins(NavigationMixin) {
 
   selectedChannel: RaidenChannel | null = null;
   expanded: { [id: number]: boolean } = {};
+  truncate = Filters.truncate;
 
   channelSelected(payload: { channel: RaidenChannel; expanded: boolean }) {
     const { expanded, channel } = payload;
@@ -166,7 +188,7 @@ export default class Channels extends Mixins(NavigationMixin) {
   height: 100%;
 
   &:first-child {
-    padding-top: 50px;
+    padding-top: 40px;
   }
 
   &__overlay {

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -181,7 +181,9 @@
     "settleable": {
       "header": "Settleable"
     },
-    "snackbar-close": "Close"
+    "snackbar-close": "Close",
+    "token-info": "{symbol} | {name}",
+    "title": "Channels on"
   },
   "channel-list": {
     "channel": {


### PR DESCRIPTION
Fixes #1540 

**Short description**
Adds a title to the channels list to clarify that only channels for a specific token display.

![image](https://user-images.githubusercontent.com/2269732/83631424-cc0bdf00-a59d-11ea-952a-fd7dbf065f6f.png)


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to the dApp with an account that has open channels
2. Click on the channels button
3. Verify that the channels list has a title that contains the token name and symbol


