### PR TITLE
Fix UDC deposit and implement checking allowance before deposit

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,15 +1,20 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- [#1637] Fix depositToUDC failing if services already have withdrawn some fees
+
+### Added
+- [#1642] Check token's allowance before deposit and skip approve
 
 ### Changed
-
 - [#837] Changes the action tags from camel to path format. This change affects the event types exposed through the public API.
 
 [#837]: https://github.com/raiden-network/light-client/issues/837
+[#1637]: https://github.com/raiden-network/light-client/issues/1637
+[#1642]: https://github.com/raiden-network/light-client/issues/1642
 
 ## [0.9.0] - 2020-05-28
-
 ### Added
 - [#1473] Expose config$ observable
 

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -555,7 +555,7 @@ export const monitorUdcBalanceEpic = (
     pluckDistinct('state', 'blockNumber'),
     // it's seems ugly to call on each block, but UserDepositContract doesn't expose deposits as
     // events, and ethers actually do that to monitor token balances, so it's equivalent
-    exhaustMap(() => userDepositContract.functions.balances(address) as Promise<UInt<32>>),
+    exhaustMap(() => userDepositContract.functions.effectiveBalance(address) as Promise<UInt<32>>),
     distinctUntilChanged((x, y) => y.eq(x)),
     map(udcDeposited),
   );

--- a/raiden-ts/tests/tsconfig.json
+++ b/raiden-ts/tests/tsconfig.json
@@ -6,5 +6,12 @@
   "files": [
     "../src/global.d.ts",
     "../tests/global.d.ts"
-  ]
+  ],
+  "compilerOptions": {
+    "baseUrl": "..",
+    "paths": {
+      "raiden-ts/*": ["src/*"],
+      "matrix-js-sdk": ["node_modules/@types/matrix-js-sdk/index.d.ts"]
+    }
+  }
 }

--- a/raiden-ts/tests/unit/epics/monitor.spec.ts
+++ b/raiden-ts/tests/unit/epics/monitor.spec.ts
@@ -35,18 +35,18 @@ test('monitorUdcBalanceEpic', async () => {
   const { action$, state$ } = epicFixtures(depsMock);
   const deposit = bigNumberify(23) as UInt<32>;
 
-  depsMock.userDepositContract.functions.balances.mockResolvedValue(Zero);
+  depsMock.userDepositContract.functions.effectiveBalance.mockResolvedValue(Zero);
 
   const promise = monitorUdcBalanceEpic(action$, state$, depsMock).pipe(toArray()).toPromise();
 
   setTimeout(() => {
-    depsMock.userDepositContract.functions.balances.mockResolvedValueOnce(deposit);
+    depsMock.userDepositContract.functions.effectiveBalance.mockResolvedValueOnce(deposit);
     action$.next(newBlock({ blockNumber: 2 }));
   }, 10);
   setTimeout(() => action$.complete(), 50);
 
   await expect(promise).resolves.toEqual([udcDeposited(Zero as UInt<32>), udcDeposited(deposit)]);
-  expect(depsMock.userDepositContract.functions.balances).toHaveBeenCalledTimes(2);
+  expect(depsMock.userDepositContract.functions.effectiveBalance).toHaveBeenCalledTimes(2);
 });
 
 describe('monitorRequestEpic', () => {

--- a/raiden-ts/tsconfig.json
+++ b/raiden-ts/tsconfig.json
@@ -12,7 +12,6 @@
     "lib": ["es2015", "es2016", "es2017", "dom"],
     "baseUrl": ".",
     "paths": {
-      "raiden-ts/*": ["src/*"],
       "matrix-js-sdk": ["node_modules/@types/matrix-js-sdk/index.d.ts"]
     }
   }


### PR DESCRIPTION
Fixes #1637 
Implements #1642 

**Short description**
Implements the fix and proposal for issues above. This went on the same PR because the proposal issue came to my mind as a nice optimization while working on the fix, and is small enough and fully backwards compatible.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Ensure some service (or oneself, manually before #1421 is completed) withdraws from your deposit on UDC
2. Try to deposit a new amount smaller than what was withdrawn (so current balance plus your new deposit is smaller than the previous total deposit, which isn't reduced by withdraws)
3. Check above deposit works now (bug is fixed)
4. Try depositing again
6. On approve's Metamask prompt, edit allowance to 1M tokens, increase gasLimita little to ensure it'll succeed, e.g. to 46k
6. Perform the deposit
7. Try to deposit again, a smallish amount
8. Verify you got directly the `deposit` prompt, and skipped the previously mandatory `approve` prompt/tx, as you already have approved enough for both deposits.
