### PR TITLE
dApp: Displays notifications

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- [#1374] Adds notifications when a monitoring service submits a proof.
 - [#1421] Dialog to withdraw from the user deposit.
 - [#168] Notification panel
 
@@ -21,6 +22,7 @@
 [#1540]: https://github.com/raiden-network/light-client/issues/1540
 [#1579]: https://github.com/raiden-network/light-client/issues/1579
 [#1421]: https://github.com/raiden-network/light-client/issues/1421
+[#1374]: https://github.com/raiden-network/light-client/issues/1374
 [#168]: https://github.com/raiden-network/light-client/issues/168
 
 ## [0.9.0] - 2020-05-28

--- a/raiden-dapp/src/App.vue
+++ b/raiden-dapp/src/App.vue
@@ -5,11 +5,11 @@
       <router-view name="notifications" />
       <div id="application-content">
         <app-header />
-        <v-content>
+        <v-main>
           <v-container fluid class="application__container fill-height">
             <router-view />
           </v-container>
-        </v-content>
+        </v-main>
       </div>
     </div>
     <div class="policy">
@@ -93,7 +93,7 @@ export default class App extends Mixins(NavigationMixin) {
   }
 }
 
-.v-content {
+.v-main {
   height: calc(100% - 120px);
   margin-bottom: auto;
 }

--- a/raiden-dapp/src/components/AppHeader.vue
+++ b/raiden-dapp/src/components/AppHeader.vue
@@ -44,9 +44,23 @@
               icon
               height="30px"
               width="25px"
-              @click.native="navigateToNotifications()"
+              @click.native="notificationPanel()"
             >
+              <v-badge
+                v-if="newNotifications"
+                color="notification"
+                overlap
+                bordered
+                dot
+              >
+                <v-img
+                  height="30px"
+                  width="25px"
+                  :src="require('@/assets/notifications.svg')"
+                />
+              </v-badge>
               <v-img
+                v-else
                 height="30px"
                 width="25px"
                 :src="require('@/assets/notifications.svg')"
@@ -83,7 +97,7 @@ import AddressDisplay from '@/components/AddressDisplay.vue';
     AddressDisplay
   },
   computed: {
-    ...mapState(['loading', 'defaultAccount']),
+    ...mapState(['loading', 'defaultAccount', 'newNotifications']),
     ...mapGetters(['network', 'isConnected'])
   }
 })
@@ -91,6 +105,12 @@ export default class AppHeader extends Mixins(NavigationMixin) {
   isConnected!: boolean;
   defaultAccount!: string;
   network!: string;
+  newNotifications!: boolean;
+
+  notificationPanel = () => {
+    this.$raiden.viewedNotifications();
+    this.navigateToNotifications();
+  };
 
   get canGoBack(): boolean {
     const routesWithoutBackBtn: string[] = [

--- a/raiden-dapp/src/components/AppHeader.vue
+++ b/raiden-dapp/src/components/AppHeader.vue
@@ -85,11 +85,16 @@
 
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator';
-import { mapGetters, mapState } from 'vuex';
+import { createNamespacedHelpers, mapGetters, mapState } from 'vuex';
 import { RouteNames } from '@/router/route-names';
 import NavigationMixin from '@/mixins/navigation-mixin';
 import HeaderIdenticon from '@/components/HeaderIdenticon.vue';
 import AddressDisplay from '@/components/AddressDisplay.vue';
+
+const {
+  mapState: mapNotificationsState,
+  mapMutations
+} = createNamespacedHelpers('notifications');
 
 @Component({
   components: {
@@ -97,8 +102,12 @@ import AddressDisplay from '@/components/AddressDisplay.vue';
     AddressDisplay
   },
   computed: {
-    ...mapState(['loading', 'defaultAccount', 'newNotifications']),
+    ...mapState(['loading', 'defaultAccount']),
+    ...mapNotificationsState(['newNotifications']),
     ...mapGetters(['network', 'isConnected'])
+  },
+  methods: {
+    ...mapMutations(['notificationsViewed'])
   }
 })
 export default class AppHeader extends Mixins(NavigationMixin) {
@@ -106,11 +115,12 @@ export default class AppHeader extends Mixins(NavigationMixin) {
   defaultAccount!: string;
   network!: string;
   newNotifications!: boolean;
+  notificationsViewed!: () => void;
 
-  notificationPanel = () => {
-    this.$raiden.viewedNotifications();
+  notificationPanel() {
+    this.notificationsViewed();
     this.navigateToNotifications();
-  };
+  }
 
   get canGoBack(): boolean {
     const routesWithoutBackBtn: string[] = [

--- a/raiden-dapp/src/components/notification-panel/NotificationCard.vue
+++ b/raiden-dapp/src/components/notification-panel/NotificationCard.vue
@@ -1,25 +1,47 @@
 <template>
   <v-card class="notification-card">
-    <div class="notification-card__details-wrapper">
-      <v-avatar
-        class="notification-card__details-wrapper__icon"
-        tile
-        size="80"
-        color="grey"
-      />
-      <div>
-        <v-card-title></v-card-title>
-        <v-card-subtitle></v-card-subtitle>
-      </div>
-    </div>
+    <v-row class="notification-card__content" no-gutters>
+      <v-col cols="3">
+        <v-avatar
+          class="notification-card__content__icon"
+          tile
+          size="80"
+          color="grey"
+        />
+      </v-col>
+      <v-col class="notification-card__content__details">
+        <div class="notification-card__content__details__header">
+          <span class="notification-card__content__details__header--title">
+            {{ notification.title }}
+          </span>
+          <v-btn icon x-small @click="deleteNotification(notification.id)">
+            <v-icon icon>mdi-close</v-icon>
+          </v-btn>
+        </div>
+        <div class="notification-card__content__details__description">
+          <span>{{ notification.description }}</span>
+        </div>
+        <span class="notification-card__content__details--received">
+          {{ notification.received | formatDate }}
+        </span>
+      </v-col>
+    </v-row>
   </v-card>
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator';
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Notification } from '@/model/types';
 
 @Component({})
-export default class NotificationCard extends Vue {}
+export default class NotificationCard extends Vue {
+  @Prop({ required: true })
+  notification!: Notification;
+
+  deleteNotification(id: string) {
+    this.$raiden.deleteNotification(id);
+  }
+}
 </script>
 
 <style scoped lang="scss">
@@ -27,14 +49,42 @@ export default class NotificationCard extends Vue {}
 
 .notification-card {
   background-color: $notification-card-background;
-  border-radius: 50px;
+  border-radius: 20px !important;
   height: 200px;
 
-  &__details-wrapper {
-    display: flex;
+  &__content {
+    height: 100%;
+    padding: 30px 30px 0 30px;
+
+    &__details {
+      display: flex;
+      flex-direction: column;
+
+      &__header {
+        display: flex;
+
+        &--title {
+          display: flex;
+          flex: 1;
+        }
+      }
+
+      &__description {
+        padding-top: 10px;
+      }
+
+      &--received {
+        color: $secondary-text-color;
+        display: flex;
+        align-items: flex-end;
+        flex: 1;
+        padding-bottom: 30px;
+        font-size: 12px;
+      }
+    }
 
     &__icon {
-      margin: 24px 10px 0 20px;
+      margin-top: 5px;
     }
   }
 }

--- a/raiden-dapp/src/components/notification-panel/NotificationCard.vue
+++ b/raiden-dapp/src/components/notification-panel/NotificationCard.vue
@@ -14,7 +14,7 @@
           <span class="notification-card__content__details__header--title">
             {{ notification.title }}
           </span>
-          <v-btn icon x-small @click="deleteNotification(notification.id)">
+          <v-btn icon x-small @click="notificationDelete(notification.id)">
             <v-icon icon>mdi-close</v-icon>
           </v-btn>
         </div>
@@ -31,16 +31,21 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
-import { Notification } from '@/model/types';
+import { Notification } from '@/store/notifications/types';
+import { createNamespacedHelpers } from 'vuex';
 
-@Component({})
+const { mapMutations } = createNamespacedHelpers('notifications');
+
+@Component({
+  methods: {
+    ...mapMutations(['notificationDelete'])
+  }
+})
 export default class NotificationCard extends Vue {
   @Prop({ required: true })
   notification!: Notification;
 
-  deleteNotification(id: string) {
-    this.$raiden.deleteNotification(id);
-  }
+  notificationDelete!: (id: number) => void;
 }
 </script>
 

--- a/raiden-dapp/src/components/notification-panel/NotificationCard.vue
+++ b/raiden-dapp/src/components/notification-panel/NotificationCard.vue
@@ -11,14 +11,18 @@
       </v-col>
       <v-col class="notification-card__content__details">
         <div class="notification-card__content__details__header">
-          <span class="notification-card__content__details__header--title">
+          <span
+            class="notification-card__content__details__header--title text--primary title"
+          >
             {{ notification.title }}
           </span>
           <v-btn icon x-small @click="notificationDelete(notification.id)">
             <v-icon icon>mdi-close</v-icon>
           </v-btn>
         </div>
-        <div class="notification-card__content__details__description">
+        <div
+          class="notification-card__content__details__description text--secondary"
+        >
           <span>{{ notification.description }}</span>
         </div>
         <span class="notification-card__content__details--received">
@@ -51,6 +55,7 @@ export default class NotificationCard extends Vue {
 
 <style scoped lang="scss">
 @import '@/scss/colors';
+@import '@/scss/scroll';
 
 .notification-card {
   background-color: $notification-card-background;
@@ -75,7 +80,11 @@ export default class NotificationCard extends Vue {
       }
 
       &__description {
-        padding-top: 10px;
+        margin-top: 10px;
+        max-height: 100px;
+        overflow-y: scroll;
+        padding-bottom: 10px;
+        @extend .themed-scrollbar;
       }
 
       &--received {

--- a/raiden-dapp/src/components/notification-panel/NotificationCard.vue
+++ b/raiden-dapp/src/components/notification-panel/NotificationCard.vue
@@ -11,12 +11,17 @@
       </v-col>
       <v-col class="notification-card__content__details">
         <div class="notification-card__content__details__header">
-          <span
+          <div
             class="notification-card__content__details__header--title text--primary title"
           >
             {{ notification.title }}
-          </span>
-          <v-btn icon x-small @click="notificationDelete(notification.id)">
+          </div>
+          <v-btn
+            icon
+            x-small
+            class="notification-card__dismiss"
+            @click="notificationDelete(notification.id)"
+          >
             <v-icon icon>mdi-close</v-icon>
           </v-btn>
         </div>
@@ -62,6 +67,10 @@ export default class NotificationCard extends Vue {
   border-radius: 20px !important;
   height: 200px;
 
+  &__dismiss {
+    padding-left: 14px;
+  }
+
   &__content {
     height: 100%;
     padding: 30px 30px 0 30px;
@@ -69,11 +78,14 @@ export default class NotificationCard extends Vue {
     &__details {
       display: flex;
       flex-direction: column;
+      max-width: 350px;
 
       &__header {
         display: flex;
 
         &--title {
+          overflow-x: hidden;
+          text-overflow: ellipsis;
           display: flex;
           flex: 1;
         }

--- a/raiden-dapp/src/filters.ts
+++ b/raiden-dapp/src/filters.ts
@@ -5,7 +5,10 @@ import split from 'lodash/split';
 import capitalize from 'lodash/capitalize';
 
 export default class Filters {
-  static truncate(value: string, width: number = 12) {
+  static truncate(value?: string, width: number = 12) {
+    if (!value) {
+      return '';
+    }
     const separator = '...';
     if (value.length <= width) {
       return value;

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -16,6 +16,9 @@
       "no-provider": "No Web3 provider detected, please install e.g. MetaMask."
     }
   },
+  "notifications": {
+    "no-notifications": "No notifications"
+  },
   "general": {
     "buttons": {
       "cancel": "Cancel",

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -17,7 +17,25 @@
     }
   },
   "notifications": {
-    "no-notifications": "No notifications"
+    "no-notifications": "No notifications",
+    "ms-balance-proof": {
+      "title": "Balance proof submitted",
+      "description": "The monitoring service {monitoringService} successfully submitted a balance proof for a channel with {partner} claiming a reward of {reward}. ({txHash})"
+    },
+    "withdrawal": {
+      "success": {
+        "title": "User Deposit Withdrawal",
+        "description": "A planned withdrawal of {amount} {symbol} was successfully completed withdrawing {withdrawal} {symbol}"
+      },
+      "failure": {
+        "title": "User Deposit Withdrawal",
+        "description": "The planned withdrawal of {amount} {symbol} failed: {message}",
+        "descriptions": {
+          "UDC_WITHDRAW_NO_BALANCE": "We could not complete the withdrawal of {amount} {symbol} because there was not enough balance.",
+          "UDC_WITHDRAW_FAILED": "We could not complete the withdrawal of {amount} {symbol} because the transaction failed."
+        }
+      }
+    }
   },
   "general": {
     "buttons": {

--- a/raiden-dapp/src/model/types.ts
+++ b/raiden-dapp/src/model/types.ts
@@ -69,13 +69,6 @@ export interface Transfer {
   transferTotal: BigNumber;
 }
 
-export interface Notification {
-  id: string;
-  title: string;
-  description: string;
-  received: Date;
-}
-
 export const emptyDescription = (): StepDescription => ({
   label: '',
   title: '',

--- a/raiden-dapp/src/model/types.ts
+++ b/raiden-dapp/src/model/types.ts
@@ -69,6 +69,13 @@ export interface Transfer {
   transferTotal: BigNumber;
 }
 
+export interface Notification {
+  id: string;
+  title: string;
+  description: string;
+  received: Date;
+}
+
 export const emptyDescription = (): StepDescription => ({
   label: '',
   title: '',

--- a/raiden-dapp/src/plugins/vuetify.ts
+++ b/raiden-dapp/src/plugins/vuetify.ts
@@ -15,6 +15,7 @@ export default new Vuetify({
     dark: true,
     themes: {
       dark: {
+        notification: '#ea6464',
         primary: '#28A5C8',
         secondary: '#0A6E87',
         pending: '#fdd327',

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -312,12 +312,16 @@ export default class RaidenService {
     reward: BigNumber,
     txHash: string
   ) {
+    const token = this.store.getters.udcToken;
+    const decimals = token.decimals ?? 18;
+    const amount = BalanceUtils.toUnits(reward, decimals);
+
     await this.store.dispatch('notifications/notify', {
       title: i18n.t('notifications.ms-balance-proof.title'),
       description: i18n.t('notifications.ms-balance-proof.description', {
         monitoringService,
         partner,
-        reward,
+        reward: amount,
         txHash
       })
     } as Notification);

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -461,6 +461,14 @@ export default class RaidenService {
 
     return Object.values(tokens);
   }
+
+  deleteNotification(id: string) {
+    this.store.commit('deleteNotification', id);
+  }
+
+  viewedNotifications() {
+    this.store.commit('viewedNotifications');
+  }
 }
 
 export class EnsResolveFailed extends Error {}

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -18,8 +18,7 @@ import {
   PlaceHolderNetwork,
   Token,
   TokenModel,
-  Presences,
-  Notification
+  Presences
 } from '@/model/types';
 import map from 'lodash/map';
 import flatMap from 'lodash/flatMap';
@@ -30,6 +29,7 @@ import orderBy from 'lodash/orderBy';
 import isEqual from 'lodash/isEqual';
 import isEmpty from 'lodash/isEmpty';
 import { BigNumber, Network } from 'ethers/utils';
+import { notifications } from '@/store/notifications';
 
 Vue.use(Vuex);
 
@@ -52,9 +52,7 @@ const _defaultState: RootState = {
     useRaidenAccount: true
   },
   config: {},
-  userDepositTokenAddress: '',
-  notifications: [],
-  newNotifications: false
+  userDepositTokenAddress: ''
 };
 
 export function defaultState(): RootState {
@@ -138,14 +136,6 @@ const store: StoreOptions<RootState> = {
     },
     userDepositTokenAddress(state: RootState, address: string) {
       state.userDepositTokenAddress = address;
-    },
-    deleteNotification(state: RootState, id: string) {
-      state.notifications = state.notifications.filter(
-        notification => notification.id != id
-      );
-    },
-    viewedNotifications(state: RootState) {
-      state.newNotifications = false;
     }
   },
   actions: {},
@@ -252,12 +242,12 @@ const store: StoreOptions<RootState> = {
     },
     udcToken: (state: RootState): Token => {
       return state.tokens[state.userDepositTokenAddress];
-    },
-    notifications: (state: RootState): Notification[] => {
-      return state.notifications;
     }
   },
-  plugins: [settingsLocalStorage.plugin]
+  plugins: [settingsLocalStorage.plugin],
+  modules: {
+    notifications
+  }
 };
 
 export default new Vuex.Store(store);

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -16,9 +16,10 @@ import {
   DeniedReason,
   emptyTokenModel,
   PlaceHolderNetwork,
-  Presences,
   Token,
-  TokenModel
+  TokenModel,
+  Presences,
+  Notification
 } from '@/model/types';
 import map from 'lodash/map';
 import flatMap from 'lodash/flatMap';
@@ -51,7 +52,9 @@ const _defaultState: RootState = {
     useRaidenAccount: true
   },
   config: {},
-  userDepositTokenAddress: ''
+  userDepositTokenAddress: '',
+  notifications: [],
+  newNotifications: false
 };
 
 export function defaultState(): RootState {
@@ -135,6 +138,14 @@ const store: StoreOptions<RootState> = {
     },
     userDepositTokenAddress(state: RootState, address: string) {
       state.userDepositTokenAddress = address;
+    },
+    deleteNotification(state: RootState, id: string) {
+      state.notifications = state.notifications.filter(
+        notification => notification.id != id
+      );
+    },
+    viewedNotifications(state: RootState) {
+      state.newNotifications = false;
     }
   },
   actions: {},
@@ -241,6 +252,9 @@ const store: StoreOptions<RootState> = {
     },
     udcToken: (state: RootState): Token => {
       return state.tokens[state.userDepositTokenAddress];
+    },
+    notifications: (state: RootState): Notification[] => {
+      return state.notifications;
     }
   },
   plugins: [settingsLocalStorage.plugin]

--- a/raiden-dapp/src/store/notifications/actions.ts
+++ b/raiden-dapp/src/store/notifications/actions.ts
@@ -1,0 +1,16 @@
+import { ActionTree } from 'vuex';
+import { RootState } from '@/types';
+import { NotificationsState } from '@/store/notifications/types';
+
+export const actions: ActionTree<NotificationsState, RootState> = {
+  notify: (
+    { commit, getters: { nextNotificationId } },
+    notification: Notification
+  ) => {
+    commit('notificationAdd', {
+      ...notification,
+      id: nextNotificationId,
+      received: new Date()
+    });
+  }
+};

--- a/raiden-dapp/src/store/notifications/getters.ts
+++ b/raiden-dapp/src/store/notifications/getters.ts
@@ -1,0 +1,17 @@
+import { GetterTree } from 'vuex';
+import { RootState } from '@/types';
+import { Notification, NotificationsState } from '@/store/notifications/types';
+
+export const getters: GetterTree<NotificationsState, RootState> = {
+  notifications: (state: NotificationsState): Notification[] => {
+    return state.notifications.sort((a, b) => b.id - a.id);
+  },
+  nextNotificationId: ({ notifications }: NotificationsState): number => {
+    if (notifications.length === 0) {
+      return 1;
+    }
+    return notifications
+      .map(notification => notification.id)
+      .sort((a, b) => b - a)[0];
+  }
+};

--- a/raiden-dapp/src/store/notifications/index.ts
+++ b/raiden-dapp/src/store/notifications/index.ts
@@ -1,0 +1,15 @@
+import { actions } from './actions';
+import { mutations } from './mutations';
+import { getters } from './getters';
+import state from './state';
+import { RootState } from '@/types';
+import { NotificationsState } from '@/store/notifications/types';
+import { Module } from 'vuex';
+
+export const notifications: Module<NotificationsState, RootState> = {
+  namespaced: true,
+  mutations,
+  actions,
+  state,
+  getters
+};

--- a/raiden-dapp/src/store/notifications/mutations.ts
+++ b/raiden-dapp/src/store/notifications/mutations.ts
@@ -1,0 +1,17 @@
+import { Notification, NotificationsState } from '@/store/notifications/types';
+import { MutationTree } from 'vuex';
+
+export const mutations: MutationTree<NotificationsState> = {
+  notificationDelete(state: NotificationsState, id: number) {
+    state.notifications = state.notifications.filter(
+      notification => notification.id !== id
+    );
+  },
+  notificationsViewed(state: NotificationsState) {
+    state.newNotifications = false;
+  },
+  notificationAdd(state: NotificationsState, notification: Notification) {
+    state.notifications.push(notification);
+    state.newNotifications = true;
+  }
+};

--- a/raiden-dapp/src/store/notifications/state.ts
+++ b/raiden-dapp/src/store/notifications/state.ts
@@ -1,0 +1,10 @@
+import { NotificationsState } from '@/store/notifications/types';
+
+export const defaultState = (): NotificationsState => ({
+  notifications: [],
+  newNotifications: false
+});
+
+const state: NotificationsState = defaultState();
+
+export default state;

--- a/raiden-dapp/src/store/notifications/types.d.ts
+++ b/raiden-dapp/src/store/notifications/types.d.ts
@@ -1,0 +1,11 @@
+export interface Notification {
+  id: number;
+  title: string;
+  description: string;
+  received: Date;
+}
+
+export interface NotificationsState {
+  notifications: Notification[];
+  newNotifications: boolean;
+}

--- a/raiden-dapp/src/types.d.ts
+++ b/raiden-dapp/src/types.d.ts
@@ -1,6 +1,6 @@
 import RaidenService from '@/services/raiden-service';
 import { RaidenChannels, RaidenTransfer, RaidenConfig } from 'raiden-ts';
-import { DeniedReason, Token, Presences } from '@/model/types';
+import { DeniedReason, Token, Presences, Notification } from '@/model/types';
 import { Network } from 'ethers/utils';
 
 export type Tokens = { [token: string]: Token };
@@ -25,6 +25,8 @@ export interface RootState {
   settings: Settings;
   config: Partial<RaidenConfig>;
   userDepositTokenAddress: string;
+  notifications: Notification[];
+  newNotifications: boolean;
 }
 
 declare global {

--- a/raiden-dapp/src/types.d.ts
+++ b/raiden-dapp/src/types.d.ts
@@ -1,6 +1,6 @@
 import RaidenService from '@/services/raiden-service';
 import { RaidenChannels, RaidenTransfer, RaidenConfig } from 'raiden-ts';
-import { DeniedReason, Token, Presences, Notification } from '@/model/types';
+import { DeniedReason, Token, Presences } from '@/model/types';
 import { Network } from 'ethers/utils';
 
 export type Tokens = { [token: string]: Token };
@@ -25,8 +25,6 @@ export interface RootState {
   settings: Settings;
   config: Partial<RaidenConfig>;
   userDepositTokenAddress: string;
-  notifications: Notification[];
-  newNotifications: boolean;
 }
 
 declare global {

--- a/raiden-dapp/src/views/NotificationPanel.vue
+++ b/raiden-dapp/src/views/NotificationPanel.vue
@@ -43,10 +43,12 @@
 
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator';
-import { mapGetters } from 'vuex';
-import { Notification } from '@/model/types';
+import { createNamespacedHelpers } from 'vuex';
 import NavigationMixin from '@/mixins/navigation-mixin';
 import NotificationCard from '@/components/notification-panel/NotificationCard.vue';
+import { Notification } from '@/store/notifications/types';
+
+const { mapGetters } = createNamespacedHelpers('notifications');
 
 @Component({
   components: {

--- a/raiden-dapp/src/views/NotificationPanel.vue
+++ b/raiden-dapp/src/views/NotificationPanel.vue
@@ -4,24 +4,61 @@
       <div class="notification-panel-content__close">
         <v-icon icon @click="onModalBackClicked()">mdi-close</v-icon>
       </div>
-      <div class="notification-panel-content__notification-wrapper">
-        <notification-card />
-      </div>
+      <v-row
+        v-if="notifications.length === 0"
+        class="notification-panel-content__no-notifications full-height"
+        no-gutters
+        justify="center"
+        align="center"
+      >
+        {{ $t('notifications.no-notifications') }}
+      </v-row>
+      <v-container
+        v-else
+        class="notification-panel-content__notifications"
+        fluid
+      >
+        <div
+          class="notification-panel-content__notifications__notification-wrapper"
+        >
+          <v-list color="transparent">
+            <div v-for="(notification, index) in notifications" :key="index">
+              <v-lazy
+                transition="fade-transition"
+                :options="{ threshold: 0.7 }"
+                min-height="200"
+              >
+                <notification-card
+                  :notification="notification"
+                  class="notification-panel-content__notifications__notification-wrapper__notification"
+                />
+              </v-lazy>
+            </div>
+          </v-list>
+        </div>
+      </v-container>
     </div>
   </div>
 </template>
 
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator';
+import { mapGetters } from 'vuex';
+import { Notification } from '@/model/types';
 import NavigationMixin from '@/mixins/navigation-mixin';
 import NotificationCard from '@/components/notification-panel/NotificationCard.vue';
 
 @Component({
   components: {
     NotificationCard
+  },
+  computed: {
+    ...mapGetters(['notifications'])
   }
 })
-export default class NotificationPanel extends Mixins(NavigationMixin) {}
+export default class NotificationPanel extends Mixins(NavigationMixin) {
+  notifications!: Notification[];
+}
 </script>
 
 <style scoped lang="scss">
@@ -62,8 +99,26 @@ export default class NotificationPanel extends Mixins(NavigationMixin) {}
     margin: 30px 30px 0 0;
   }
 
-  &__notification-wrapper {
-    margin: 20px 40px 0 40px;
+  &__no-notifications {
+    font-size: 24px;
+    margin-bottom: 60px;
+  }
+
+  &__notifications {
+    height: 100%;
+    margin-bottom: 30px;
+    overflow-y: scroll;
+    scrollbar-width: none;
+    width: 100%;
+
+    &__notification-wrapper {
+      max-height: 200px;
+      margin: 0 25px 0 25px;
+
+      &__notification {
+        margin-bottom: 20px;
+      }
+    }
   }
 }
 </style>

--- a/raiden-dapp/tests/unit/app.spec.ts
+++ b/raiden-dapp/tests/unit/app.spec.ts
@@ -1,5 +1,6 @@
 jest.mock('vue-router');
 jest.mock('@/services/raiden-service');
+jest.mock('@/i18n', () => jest.fn());
 import Mocked = jest.Mocked;
 import { shallowMount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';

--- a/raiden-dapp/tests/unit/components/account/withdrawal.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/withdrawal.spec.ts
@@ -1,6 +1,7 @@
 import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
 
 jest.mock('@/services/raiden-service');
+jest.mock('@/i18n', () => jest.fn());
 
 import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';

--- a/raiden-dapp/tests/unit/components/app-header.spec.ts
+++ b/raiden-dapp/tests/unit/components/app-header.spec.ts
@@ -5,6 +5,7 @@ import store from '@/store';
 import { $identicon } from '../utils/mocks';
 import AppHeader from '@/components/AppHeader.vue';
 import { RouteNames } from '@/router/route-names';
+import { TestData } from '../data/mock-data';
 
 Vue.use(Vuetify);
 
@@ -48,8 +49,7 @@ describe('AppHeader.vue', () => {
 
     expect(newNotificationsBadge.exists()).toBe(false);
 
-    // TODO: Needs the proper action/mutation for setting newNotifications flag to true
-    store.state.newNotifications = true;
+    await store.dispatch('notifications/notify', TestData.notifications);
 
     await wrapper.vm.$nextTick();
     newNotificationsBadge = wrapper.find('.v-badge__badge');

--- a/raiden-dapp/tests/unit/components/app-header.spec.ts
+++ b/raiden-dapp/tests/unit/components/app-header.spec.ts
@@ -57,14 +57,14 @@ describe('AppHeader.vue', () => {
     expect(newNotificationsBadge.exists()).toBe(true);
   });
 
-  test('clicking notification icon calls notificationPanel method', async () => {
+  test('clicking notification icon calls navigates to notifications', async () => {
     wrapper = createWrapper(RouteNames.CHANNELS);
-    (wrapper.vm as any).notificationPanel = jest.fn();
+    (wrapper.vm as any).navigateToNotifications = jest.fn();
     const notificationsButton = wrapper.findAll('button').at(1);
 
     notificationsButton.trigger('click');
     await wrapper.vm.$nextTick();
 
-    expect((wrapper.vm as any).notificationPanel).toHaveBeenCalled();
+    expect((wrapper.vm as any).navigateToNotifications).toHaveBeenCalled();
   });
 });

--- a/raiden-dapp/tests/unit/components/app-header.spec.ts
+++ b/raiden-dapp/tests/unit/components/app-header.spec.ts
@@ -41,4 +41,30 @@ describe('AppHeader.vue', () => {
     wrapper = createWrapper(RouteNames.CHANNELS);
     expect((wrapper.vm as any).canGoBack).toBe(true);
   });
+
+  test('new notifications displays notification badge', async () => {
+    wrapper = createWrapper(RouteNames.CHANNELS);
+    let newNotificationsBadge = wrapper.find('.v-badge__badge');
+
+    expect(newNotificationsBadge.exists()).toBe(false);
+
+    // TODO: Needs the proper action/mutation for setting newNotifications flag to true
+    store.state.newNotifications = true;
+
+    await wrapper.vm.$nextTick();
+    newNotificationsBadge = wrapper.find('.v-badge__badge');
+
+    expect(newNotificationsBadge.exists()).toBe(true);
+  });
+
+  test('clicking notification icon calls notificationPanel method', async () => {
+    wrapper = createWrapper(RouteNames.CHANNELS);
+    (wrapper.vm as any).notificationPanel = jest.fn();
+    const notificationsButton = wrapper.findAll('button').at(1);
+
+    notificationsButton.trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as any).notificationPanel).toHaveBeenCalled();
+  });
 });

--- a/raiden-dapp/tests/unit/components/channels/channels-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/channels/channels-dialog.spec.ts
@@ -1,4 +1,5 @@
 jest.mock('@/services/raiden-service');
+jest.mock('@/i18n', () => jest.fn());
 
 import { One } from 'ethers/constants';
 import ChannelDepositDialog from '@/components/dialogs/ChannelDepositDialog.vue';

--- a/raiden-dapp/tests/unit/components/dialogs/udc-withdrawal-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/dialogs/udc-withdrawal-dialog.spec.ts
@@ -1,4 +1,5 @@
 jest.mock('@/services/raiden-service');
+jest.mock('@/i18n', () => jest.fn());
 
 import flushPromises from 'flush-promises';
 import RaidenService from '@/services/raiden-service';

--- a/raiden-dapp/tests/unit/components/navigation/channels.spec.ts
+++ b/raiden-dapp/tests/unit/components/navigation/channels.spec.ts
@@ -15,6 +15,8 @@ import Mocked = jest.Mocked;
 import { RouteNames } from '@/router/route-names';
 import VueRouter from 'vue-router';
 
+jest.mock('@/i18n', () => jest.fn());
+
 Vue.use(Vuetify);
 Vue.use(Vuex);
 Vue.filter('displayFormat', Filters.displayFormat);

--- a/raiden-dapp/tests/unit/components/navigation/open-channel.spec.ts
+++ b/raiden-dapp/tests/unit/components/navigation/open-channel.spec.ts
@@ -22,6 +22,8 @@ import { parseUnits } from 'ethers/utils';
 import { RaidenError, ErrorCodes } from 'raiden-ts';
 import RaidenService from '@/services/raiden-service';
 
+jest.mock('@/i18n', () => jest.fn());
+
 Vue.use(Vuetify);
 Vue.filter('truncate', Filters.truncate);
 

--- a/raiden-dapp/tests/unit/components/navigation/transfer.spec.ts
+++ b/raiden-dapp/tests/unit/components/navigation/transfer.spec.ts
@@ -18,6 +18,8 @@ import { One, Zero } from 'ethers/constants';
 import { BigNumber } from 'ethers/utils';
 import { $identicon } from '../../utils/mocks';
 
+jest.mock('@/i18n', () => jest.fn());
+
 import Mocked = jest.Mocked;
 import { RouteNames } from '@/router/route-names';
 

--- a/raiden-dapp/tests/unit/components/notification-panel/notification-card.spec.ts
+++ b/raiden-dapp/tests/unit/components/notification-panel/notification-card.spec.ts
@@ -4,6 +4,7 @@ import Vue from 'vue';
 import Vuetify from 'vuetify';
 import Filters from '@/filters';
 import NotificationCard from '@/components/notification-panel/NotificationCard.vue';
+import store from '@/store';
 
 Vue.use(Vuetify);
 Vue.filter('formatDate', Filters.formatDate);
@@ -16,6 +17,7 @@ describe('NotificationCard.vue', () => {
     vuetify = new Vuetify();
     wrapper = mount(NotificationCard, {
       vuetify,
+      store,
       propsData: { notification: TestData.notifications }
     });
   });
@@ -47,14 +49,12 @@ describe('NotificationCard.vue', () => {
   });
 
   test('clicking "x"-icon calls method for deleting notification', async () => {
-    (wrapper.vm as any).deleteNotification = jest.fn();
+    await store.dispatch('notifications/notify', TestData.notifications);
     const deleteNotificationButton = wrapper.find('button');
     deleteNotificationButton.trigger('click');
     await wrapper.vm.$nextTick();
 
-    expect((wrapper.vm as any).deleteNotification).toHaveBeenCalledTimes(1);
-    expect((wrapper.vm as any).deleteNotification).toHaveBeenCalledWith(
-      TestData.notifications.id
-    );
+    // @ts-ignore
+    expect(store.state.notifications.notifications).toHaveLength(0);
   });
 });

--- a/raiden-dapp/tests/unit/components/notification-panel/notification-card.spec.ts
+++ b/raiden-dapp/tests/unit/components/notification-panel/notification-card.spec.ts
@@ -1,0 +1,60 @@
+import { mount, Wrapper } from '@vue/test-utils';
+import { TestData } from '../../data/mock-data';
+import Vue from 'vue';
+import Vuetify from 'vuetify';
+import Filters from '@/filters';
+import NotificationCard from '@/components/notification-panel/NotificationCard.vue';
+
+Vue.use(Vuetify);
+Vue.filter('formatDate', Filters.formatDate);
+
+describe('NotificationCard.vue', () => {
+  let wrapper: Wrapper<NotificationCard>;
+  let vuetify: typeof Vuetify;
+
+  beforeEach(() => {
+    vuetify = new Vuetify();
+    wrapper = mount(NotificationCard, {
+      vuetify,
+      propsData: { notification: TestData.notifications }
+    });
+  });
+
+  test('displays notification title', () => {
+    const notificationTitle = wrapper.find(
+      '.notification-card__content__details__header--title'
+    );
+
+    expect(notificationTitle.text()).toBe('BALANCE PROOF SUBMITTED');
+  });
+
+  test('displays notification description', () => {
+    const notificationDescription = wrapper.find(
+      '.notification-card__content__details__description'
+    );
+
+    expect(notificationDescription.text()).toContain(
+      'The monitoring service has submitted a balance proof'
+    );
+  });
+
+  test('displays correctly formatted date', () => {
+    const notificationReceived = wrapper.find(
+      '.notification-card__content__details--received'
+    );
+
+    expect(notificationReceived.text()).toBe('6/5/1986 12:00:00 AM');
+  });
+
+  test('clicking "x"-icon calls method for deleting notification', async () => {
+    (wrapper.vm as any).deleteNotification = jest.fn();
+    const deleteNotificationButton = wrapper.find('button');
+    deleteNotificationButton.trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as any).deleteNotification).toHaveBeenCalledTimes(1);
+    expect((wrapper.vm as any).deleteNotification).toHaveBeenCalledWith(
+      TestData.notifications.id
+    );
+  });
+});

--- a/raiden-dapp/tests/unit/data/mock-data.ts
+++ b/raiden-dapp/tests/unit/data/mock-data.ts
@@ -1,4 +1,4 @@
-import { Token, Transfer } from '@/model/types';
+import { Token, Transfer, Notification } from '@/model/types';
 import { parseUnits, BigNumber } from 'ethers/utils';
 
 import { Zero } from 'ethers/constants';
@@ -158,5 +158,12 @@ export class TestData {
     } as Token,
     pfsAddress: 'https://pfsadr.org',
     paymentId
+  };
+
+  static notifications: Notification = {
+    id: '1',
+    title: 'BALANCE PROOF SUBMITTED',
+    description: 'The monitoring service has submitted a balance proof.',
+    received: new Date('June 5, 1986')
   };
 }

--- a/raiden-dapp/tests/unit/data/mock-data.ts
+++ b/raiden-dapp/tests/unit/data/mock-data.ts
@@ -1,4 +1,4 @@
-import { Token, Transfer, Notification } from '@/model/types';
+import { Token, Transfer } from '@/model/types';
 import { parseUnits, BigNumber } from 'ethers/utils';
 
 import { Zero } from 'ethers/constants';
@@ -11,6 +11,7 @@ import {
 import { Route } from 'vue-router';
 import { RouteNames } from '@/router/route-names';
 import { Tokens } from '@/types';
+import { Notification } from '@/store/notifications/types';
 
 export const paymentId = new BigNumber(4444);
 
@@ -161,7 +162,7 @@ export class TestData {
   };
 
   static notifications: Notification = {
-    id: '1',
+    id: 1,
     title: 'BALANCE PROOF SUBMITTED',
     description: 'The monitoring service has submitted a balance proof.',
     received: new Date('June 5, 1986')

--- a/raiden-dapp/tests/unit/plugins.spec.ts
+++ b/raiden-dapp/tests/unit/plugins.spec.ts
@@ -5,6 +5,8 @@ import { createLocalVue } from '@vue/test-utils';
 import { RaidenPlugin } from '@/plugins/raiden';
 import RaidenService from '@/services/raiden-service';
 
+jest.mock('@/i18n', () => jest.fn());
+
 Vue.config.productionTip = false;
 
 describe('plugins', () => {

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -729,7 +729,8 @@ describe('RaidenService', () => {
         monitoringService: '0x1234',
         partner: '0x1001',
         reward: parseEther('5'),
-        txHash: '0x0001'
+        txHash: '0x0001',
+        confirmed: true
       },
       meta: {}
     });

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -720,6 +720,9 @@ describe('RaidenService', () => {
 
   test('notify that monitor balance proof was send', async () => {
     expect.assertions(1);
+    (store.getters as any) = {
+      udcToken: {}
+    };
     const subject = new BehaviorSubject({});
     (raiden as any).events$ = subject;
     await setupSDK();

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -711,4 +711,14 @@ describe('RaidenService', () => {
 
     expect(store.commit).toHaveBeenLastCalledWith('updateConfig', config);
   });
+
+  test('commit deleteNotification when a user deletes a notification', () => {
+    raidenService.deleteNotification('1');
+    expect(store.commit).toBeCalledWith('deleteNotification', '1');
+  });
+
+  test('commits viewedNotifications when a user views the notification panel', () => {
+    raidenService.viewedNotifications();
+    expect(store.commit).toBeCalledWith('viewedNotifications');
+  });
 });

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -1,5 +1,6 @@
 jest.mock('vuex');
 jest.mock('raiden-ts');
+jest.mock('@/i18n', () => jest.fn());
 
 import { DeniedReason, Token, TokenModel } from '@/model/types';
 import RaidenService from '@/services/raiden-service';
@@ -710,15 +711,5 @@ describe('RaidenService', () => {
     subject.next(config);
 
     expect(store.commit).toHaveBeenLastCalledWith('updateConfig', config);
-  });
-
-  test('commit deleteNotification when a user deletes a notification', () => {
-    raidenService.deleteNotification('1');
-    expect(store.commit).toBeCalledWith('deleteNotification', '1');
-  });
-
-  test('commits viewedNotifications when a user views the notification panel', () => {
-    raidenService.viewedNotifications();
-    expect(store.commit).toBeCalledWith('viewedNotifications');
   });
 });

--- a/raiden-dapp/tests/unit/store.spec.ts
+++ b/raiden-dapp/tests/unit/store.spec.ts
@@ -342,4 +342,16 @@ describe('store', () => {
     store.commit('updateConfig', { caps: {} });
     expect(store.getters.canReceive).toBe(true);
   });
+
+  test('notifications getter returns an empty array when there are no notifications', () => {
+    expect(store.getters.notifications).toEqual([]);
+  });
+
+  test('viewedNotifications mutations sets newNotifications state to false', () => {
+    // TODO: Needs the proper action/mutation for setting newNotifications flag to true
+    store.state.newNotifications = true;
+
+    store.commit('viewedNotifications');
+    expect(store.state.newNotifications).toBe(false);
+  });
 });

--- a/raiden-dapp/tests/unit/store.spec.ts
+++ b/raiden-dapp/tests/unit/store.spec.ts
@@ -342,16 +342,4 @@ describe('store', () => {
     store.commit('updateConfig', { caps: {} });
     expect(store.getters.canReceive).toBe(true);
   });
-
-  test('notifications getter returns an empty array when there are no notifications', () => {
-    expect(store.getters.notifications).toEqual([]);
-  });
-
-  test('viewedNotifications mutations sets newNotifications state to false', () => {
-    // TODO: Needs the proper action/mutation for setting newNotifications flag to true
-    store.state.newNotifications = true;
-
-    store.commit('viewedNotifications');
-    expect(store.state.newNotifications).toBe(false);
-  });
 });

--- a/raiden-dapp/tests/unit/views/home.spec.ts
+++ b/raiden-dapp/tests/unit/views/home.spec.ts
@@ -1,4 +1,6 @@
 jest.mock('@/services/raiden-service');
+jest.mock('@/i18n', () => jest.fn());
+
 import flushPromises from 'flush-promises';
 import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';

--- a/raiden-dapp/tests/unit/views/notification-panel.spec.ts
+++ b/raiden-dapp/tests/unit/views/notification-panel.spec.ts
@@ -1,0 +1,47 @@
+jest.mock('vue-router');
+import Mocked = jest.Mocked;
+import Vue from 'vue';
+import Vuex from 'vuex';
+import store from '@/store/index';
+import VueRouter from 'vue-router';
+import Vuetify from 'vuetify';
+import { mount, Wrapper } from '@vue/test-utils';
+import NotificationPanel from '@/views/NotificationPanel.vue';
+
+Vue.use(Vuetify);
+Vue.use(Vuex);
+
+describe('NotificationPanel.vue', () => {
+  let wrapper: Wrapper<NotificationPanel>;
+  let router: Mocked<VueRouter>;
+  let vuetify: typeof Vuetify;
+
+  beforeEach(() => {
+    vuetify = new Vuetify();
+    router = new VueRouter() as Mocked<VueRouter>;
+    wrapper = mount(NotificationPanel, {
+      vuetify,
+      store,
+      mocks: {
+        $router: router,
+        $t: (msg: string) => msg
+      }
+    });
+  });
+
+  test('displays text when no notifications are available', () => {
+    const noNotificationsHeader = wrapper.find(
+      '.notification-panel-content__no-notifications'
+    );
+
+    expect(noNotificationsHeader.text()).toBe('notifications.no-notifications');
+  });
+
+  test('go to previous screen when close button is clicked', () => {
+    const notificationPanelCloseButton = wrapper.find('button');
+    notificationPanelCloseButton.trigger('click');
+
+    expect(router.go).toHaveBeenCalledTimes(1);
+    expect(router.go).toHaveBeenCalledWith(-1);
+  });
+});

--- a/raiden-ts/src/errors.json
+++ b/raiden-ts/src/errors.json
@@ -80,7 +80,7 @@
   "UDC_PLAN_WITHDRAW_FAILED" : "An error occurred while planning to withdraw from the User Deposit contract.",
   "UDC_PLAN_WITHDRAW_GT_ZERO" : "The planned withdraw amount has to be greater than zero.",
   "UDC_PLAN_WITHDRAW_EXCEEDS_AVAILABLE" : "The planned withdraw amount exceeds the total amount available for withdrawing.",
-  "UDC_PLAN_WITHDRAW_NO_BALANCE" : "There is no balances left to withdraw from UDC.",
+  "UDC_WITHDRAW_NO_BALANCE" : "There is no balances left to withdraw from UDC.",
   "UDC_WITHDRAW_FAILED" : "An error occurred while withdrawing from the UDC."
 }
 

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -802,7 +802,7 @@ export const udcWithdrawPlannedEpic = (
       const contract = getContractWithSigner(userDepositContract, signer);
       return defer(() => {
         assert(balance.gt(Zero), [
-          ErrorCodes.UDC_PLAN_WITHDRAW_NO_BALANCE,
+          ErrorCodes.UDC_WITHDRAW_NO_BALANCE,
           {
             balance: balance.toString(),
           },

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -873,9 +873,9 @@ export const msMonitorNewBPEpic = (
     filter(([, , , , , raidenAddress]) => raidenAddress === address),
     withLatestFrom(state$),
     map(([[tokenNetwork, id, reward, nonce, monitoringService, , event], state]) => {
-      const channel = Object.values(state.channels).find(
-        (c) => c.tokenNetwork === tokenNetwork && id.eq(c.id),
-      );
+      const channel = Object.values(state.channels)
+        .concat(Object.values(state.oldChannels))
+        .find((c) => c.tokenNetwork === tokenNetwork && id.eq(c.id));
       if (!channel) return;
       return msBalanceProofSent({
         tokenNetwork,


### PR DESCRIPTION
Fixes #1758
Fixes #1374  

**Short description**
This PR adds frontend logic and templates for receiving, viewing, and deleting notifications in the notification panel. A first notification to be added should be the notification regarding balance proof, issue #1374 . This needs additional work outside this PR, @kelsos is looking into that.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Go to the UDC screen
2. Withdraw an amount
3. Wait 100 blocks
4. Notification area should show a small red dot and contain a notification
5. Enable receiving/ have enough in UDC
6. Send from python client some tokens
7. Close LC
8. Close channel from PyC
9. Wait for Settlement period to pass
10. Open LC 
11. Notification area should show a small red dot and contain a notification
