### PR TITLE
Support config.pfs=undefined as auto mode

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - [#1637] Fix depositToUDC failing if services already have withdrawn some fees
+- [#1651] Fix PFS being disabled if passed an undefined default config
 
 ### Added
 - [#1642] Check token's allowance before deposit and skip approve
@@ -15,6 +16,7 @@
 [#1637]: https://github.com/raiden-network/light-client/issues/1637
 [#1642]: https://github.com/raiden-network/light-client/issues/1642
 [#1649]: https://github.com/raiden-network/light-client/pull/1649
+[#1651]: https://github.com/raiden-network/light-client/issues/1651
 
 ## [0.9.0] - 2020-05-28
 ### Added

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -198,9 +198,9 @@ export const pathFindServiceEpic = (
                 ? // first, use action.payload.pfs as is, if present
                   of(action.payload.pfs)
                 : configPfs
-                ? // or if config.pfs isn't disabled (null) nor auto (''), fetch & use it
+                ? // or if config.pfs isn't disabled (null) nor auto (''|undefined), fetch & use it
                   pfsInfo(configPfs, deps)
-                : // else (action unset, config.pfs=''=auto mode)
+                : // else (action unset, config.pfs=''|undefined=auto mode)
                   latest$.pipe(
                     pluck('pfsList'), // get cached pfsList
                     // if needed, wait for list to be populated
@@ -493,7 +493,7 @@ export const pfsServiceRegistryMonitorEpic = (
     // monitors config.pfs, and only monitors contract if it's empty
     pluckDistinct('pfs'),
     switchMap((pfs) =>
-      pfs !== ''
+      pfs !== '' && pfs !== undefined
         ? // disable ServiceRegistry monitoring if/while pfs is null=disabled or truty
           EMPTY
         : // type of elements emitted by getEventsStream (past and new events coming from contract):


### PR DESCRIPTION
Fixes #1651

**Short description**
Accept `undefined` also as enabling PFS auto mode, so if one forgets to `export VUE_APP_PFS` on terminal before serving dApp, it'll also enable PFS as the default `config.pfs=''`.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Bug fix
