### PR TITLE
sdk: Introduces withdraw form the UDC functionality

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#1651] Fix PFS being disabled if passed an undefined default config
 
 ### Added
+- [#1421] Adds support for withdrawing tokens from the UDC
 - [#1642] Check token's allowance before deposit and skip approve
 
 ### Changed
@@ -15,6 +16,7 @@
 - [#1649] Have constant error messages and codes in public Raiden API.
 
 [#837]: https://github.com/raiden-network/light-client/issues/837
+[#1421]: https://github.com/raiden-network/light-client/issues/1421
 [#1514]: https://github.com/raiden-network/light-client/issues/1514
 [#1607]: https://github.com/raiden-network/light-client/issues/1607
 [#1637]: https://github.com/raiden-network/light-client/issues/1637

--- a/raiden-ts/src/actions.ts
+++ b/raiden-ts/src/actions.ts
@@ -56,6 +56,8 @@ export const RaidenEvents = [
   RaidenActions.newBlock,
   RaidenActions.matrixPresence.success,
   RaidenActions.tokenMonitored,
+  RaidenActions.udcWithdrawn,
+  RaidenActions.udcWithdraw.failure,
 ];
 /* Tagged union of RaidenEvents actions */
 export type RaidenEvent = ActionType<typeof RaidenEvents>;

--- a/raiden-ts/src/errors.json
+++ b/raiden-ts/src/errors.json
@@ -69,6 +69,12 @@
   "DTA_ARRAY_LENGTH_DIFFERENCE": "Expected length of HEX string differs from integer array input.",
   "DTA_UNENCODABLE_DATA": "Passed data is not a HEX string nor integer array.",
   "DTA_NON_POSITIVE_NUMBER": "Number must be positive.",
-  "DTA_INVALID_ADDRESS": "Invalid address."
+  "DTA_INVALID_ADDRESS": "Invalid address.",
+
+  "UDC_PLAN_WITHDRAW_FAILED" : "An error occurred while planning to withdraw from the User Deposit contract.",
+  "UDC_PLAN_WITHDRAW_GT_ZERO" : "The planned withdraw amount has to be greater than zero.",
+  "UDC_PLAN_WITHDRAW_EXCEEDS_AVAILABLE" : "The planned withdraw amount exceed the total amount available for withdrawing.",
+  "UDC_PLAN_WITHDRAW_NO_BALANCE" : "There is no balances left to withdraw from UDC.",
+  "UDC_WITHDRAW_FAILED" : "An error occurred while withdrawing from the UDC."
 }
 

--- a/raiden-ts/src/errors.json
+++ b/raiden-ts/src/errors.json
@@ -73,7 +73,7 @@
 
   "UDC_PLAN_WITHDRAW_FAILED" : "An error occurred while planning to withdraw from the User Deposit contract.",
   "UDC_PLAN_WITHDRAW_GT_ZERO" : "The planned withdraw amount has to be greater than zero.",
-  "UDC_PLAN_WITHDRAW_EXCEEDS_AVAILABLE" : "The planned withdraw amount exceed the total amount available for withdrawing.",
+  "UDC_PLAN_WITHDRAW_EXCEEDS_AVAILABLE" : "The planned withdraw amount exceeds the total amount available for withdrawing.",
   "UDC_PLAN_WITHDRAW_NO_BALANCE" : "There is no balances left to withdraw from UDC.",
   "UDC_WITHDRAW_FAILED" : "An error occurred while withdrawing from the UDC."
 }

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -11,8 +11,17 @@ import { createLogger } from 'redux-logger';
 
 import constant from 'lodash/constant';
 import memoize from 'lodash/memoize';
-import { Observable, AsyncSubject, merge, defer, EMPTY, ReplaySubject, of } from 'rxjs';
-import { first, filter, map, mergeMap, skip, pluck } from 'rxjs/operators';
+import {
+  Observable,
+  AsyncSubject,
+  merge,
+  defer,
+  EMPTY,
+  ReplaySubject,
+  of,
+  throwError,
+} from 'rxjs';
+import { first, filter, map, mergeMap, skip, pluck, switchMap } from 'rxjs/operators';
 import logging from 'loglevel';
 
 import { TokenNetworkRegistryFactory } from './contracts/TokenNetworkRegistryFactory';
@@ -58,7 +67,7 @@ import {
   transferKey,
   transferKeyToMeta,
 } from './transfers/utils';
-import { pathFind } from './services/actions';
+import { pathFind, udcWithdraw, udcWithdrawPlanned } from './services/actions';
 import { Paths, RaidenPaths, PFS, RaidenPFS, IOU } from './services/types';
 import { pfsListInfo } from './services/utils';
 import { Address, Secret, Storage, Hash, UInt, decode, isntNil } from './utils/types';
@@ -1255,6 +1264,25 @@ export class Raiden {
       { log: this.log },
     );
     return receipt.transactionHash as Hash;
+  }
+
+  public async planUdcWithdraw(value: BigNumberish): Promise<Hash> {
+    const withdrawPlan = merge(
+      this.action$.pipe(
+        filter(udcWithdraw.failure.is),
+        switchMap((action) => throwError(action.payload)),
+      ),
+      this.action$.pipe(
+        filter(udcWithdrawPlanned.is),
+        filter((action) => !!action.meta.txHash),
+        map((action) => action.meta.txHash!),
+      ),
+    )
+      .pipe(first())
+      .toPromise();
+
+    this.store.dispatch(udcWithdraw.request({ amount: bigNumberify(value) as UInt<32> }, {}));
+    return withdrawPlan;
   }
 }
 

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -1259,7 +1259,7 @@ export class Raiden {
 
   public async planUdcWithdraw(value: BigNumberish): Promise<Hash> {
     const meta = { amount: bigNumberify(value) as UInt<32> };
-    const promise = asyncActionToPromise(udcWithdraw, meta, this.action$, false).then(
+    const promise = asyncActionToPromise(udcWithdraw, meta, this.action$, true).then(
       ({ txHash }) => txHash!,
     );
     this.store.dispatch(udcWithdraw.request(undefined, meta));

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -1258,12 +1258,12 @@ export class Raiden {
   }
 
   public async planUdcWithdraw(value: BigNumberish): Promise<Hash> {
-    return asyncActionToPromise(
-      udcWithdraw,
-      { amount: bigNumberify(value) as UInt<32> },
-      this.action$,
-      false,
-    ).then(({ txHash }) => txHash!);
+    const meta = { amount: bigNumberify(value) as UInt<32> };
+    const promise = asyncActionToPromise(udcWithdraw, meta, this.action$, false).then(
+      ({ txHash }) => txHash!,
+    );
+    this.store.dispatch(udcWithdraw.request({}, meta));
+    return promise;
   }
 }
 

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -1274,14 +1274,14 @@ export class Raiden {
       ),
       this.action$.pipe(
         filter(udcWithdrawPlanned.is),
-        filter((action) => !!action.meta.txHash),
-        map((action) => action.meta.txHash!),
+        filter((action) => !!action.payload.txHash),
+        map((action) => action.payload.txHash!),
       ),
     )
       .pipe(first())
       .toPromise();
 
-    this.store.dispatch(udcWithdraw.request({ amount: bigNumberify(value) as UInt<32> }, {}));
+    this.store.dispatch(udcWithdraw.request({}, { amount: bigNumberify(value) as UInt<32> }));
     return withdrawPlan;
   }
 }

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -1262,7 +1262,7 @@ export class Raiden {
     const promise = asyncActionToPromise(udcWithdraw, meta, this.action$, false).then(
       ({ txHash }) => txHash!,
     );
-    this.store.dispatch(udcWithdraw.request({}, meta));
+    this.store.dispatch(udcWithdraw.request(undefined, meta));
     return promise;
   }
 }

--- a/raiden-ts/src/services/actions.ts
+++ b/raiden-ts/src/services/actions.ts
@@ -2,7 +2,7 @@
 import * as t from 'io-ts';
 
 import { createAction, ActionType, createAsyncAction } from '../utils/actions';
-import { Address, UInt, Signed } from '../utils/types';
+import { Address, UInt, Signed, Hash } from '../utils/types';
 import { Paths, PFS, IOU } from './types';
 
 const PathId = t.type({
@@ -45,3 +45,26 @@ export interface iouClear extends ActionType<typeof iouClear> {}
 
 export const udcDeposited = createAction('udc/deposited', UInt(32));
 export interface udcDeposited extends ActionType<typeof udcDeposited> {}
+
+export const udcWithdraw = createAsyncAction(
+  t.partial({}),
+  'udc/withdraw/request',
+  'udc/withdraw/success',
+  'udc/withdraw/failure',
+  t.type({ amount: UInt(32) }),
+  t.type({ txHash: Hash, amount: UInt(32) }),
+);
+
+export namespace udcWithdraw {
+  export interface request extends ActionType<typeof udcWithdraw.request> {}
+  export interface success extends ActionType<typeof udcWithdraw.success> {}
+  export interface failure extends ActionType<typeof udcWithdraw.failure> {}
+}
+
+export const udcWithdrawPlanned = createAction(
+  'udc/withdraw/planned',
+  t.type({ amount: UInt(32), block: UInt(32) }),
+  t.partial({ txHash: Hash }),
+);
+
+export interface udcWithdrawPlanned extends ActionType<typeof udcWithdrawPlanned> {}

--- a/raiden-ts/src/services/actions.ts
+++ b/raiden-ts/src/services/actions.ts
@@ -46,13 +46,17 @@ export interface iouClear extends ActionType<typeof iouClear> {}
 export const udcDeposited = createAction('udc/deposited', UInt(32));
 export interface udcDeposited extends ActionType<typeof udcDeposited> {}
 
+const UdcWithdrawId = t.type({
+  amount: UInt(32),
+});
+
 export const udcWithdraw = createAsyncAction(
-  t.partial({}),
+  UdcWithdrawId,
   'udc/withdraw/request',
   'udc/withdraw/success',
   'udc/withdraw/failure',
-  t.type({ amount: UInt(32) }),
-  t.type({ txHash: Hash, amount: UInt(32) }),
+  t.type({}),
+  t.type({ txHash: Hash, withdrawal: UInt(32) }),
 );
 
 export namespace udcWithdraw {
@@ -63,8 +67,8 @@ export namespace udcWithdraw {
 
 export const udcWithdrawPlanned = createAction(
   'udc/withdraw/planned',
-  t.type({ amount: UInt(32), block: UInt(32) }),
-  t.partial({ txHash: Hash }),
+  t.intersection([t.partial({ txHash: Hash }), t.type({ block: t.number })]),
+  UdcWithdrawId,
 );
 
 export interface udcWithdrawPlanned extends ActionType<typeof udcWithdrawPlanned> {}

--- a/raiden-ts/src/services/actions.ts
+++ b/raiden-ts/src/services/actions.ts
@@ -56,7 +56,10 @@ export const udcWithdraw = createAsyncAction(
   'udc/withdraw/success',
   'udc/withdraw/failure',
   t.undefined,
-  t.intersection([t.partial({ txHash: Hash }), t.type({ block: t.number })]),
+  t.intersection([
+    t.type({ block: t.number }),
+    t.partial({ txHash: Hash, txBlock: t.number, confirmed: t.union([t.undefined, t.boolean]) }),
+  ]),
 );
 
 export namespace udcWithdraw {
@@ -67,7 +70,12 @@ export namespace udcWithdraw {
 
 export const udcWithdrawn = createAction(
   'udc/withdrawn',
-  t.type({ txHash: Hash, withdrawal: UInt(32) }),
+  t.type({
+    withdrawal: UInt(32),
+    txHash: Hash,
+    txBlock: t.number,
+    confirmed: t.union([t.undefined, t.boolean]),
+  }),
   UdcWithdrawId,
 );
 

--- a/raiden-ts/src/services/actions.ts
+++ b/raiden-ts/src/services/actions.ts
@@ -55,7 +55,7 @@ export const udcWithdraw = createAsyncAction(
   'udc/withdraw/request',
   'udc/withdraw/success',
   'udc/withdraw/failure',
-  t.type({}),
+  t.undefined,
   t.intersection([t.partial({ txHash: Hash }), t.type({ block: t.number })]),
 );
 

--- a/raiden-ts/src/services/actions.ts
+++ b/raiden-ts/src/services/actions.ts
@@ -56,7 +56,7 @@ export const udcWithdraw = createAsyncAction(
   'udc/withdraw/success',
   'udc/withdraw/failure',
   t.type({}),
-  t.type({ txHash: Hash, withdrawal: UInt(32) }),
+  t.intersection([t.partial({ txHash: Hash }), t.type({ block: t.number })]),
 );
 
 export namespace udcWithdraw {
@@ -65,10 +65,10 @@ export namespace udcWithdraw {
   export interface failure extends ActionType<typeof udcWithdraw.failure> {}
 }
 
-export const udcWithdrawPlanned = createAction(
-  'udc/withdraw/planned',
-  t.intersection([t.partial({ txHash: Hash }), t.type({ block: t.number })]),
+export const udcWithdrawn = createAction(
+  'udc/withdrawn',
+  t.type({ txHash: Hash, withdrawal: UInt(32) }),
   UdcWithdrawId,
 );
 
-export interface udcWithdrawPlanned extends ActionType<typeof udcWithdrawPlanned> {}
+export interface udcWithdrawn extends ActionType<typeof udcWithdrawn> {}

--- a/raiden-ts/tests/unit/epics/udc.spec.ts
+++ b/raiden-ts/tests/unit/epics/udc.spec.ts
@@ -40,7 +40,7 @@ describe('udcWithdraw', () => {
       blockNumber: raiden.deps.provider.blockNumber,
     });
 
-    raiden.store.dispatch(udcWithdraw.request({}, { amount: amount as UInt<32> }));
+    raiden.store.dispatch(udcWithdraw.request(undefined, { amount: amount as UInt<32> }));
 
     await waitBlock(raiden.deps.provider.blockNumber + confirmationBlocks);
     expect(raiden.output).toContainEqual(
@@ -53,7 +53,7 @@ describe('udcWithdraw', () => {
 
   test('withdraw require: zero amount', async () => {
     const [raiden] = await makeRaidens(1);
-    raiden.store.dispatch(udcWithdraw.request({}, { amount: Zero as UInt<32> }));
+    raiden.store.dispatch(udcWithdraw.request(undefined, { amount: Zero as UInt<32> }));
     await waitBlock();
     expect(raiden.output).toContainEqual(
       udcWithdraw.failure(expect.any(Error), { amount: Zero as UInt<32> }),
@@ -63,7 +63,7 @@ describe('udcWithdraw', () => {
   test('withdraw require: not enough balance', async () => {
     const [raiden] = await makeRaidens(1);
     const amount = parseEther('500');
-    raiden.store.dispatch(udcWithdraw.request({}, { amount: amount as UInt<32> }));
+    raiden.store.dispatch(udcWithdraw.request(undefined, { amount: amount as UInt<32> }));
     await waitBlock();
     expect(raiden.output).toContainEqual(
       udcWithdraw.failure(expect.any(Error), { amount: amount as UInt<32> }),

--- a/raiden-ts/tests/unit/epics/udc.spec.ts
+++ b/raiden-ts/tests/unit/epics/udc.spec.ts
@@ -1,0 +1,107 @@
+import { makeRaidens, makeTransaction, waitBlock } from '../mocks';
+import { bigNumberify, parseEther } from 'ethers/utils';
+import { udcWithdraw, udcWithdrawn } from 'raiden-ts/services/actions';
+import { confirmationBlocks } from '../fixtures';
+import { Hash, UInt } from 'raiden-ts/utils/types';
+import { Zero } from 'ethers/constants';
+
+describe('udcWithdraw', () => {
+  test('planned withdraw picked on startup', async () => {
+    const [raiden] = await makeRaidens(1, false);
+    const amount = parseEther('5');
+    const withdrawBlock = bigNumberify(500);
+    raiden.deps.userDepositContract.functions.withdraw_plans.mockResolvedValue({
+      amount: amount,
+      withdraw_block: withdrawBlock,
+      0: amount,
+      1: withdrawBlock,
+    });
+    await raiden.start();
+    expect(raiden.output).toContainEqual(
+      udcWithdraw.success({ block: withdrawBlock.toNumber() }, { amount: amount as UInt<32> }),
+    );
+  });
+
+  test('withdraw request: success', async () => {
+    const [raiden] = await makeRaidens(1);
+    const amount = parseEther('5');
+    const withdrawBlock = bigNumberify(500);
+    raiden.deps.userDepositContract.functions.withdraw_plans.mockResolvedValue({
+      amount: amount,
+      withdraw_block: withdrawBlock,
+      0: amount,
+      1: withdrawBlock,
+    });
+    const planTx = makeTransaction(1);
+    raiden.deps.userDepositContract.functions.planWithdraw.mockResolvedValue(planTx);
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    raiden.deps.provider.getTransactionReceipt.mockResolvedValue({
+      blockNumber: raiden.deps.provider.blockNumber,
+    });
+
+    raiden.store.dispatch(udcWithdraw.request({}, { amount: amount as UInt<32> }));
+
+    await waitBlock(raiden.deps.provider.blockNumber + confirmationBlocks);
+    expect(raiden.output).toContainEqual(
+      udcWithdraw.success(
+        { block: withdrawBlock.toNumber(), txHash: planTx.hash as Hash },
+        { amount: amount as UInt<32> },
+      ),
+    );
+  });
+
+  test('withdraw require: zero amount', async () => {
+    const [raiden] = await makeRaidens(1);
+    raiden.store.dispatch(udcWithdraw.request({}, { amount: Zero as UInt<32> }));
+    await waitBlock();
+    expect(raiden.output).toContainEqual(
+      udcWithdraw.failure(expect.any(Error), { amount: Zero as UInt<32> }),
+    );
+  });
+
+  test('withdraw require: not enough balance', async () => {
+    const [raiden] = await makeRaidens(1);
+    const amount = parseEther('500');
+    raiden.store.dispatch(udcWithdraw.request({}, { amount: amount as UInt<32> }));
+    await waitBlock();
+    expect(raiden.output).toContainEqual(
+      udcWithdraw.failure(expect.any(Error), { amount: amount as UInt<32> }),
+    );
+  });
+
+  test('withdraw is successful', async () => {
+    const [raiden] = await makeRaidens(1);
+    const amount = parseEther('5');
+    const withdrawTx = makeTransaction(1);
+    raiden.deps.userDepositContract.functions.withdraw.mockResolvedValue(withdrawTx);
+    raiden.deps.userDepositContract.functions.balances
+      .mockClear()
+      .mockResolvedValueOnce(parseEther('5'))
+      .mockResolvedValueOnce(Zero);
+    raiden.store.dispatch(udcWithdraw.success({ block: 200 }, { amount: amount as UInt<32> }));
+    await waitBlock(200);
+    expect(raiden.output).toContainEqual(
+      udcWithdrawn(
+        {
+          withdrawal: amount as UInt<32>,
+          txHash: withdrawTx.hash as Hash,
+        },
+        { amount: amount as UInt<32> },
+      ),
+    );
+  });
+
+  test('withdraw: not balance remaining', async () => {
+    const [raiden] = await makeRaidens(1);
+    const amount = parseEther('5');
+    const withdrawTx = makeTransaction(1);
+    raiden.deps.userDepositContract.functions.withdraw.mockResolvedValue(withdrawTx);
+    raiden.deps.userDepositContract.functions.balances.mockClear().mockResolvedValueOnce(Zero);
+    raiden.store.dispatch(udcWithdraw.success({ block: 200 }, { amount: amount as UInt<32> }));
+    await waitBlock(200);
+    expect(raiden.output).toContainEqual(
+      udcWithdraw.failure(expect.any(Error), { amount: amount as UInt<32> }),
+    );
+  });
+});

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -647,6 +647,8 @@ export interface MockedRaiden {
   store: Store<RaidenState, RaidenAction>;
   deps: MockRaidenEpicDeps;
   output: RaidenAction[];
+  start: () => Promise<void>;
+  started: boolean;
 }
 
 const mockedClients: MockedRaiden[] = [];
@@ -667,9 +669,10 @@ export function stopRaiden(raiden: MockedRaiden) {
  * Create a mock of a Raiden client for epics
  *
  * @param wallet - Use this wallet instead of generating a random one
+ * @param start - Automatically starts the client if set too true (default)
  * @returns Mocked Raiden Epics params
  */
-export async function makeRaiden(wallet?: Wallet): Promise<MockedRaiden> {
+export async function makeRaiden(wallet?: Wallet, start = true): Promise<MockedRaiden> {
   const network: Network = { name: 'testnet', chainId: 1337 };
   const { JsonRpcProvider } = jest.requireActual('ethers/providers');
   const provider = new JsonRpcProvider() as jest.Mocked<JsonRpcProvider>;
@@ -894,6 +897,17 @@ export async function makeRaiden(wallet?: Wallet): Promise<MockedRaiden> {
     store,
     deps,
     output,
+    start: async () => {
+      epicMiddleware.run(raidenRootEpic);
+      await raiden.deps.latest$
+        .pipe(
+          filter(({ state }) => state.blockNumber >= raiden.deps.provider.blockNumber),
+          take(1),
+        )
+        .toPromise();
+      // raiden.store.dispatch(newBlock({ blockNumber: provider.blockNumber }));
+    },
+    started: false,
   };
   mockedClients.push(raiden);
   mockedCleanups.push(() => {
@@ -903,14 +917,10 @@ export async function makeRaiden(wallet?: Wallet): Promise<MockedRaiden> {
     if (idx >= 0) mockedClients.splice(idx, 1);
   });
 
-  epicMiddleware.run(raidenRootEpic);
-  await raiden.deps.latest$
-    .pipe(
-      filter(({ state }) => state.blockNumber >= raiden.deps.provider.blockNumber),
-      take(1),
-    )
-    .toPromise();
-  // raiden.store.dispatch(newBlock({ blockNumber: provider.blockNumber }));
+  if (start) {
+    await raiden.start();
+    raiden.started = true;
+  }
   return raiden;
 }
 
@@ -920,10 +930,11 @@ const cachedWallets = Array.from({ length: 3 }, makeWallet);
  * Create multiple mocked clients
  *
  * @param length - Number of clients to create
+ * @param start - Automatically starts the client if set too true (default)
  * @returns Array of mocked clients
  */
-export async function makeRaidens(length: number): Promise<MockedRaiden[]> {
-  return Promise.all(Array.from({ length }, (_, i) => makeRaiden(cachedWallets[i])));
+export async function makeRaidens(length: number, start = true): Promise<MockedRaiden[]> {
+  return Promise.all(Array.from({ length }, (_, i) => makeRaiden(cachedWallets[i], start)));
 }
 
 /**

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -442,6 +442,12 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
   userDepositContract.functions.balances.mockResolvedValue(parseEther('5'));
   userDepositContract.functions.total_deposit.mockResolvedValue(parseEther('5'));
   userDepositContract.functions.effectiveBalance.mockResolvedValue(parseEther('5'));
+  userDepositContract.functions.withdraw_plans.mockResolvedValue({
+    amount: Zero,
+    withdraw_block: Zero,
+    0: Zero,
+    1: Zero,
+  });
 
   const secretRegistryContract = SecretRegistryFactory.connect(address, signer) as MockedContract<
     SecretRegistry
@@ -778,6 +784,12 @@ export async function makeRaiden(wallet?: Wallet): Promise<MockedRaiden> {
   userDepositContract.functions.balances.mockResolvedValue(parseEther('5'));
   userDepositContract.functions.total_deposit.mockResolvedValue(parseEther('5'));
   userDepositContract.functions.effectiveBalance.mockResolvedValue(parseEther('5'));
+  userDepositContract.functions.withdraw_plans.mockResolvedValue({
+    amount: Zero,
+    withdraw_block: Zero,
+    0: Zero,
+    1: Zero,
+  });
 
   const secretRegistryContract = SecretRegistryFactory.connect(address, signer) as MockedContract<
     SecretRegistry


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

SDK part #1421  

**Short description**


**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Run the dApp
2. Open Vue dev tools
3. Select App (so that it attaches to $vm0)
4. Go to console
5. `raiden = $vm0.$raiden.raiden`
6. `await raiden.planUdcWithdraw(200000)`
7. wait for 100 blocks for the withdraw to happen