### PR TITLE
Fix settling when one side closes/updates with outdated BalanceProof

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - [#1514] Fix handling of expired LockedTransfer and WithdrawRequest
+- [#1607] Fix settling when one side closes/updates with outdated BalanceProof
 - [#1637] Fix depositToUDC failing if services already have withdrawn some fees
 - [#1651] Fix PFS being disabled if passed an undefined default config
 
@@ -15,6 +16,7 @@
 
 [#837]: https://github.com/raiden-network/light-client/issues/837
 [#1514]: https://github.com/raiden-network/light-client/issues/1514
+[#1607]: https://github.com/raiden-network/light-client/issues/1607
 [#1637]: https://github.com/raiden-network/light-client/issues/1637
 [#1642]: https://github.com/raiden-network/light-client/issues/1642
 [#1649]: https://github.com/raiden-network/light-client/pull/1649

--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -806,11 +806,7 @@ export const channelCloseEpic = (
       }
 
       const balanceProof = channel.partner.balanceProof;
-      const balanceHash = createBalanceHash(
-        balanceProof.transferredAmount,
-        balanceProof.lockedAmount,
-        balanceProof.locksroot,
-      );
+      const balanceHash = createBalanceHash(balanceProof);
       const nonce = balanceProof.nonce;
       const additionalHash = balanceProof.additionalHash;
       const nonClosingSignature = balanceProof.signature;
@@ -900,11 +896,7 @@ export const channelUpdateEpic = (
       );
       const channel = state.channels[channelKey(action.meta)];
 
-      const balanceHash = createBalanceHash(
-        channel.partner.balanceProof.transferredAmount,
-        channel.partner.balanceProof.lockedAmount,
-        channel.partner.balanceProof.locksroot,
-      );
+      const balanceHash = createBalanceHash(channel.partner.balanceProof);
       const nonce = channel.partner.balanceProof.nonce;
       const additionalHash = channel.partner.balanceProof.additionalHash;
       const closingSignature = channel.partner.balanceProof.signature;
@@ -1154,7 +1146,7 @@ function checkPendingAction(
 /**
  * Process new blocks and re-emit confirmed or removed actions
  *
- * @param action$ - Observable of channelSettle actions
+ * @param action$ - Observable of RaidenActions
  * @param state$ - Observable of RaidenStates
  * @param deps - RaidenEpicDeps members
  * @param deps.config$ - Config observable

--- a/raiden-ts/src/channels/reducer.ts
+++ b/raiden-ts/src/channels/reducer.ts
@@ -1,10 +1,9 @@
-import { Zero, AddressZero, HashZero, One } from 'ethers/constants';
+import { Zero, AddressZero, One } from 'ethers/constants';
 
-import { UInt, Address, Hash } from '../utils/types';
+import { UInt, Address } from '../utils/types';
 import { Reducer, createReducer, isActionOf } from '../utils/actions';
 import { partialCombineReducers } from '../utils/redux';
 import { RaidenState, initialState } from '../state';
-import { SignatureZero } from '../constants';
 import { RaidenAction, ConfirmableActions } from '../actions';
 import { transferSecretRegister } from '../transfers/actions';
 import { Direction } from '../transfers/state';
@@ -20,6 +19,7 @@ import {
 } from './actions';
 import { Channel, ChannelState, ChannelEnd } from './state';
 import { channelKey, channelUniqueKey } from './utils';
+import { BalanceProofZero } from './types';
 
 // state.blockNumber specific reducer, handles only newBlock action
 const blockNumber = createReducer(initialState.blockNumber).handle(
@@ -56,17 +56,7 @@ const emptyChannelEnd: ChannelEnd = {
   deposit: Zero as UInt<32>,
   withdraw: Zero as UInt<32>,
   locks: [],
-  balanceProof: {
-    chainId: Zero as UInt<32>,
-    tokenNetworkAddress: AddressZero as Address,
-    channelId: Zero as UInt<32>,
-    nonce: Zero as UInt<8>,
-    transferredAmount: Zero as UInt<32>,
-    lockedAmount: Zero as UInt<32>,
-    locksroot: HashZero as Hash,
-    additionalHash: HashZero as Hash,
-    signature: SignatureZero,
-  },
+  balanceProof: BalanceProofZero,
   withdrawRequests: [],
   nextNonce: One as UInt<8>,
 };

--- a/raiden-ts/src/channels/types.ts
+++ b/raiden-ts/src/channels/types.ts
@@ -1,6 +1,8 @@
 import * as t from 'io-ts';
+import { Zero, AddressZero, HashZero } from 'ethers/constants';
 
-import { Address, Hash, UInt } from '../utils/types';
+import { SignatureZero } from '../constants';
+import { Address, Hash, UInt, Signed } from '../utils/types';
 
 // should these become brands?
 export const ChannelKey = t.string;
@@ -28,16 +30,30 @@ export interface Lock extends t.TypeOf<typeof Lock> {}
  * because BP signature requires the hash of the message, for authentication of data not included
  * nor relevant for the smartcontract/BP itself, but so for the peers (e.g. payment_id)
  */
-export const BalanceProof = t.type({
-  // channel data
-  chainId: UInt(32),
-  tokenNetworkAddress: Address,
-  channelId: UInt(32),
-  // balance proof data
-  nonce: UInt(8),
-  transferredAmount: UInt(32),
-  lockedAmount: UInt(32),
-  locksroot: Hash,
-  additionalHash: Hash,
-});
+export const BalanceProof = t.readonly(
+  t.type({
+    // channel data
+    chainId: UInt(32),
+    tokenNetworkAddress: Address,
+    channelId: UInt(32),
+    // balance proof data
+    nonce: UInt(8),
+    transferredAmount: UInt(32),
+    lockedAmount: UInt(32),
+    locksroot: Hash,
+    additionalHash: Hash,
+  }),
+);
 export interface BalanceProof extends t.TypeOf<typeof BalanceProof> {}
+
+export const BalanceProofZero: Signed<BalanceProof> = {
+  chainId: Zero as UInt<32>,
+  tokenNetworkAddress: AddressZero as Address,
+  channelId: Zero as UInt<32>,
+  nonce: Zero as UInt<8>,
+  transferredAmount: Zero as UInt<32>,
+  lockedAmount: Zero as UInt<32>,
+  locksroot: HashZero as Hash,
+  additionalHash: HashZero as Hash,
+  signature: SignatureZero,
+};

--- a/raiden-ts/src/errors.json
+++ b/raiden-ts/src/errors.json
@@ -20,6 +20,7 @@
   "CNL_OPENCHANNEL_FAILED": "Token networks openChannel transaction failed.",
   "CNL_SETTOTALDEPOSIT_FAILED": "Token networks setTotalDeposit transaction failed.",
   "CNL_CLOSECHANNEL_FAILED": "Token networks closeChannel transaction failed.",
+  "CNL_SETTLECHANNEL_INVALID_BALANCEHASH": "Could not find BalanceProof matching on-chain closing data. This client may have had its state cleared and can't settle.",
   "CNL_SETTLECHANNEL_FAILED": "Token networks settleChannel transaction failed.",
   "CNL_UPDATE_NONCLOSING_BP_FAILED": "updateNonClosingBalanceProof transaction failed.",
   "CNL_ONCHAIN_UNLOCK_FAILED": "on-chain unlock transaction failed.",

--- a/raiden-ts/src/messages/utils.ts
+++ b/raiden-ts/src/messages/utils.ts
@@ -7,7 +7,7 @@ import { HashZero } from 'ethers/constants';
 import logging from 'loglevel';
 
 import { assert } from '../utils';
-import { Address, Hash, HexString, Signature, UInt, Signed, decode } from '../utils/types';
+import { Address, Hash, HexString, Signature, Signed, decode } from '../utils/types';
 import { encode, losslessParse, losslessStringify } from '../utils/data';
 import { BalanceProof } from '../channels/types';
 import { EnvelopeMessage, Message, MessageType, Metadata } from './types';
@@ -54,16 +54,17 @@ export function createMetadataHash(metadata: Metadata): Hash {
 /**
  * Returns a balance_hash from transferred&locked amounts & locksroot
  *
- * @param transferredAmount - EnvelopeMessage.transferred_amount
- * @param lockedAmount - EnvelopeMessage.locked_amount
- * @param locksroot - Hash of all current locks
+ * @param bp - BalanceProof-like object
+ * @param bp.transferredAmount - balanceProof's transferredAmount
+ * @param bp.lockedAmount - balanceProof's lockedAmount
+ * @param bp.locksroot - balanceProof's locksroot
  * @returns Hash of the balance
  */
-export function createBalanceHash(
-  transferredAmount: UInt<32>,
-  lockedAmount: UInt<32>,
-  locksroot: Hash,
-): Hash {
+export function createBalanceHash({
+  transferredAmount,
+  lockedAmount,
+  locksroot,
+}: Pick<BalanceProof, 'transferredAmount' | 'lockedAmount' | 'locksroot'>): Hash {
   return (transferredAmount.isZero() && lockedAmount.isZero() && locksroot === HashZero
     ? HashZero
     : keccak256(
@@ -152,11 +153,11 @@ export function packMessage(message: Message) {
     case MessageType.UNLOCK:
     case MessageType.LOCK_EXPIRED: {
       const additionalHash = createMessageHash(message),
-        balanceHash = createBalanceHash(
-          message.transferred_amount,
-          message.locked_amount,
-          message.locksroot,
-        );
+        balanceHash = createBalanceHash({
+          transferredAmount: message.transferred_amount,
+          lockedAmount: message.locked_amount,
+          locksroot: message.locksroot,
+        });
       return hexlify(
         concat([
           encode(message.token_network_address, 20),

--- a/raiden-ts/src/migration/3.ts
+++ b/raiden-ts/src/migration/3.ts
@@ -1,20 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { AddressZero, Zero, HashZero } from 'ethers/constants';
+import { Zero } from 'ethers/constants';
 import findKey from 'lodash/findKey';
 
-import { SignatureZero } from '../constants';
-
-const emptyBP = {
-  chainId: Zero,
-  tokenNetworkAddress: AddressZero,
-  channelId: Zero,
-  nonce: Zero,
-  transferredAmount: Zero,
-  lockedAmount: Zero,
-  locksroot: HashZero,
-  additionalHash: HashZero,
-  signature: SignatureZero,
-};
+import { BalanceProofZero } from '../channels';
 
 function migrateChannelEnd(channel: any, endsAddr: any) {
   for (const [prop, addr] of Object.entries<any>(endsAddr)) {
@@ -25,7 +13,7 @@ function migrateChannelEnd(channel: any, endsAddr: any) {
       delete channel[prop].balanceProof.messageHash;
       delete channel[prop].balanceProof.sender;
     } else {
-      Object.assign(channel[prop], { balanceProof: emptyBP, locks: [] });
+      Object.assign(channel[prop], { balanceProof: BalanceProofZero, locks: [] });
     }
     Object.assign(channel[prop], { address: addr });
     if (!('withdraw' in channel[prop])) {

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -607,11 +607,7 @@ function makeMonitoringRequest$({
       take(1), // take/act on first time all conditions above pass
       mergeMap(([, { monitoringReward, monitoringRoom }]) => {
         const balanceProof = channel.partner.balanceProof;
-        const balanceHash = createBalanceHash(
-          balanceProof.transferredAmount,
-          balanceProof.lockedAmount,
-          balanceProof.locksroot,
-        );
+        const balanceHash = createBalanceHash(balanceProof);
 
         const nonClosingMessage = concat([
           encode(channel.tokenNetwork, 20),

--- a/raiden-ts/src/transfers/actions.ts
+++ b/raiden-ts/src/transfers/actions.ts
@@ -192,10 +192,6 @@ export const transferRefunded = createAction(
 );
 export interface transferRefunded extends ActionType<typeof transferRefunded> {}
 
-/** A pending transfer isn't needed anymore and should be cleared from state */
-export const transferClear = createAction('transfer/clear', undefined, TransferId);
-export interface transferClear extends ActionType<typeof transferClear> {}
-
 // Withdraw actions
 
 const WithdrawId = t.type({

--- a/raiden-ts/src/transfers/reducer.ts
+++ b/raiden-ts/src/transfers/reducer.ts
@@ -1,5 +1,3 @@
-import unset from 'lodash/fp/unset';
-
 import { channelKey } from '../channels/utils';
 import { RaidenState, initialState } from '../state';
 import { RaidenAction } from '../actions';
@@ -19,7 +17,6 @@ import {
   transferRefunded,
   transferUnlockProcessed,
   transferExpireProcessed,
-  transferClear,
   withdrawReceive,
   transferSecretRequest,
   transferSecretRegister,
@@ -226,13 +223,6 @@ function channelCloseSuccessReducer(
   return state;
 }
 
-function transferClearReducer(state: RaidenState, action: transferClear): RaidenState {
-  const secrethash = action.meta.secrethash;
-  if (!(secrethash in state[action.meta.direction])) return state;
-  state = unset([action.meta.direction, secrethash], state);
-  return state;
-}
-
 function withdrawReducer(
   state: RaidenState,
   action: withdrawReceive.request | withdrawReceive.success | withdrawReceive.failure,
@@ -304,7 +294,6 @@ const transfersReducer: Reducer<RaidenState, RaidenAction> = createReducer(initi
   .handle(transferSecretRequest, transferSecretRequestedReducer)
   .handle(transferSecretReveal, transferSecretReveledReducer)
   .handle(channelClose.success, channelCloseSuccessReducer)
-  .handle(transferClear, transferClearReducer)
   .handle(
     [withdrawReceive.request, withdrawReceive.success, withdrawReceive.failure],
     withdrawReducer,

--- a/raiden-ts/tests/unit/epics/monitor.spec.ts
+++ b/raiden-ts/tests/unit/epics/monitor.spec.ts
@@ -218,11 +218,7 @@ describe('monitorRequestEpic', () => {
               token_network_address: tokenNetwork,
               channel_identifier: partnerBP.channelId,
               nonce: partnerBP.nonce,
-              balance_hash: createBalanceHash(
-                partnerBP.transferredAmount,
-                partnerBP.lockedAmount,
-                partnerBP.locksroot,
-              ),
+              balance_hash: createBalanceHash(partnerBP),
               additional_hash: partnerBP.additionalHash,
               signature: partnerBP.signature,
             },

--- a/raiden-ts/tests/unit/messages.spec.ts
+++ b/raiden-ts/tests/unit/messages.spec.ts
@@ -556,11 +556,11 @@ describe('sign/verify, pack & encode/decode ', () => {
   });
 
   test('RequestMonitoring', async () => {
-    const balanceHash = createBalanceHash(
-      Zero as UInt<32>,
-      One as UInt<32>,
-      '0x607e890c54e5ba67cd483bedae3ba9da9bf2ef2fbf237b9fb39a723b2296077b' as Hash,
-    );
+    const balanceHash = createBalanceHash({
+      transferredAmount: Zero as UInt<32>,
+      lockedAmount: One as UInt<32>,
+      locksroot: '0x607e890c54e5ba67cd483bedae3ba9da9bf2ef2fbf237b9fb39a723b2296077b' as Hash,
+    });
     const message: MonitorRequest = {
       type: MessageType.MONITOR_REQUEST,
       balance_proof: {

--- a/raiden-ts/tests/unit/reducers.spec.ts
+++ b/raiden-ts/tests/unit/reducers.spec.ts
@@ -23,7 +23,6 @@ import {
   transferSigned,
   transferProcessed,
   transferUnlock,
-  transferClear,
   transferExpire,
   transferSecretReveal,
   transferRefunded,
@@ -1217,26 +1216,6 @@ describe('raidenReducer', () => {
       ].reduce(raidenReducer, newState);
 
       expect(newState.sent[secrethash]?.channelClosed?.[1]).toBe(txHash);
-    });
-
-    test('transfer cleared', () => {
-      let newState = [
-        transferSigned({ message: transfer, fee, partner }, { secrethash, direction }),
-        transferSecret({ secret }, { secrethash, direction }),
-      ].reduce(raidenReducer, state);
-
-      expect(newState.sent[secrethash].transfer[1]).toBe(transfer);
-      expect(newState.sent[secrethash].secret).toStrictEqual([
-        expect.any(Number),
-        { value: secret, registerBlock: 0 },
-      ]);
-
-      newState = [transferClear(undefined, { secrethash, direction })].reduce(
-        raidenReducer,
-        newState,
-      );
-
-      expect(newState.sent[secrethash]).toBeUndefined();
     });
 
     // withdraw request is under transfer just to use its pending transfer setup/vars

--- a/raiden-ts/tests/unit/state.spec.ts
+++ b/raiden-ts/tests/unit/state.spec.ts
@@ -4,14 +4,14 @@ import path from 'path';
 import { bigNumberify } from 'ethers/utils';
 import { Zero, AddressZero, HashZero, One } from 'ethers/constants';
 
-import { ChannelState } from 'raiden-ts/channels';
+import { ChannelState, BalanceProofZero } from 'raiden-ts/channels';
 import {
   decodeRaidenState,
   encodeRaidenState,
   RaidenState,
   CURRENT_STATE_VERSION,
 } from 'raiden-ts/state';
-import { Address, UInt, Hash } from 'raiden-ts/utils/types';
+import { Address, UInt } from 'raiden-ts/utils/types';
 import { makeDefaultConfig } from 'raiden-ts/config';
 import { SignatureZero } from 'raiden-ts/constants';
 
@@ -39,17 +39,7 @@ describe('RaidenState codecs', () => {
             deposit: bigNumberify(200) as UInt<32>,
             withdraw: Zero as UInt<32>,
             locks: [],
-            balanceProof: {
-              chainId: Zero as UInt<32>,
-              tokenNetworkAddress: AddressZero as Address,
-              channelId: Zero as UInt<32>,
-              nonce: Zero as UInt<8>,
-              transferredAmount: Zero as UInt<32>,
-              lockedAmount: Zero as UInt<32>,
-              locksroot: HashZero as Hash,
-              additionalHash: HashZero as Hash,
-              signature: SignatureZero,
-            },
+            balanceProof: BalanceProofZero,
             withdrawRequests: [],
             nextNonce: One as UInt<8>,
           },
@@ -58,17 +48,7 @@ describe('RaidenState codecs', () => {
             deposit: bigNumberify(210) as UInt<32>,
             withdraw: Zero as UInt<32>,
             locks: [],
-            balanceProof: {
-              chainId: Zero as UInt<32>,
-              tokenNetworkAddress: AddressZero as Address,
-              channelId: Zero as UInt<32>,
-              nonce: Zero as UInt<8>,
-              transferredAmount: Zero as UInt<32>,
-              lockedAmount: Zero as UInt<32>,
-              locksroot: HashZero as Hash,
-              additionalHash: HashZero as Hash,
-              signature: SignatureZero,
-            },
+            balanceProof: BalanceProofZero,
             withdrawRequests: [],
             nextNonce: One as UInt<8>,
           },
@@ -269,17 +249,7 @@ describe('RaidenState codecs', () => {
             deposit: bigNumberify(200),
             withdraw: Zero,
             locks: [],
-            balanceProof: {
-              chainId: Zero,
-              tokenNetworkAddress: AddressZero,
-              channelId: Zero,
-              nonce: Zero,
-              transferredAmount: Zero,
-              lockedAmount: Zero,
-              locksroot: HashZero,
-              additionalHash: HashZero,
-              signature: SignatureZero,
-            },
+            balanceProof: BalanceProofZero,
             withdrawRequests: [],
             nextNonce: One,
           },
@@ -288,17 +258,7 @@ describe('RaidenState codecs', () => {
             deposit: bigNumberify(210),
             withdraw: Zero,
             locks: [],
-            balanceProof: {
-              chainId: Zero,
-              tokenNetworkAddress: AddressZero,
-              channelId: Zero,
-              nonce: Zero,
-              transferredAmount: Zero,
-              lockedAmount: Zero,
-              locksroot: HashZero,
-              additionalHash: HashZero,
-              signature: SignatureZero,
-            },
+            balanceProof: BalanceProofZero,
             withdrawRequests: [],
             nextNonce: One,
           },


### PR DESCRIPTION
Fixes #1607

**Short description**
Search on transfer history for matching EnvelopeMessage (if needed) and use its values to settle channel.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. This condition won't happen naturally on real life, each end usually going to close/settle with their latest view of partner's BalanceProof, in order to get the most tokens, but an attacker could specifically chose to close with outdated BP in order to prevent us from settling the channel.
2. Therefore, specially tweaked tests were made to trigger this condition and ensure we still can find the right BP and settle nonetheless.
