### PR TITLE
Filters out service tokens from token select

### DIFF
--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -77,6 +77,7 @@ export default class RaidenService {
       placeholders[token] = { address: token };
     }
 
+    this.store.commit('updateTokenAddresses', allTokens);
     this.store.commit('updateTokens', placeholders);
     await this.fetchTokenData(toFetch);
   }

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -41,6 +41,7 @@ const _defaultState: RootState = {
   accessDenied: DeniedReason.UNDEFINED,
   channels: {},
   tokens: {},
+  tokenAddresses: [],
   transfers: {},
   presences: {},
   network: PlaceHolderNetwork,
@@ -104,6 +105,9 @@ const store: StoreOptions<RootState> = {
           state.tokens[address] = { ...state.tokens[address], ...token };
         else state.tokens = { ...state.tokens, [address]: token };
     },
+    updateTokenAddresses(state: RootState, addresses: string[]) {
+      state.tokenAddresses = [...addresses];
+    },
     updatePresence(state: RootState, presence: Presences) {
       state.presences = { ...state.presences, ...presence };
     },
@@ -156,13 +160,16 @@ const store: StoreOptions<RootState> = {
       );
     },
     allTokens: (state: RootState): Token[] =>
-      Object.values(state.tokens).sort((a: Token, b: Token) => {
-        if (hasNonZeroBalance(a, b)) {
-          return (b.balance! as BigNumber).gt(a.balance! as BigNumber) ? 1 : -1;
-        }
-
-        return a.symbol && b.symbol ? a.symbol.localeCompare(b.symbol) : 0;
-      }),
+      Object.values(state.tokens)
+        .sort((a: Token, b: Token) => {
+          if (hasNonZeroBalance(a, b)) {
+            return (b.balance! as BigNumber).gt(a.balance! as BigNumber)
+              ? 1
+              : -1;
+          }
+          return a.symbol && b.symbol ? a.symbol.localeCompare(b.symbol) : 0;
+        })
+        .filter(token => state.tokenAddresses.includes(token.address)),
     channels: (state: RootState) => (tokenAddress: string) => {
       let channels: RaidenChannel[] = [];
       const tokenChannels = state.channels[tokenAddress];

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -161,6 +161,7 @@ const store: StoreOptions<RootState> = {
     },
     allTokens: (state: RootState): Token[] =>
       Object.values(state.tokens)
+        .filter(token => state.tokenAddresses.includes(token.address))
         .sort((a: Token, b: Token) => {
           if (hasNonZeroBalance(a, b)) {
             return (b.balance! as BigNumber).gt(a.balance! as BigNumber)
@@ -168,8 +169,7 @@ const store: StoreOptions<RootState> = {
               : -1;
           }
           return a.symbol && b.symbol ? a.symbol.localeCompare(b.symbol) : 0;
-        })
-        .filter(token => state.tokenAddresses.includes(token.address)),
+        }),
     channels: (state: RootState) => (tokenAddress: string) => {
       let channels: RaidenChannel[] = [];
       const tokenChannels = state.channels[tokenAddress];

--- a/raiden-dapp/src/types.d.ts
+++ b/raiden-dapp/src/types.d.ts
@@ -17,6 +17,7 @@ export interface RootState {
   accessDenied: DeniedReason;
   channels: RaidenChannels;
   tokens: Tokens;
+  tokenAddresses: string[];
   network: Network;
   presences: Presences;
   transfers: Transfers;

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -659,16 +659,14 @@ describe('RaidenService', () => {
       store.commit.mockReset();
       await raidenService.fetchTokenList();
       await flushPromises();
-      expect(store.commit).toBeCalledTimes(2);
-      expect(store.commit).toHaveBeenNthCalledWith(
-        1,
+      expect(store.commit).toBeCalledTimes(3);
+      expect(store.commit).toHaveBeenCalledWith(
         'updateTokens',
         expect.objectContaining({
           [mockToken1]: { address: mockToken1 }
         })
       );
-      expect(store.commit).toHaveBeenNthCalledWith(
-        2,
+      expect(store.commit).toHaveBeenCalledWith(
         'updateTokens',
         expect.objectContaining({
           [mockToken1]: {
@@ -679,6 +677,10 @@ describe('RaidenService', () => {
             name: 'Mock Token'
           }
         })
+      );
+      expect(store.commit).toHaveBeenCalledWith(
+        'updateTokenAddresses',
+        expect.arrayContaining([mockToken1, mockToken2])
       );
     });
   });

--- a/raiden-dapp/tests/unit/store.spec.ts
+++ b/raiden-dapp/tests/unit/store.spec.ts
@@ -145,6 +145,9 @@ describe('store', () => {
   });
 
   test('the allTokens getter returns the cached tokens as an array', () => {
+    const tokenAddresses: string[] = ['0x456', '0x123', '0x789', '0x789'];
+    store.commit('updateTokenAddresses', tokenAddresses);
+
     const tokens: Tokens = {
       '0x123': {
         address: '0x123',


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes # 

**Short description**
This PR takes care of the bug that displays the service token in the token list view and select hub view.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to the dApp on mainnet
2. Choose to connect new token
