### PR TITLE
Implement open channel endpoint + extend decode error handling

### DIFF
--- a/raiden-cli/src/routes/channels.ts
+++ b/raiden-cli/src/routes/channels.ts
@@ -20,75 +20,82 @@ function isConflictError(error: RaidenError): boolean {
   );
 }
 
+async function getAllChannels(this: Cli, _request: Request, response: Response) {
+  const channelDictionary = await this.raiden.channels$.pipe(first()).toPromise();
+  const channelList = flattenChannelDictionary(channelDictionary);
+  const formattedChannels = transformSdkChannelFormatToApi(channelList);
+  response.json(formattedChannels);
+}
+
+async function getChannelsForToken(this: Cli, request: Request, response: Response) {
+  const channelDictionary = await this.raiden.channels$.pipe(first()).toPromise();
+  const channelList = flattenChannelDictionary(channelDictionary);
+  const filteredChannels = filterChannels(channelList, request.params.tokenAddress);
+  const formattedChannels = transformSdkChannelFormatToApi(filteredChannels);
+  response.json(formattedChannels);
+}
+
+async function getChannelsForTokenAndPartner(this: Cli, request: Request, response: Response) {
+  const channelDictionary = await this.raiden.channels$.pipe(first()).toPromise();
+  const channelList = flattenChannelDictionary(channelDictionary);
+  const filteredChannels = filterChannels(
+    channelList,
+    request.params.tokenAddress,
+    request.params.partnerAddress,
+  );
+  const formattedChannels = transformSdkChannelFormatToApi(filteredChannels);
+
+  if (formattedChannels.length) {
+    response.json(formattedChannels[0]);
+  } else {
+    response.status(404).send('The channel does not exist');
+  }
+}
+
+async function openChannel(this: Cli, request: Request, response: Response, next: NextFunction) {
+  try {
+    // TODO: We ignore the provided `reveal_timeout` until #1656 provides
+    // a better solution.
+    await this.raiden.openChannel(request.body.token_address, request.body.partner_address, {
+      settleTimeout: request.body.settle_timeout,
+      deposit: request.body.total_deposit,
+    });
+    const channelDictionary = await this.raiden.channels$.pipe(first()).toPromise();
+    const newChannel = channelDictionary[request.body.token_address][request.body.partner_address];
+    response.status(201).json(newChannel);
+  } catch (error) {
+    console.log(error.code);
+    if (isInvalidParameterError(error)) {
+      response.status(400).send(error.message);
+    } else if (isConflictError(error)) {
+      response.status(409).send(error.message);
+    } else {
+      next(error);
+    }
+
+    // FIXME: Based on #1698 there must be a case with status code 402
+  }
+}
+
 export function makeChannelsRouter(this: Cli): Router {
   const router = Router();
 
-  router.get('/', async (_request: Request, response: Response) => {
-    const channelDictionary = await this.raiden.channels$.pipe(first()).toPromise();
-    const channelList = flattenChannelDictionary(channelDictionary);
-    const formattedChannels = transformSdkChannelFormatToApi(channelList);
-    response.json(formattedChannels);
-  });
+  router.get('/', getAllChannels.bind(this));
 
   router.get(
     '/:tokenAddress',
     validateAddressParameter.bind('tokenAddress'),
-    async (request: Request, response: Response) => {
-      const channelDictionary = await this.raiden.channels$.pipe(first()).toPromise();
-      const channelList = flattenChannelDictionary(channelDictionary);
-      const filteredChannels = filterChannels(channelList, request.params.tokenAddress);
-      const formattedChannels = transformSdkChannelFormatToApi(filteredChannels);
-      response.json(formattedChannels);
-    },
+    getChannelsForToken.bind(this),
   );
 
   router.get(
     '/:tokenAddress/:partnerAddress',
     validateAddressParameter.bind('tokenAddress'),
     validateAddressParameter.bind('partnerAddress'),
-    async (request: Request, response: Response) => {
-      const channelDictionary = await this.raiden.channels$.pipe(first()).toPromise();
-      const channelList = flattenChannelDictionary(channelDictionary);
-      const filteredChannels = filterChannels(
-        channelList,
-        request.params.tokenAddress,
-        request.params.partnerAddress,
-      );
-      const formattedChannels = transformSdkChannelFormatToApi(filteredChannels);
-
-      if (formattedChannels.length) {
-        response.json(formattedChannels[0]);
-      } else {
-        response.status(404).send('The channel does not exist');
-      }
-    },
+    getChannelsForTokenAndPartner.bind(this),
   );
 
-  router.put('/', async (request: Request, response: Response, next: NextFunction) => {
-    try {
-      // TODO: We ignore the provided `reveal_timeout` until #1656 provides
-      // a better solution.
-      await this.raiden.openChannel(request.body.token_address, request.body.partner_address, {
-        settleTimeout: request.body.settle_timeout,
-        deposit: request.body.total_deposit,
-      });
-      const channelDictionary = await this.raiden.channels$.pipe(first()).toPromise();
-      const newChannel =
-        channelDictionary[request.body.token_address][request.body.partner_address];
-      response.status(201).json(newChannel);
-    } catch (error) {
-      console.log(error.code);
-      if (isInvalidParameterError(error)) {
-        response.status(400).send(error.message);
-      } else if (isConflictError(error)) {
-        response.status(409).send(error.message);
-      } else {
-        next(error);
-      }
-
-      // FIXME: Based on #1698 there must be a case with status code 402
-    }
-  });
+  router.put('/', openChannel.bind(this));
 
   router.patch('/:tokenAddress/:partnerAddress', (_request: Request, response: Response) => {
     response.status(404).send('Not implemented yet');

--- a/raiden-cli/src/routes/channels.ts
+++ b/raiden-cli/src/routes/channels.ts
@@ -1,12 +1,24 @@
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { first } from 'rxjs/operators';
+import { ErrorCodes, RaidenError } from 'raiden-ts';
 import { Cli } from '../types';
-import { validateAddressParameter } from '../utils/validation';
+import {
+  validateAddressParameter,
+  isInvalidParameterError,
+  isTransactionWouldFailError,
+} from '../utils/validation';
 import {
   flattenChannelDictionary,
   transformSdkChannelFormatToApi,
   filterChannels,
 } from '../utils/channels';
+
+function isConflictError(error: RaidenError): boolean {
+  return (
+    [ErrorCodes.RDN_UNKNOWN_TOKEN_NETWORK, ErrorCodes.CNL_INVALID_STATE].includes(error.message) ||
+    isTransactionWouldFailError(error)
+  );
+}
 
 export function makeChannelsRouter(this: Cli): Router {
   const router = Router();
@@ -52,8 +64,30 @@ export function makeChannelsRouter(this: Cli): Router {
     },
   );
 
-  router.put('/', (_request: Request, response: Response) => {
-    response.status(404).send('Not implemented yet');
+  router.put('/', async (request: Request, response: Response, next: NextFunction) => {
+    try {
+      // TODO: We ignore the provided `reveal_timeout` until #1656 provides
+      // a better solution.
+      await this.raiden.openChannel(request.body.token_address, request.body.partner_address, {
+        settleTimeout: request.body.settle_timeout,
+        deposit: request.body.total_deposit,
+      });
+      const channelDictionary = await this.raiden.channels$.pipe(first()).toPromise();
+      const newChannel =
+        channelDictionary[request.body.token_address][request.body.partner_address];
+      response.status(201).json(newChannel);
+    } catch (error) {
+      console.log(error.code);
+      if (isInvalidParameterError(error)) {
+        response.status(400).send(error.message);
+      } else if (isConflictError(error)) {
+        response.status(409).send(error.message);
+      } else {
+        next(error);
+      }
+
+      // FIXME: Based on #1698 there must be a case with status code 402
+    }
   });
 
   router.patch('/:tokenAddress/:partnerAddress', (_request: Request, response: Response) => {

--- a/raiden-cli/src/routes/channels.ts
+++ b/raiden-cli/src/routes/channels.ts
@@ -61,16 +61,15 @@ async function openChannel(this: Cli, request: Request, response: Response, next
       channelDictionary[request.body.token_address]?.[request.body.partner_address];
     response.status(201).json(transformSdkChannelFormatToApi(newChannel));
   } catch (error) {
-    console.log(error.code);
     if (isInvalidParameterError(error)) {
       response.status(400).send(error.message);
+    } else if (error.code === 'INSUFFICIENT_FUNDS') {
+      response.status(402).send(error.message);
     } else if (isConflictError(error)) {
       response.status(409).send(error.message);
     } else {
       next(error);
     }
-
-    // FIXME: Based on #1698 there must be a case with status code 402
   }
 }
 

--- a/raiden-cli/src/utils/channels.ts
+++ b/raiden-cli/src/utils/channels.ts
@@ -27,18 +27,16 @@ export function filterChannels(
 }
 
 /* eslint-disable @typescript-eslint/camelcase */
-export function transformSdkChannelFormatToApi(channels: RaidenChannel[]): ApiChannel[] {
-  return channels.map((channel) => {
-    return {
-      channel_identifier: channel.id ?? 0, // FIXME: old "bug" in the SDK
-      token_network_address: channel.tokenNetwork,
-      partner_address: channel.partner,
-      token_address: channel.token,
-      balance: channel.balance.toString(),
-      total_deposit: channel.ownDeposit.toString(),
-      state: channel.state,
-      settle_timeout: channel.settleTimeout ?? 0,
-      reveal_timeout: 0, // FIXME: Not defined here. Python client handles reveal timeout differently,
-    } as ApiChannel;
-  });
+export function transformSdkChannelFormatToApi(channel: RaidenChannel): ApiChannel {
+  return {
+    channel_identifier: channel.id ?? 0, // FIXME: old "bug" in the SDK
+    token_network_address: channel.tokenNetwork,
+    partner_address: channel.partner,
+    token_address: channel.token,
+    balance: channel.balance.toString(),
+    total_deposit: channel.ownDeposit.toString(),
+    state: channel.state,
+    settle_timeout: channel.settleTimeout ?? 0,
+    reveal_timeout: 0, // FIXME: Not defined here. Python client handles reveal timeout differently,
+  };
 }

--- a/raiden-cli/src/utils/validation.ts
+++ b/raiden-cli/src/utils/validation.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { Address } from 'raiden-ts';
+import { Address, RaidenError, ErrorCodes } from 'raiden-ts';
 
 export function validateAddressParameter(
   this: string,
@@ -16,4 +16,28 @@ export function validateAddressParameter(
   } else {
     next();
   }
+}
+
+export function isInvalidParameterError(error: RaidenError): boolean {
+  return [
+    ErrorCodes.DTA_NEGATIVE_NUMBER,
+    ErrorCodes.DTA_NUMBER_TOO_LARGE,
+    ErrorCodes.DTA_ARRAY_LENGTH_DIFFERENCE,
+    ErrorCodes.DTA_UNENCODABLE_DATA,
+    ErrorCodes.DTA_NON_POSITIVE_NUMBER,
+    ErrorCodes.DTA_INVALID_ADDRESS,
+    ErrorCodes.DTA_INVALID_DEPOSIT,
+    ErrorCodes.DTA_INVALID_TIMEOUT,
+  ].includes(error.message);
+}
+
+/**
+ * This checks for a typical error message pattern that gets thrown by EthersJS.
+ * It occurs while trying to estimate the amount of gas for a transaction.
+ * For the use-case here this usually means that the parameter for the contracts
+ * function call lead to a failing require statement. An example would be
+ * insufficient tokens funds for depositing.
+ */
+export function isTransactionWouldFailError(error: Error): boolean {
+  return /gas required exceeds allowance .* or always failing transaction/.test(error.message);
 }

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Added
 - [#1421] Adds support for withdrawing tokens from the UDC
 - [#1642] Check token's allowance before deposit and skip approve
+- [#1701] Allow parameter decoding to throw and log customized errors
+- [#1701] Add and extend error codes for user parameter validation
 
 ### Changed
 - [#837] Changes the action tags from camel to path format. This change affects the event types exposed through the public API.
@@ -23,6 +25,7 @@
 [#1642]: https://github.com/raiden-network/light-client/issues/1642
 [#1649]: https://github.com/raiden-network/light-client/pull/1649
 [#1651]: https://github.com/raiden-network/light-client/issues/1651
+[#1701]: https://github.com/raiden-network/light-client/pull/1701
 
 ## [0.9.0] - 2020-05-28
 ### Added

--- a/raiden-ts/src/errors.json
+++ b/raiden-ts/src/errors.json
@@ -69,7 +69,9 @@
   "DTA_ARRAY_LENGTH_DIFFERENCE": "Expected length of HEX string differs from integer array input.",
   "DTA_UNENCODABLE_DATA": "Passed data is not a HEX string nor integer array.",
   "DTA_NON_POSITIVE_NUMBER": "Number must be positive.",
-  "DTA_INVALID_ADDRESS": "Invalid address.",
+  "DTA_INVALID_ADDRESS": "Invalid address parameter.",
+  "DTA_INVALID_DEPOSIT": "Invalid deposit parameter.",
+  "DTA_INVALID_TIMEOUT": "Invalid timeout parameter.",
 
   "UDC_PLAN_WITHDRAW_FAILED" : "An error occurred while planning to withdraw from the User Deposit contract.",
   "UDC_PLAN_WITHDRAW_GT_ZERO" : "The planned withdraw amount has to be greater than zero.",


### PR DESCRIPTION
Related to: #1646

**Short description**

This PR consists of two changes that go hand in hand.
First the decode error handling by the SDK has been extended. This has been
already taking advantage of for the `openChannel` method.
Second has the **PUT** `/api/v1/channels` endpoint become implemented with
a first version of the error validation
Checkout the according commit messages to get more insights.


**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

Example `curl` request: 

```
curl -i -X PUT http://localhost:5001/api/v1/channels -H 'Content-Type: application/json' --data-raw '{"token_address": "0x0f84DB873066d53379eC99048609d51b6239c409", "partner_address": "0x1F916ab5cf1B30B22f24Ebf435f53Ee665344Acf", "total_deposit": "1"}'
```
