### PR TITLE
dApp: Removes sign transaction message from transfer dialog

### DIFF
--- a/raiden-dapp/src/components/dialogs/TransferProgressDialog.vue
+++ b/raiden-dapp/src/components/dialogs/TransferProgressDialog.vue
@@ -51,10 +51,7 @@
             <span v-if="error">
               {{ error }}
             </span>
-            <span v-else-if="inProgress">
-              {{ $t('transfer.steps.transfer.description') }}
-            </span>
-            <span v-else>
+            <span v-else-if="!inProgress">
               {{ $t('transfer.steps.done.description') }}
             </span>
           </div>

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -326,8 +326,7 @@
         }
       },
       "transfer": {
-        "title": "Transferring Tokens",
-        "description": "Sign the transaction in MetaMask and close this dialogue to continue using the dApp. Your transfer will finish in the background."
+        "title": "Transferring Tokens"
       },
       "done": {
         "title": "Send Successful",


### PR DESCRIPTION
Fixes #1661 

**Short description**
Removes paragraph about "Signing transaction in MetaMask..." from the transfer progress dialog. We decided in the planning to omit this message.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to the dApp and proceed to make a transfer.
