### PR TITLE
Refactor ConfirmableActions to store and confirm any matching action

### DIFF
--- a/raiden-ts/src/actions.ts
+++ b/raiden-ts/src/actions.ts
@@ -1,11 +1,16 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * Aggregate types and exported properties from actions from all modules
  */
 import * as t from 'io-ts';
+import { either, Either } from 'fp-ts/lib/Either';
+import mapKeys from 'lodash/mapKeys';
+import property from 'lodash/property';
+import reduce from 'lodash/reduce';
 
 import { ShutdownReason } from './constants';
 import { PartialRaidenConfig } from './config';
-import { ActionType, createAction, Action } from './utils/actions';
+import { ActionType, createAction, Action, AnyAC, TTypeOf, ActionCreator } from './utils/actions';
 import { ErrorCodec } from './utils/error';
 import { Hash } from './utils/types';
 
@@ -55,15 +60,43 @@ export const RaidenEvents = [
 /* Tagged union of RaidenEvents actions */
 export type RaidenEvent = ActionType<typeof RaidenEvents>;
 
+type ValueOf<T> = T[keyof T];
+type UnionToActionsMap<T extends AnyAC> = {
+  [K in TTypeOf<T>]: Extract<T, ActionCreator<K, any, any, any>>;
+};
+// receives an actions module/mapping, where values can be either ACs or AACs, and return a mapping
+// type where ACs are flattened from AACs and keys are their type tag literals
+type ActionsMap<T extends Record<string, AnyAC | Record<string, AnyAC>>> = UnionToActionsMap<
+  ValueOf<
+    {
+      [K in keyof T]: T[K] extends AnyAC
+        ? T[K]
+        : T[K] extends Record<string, AnyAC>
+        ? ValueOf<T[K]>
+        : never;
+    }
+  >
+>;
+
+// type and object mapping from every action type to its ActionCreator object
+type RaidenActionsMap = Readonly<ActionsMap<typeof RaidenActions>>;
+const RaidenActionsMap = reduce(
+  RaidenActions,
+  (acc, v) => ({ ...acc, ...('type' in v ? { [v.type]: v } : mapKeys(v, property('type'))) }),
+  {} as Partial<RaidenActionsMap>,
+) as RaidenActionsMap;
+
 /**
- * Codec which decodes/validates actions which can be confirmed on-chain
+ * Pure codec which decodes/validates actions which can be confirmed on-chain
  *
  * Note that this isn't a complete ActionCreator, but it helps identify and narrow actions which
  * matches this schema. Also important is that this codec isn't `t.exact`, and therefore it wil
  * validate objects with additional properties (like meta and payload properties), as long as it
  * matches the required schema below.
+ * Use [[ConfirmableAction]] to ensure it both complies with and decodes/validates also to the
+ * actual corresponding action registered in [[RaidenActionsMap]]
  */
-export const ConfirmableAction = t.readonly(
+const _ConfirmableAction = t.readonly(
   t.type({
     type: t.string,
     payload: t.readonly(
@@ -76,4 +109,28 @@ export const ConfirmableAction = t.readonly(
   }),
 );
 /** The type of a confirmable action object. */
-export type ConfirmableAction = t.TypeOf<typeof ConfirmableAction>;
+export type ConfirmableAction = t.TypeOf<typeof _ConfirmableAction>;
+
+/**
+ * Special custom codec with validates a type equivalent to:
+ * ConfirmableAction & ValueOf<RaidenActionsMap>
+ * i.e. a ConfirmableAction intersected with an union of any possible registered RaidenAction.
+ * This is needed in order to properly handle members of actions which require special encoding/
+ * decoding logic, like BigNumbers, otherwise when decoding actions (e.g. from
+ * RaidenState['pendingTxs']), the members would be kept but not decoded properly.
+ */
+export const ConfirmableAction = new t.Type<
+  ConfirmableAction,
+  { type: string; payload: { txHash: string; txBlock: number; confirmed: boolean | undefined } }
+>(
+  'ConfirmableAction',
+  _ConfirmableAction.is,
+  (u, c) =>
+    either.chain(_ConfirmableAction.validate(u, c), (v) => {
+      const type = v.type as keyof RaidenActionsMap;
+      if (!(type in RaidenActionsMap)) return t.failure(v, c);
+      return RaidenActionsMap[type].codec.validate(v, c) as Either<t.Errors, ConfirmableAction>;
+    }),
+  (a) =>
+    RaidenActionsMap[a.type as keyof RaidenActionsMap].codec.encode(a as any) as ConfirmableAction,
+);

--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -1153,7 +1153,7 @@ function checkPendingAction(
   provider: RaidenEpicDeps['provider'],
   blockNumber: number,
   confirmationBlocks: number,
-): Observable<ConfirmableAction> {
+): Observable<RaidenAction> {
   return retryAsync$(
     () => provider.getTransactionReceipt(action.payload.txHash),
     provider.pollingInterval,
@@ -1165,13 +1165,13 @@ function checkPendingAction(
           // beyond setting confirmed, also re-set blockNumber,
           // which may have changed on a reorg
           payload: { ...action.payload, txBlock: receipt.blockNumber!, confirmed: true },
-        };
+        } as RaidenAction;
       } else if (action.payload.txBlock + 2 * confirmationBlocks < blockNumber) {
         // if this txs didn't get confirmed for more than 2*confirmationBlocks, it was removed
         return {
           ...action,
           payload: { ...action.payload, confirmed: false },
-        };
+        } as RaidenAction;
       } // else, it seems removed, but give it twice confirmationBlocks to be picked up again
     }),
     filter(isntNil),
@@ -1192,7 +1192,7 @@ export const confirmationEpic = (
   {}: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
   { config$, provider }: RaidenEpicDeps,
-): Observable<ConfirmableAction> =>
+): Observable<RaidenAction> =>
   combineLatest(
     state$.pipe(pluckDistinct('blockNumber')),
     state$.pipe(pluck('pendingTxs')),

--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -1165,13 +1165,13 @@ function checkPendingAction(
           // beyond setting confirmed, also re-set blockNumber,
           // which may have changed on a reorg
           payload: { ...action.payload, txBlock: receipt.blockNumber!, confirmed: true },
-        } as ConfirmableAction;
+        };
       } else if (action.payload.txBlock + 2 * confirmationBlocks < blockNumber) {
         // if this txs didn't get confirmed for more than 2*confirmationBlocks, it was removed
         return {
           ...action,
           payload: { ...action.payload, confirmed: false },
-        } as ConfirmableAction;
+        };
       } // else, it seems removed, but give it twice confirmationBlocks to be picked up again
     }),
     filter(isntNil),

--- a/raiden-ts/src/channels/reducer.ts
+++ b/raiden-ts/src/channels/reducer.ts
@@ -1,10 +1,10 @@
 import { Zero, AddressZero, One } from 'ethers/constants';
 
 import { UInt, Address } from '../utils/types';
-import { Reducer, createReducer, isActionOf } from '../utils/actions';
+import { Reducer, createReducer } from '../utils/actions';
 import { partialCombineReducers } from '../utils/redux';
 import { RaidenState, initialState } from '../state';
-import { RaidenAction, ConfirmableActions } from '../actions';
+import { RaidenAction, ConfirmableAction } from '../actions';
 import { transferSecretRegister } from '../transfers/actions';
 import { Direction } from '../transfers/state';
 import {
@@ -38,7 +38,7 @@ const pendingTxs: Reducer<RaidenState['pendingTxs'], RaidenAction> = (
   action: RaidenAction,
 ): RaidenState['pendingTxs'] => {
   // filter out non-ConfirmableActions's
-  if (!isActionOf(ConfirmableActions, action)) return state;
+  if (!ConfirmableAction.is(action)) return state;
   // if confirmed==undefined, add action to state
   else if (action.payload.confirmed === undefined) return [...state, action];
   // else (either confirmed or removed), remove from state

--- a/raiden-ts/src/channels/reducer.ts
+++ b/raiden-ts/src/channels/reducer.ts
@@ -254,7 +254,10 @@ const completeReducer = createReducer(initialState)
  * name of the reducer. channels root reducer instead must be handled the complete state instead,
  * so it compose the output with each key/nested/combined state.
  */
-const partialReducer = partialCombineReducers({ blockNumber, tokens, pendingTxs }, initialState);
+const partialReducer = partialCombineReducers<RaidenState, RaidenAction>(
+  { blockNumber, tokens, pendingTxs },
+  initialState,
+);
 /**
  * channelsReducer is a reduce-reducers like reducer; in contract with combineReducers, which
  * gives just a specific slice of the state to the reducer (like blockNumber above, which receives

--- a/raiden-ts/src/utils/actions.ts
+++ b/raiden-ts/src/utils/actions.ts
@@ -122,6 +122,9 @@ export type ActionCreator<
 > = ActionFactory<TType, TPayload, TMeta, TError> &
   ActionCreatorMembers<TType, TPayload, TMeta, TError>;
 
+export type AnyAC = ActionCreator<any, any, any, any>;
+export type TTypeOf<T> = T extends ActionCreator<infer TType, any, any, any> ? TType : never;
+
 /**
  * Type helper to extract the type of an action or a mapping of actions
  * Usage: const action: ActionType<typeof actionCreator>;
@@ -283,6 +286,8 @@ export type AsyncActionCreator<
   success: ActionCreator<TSuccessType, TSuccessPayload, TMeta>;
   failure: ActionCreator<TFailureType, TFailurePayload, TMeta, true>;
 };
+
+export type AnyAAC = AsyncActionCreator<any, any, any, any, any, any, any>;
 
 // overloads to account for the optional failure payload (defaults to ErrorCodec)
 export function createAsyncAction<
@@ -543,14 +548,6 @@ export async function asyncActionToPromise<
 // createReducer
 
 /**
- * A simplified schema for ActionCreator<any, any, any, any>, to optimize createReducer
- */
-export type AnyAC = ((payload: any, meta: any) => Action) & {
-  type: string;
-  is: (action: unknown) => action is Action;
-};
-
-/**
  * Create a reducer which can be extended with additional actions handlers
  *
  * Usage:
@@ -563,6 +560,13 @@ export type AnyAC = ((payload: any, meta: any) => Action) & {
  * @returns A reducer function, extended with a handle method to extend it
  */
 export function createReducer<S, A extends Action = Action>(initialState: S) {
+  /**
+   * A simplified schema for ActionCreator<any, any, any, any>, to optimize createReducer
+   */
+  type AnyAC = ((payload: any, meta: any) => Action) & {
+    type: string;
+    is: (action: unknown) => action is Action;
+  };
   // generic handlers as a indexed type for `makeReducer`
   type Handlers = {
     [type: string]: [AnyAC, (state: S, action: A) => S];

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -25,7 +25,7 @@ import 'raiden-ts/polyfills';
 import { Raiden } from 'raiden-ts/raiden';
 import { ShutdownReason } from 'raiden-ts/constants';
 import { makeInitialState, RaidenState } from 'raiden-ts/state';
-import { raidenShutdown, ConfirmableActions } from 'raiden-ts/actions';
+import { raidenShutdown, ConfirmableAction } from 'raiden-ts/actions';
 import { newBlock, tokenMonitored } from 'raiden-ts/channels/actions';
 import { ChannelState } from 'raiden-ts/channels/state';
 import { Storage, Secret, Address } from 'raiden-ts/utils/types';
@@ -81,7 +81,7 @@ describe('Raiden', () => {
     );
     raiden.action$
       .pipe(
-        filter(isActionOf(ConfirmableActions)),
+        filter(ConfirmableAction.is),
         filter((a) => a.payload.confirmed === undefined),
       )
       .subscribe((a) =>

--- a/raiden-ts/tests/unit/actions.spec.ts
+++ b/raiden-ts/tests/unit/actions.spec.ts
@@ -14,6 +14,7 @@ import {
   asyncActionToPromise,
   createReducer,
 } from 'raiden-ts/utils/actions';
+import { ConfirmableAction } from 'raiden-ts/actions';
 
 describe('action factories not tested in reducers.spec.ts', () => {
   const tokenNetwork = '0x0000000000000000000000000000000000020001' as Address,
@@ -222,4 +223,49 @@ describe('utils/actions', () => {
     // const reducer2 = reducer1.handle(decrement, s => s - 1); // forbidden, already handled
     // const reducer3 = sqrReducer.handle(noop, s => s); // forbidden, already handled
   });
+});
+
+test('ConfirmableAction', () => {
+  // a ConfirmableAction with BigNumber members
+  const action = {
+    type: channelDeposit.success.type,
+    payload: {
+      id: 17,
+      participant: '0x0000000000000000000000000000000000020001',
+      totalDeposit: '255',
+      txHash: '0x0000000000000000000000000000000000000020111111111111111111111111',
+      txBlock: 121,
+      // confirmed: undefined, // to test undefined property is filled
+    },
+    meta: {
+      tokenNetwork: '0x0000000000000000000000000000000000020001',
+      partner: '0x0000000000000000000000000000000000000020',
+    },
+  };
+  const decoded = decode(channelDeposit.success.codec, action);
+
+  // ensure actual action/codec validates above object
+  expect(channelDeposit.success.is(decoded)).toBe(true);
+  expect(channelDeposit.success.codec.is(decoded)).toBe(true);
+  expect(channelDeposit.success.codec.encode(decoded)).toEqual(action);
+
+  // ensure ConfirmableAction codec encodes/decodes exactly like the action codec
+  expect(ConfirmableAction.is(decoded)).toBe(true);
+  expect(decode(ConfirmableAction, action)).toEqual(decoded);
+  expect(ConfirmableAction.encode(decoded)).toEqual(action);
+
+  // ensure decoding<=>encoding roundtrips with just ConfirmableAction doesn't change object
+  expect(ConfirmableAction.encode(decode(ConfirmableAction, action))).toEqual(action);
+  expect(decode(ConfirmableAction, ConfirmableAction.encode(decoded))).toEqual(decoded);
+
+  // notice this is a valid 'ConfirmableAction' (per pure codec), but not a valid action of that
+  // type, and decoding must validate as false
+  const confirmable: ConfirmableAction = { type: decoded.type, payload: decoded.payload };
+  expect(() => decode(ConfirmableAction, confirmable)).toThrowError(/Invalid value.*\/meta:/);
+
+  // same, but with an unknown type
+  const confirmable2: ConfirmableAction = { type: 'unknown/action', payload: decoded.payload };
+  expect(() => decode(ConfirmableAction, confirmable2)).toThrowError(
+    /Invalid value.*ConfirmableAction/,
+  );
 });

--- a/raiden-ts/tests/unit/epics/raiden.spec.ts
+++ b/raiden-ts/tests/unit/epics/raiden.spec.ts
@@ -10,12 +10,7 @@ import { defaultAbiCoder } from 'ethers/utils/abi-coder';
 import { range } from 'lodash';
 
 import { UInt } from 'raiden-ts/utils/types';
-import {
-  RaidenAction,
-  raidenShutdown,
-  raidenConfigUpdate,
-  ConfirmableAction,
-} from 'raiden-ts/actions';
+import { RaidenAction, raidenShutdown, raidenConfigUpdate } from 'raiden-ts/actions';
 import { RaidenState } from 'raiden-ts/state';
 import {
   newBlock,
@@ -433,7 +428,7 @@ describe('raiden epic', () => {
 
     test('confirmed', async () => {
       expect.assertions(7);
-      let output: ConfirmableAction | undefined = undefined;
+      let output: RaidenAction | undefined = undefined;
 
       const sub = confirmationEpic(action$, state$, depsMock).subscribe((o) => {
         action$.next(o);
@@ -505,7 +500,7 @@ describe('raiden epic', () => {
 
     test('confirmed', async () => {
       expect.assertions(4);
-      let output: ConfirmableAction | undefined = undefined;
+      let output: RaidenAction | undefined = undefined;
 
       const sub = confirmationEpic(action$, state$, depsMock).subscribe((o) => {
         action$.next(o);

--- a/raiden-ts/tests/unit/epics/receive.spec.ts
+++ b/raiden-ts/tests/unit/epics/receive.spec.ts
@@ -903,7 +903,7 @@ describe('receive transfers', () => {
       data: '0x',
       chainId: depsMock.network.chainId,
       from: depsMock.address,
-      wait: jest.fn().mockResolvedValue({ byzantium: true, status: 0 }),
+      wait: jest.fn().mockResolvedValue({ status: 0, transactionHash: txHash, blockNumber: 1 }),
     });
 
     // then succeeds
@@ -917,7 +917,7 @@ describe('receive transfers', () => {
       data: '0x',
       chainId: depsMock.network.chainId,
       from: depsMock.address,
-      wait: jest.fn().mockResolvedValue({ byzantium: true, status: 1 }),
+      wait: jest.fn().mockResolvedValue({ status: 1, transactionHash: txHash, blockNumber: 1 }),
     });
 
     await expect(

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -160,8 +160,9 @@ export function makeTransaction(
   status = 1,
   overrides?: Partial<MockedTransaction>,
 ): MockedTransaction {
+  const transactionHash = makeHash();
   return {
-    hash: makeHash(),
+    hash: transactionHash,
     confirmations: 1,
     nonce: 0,
     gasLimit: bigNumberify(1e5),
@@ -170,7 +171,9 @@ export function makeTransaction(
     data: '0x',
     chainId: 1337,
     from: makeAddress(),
-    wait: jest.fn().mockResolvedValue({ byzantium: true, status }),
+    wait: jest
+      .fn()
+      .mockResolvedValue({ byzantium: true, status, transactionHash, blockNumber: 1 }),
     ...overrides,
   };
 }


### PR DESCRIPTION
Part of #1660 

**Short description**
ConfirmableActions so far was an explicit union of actions which we had to keep up to date and needed to explicitly match the schema (not allowing optional parameters). This PR makes it instead decode/validate/filter any action which now matches the schema, including ones which may have the properties as optionals. It also does ensure decoding the serialized actions will also validate it against its original codec.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. There's an specific test which tests every possible case on this
