### PR TITLE
Monitors MS contract and emit event when it acts

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -8,17 +8,19 @@
 - [#1651] Fix PFS being disabled if passed an undefined default config
 
 ### Added
+- [#1374] Monitors MonitoringService contract and emit event when MS acts
 - [#1421] Adds support for withdrawing tokens from the UDC
 - [#1642] Check token's allowance before deposit and skip approve
 - [#1701] Allow parameter decoding to throw and log customized errors
 - [#1701] Add and extend error codes for user parameter validation
 
 ### Changed
-- [#1610] Updates smart contracts to v0.37.0 (Alderaan)
 - [#837] Changes the action tags from camel to path format. This change affects the event types exposed through the public API.
+- [#1610] Updates smart contracts to v0.37.0 (Alderaan)
 - [#1649] Have constant error messages and codes in public Raiden API.
 
 [#837]: https://github.com/raiden-network/light-client/issues/837
+[#1374]: https://github.com/raiden-network/light-client/issues/1374
 [#1421]: https://github.com/raiden-network/light-client/issues/1421
 [#1514]: https://github.com/raiden-network/light-client/issues/1514
 [#1607]: https://github.com/raiden-network/light-client/issues/1607

--- a/raiden-ts/src/actions.ts
+++ b/raiden-ts/src/actions.ts
@@ -58,6 +58,7 @@ export const RaidenEvents = [
   RaidenActions.tokenMonitored,
   RaidenActions.udcWithdrawn,
   RaidenActions.udcWithdraw.failure,
+  RaidenActions.msBalanceProofSent,
 ];
 /* Tagged union of RaidenEvents actions */
 export type RaidenEvent = ActionType<typeof RaidenEvents>;

--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -1164,7 +1164,11 @@ function checkPendingAction(
           ...action,
           // beyond setting confirmed, also re-set blockNumber,
           // which may have changed on a reorg
-          payload: { ...action.payload, txBlock: receipt.blockNumber!, confirmed: true },
+          payload: {
+            ...action.payload,
+            txBlock: receipt.blockNumber ?? action.payload.txBlock,
+            confirmed: true,
+          },
         } as RaidenAction;
       } else if (action.payload.txBlock + 2 * confirmationBlocks < blockNumber) {
         // if this txs didn't get confirmed for more than 2*confirmationBlocks, it was removed

--- a/raiden-ts/src/channels/reducer.ts
+++ b/raiden-ts/src/channels/reducer.ts
@@ -30,7 +30,8 @@ const blockNumber = createReducer(initialState.blockNumber).handle(
 // state.tokens specific reducer, handles only tokenMonitored action
 const tokens = createReducer(initialState.tokens).handle(
   tokenMonitored,
-  (state, { payload: { token, tokenNetwork } }) => ({ ...state, [token]: tokenNetwork }),
+  (state, { payload: { token, tokenNetwork } }) =>
+    state[token] === tokenNetwork ? state : { ...state, [token]: tokenNetwork },
 );
 
 const pendingTxs: Reducer<RaidenState['pendingTxs'], RaidenAction> = (

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -22,6 +22,7 @@ import { ServiceRegistryFactory } from './contracts/ServiceRegistryFactory';
 import { CustomTokenFactory } from './contracts/CustomTokenFactory';
 import { UserDepositFactory } from './contracts/UserDepositFactory';
 import { SecretRegistryFactory } from './contracts/SecretRegistryFactory';
+import { MonitoringServiceFactory } from './contracts/MonitoringServiceFactory';
 
 import versions from './versions.json';
 import { ContractsInfo, EventTypes, OnChange, RaidenEpicDeps, Latest } from './types';
@@ -226,6 +227,10 @@ export class Raiden {
       ),
       secretRegistryContract: SecretRegistryFactory.connect(
         contractsInfo.SecretRegistry.address,
+        main?.signer ?? signer,
+      ),
+      monitoringServiceContract: MonitoringServiceFactory.connect(
+        contractsInfo.MonitoringService.address,
         main?.signer ?? signer,
       ),
       main,

--- a/raiden-ts/src/services/actions.ts
+++ b/raiden-ts/src/services/actions.ts
@@ -80,3 +80,19 @@ export const udcWithdrawn = createAction(
 );
 
 export interface udcWithdrawn extends ActionType<typeof udcWithdrawn> {}
+
+export const msBalanceProofSent = createAction(
+  'ms/balanceProof/sent',
+  t.type({
+    tokenNetwork: Address,
+    partner: Address,
+    id: t.number,
+    reward: UInt(32),
+    nonce: UInt(8),
+    monitoringService: Address,
+    txHash: Hash,
+    txBlock: t.number,
+    confirmed: t.union([t.undefined, t.boolean]),
+  }),
+);
+export interface msBalanceProofSent extends ActionType<typeof msBalanceProofSent> {}

--- a/raiden-ts/src/state.ts
+++ b/raiden-ts/src/state.ts
@@ -108,7 +108,7 @@ type PartialState = { config?: PartialRaidenConfig } & Omit<Partial<RaidenState>
  * @param obj.network - ether's Network object for the current blockchain
  * @param obj.address - current account's address
  * @param obj.contractsInfo - ContractsInfo mapping
- * @param overwrites - A partial object to overwrite top-level properties of the returned config
+ * @param overrides - A partial object to overwrite top-level properties of the returned config
  * @returns A full config object
  */
 export function makeInitialState(
@@ -117,7 +117,7 @@ export function makeInitialState(
     address,
     contractsInfo,
   }: { network: Network; address: Address; contractsInfo: ContractsInfo },
-  overwrites: PartialState = {},
+  overrides: PartialState = {},
 ): RaidenState {
   return {
     address,
@@ -125,7 +125,6 @@ export function makeInitialState(
     chainId: network.chainId,
     registry: contractsInfo.TokenNetworkRegistry.address,
     blockNumber: contractsInfo.TokenNetworkRegistry.block_number,
-    config: overwrites.config ?? {},
     channels: {},
     oldChannels: {},
     tokens: {},
@@ -134,6 +133,8 @@ export function makeInitialState(
     received: {},
     iou: {},
     pendingTxs: [],
+    config: {},
+    ...overrides,
   };
 }
 

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -11,6 +11,7 @@ import { TokenNetwork } from './contracts/TokenNetwork';
 import { HumanStandardToken } from './contracts/HumanStandardToken';
 import { UserDeposit } from './contracts/UserDeposit';
 import { SecretRegistry } from './contracts/SecretRegistry';
+import { MonitoringService } from './contracts/MonitoringService';
 
 import { RaidenAction } from './actions';
 import { RaidenState } from './state';
@@ -58,6 +59,7 @@ export interface RaidenEpicDeps {
   serviceRegistryContract: ServiceRegistry;
   userDepositContract: UserDeposit;
   secretRegistryContract: SecretRegistry;
+  monitoringServiceContract: MonitoringService;
   main?: { signer: Signer; address: Address };
 }
 

--- a/raiden-ts/tests/unit/epics/raiden.spec.ts
+++ b/raiden-ts/tests/unit/epics/raiden.spec.ts
@@ -1,556 +1,384 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { epicFixtures } from '../fixtures';
-import { raidenEpicDeps, makeLog } from '../mocks';
+import { makeLog, makeRaiden, makeAddress, waitBlock } from '../mocks';
+import {
+  token,
+  tokenNetwork,
+  id,
+  openBlock,
+  settleTimeout,
+  isFirstParticipant,
+  confirmationBlocks,
+  txHash,
+} from '../fixtures';
 
-import { marbles } from 'rxjs-marbles/jest';
-import { of, from, timer, Observable, EMPTY, merge, ReplaySubject } from 'rxjs';
-import { first, takeUntil, toArray, delay, tap, ignoreElements } from 'rxjs/operators';
-import { bigNumberify } from 'ethers/utils';
 import { defaultAbiCoder } from 'ethers/utils/abi-coder';
-import { range } from 'lodash';
 
-import { UInt } from 'raiden-ts/utils/types';
-import { RaidenAction, raidenShutdown, raidenConfigUpdate } from 'raiden-ts/actions';
-import { RaidenState } from 'raiden-ts/state';
-import {
-  newBlock,
-  tokenMonitored,
-  channelMonitor,
-  channelOpen,
-  channelDeposit,
-  channelClose,
-  channelSettleable,
-  channelSettle,
-} from 'raiden-ts/channels/actions';
-import { raidenReducer } from 'raiden-ts/reducer';
-import { raidenRootEpic } from 'raiden-ts/epics';
-import {
-  initMonitorProviderEpic,
-  tokenMonitoredEpic,
-  initTokensRegistryEpic,
-  confirmationEpic,
-} from 'raiden-ts/channels/epics';
+import { raidenShutdown } from 'raiden-ts/actions';
+import { newBlock, tokenMonitored, channelMonitor, channelOpen } from 'raiden-ts/channels/actions';
 import { ShutdownReason } from 'raiden-ts/constants';
-import { pluckDistinct } from 'raiden-ts/utils/rx';
 import { RaidenError, ErrorCodes } from 'raiden-ts/utils/error';
 
-describe('raiden epic', () => {
-  let depsMock = raidenEpicDeps(),
-    {
-      token,
-      tokenNetworkContract,
-      tokenNetwork,
-      channelId,
-      partner,
-      settleTimeout,
-      isFirstParticipant,
-      txHash,
-      state,
-      matrixServer,
-      state$,
-      action$,
-    } = epicFixtures(depsMock);
+const partner = makeAddress();
 
-  const fetch = jest.fn(async () => ({
-    ok: true,
-    status: 200,
-    text: jest.fn(async () => `- ${matrixServer}`),
-  }));
-  Object.assign(global, { fetch });
-
-  beforeEach(() => {
-    depsMock = raidenEpicDeps();
-    ({
-      token,
-      tokenNetworkContract,
-      tokenNetwork,
-      channelId,
-      partner,
-      settleTimeout,
-      isFirstParticipant,
-      txHash,
-      state,
-      matrixServer,
-      state$,
-      action$,
-    } = epicFixtures(depsMock));
+describe('raiden init epics', () => {
+  test('init newBlock', async () => {
+    expect.assertions(2);
+    const raiden = await makeRaiden(undefined, false);
+    expect(raiden.output).toHaveLength(0);
+    await raiden.start();
+    expect(raiden.output).toContainEqual(newBlock({ blockNumber: expect.any(Number) }));
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
+  test('init previous tokenMonitored', async () => {
+    expect.assertions(2);
+    const raiden = await makeRaiden(undefined, false);
+    // change initial state before starting
+    raiden.store.dispatch(tokenMonitored({ token, tokenNetwork }));
+    expect(raiden.store.getState().tokens).toEqual({ [token]: tokenNetwork });
+    await raiden.start();
+    await waitBlock();
+    expect(raiden.output).toContainEqual(tokenMonitored({ token, tokenNetwork }));
   });
 
-  describe('raiden initialization & shutdown', () => {
-    test(
-      'init newBlock, tokenMonitored, channelMonitor events',
-      marbles((m) => {
-        const newState = [
-          tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-          channelOpen.success(
-            {
-              id: channelId,
-              settleTimeout,
-              isFirstParticipant,
-              token,
-              txHash,
-              txBlock: 121,
-              confirmed: true,
-            },
-            { tokenNetwork, partner },
-          ),
-          channelDeposit.success(
-            {
-              id: channelId,
-              participant: depsMock.address,
-              totalDeposit: bigNumberify(200) as UInt<32>,
-              txHash,
-              txBlock: 122,
-              confirmed: true,
-            },
-            { tokenNetwork, partner },
-          ),
-          channelDeposit.success(
-            {
-              id: channelId,
-              participant: partner,
-              totalDeposit: bigNumberify(200) as UInt<32>,
-              txHash,
-              txBlock: 123,
-              confirmed: true,
-            },
-            { tokenNetwork, partner },
-          ),
-          newBlock({ blockNumber: 128 }),
-          channelClose.success(
-            { id: channelId, participant: partner, txHash, txBlock: 128, confirmed: true },
-            { tokenNetwork, partner },
-          ),
-          newBlock({ blockNumber: 629 }),
-          channelSettleable({ settleableBlock: 629 }, { tokenNetwork, partner }),
-          newBlock({ blockNumber: 633 }),
-          // channel is left in 'settling' state
-          channelSettle.request(undefined, { tokenNetwork, partner }),
-        ].reduce(raidenReducer, state);
+  test('init tokenMonitored with scanned tokenNetwork', async () => {
+    expect.assertions(3);
+    const raiden = await makeRaiden(undefined, false);
+    const { registryContract } = raiden.deps;
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
 
-        /* this test requires mocked provider, or else emit is called with setTimeout and doesn't
-         * run before the return of the function.
-         */
-        // See: https://github.com/cartant/rxjs-marbles/issues/11
-        depsMock.provider.getBlockNumber.mockReturnValueOnce(
-          (of(633) as unknown) as Promise<number>,
-        );
-        const action$ = m.cold('--b-------d|', {
-            b: newBlock({ blockNumber: 634 }),
-            d: raidenShutdown({ reason: ShutdownReason.STOP }),
+    const otherToken = makeAddress();
+    const otherTokenNetwork = makeAddress();
+
+    raiden.deps.provider.getLogs.mockImplementation(async ({ address, topics }) => {
+      if (address === registryContract.address) {
+        // on registryContract's getLogs, return 2 registered tokenNetworks
+        return [
+          makeLog({ filter: registryContract.filters.TokenNetworkCreated(token, tokenNetwork) }),
+          makeLog({
+            filter: registryContract.filters.TokenNetworkCreated(otherToken, otherTokenNetwork),
           }),
-          state$ = m.cold('-s----|', { s: newState }),
-          emitBlock$ = m.cold('----------b-|').pipe(
-            tap(() => depsMock.provider.emit('block', 635)),
-            ignoreElements(),
-          );
-        m.expect(merge(emitBlock$, raidenRootEpic(action$, state$, depsMock))).toBeObservable(
-          m.cold('b(tc)-----B-|', {
-            b: newBlock({ blockNumber: 633 }),
-            t: tokenMonitored({ token, tokenNetwork }),
-            // ensure channelMonitor is emitted by init even for 'settling' channel
-            c: channelMonitor({ id: channelId }, { tokenNetwork, partner }),
-            B: newBlock({ blockNumber: 635 }),
+        ];
+      } else if (
+        address === tokenNetwork &&
+        topics?.[3] === defaultAbiCoder.encode(['address'], [raiden.address])
+      ) {
+        // on tokenNetwork ChannelOpened getLogs, return a channel (network of interest)
+        return [
+          makeLog({
+            filter: tokenNetworkContract.filters.ChannelOpened(
+              id,
+              raiden.address,
+              raiden.address,
+              null,
+            ),
           }),
-        );
-      }),
+        ];
+      }
+      return [];
+    });
+    await raiden.start();
+    await waitBlock();
+
+    expect(raiden.output).toContainEqual(
+      tokenMonitored({ token, tokenNetwork, fromBlock: expect.any(Number) }),
     );
-
-    test('initTokensRegistryEpic: scan initially, monitor previous then', async () => {
-      depsMock.provider.getLogs.mockResolvedValueOnce([
-        makeLog({
-          blockNumber: 121,
-          filter: depsMock.registryContract.filters.TokenNetworkCreated(token, tokenNetwork),
-        }),
-      ]);
-
-      // without an open channel, TokenNetwork isn't of interest and shouldn't be monitored
-      await expect(
-        initTokensRegistryEpic(EMPTY, of(state), depsMock).toPromise(),
-      ).resolves.toBeUndefined();
-
-      expect(depsMock.provider.getLogs).toHaveBeenCalledTimes(3);
-      expect(depsMock.provider.getLogs).toHaveBeenCalledWith(
-        expect.objectContaining({
-          ...depsMock.registryContract.filters.TokenNetworkCreated(null, null),
-          fromBlock: depsMock.contractsInfo.TokenNetworkRegistry.block_number,
-          toBlock: 'latest',
-        }),
-      );
-
-      depsMock.provider.getLogs.mockClear();
-
-      // mocks getLogs for TokenNetworkCreated events
-      depsMock.provider.getLogs.mockResolvedValueOnce([
-        makeLog({
-          blockNumber: 121,
-          filter: depsMock.registryContract.filters.TokenNetworkCreated(token, tokenNetwork),
-        }),
-      ]);
-
-      // mocks getLogs for TokenNetworkCreated events
-      depsMock.provider.getLogs.mockResolvedValueOnce([
-        makeLog({
-          blockNumber: 122,
-          filter: tokenNetworkContract.filters.ChannelOpened(
-            channelId,
-            depsMock.address,
-            partner,
-            null,
-          ),
-          data: defaultAbiCoder.encode(['uint256'], [settleTimeout]),
-        }),
-      ]);
-
-      await expect(
-        initTokensRegistryEpic(EMPTY, of(state), depsMock).pipe(toArray()).toPromise(),
-      ).resolves.toEqual([tokenMonitored({ token, tokenNetwork, fromBlock: 121 })]);
-
-      expect(depsMock.provider.getLogs).toHaveBeenCalledTimes(2);
-      expect(depsMock.provider.getLogs).toHaveBeenCalledWith(
-        expect.objectContaining({
-          address: tokenNetwork,
-          topics: expect.arrayContaining([
-            expect.stringMatching(depsMock.address.substr(2).toLowerCase()),
-          ]),
-          toBlock: 'latest',
-        }),
-      );
-
-      depsMock.provider.getLogs.mockClear();
-
-      await expect(
-        initTokensRegistryEpic(
-          EMPTY,
-          of([tokenMonitored({ token, tokenNetwork })].reduce(raidenReducer, state)),
-          depsMock,
-        )
-          .pipe(toArray())
-          .toPromise(),
-      ).resolves.toEqual([tokenMonitored({ token, tokenNetwork })]);
-      expect(depsMock.provider.getLogs).toHaveBeenCalledTimes(0);
-    });
-
-    test('ShutdownReason.ACCOUNT_CHANGED', async () => {
-      const action$ = EMPTY as Observable<RaidenAction>,
-        state$ = of(state);
-
-      depsMock.provider.listAccounts.mockResolvedValue([]);
-      // listAccounts first return array with address, then empty
-      depsMock.provider.listAccounts.mockResolvedValueOnce([depsMock.address]);
-
-      await expect(
-        initMonitorProviderEpic(action$, state$, depsMock).pipe(first()).toPromise(),
-      ).resolves.toEqual(raidenShutdown({ reason: ShutdownReason.ACCOUNT_CHANGED }));
-    });
-
-    test('ShutdownReason.NETWORK_CHANGED', async () => {
-      const action$ = EMPTY as Observable<RaidenAction>,
-        state$ = of(state);
-
-      depsMock.provider.getNetwork.mockResolvedValueOnce({ chainId: 899, name: 'unknown' });
-
-      await expect(
-        initMonitorProviderEpic(action$, state$, depsMock).pipe(first()).toPromise(),
-      ).resolves.toEqual(raidenShutdown({ reason: ShutdownReason.NETWORK_CHANGED }));
-    });
-
-    test('unexpected exception triggers shutdown', async () => {
-      const action$ = new ReplaySubject<RaidenAction>(1),
-        state$ = depsMock.latest$.pipe(pluckDistinct('state'));
-      action$.next(newBlock({ blockNumber: 122 }));
-
-      const error = new RaidenError(ErrorCodes.RDN_GENERAL_ERROR);
-      depsMock.provider.listAccounts.mockRejectedValueOnce(error);
-
-      // whole raidenRootEpic completes upon raidenShutdown, with it as last emitted value
-      await expect(raidenRootEpic(action$, state$, depsMock).toPromise()).resolves.toEqual(
-        raidenShutdown({ reason: expect.anything() }),
-      );
-
-      action$.complete();
-    });
+    // output shouldn't contain anything about otherTokenNetwork; not of interest
+    expect(raiden.output).not.toContainEqual(
+      tokenMonitored(expect.objectContaining({ token: otherToken })),
+    );
+    expect(raiden.output).not.toContainEqual(
+      tokenMonitored(expect.objectContaining({ tokenNetwork: otherTokenNetwork })),
+    );
   });
 
-  describe('tokenMonitoredEpic', () => {
-    const settleTimeoutEncoded = defaultAbiCoder.encode(['uint256'], [settleTimeout]);
-
-    test('first tokenMonitored with past$ ChannelOpened event', async () => {
-      expect.assertions(2);
-
-      const action = tokenMonitored({
-          token,
-          tokenNetwork,
-          fromBlock: depsMock.contractsInfo.TokenNetworkRegistry.block_number + 1,
-        }),
-        curState = raidenReducer(state, action);
-      // give time to multicast to register
-      const action$ = of<RaidenAction>(action).pipe(delay(1)),
-        state$ = of<RaidenState>(curState);
-
-      depsMock.provider.getLogs.mockResolvedValueOnce([
-        makeLog({
-          blockNumber: 121,
-          filter: tokenNetworkContract.filters.ChannelOpened(
-            channelId,
-            depsMock.address,
-            partner,
-            null,
-          ),
-          data: settleTimeoutEncoded, // non-indexed settleTimeout = 500 goes in data
-        }),
-      ]);
-
-      const promise = tokenMonitoredEpic(action$, state$, depsMock).pipe(first()).toPromise();
-
-      await expect(promise).resolves.toEqual(
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant: true,
-            token,
-            txHash: expect.any(String),
-            txBlock: 121,
-            confirmed: undefined,
-          },
-          { tokenNetwork, partner },
-        ),
-      );
-
-      expect(depsMock.provider.getLogs).toHaveBeenCalledWith(
-        expect.objectContaining({
-          address: tokenNetworkContract.address,
-          fromBlock: depsMock.contractsInfo.TokenNetworkRegistry.block_number + 1,
-          toBlock: depsMock.provider.blockNumber,
-        }),
-      );
-    });
-
-    test('already tokenMonitored with new$ ChannelOpened event', async () => {
-      const action = tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        curState = raidenReducer(state, action);
-      const action$ = of<RaidenAction>(action),
-        state$ = of<RaidenState>(curState);
-
-      const promise = tokenMonitoredEpic(action$, state$, depsMock).pipe(first()).toPromise();
-
-      depsMock.provider.emit(
-        tokenNetworkContract.filters.ChannelOpened(null, null, null, null),
-        makeLog({
-          blockNumber: 125,
-          filter: tokenNetworkContract.filters.ChannelOpened(
-            channelId,
-            depsMock.address,
-            partner,
-            null,
-          ),
-          data: settleTimeoutEncoded, // non-indexed settleTimeout = 500 goes in data
-        }),
-      );
-
-      await expect(promise).resolves.toEqual(
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant: true,
-            token,
-            txHash: expect.any(String),
-            txBlock: 125,
-            confirmed: undefined,
-          },
-          { tokenNetwork, partner },
-        ),
-      );
-    });
-
-    test("ensure multiple tokenMonitored don't produce duplicated events", async () => {
-      const multiple = 16;
-      const action = tokenMonitored({ token, tokenNetwork, fromBlock: 1 }),
-        curState = raidenReducer(state, action);
-      const action$ = from(
-          range(multiple).map(() => tokenMonitored({ token, tokenNetwork, fromBlock: 1 })),
-        ),
-        state$ = of<RaidenState>(curState);
-
-      const promise = tokenMonitoredEpic(action$, state$, depsMock)
-        .pipe(
-          // wait a little and then complete observable, so it doesn't keep listening forever
-          takeUntil(timer(100)),
-          toArray(), // aggregate all emitted values in this period in a single array
-        )
-        .toPromise();
-
-      // even though multiple tokenMonitored events were fired, blockchain fires a single event
-      depsMock.provider.emit(
-        tokenNetworkContract.filters.ChannelOpened(null, null, null, null),
-        makeLog({
-          blockNumber: 125,
-          filter: tokenNetworkContract.filters.ChannelOpened(
-            channelId,
-            depsMock.address,
-            partner,
-            null,
-          ),
-          data: settleTimeoutEncoded, // non-indexed settleTimeout = 500 goes in data
-        }),
-      );
-
-      const result = await promise;
-      expect(result).toHaveLength(1);
-      expect(result[0]).toEqual(
-        channelOpen.success(
-          {
-            id: channelId,
-            settleTimeout,
-            isFirstParticipant: true,
-            token,
-            txHash: expect.any(String),
-            txBlock: 125,
-            confirmed: undefined,
-          },
-          { tokenNetwork, partner },
-        ),
-      );
-
-      // one for channels with us, one for channels from us
-      expect(depsMock.provider.on).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('confirmationEpic', () => {
-    beforeEach(() => action$.next(raidenConfigUpdate({ confirmationBlocks: 5 })));
-
-    test('confirmed', async () => {
-      expect.assertions(7);
-      let output: RaidenAction | undefined = undefined;
-
-      const sub = confirmationEpic(action$, state$, depsMock).subscribe((o) => {
-        action$.next(o);
-        output = o;
-      });
-
-      const currentState = async () =>
-        depsMock.latest$.pipe(pluckDistinct('state'), first()).toPromise();
-
-      const pending = channelOpen.success(
+  test('init previous channelMonitored', async () => {
+    expect.assertions(1);
+    const raiden = await makeRaiden(undefined, false);
+    // change initial state before starting
+    raiden.store.dispatch(tokenMonitored({ token, tokenNetwork }));
+    const meta = { tokenNetwork, partner };
+    raiden.store.dispatch(
+      channelOpen.success(
         {
-          id: channelId,
+          id,
           settleTimeout,
           isFirstParticipant,
           token,
           txHash,
-          txBlock: 122,
-          confirmed: undefined,
-        },
-        { tokenNetwork, partner },
-      );
-
-      action$.next(newBlock({ blockNumber: 121 }));
-      action$.next(pending);
-      action$.next(newBlock({ blockNumber: 122 }));
-
-      // pending tx (confirmed=undefined) is stored in state
-      await expect(currentState()).resolves.toMatchObject({
-        blockNumber: 122,
-        config: { confirmationBlocks: 5 },
-        pendingTxs: [pending],
-      });
-      expect(output).toBeUndefined();
-
-      // at least confirmationBlocks passed, but getTransactionReceipt returns invalid
-      depsMock.provider.getTransactionReceipt.mockResolvedValueOnce(null as any);
-      action$.next(newBlock({ blockNumber: 127 }));
-
-      expect(depsMock.provider.getTransactionReceipt).toHaveBeenCalledTimes(1);
-      expect(output).toBeUndefined();
-
-      // give some time to exhaustMap to be free'd
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      // now, confirmed, but reorged to block=123
-      depsMock.provider.getTransactionReceipt.mockResolvedValueOnce({
-        confirmations: 6,
-        blockNumber: 123,
-      } as any);
-      action$.next(newBlock({ blockNumber: 129 }));
-
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      expect(depsMock.provider.getTransactionReceipt).toHaveBeenCalledTimes(2);
-      expect(output).toMatchObject({
-        payload: {
-          txHash,
-          txBlock: 123,
+          txBlock: openBlock,
           confirmed: true,
         },
-      });
-      await expect(currentState()).resolves.toMatchObject({
-        blockNumber: 129,
-        pendingTxs: [],
-      });
+        meta,
+      ),
+    );
+    await raiden.start();
 
-      sub.unsubscribe();
+    expect(raiden.output).toContainEqual(channelMonitor({ id }, meta));
+  });
+
+  test('ShutdownReason.ACCOUNT_CHANGED', async () => {
+    expect.assertions(2);
+
+    const raiden = await makeRaiden(undefined, false);
+    // first, address is present, therefore it's a provider account
+    raiden.deps.provider.listAccounts.mockResolvedValue([raiden.address]);
+    await raiden.start();
+
+    // account is gone from listAccounts, so not available anymore
+    raiden.deps.provider.listAccounts.mockResolvedValue([]);
+    await raiden.deps.latest$.toPromise(); // raidenShutdown completes subjects
+
+    expect(raiden.started).toBe(false);
+    expect(raiden.output[raiden.output.length - 1]).toEqual(
+      raidenShutdown({ reason: ShutdownReason.ACCOUNT_CHANGED }),
+    );
+  });
+
+  test('ShutdownReason.ACCOUNT_CHANGED', async () => {
+    expect.assertions(2);
+
+    const raiden = await makeRaiden();
+
+    // change network at runtime
+    raiden.deps.provider.getNetwork.mockResolvedValue({ chainId: 899, name: 'unknown' });
+    await raiden.deps.latest$.toPromise(); // raidenShutdown completes subjects
+
+    expect(raiden.started).toBe(false);
+    expect(raiden.output[raiden.output.length - 1]).toEqual(
+      raidenShutdown({ reason: ShutdownReason.NETWORK_CHANGED }),
+    );
+  });
+
+  test('unexpected unrecoverable exception triggers shutdown', async () => {
+    expect.assertions(2);
+
+    const raiden = await makeRaiden();
+
+    // change network at runtime
+    const error = new RaidenError(ErrorCodes.RDN_GENERAL_ERROR);
+    raiden.deps.provider.listAccounts.mockRejectedValue(error);
+    await raiden.deps.latest$.toPromise(); // raidenShutdown completes subjects
+
+    expect(raiden.started).toBe(false);
+    expect(raiden.output[raiden.output.length - 1]).toEqual(raidenShutdown({ reason: error }));
+  });
+});
+
+describe('tokenMonitoredEpic', () => {
+  const settleTimeoutEncoded = defaultAbiCoder.encode(['uint256'], [settleTimeout]);
+
+  test('first tokenMonitored with past$ ChannelOpened event', async () => {
+    expect.assertions(1);
+
+    const raiden = await makeRaiden();
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+
+    raiden.deps.provider.getLogs.mockImplementation(async ({ address, topics }) => {
+      if (
+        address === tokenNetwork &&
+        topics?.[0] === tokenNetworkContract.interface.events.ChannelOpened.topic
+      )
+        return [
+          makeLog({
+            transactionHash: txHash,
+            blockNumber: openBlock,
+            filter: tokenNetworkContract.filters.ChannelOpened(id, partner, raiden.address, null),
+            data: settleTimeoutEncoded,
+          }),
+        ];
+      return [];
     });
 
-    test('confirmed', async () => {
-      expect.assertions(4);
-      let output: RaidenAction | undefined = undefined;
+    raiden.store.dispatch(
+      tokenMonitored({
+        token,
+        tokenNetwork,
+        fromBlock: 2,
+      }),
+    );
+    await waitBlock();
 
-      const sub = confirmationEpic(action$, state$, depsMock).subscribe((o) => {
-        action$.next(o);
-        output = o;
-      });
-
-      const currentState = async () =>
-        depsMock.latest$.pipe(pluckDistinct('state'), first()).toPromise();
-
-      const pending = channelOpen.success(
+    expect(raiden.output).toContainEqual(
+      channelOpen.success(
         {
-          id: channelId,
-          settleTimeout,
-          isFirstParticipant,
+          id,
           token,
+          settleTimeout,
+          isFirstParticipant: false,
           txHash,
-          txBlock: 122,
+          txBlock: openBlock,
           confirmed: undefined,
         },
         { tokenNetwork, partner },
-      );
+      ),
+    );
+  });
 
-      action$.next(newBlock({ blockNumber: 121 }));
-      action$.next(pending);
+  test('already tokenMonitored with new$ ChannelOpened event', async () => {
+    expect.assertions(1);
 
-      // can't get receipt, confirmationBlocks < n < 2*confirmationBlocks passed
-      depsMock.provider.getTransactionReceipt.mockResolvedValueOnce(null as any);
-      action$.next(newBlock({ blockNumber: 129 }));
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      expect(output).toBeUndefined();
+    const raiden = await makeRaiden(undefined, false);
+    raiden.store.dispatch(tokenMonitored({ token, tokenNetwork }));
+    await raiden.start();
 
-      // still can't get receipt, n > 2*confirmationBlocks passed
-      depsMock.provider.getTransactionReceipt.mockResolvedValueOnce(null as any);
-      action$.next(newBlock({ blockNumber: 133 }));
-      await new Promise((resolve) => setTimeout(resolve, 10));
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
 
-      expect(depsMock.provider.getTransactionReceipt).toHaveBeenCalledTimes(2);
-      expect(output).toMatchObject({
-        payload: {
+    raiden.deps.provider.emit(
+      tokenNetworkContract.filters.ChannelOpened(null, null, null, null),
+      makeLog({
+        transactionHash: txHash,
+        blockNumber: openBlock,
+        filter: tokenNetworkContract.filters.ChannelOpened(id, raiden.address, partner, null),
+        data: settleTimeoutEncoded,
+      }),
+    );
+    await waitBlock();
+
+    expect(raiden.output).toContainEqual(
+      channelOpen.success(
+        {
+          id,
+          token,
+          settleTimeout,
+          isFirstParticipant: true,
           txHash,
-          txBlock: 122,
-          confirmed: false,
+          txBlock: openBlock,
+          confirmed: undefined,
         },
-      });
-      await expect(currentState()).resolves.toMatchObject({
-        blockNumber: 133,
-        pendingTxs: [],
-      });
+        { tokenNetwork, partner },
+      ),
+    );
+  });
 
-      sub.unsubscribe();
+  test("ensure multiple tokenMonitored don't produce duplicated events", async () => {
+    expect.assertions(2);
+
+    const raiden = await makeRaiden();
+    for (let i = 0; i < 16; i++) raiden.store.dispatch(tokenMonitored({ token, tokenNetwork }));
+
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+
+    raiden.deps.provider.emit(
+      tokenNetworkContract.filters.ChannelOpened(null, null, null, null),
+      makeLog({
+        transactionHash: txHash,
+        blockNumber: openBlock,
+        filter: tokenNetworkContract.filters.ChannelOpened(id, raiden.address, partner, null),
+        data: settleTimeoutEncoded,
+      }),
+    );
+    await waitBlock();
+
+    expect(raiden.output).toContainEqual(
+      channelOpen.success(
+        {
+          id,
+          token,
+          settleTimeout,
+          isFirstParticipant: true,
+          txHash,
+          txBlock: openBlock,
+          confirmed: undefined,
+        },
+        { tokenNetwork, partner },
+      ),
+    );
+    expect(
+      raiden.output.filter(
+        (action) => channelOpen.success.is(action) && action.payload.confirmed === undefined,
+      ),
+    ).toHaveLength(1);
+  });
+});
+
+describe('confirmationEpic', () => {
+  test('confirmed', async () => {
+    expect.assertions(2);
+
+    const raiden = await makeRaiden();
+    const meta = { tokenNetwork, partner };
+
+    raiden.deps.provider.getTransactionReceipt.mockResolvedValueOnce(null as any);
+
+    raiden.store.dispatch(
+      channelOpen.success(
+        {
+          id,
+          token,
+          settleTimeout,
+          isFirstParticipant: true,
+          txHash,
+          txBlock: openBlock,
+          confirmed: undefined,
+        },
+        meta,
+      ),
+    );
+    await waitBlock(openBlock + confirmationBlocks + 2);
+    await waitBlock();
+
+    expect(raiden.output).toContainEqual(
+      channelOpen.success(
+        expect.objectContaining({
+          id,
+          txHash,
+          txBlock: openBlock,
+          confirmed: true,
+        }),
+        meta,
+      ),
+    );
+    expect(raiden.deps.provider.getTransactionReceipt).toHaveBeenCalledTimes(2);
+  });
+
+  test('removed', async () => {
+    expect.assertions(3);
+
+    const raiden = await makeRaiden();
+    const meta = { tokenNetwork, partner };
+
+    // no confirmations: tx is removed
+    raiden.deps.provider.getTransactionReceipt.mockResolvedValue({
+      transactionHash: txHash,
+      byzantium: true,
+      blockNumber: openBlock,
     });
+    raiden.deps.provider.getTransactionReceipt.mockResolvedValueOnce(null as any);
+
+    raiden.store.dispatch(
+      channelOpen.success(
+        {
+          id,
+          token,
+          settleTimeout,
+          isFirstParticipant: true,
+          txHash,
+          txBlock: openBlock,
+          confirmed: undefined,
+        },
+        meta,
+      ),
+    );
+    await waitBlock(openBlock + confirmationBlocks + 2);
+    expect(raiden.output).not.toContainEqual(
+      channelOpen.success(
+        expect.objectContaining(expect.objectContaining({ confirmed: expect.any(Boolean) })),
+        meta,
+      ),
+    );
+    await waitBlock(openBlock + 2 * confirmationBlocks + 2);
+
+    expect(raiden.output).toContainEqual(
+      channelOpen.success(
+        expect.objectContaining({
+          id,
+          txHash,
+          txBlock: openBlock,
+          confirmed: false,
+        }),
+        meta,
+      ),
+    );
+    expect(raiden.deps.provider.getTransactionReceipt).toHaveBeenCalledTimes(2);
   });
 });

--- a/raiden-ts/tests/unit/fixtures.ts
+++ b/raiden-ts/tests/unit/fixtures.ts
@@ -1,13 +1,22 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { patchEthersDefineReadOnly } from './patches';
-patchEthersDefineReadOnly();
+import {
+  makeMatrix,
+  MockRaidenEpicDeps,
+  MockedRaiden,
+  makeAddress,
+  makeHash,
+  waitBlock,
+  providersEmit,
+  makeLog,
+} from './mocks';
 
 import { Subject } from 'rxjs';
 import { first, scan, pluck } from 'rxjs/operators';
 import { Wallet } from 'ethers';
 import { AddressZero, Zero, HashZero } from 'ethers/constants';
 import { bigNumberify, defaultAbiCoder } from 'ethers/utils';
+import { Filter } from 'ethers/providers';
 
 import { Address, Hash, Int, UInt } from 'raiden-ts/utils/types';
 import { Processed, MessageType } from 'raiden-ts/messages/types';
@@ -29,18 +38,6 @@ import { ChannelState, Channel } from 'raiden-ts/channels';
 import { Direction } from 'raiden-ts/transfers/state';
 import { transfer, transferUnlock } from 'raiden-ts/transfers/actions';
 import { messageReceived } from 'raiden-ts/messages/actions';
-
-import {
-  makeMatrix,
-  MockRaidenEpicDeps,
-  MockedRaiden,
-  makeAddress,
-  makeHash,
-  waitBlock,
-  providersEmit,
-  makeLog,
-} from './mocks';
-import { Filter } from 'ethers/providers';
 
 /**
  * Composes several constants used across epics


### PR DESCRIPTION
SDK part of #1374 

**Short description**
Monitors MS contract and fires a `ms/balanceProof/sent` event through `Raiden.events$` observable if a Monitoring Service acted while we were offline and updated one of our channels.
This event's payload contain the following fields:
- `tokenNetwork`: token network from which the channel belongs
- `partner`: partner with which we had this channel
- `id`: channel Id
- `reward`: reward collected by MS from our UDC deposit for this service
- `nonce`: order of the state change on partner's channel state end which got updated
- `monitoringService`: address of the MS which acted and collected the reward
- `txHash`: hash of the transaction on-chain
- `txBlock`: when the transaction took place
- `confirmed`: if the transaction already got confirmed


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

Not that easy to test, but this worked here:
1. Ensure receiving is enabled for any channel value: e.g. `rateToSvt: { "<token_addr>": MaxUint256 }`
2. Ensure there's enough UDC deposit to pay for MS, e.g. 10SVT
3. While online, receive a transfer, check `RequestMonitoring` message was sent
4. Go offline
5. On partner (sender)'s side, close the channel
6. Don't come back online with receiver and wait `settleTimeout= 500` (default) blocks to pass
7. Channel becomes settleable, MS should have sent an update tx
8. Come back online with receiving node, see `ms/balanceProof/sent` action be detected and emitted
9. Either sender or receiver can then settle the channels, receiver should receive its due tokens
