### PR TITLE
Introduce LocksrootZero and use it for createBalanceHash

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#1607] Fix settling when one side closes/updates with outdated BalanceProof
 - [#1637] Fix depositToUDC failing if services already have withdrawn some fees
 - [#1651] Fix PFS being disabled if passed an undefined default config
+- [#1690] Fix LockExpired with empty balanceHash verification
 
 ### Added
 - [#1421] Adds support for withdrawing tokens from the UDC
@@ -27,6 +28,7 @@
 [#1642]: https://github.com/raiden-network/light-client/issues/1642
 [#1649]: https://github.com/raiden-network/light-client/pull/1649
 [#1651]: https://github.com/raiden-network/light-client/issues/1651
+[#1690]: https://github.com/raiden-network/light-client/issues/1690
 [#1701]: https://github.com/raiden-network/light-client/pull/1701
 
 ## [0.9.0] - 2020-05-28

--- a/raiden-ts/src/channels/types.ts
+++ b/raiden-ts/src/channels/types.ts
@@ -1,7 +1,7 @@
 import * as t from 'io-ts';
 import { Zero, AddressZero, HashZero } from 'ethers/constants';
 
-import { SignatureZero } from '../constants';
+import { SignatureZero, LocksrootZero } from '../constants';
 import { Address, Hash, UInt, Signed } from '../utils/types';
 
 // should these become brands?
@@ -53,7 +53,7 @@ export const BalanceProofZero: Signed<BalanceProof> = {
   nonce: Zero as UInt<8>,
   transferredAmount: Zero as UInt<32>,
   lockedAmount: Zero as UInt<32>,
-  locksroot: HashZero as Hash,
+  locksroot: LocksrootZero,
   additionalHash: HashZero as Hash,
   signature: SignatureZero,
 };

--- a/raiden-ts/src/constants.ts
+++ b/raiden-ts/src/constants.ts
@@ -1,7 +1,10 @@
-import { padZeros, hexlify } from 'ethers/utils';
-import { Signature } from './utils/types';
+import { padZeros, hexlify, keccak256 } from 'ethers/utils';
+import { Signature, Hash } from './utils/types';
 
 export const SignatureZero = hexlify(padZeros([], 65)) as Signature;
+
+// LocksrootZero = getLocksroot([]) = '0xc5d2...a470';
+export const LocksrootZero = keccak256([]) as Hash;
 
 export enum ShutdownReason {
   STOP = 'raidenStopped',

--- a/raiden-ts/src/messages/utils.ts
+++ b/raiden-ts/src/messages/utils.ts
@@ -6,6 +6,7 @@ import { encode as rlpEncode } from 'ethers/utils/rlp';
 import { HashZero } from 'ethers/constants';
 import logging from 'loglevel';
 
+import { LocksrootZero } from '../constants';
 import { assert } from '../utils';
 import { Address, Hash, HexString, Signature, Signed, decode } from '../utils/types';
 import { encode, losslessParse, losslessStringify } from '../utils/data';
@@ -65,7 +66,9 @@ export function createBalanceHash({
   lockedAmount,
   locksroot,
 }: Pick<BalanceProof, 'transferredAmount' | 'lockedAmount' | 'locksroot'>): Hash {
-  return (transferredAmount.isZero() && lockedAmount.isZero() && locksroot === HashZero
+  return (transferredAmount.isZero() &&
+  lockedAmount.isZero() &&
+  (locksroot === HashZero || locksroot === LocksrootZero)
     ? HashZero
     : keccak256(
         concat([encode(transferredAmount, 32), encode(lockedAmount, 32), encode(locksroot, 32)]),

--- a/raiden-ts/tests/unit/epics/channels.spec.ts
+++ b/raiden-ts/tests/unit/epics/channels.spec.ts
@@ -26,8 +26,10 @@ import {
 import { bigNumberify, BigNumber } from 'ethers/utils';
 import { Zero, HashZero } from 'ethers/constants';
 import { defaultAbiCoder } from 'ethers/utils/abi-coder';
+import { Filter } from 'ethers/providers';
 
 import { UInt } from 'raiden-ts/utils/types';
+import { LocksrootZero } from 'raiden-ts/constants';
 import {
   channelMonitor,
   channelOpen,
@@ -40,7 +42,6 @@ import {
 import { channelUniqueKey } from 'raiden-ts/channels/utils';
 import { ChannelState } from 'raiden-ts/channels';
 import { TokenNetwork } from 'raiden-ts/contracts/TokenNetwork';
-import { Filter } from 'ethers/providers';
 import { createBalanceHash, getBalanceProofFromEnvelopeMessage } from 'raiden-ts/messages';
 import { getLocksroot } from 'raiden-ts/transfers/utils';
 
@@ -659,11 +660,11 @@ describe('channelSettleEpic', () => {
       raiden.address,
       Zero, // self transfered amount
       Zero, // self locked amount
-      HashZero, // self locksroot
+      LocksrootZero, // self locksroot
       partner.address,
       Zero, // partner transfered amount
       Zero, // partner locked amount
-      HashZero, // partner locksroot
+      LocksrootZero, // partner locksroot
     );
     expect(settleTx.wait).toHaveBeenCalledTimes(1);
   });
@@ -727,7 +728,7 @@ describe('channelSettleEpic', () => {
       partner.address,
       Zero, // partner transfered amount
       Zero, // partner locked amount
-      HashZero, // partner locksroot
+      LocksrootZero, // partner locksroot
       raiden.address,
       Zero, // self transfered amount
       amount, // self locked amount
@@ -796,7 +797,7 @@ describe('channelSettleEpic', () => {
       raiden.address,
       Zero, // self transfered amount
       Zero, // self locked amount
-      HashZero, // self locksroot
+      LocksrootZero, // self locksroot
       partner.address,
       Zero, // partner transfered amount
       amount, // partner locked amount

--- a/raiden-ts/tests/unit/messages.spec.ts
+++ b/raiden-ts/tests/unit/messages.spec.ts
@@ -225,6 +225,32 @@ describe('sign/verify, pack & encode/decode ', () => {
     expect(decoded).toEqual(signed);
   });
 
+  test('LockExpired 2', () => {
+    const message = `{
+      "chain_id": "1",
+      "message_identifier": "12568622946510763377",
+      "signature": "0x47bf00f00cb12b54f77686604b314321f2537816818bab28604109653ab37e490071c136359bf92fd873a4e9a5185ca7016a690f5791e9af83181cd98db25c381c",
+      "locksroot": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+      "secrethash": "0x8bcfdc09e3fee24b8e8cd006d3db0c9f5f307aa0deb23d10d7ba5f334281308c",
+      "nonce": "2",
+      "transferred_amount": "0",
+      "locked_amount": "0",
+      "token_network_address": "0x5b606943b36f3569e00ec4178a9f83eea8730184",
+      "channel_identifier": "17",
+      "recipient": "0x14efa2b271969a46a094a23e0d49e32c1b617f89",
+      "type": "LockExpired"
+    }`;
+    const decoded = decodeJsonMessage(message) as Signed<LockExpired>;
+    expect(Signed(LockExpired).is(decoded)).toBe(true);
+    expect(createMessageHash(decoded)).toEqual(
+      '0xcce8018c2c0dd11a312ef2bb1c8fe660fe09a8a4ba37ab5824239ff459eecb5c',
+    );
+    expect(packMessage(decoded)).toEqual(
+      '0x5b606943b36f3569e00ec4178a9f83eea873018400000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000001100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002cce8018c2c0dd11a312ef2bb1c8fe660fe09a8a4ba37ab5824239ff459eecb5c',
+    );
+    expect(getMessageSigner(decoded)).toBe('0x1Fd883F06A01c537D08441065aA4b2Cf75c3CBF8');
+  });
+
   test('SecretRequest', async () => {
     const message: SecretRequest = {
       type: MessageType.SECRET_REQUEST,

--- a/raiden-ts/tests/unit/state.spec.ts
+++ b/raiden-ts/tests/unit/state.spec.ts
@@ -13,7 +13,7 @@ import {
 } from 'raiden-ts/state';
 import { Address, UInt } from 'raiden-ts/utils/types';
 import { makeDefaultConfig } from 'raiden-ts/config';
-import { SignatureZero } from 'raiden-ts/constants';
+import { SignatureZero, LocksrootZero } from 'raiden-ts/constants';
 
 describe('RaidenState codecs', () => {
   const address = '0x1111111111111111111111111111111111111111' as Address,
@@ -90,7 +90,7 @@ describe('RaidenState codecs', () => {
               nonce: '0',
               transferredAmount: '0',
               lockedAmount: '0',
-              locksroot: HashZero,
+              locksroot: LocksrootZero,
               additionalHash: HashZero,
               signature: SignatureZero,
             },
@@ -109,7 +109,7 @@ describe('RaidenState codecs', () => {
               nonce: '0',
               transferredAmount: '0',
               lockedAmount: '0',
-              locksroot: HashZero,
+              locksroot: LocksrootZero,
               additionalHash: HashZero,
               signature: SignatureZero,
             },
@@ -192,7 +192,7 @@ describe('RaidenState codecs', () => {
                 nonce: '0',
                 transferredAmount: '0',
                 lockedAmount: '0',
-                locksroot: HashZero,
+                locksroot: LocksrootZero,
                 additionalHash: HashZero,
                 signature: SignatureZero,
               },
@@ -211,7 +211,7 @@ describe('RaidenState codecs', () => {
                 nonce: '0',
                 transferredAmount: '0',
                 lockedAmount: '0',
-                locksroot: HashZero,
+                locksroot: LocksrootZero,
                 additionalHash: HashZero,
                 signature: SignatureZero,
               },

--- a/raiden-ts/tests/unit/utils.spec.ts
+++ b/raiden-ts/tests/unit/utils.spec.ts
@@ -34,6 +34,7 @@ import { LruCache } from 'raiden-ts/utils/lru';
 import { encode, losslessParse, losslessStringify } from 'raiden-ts/utils/data';
 import { getLocksroot, makeSecret, getSecrethash } from 'raiden-ts/transfers/utils';
 import { Lock } from 'raiden-ts/channels';
+import { LocksrootZero } from 'raiden-ts/constants';
 
 const { JsonRpcProvider } = jest.requireActual('ethers/providers');
 
@@ -364,6 +365,7 @@ describe('messages', () => {
     expect(getLocksroot([])).toBe(
       '0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
     );
+    expect(getLocksroot([])).toBe(LocksrootZero);
     const locks: Lock[] = [
       {
         amount: bigNumberify(1) as UInt<32>,


### PR DESCRIPTION
Fixes #1690 
Last bit of #1610 

**Short description**
That issue happens because we didn't special case `balanceHash` calculation for a BalanceProof/EnvelopeMessage coming with zero values but non-zero `locksroot`. This comes up from the fact that the locskroot of an empty Locks array isn't `HashZero`, but instead `keccak256(b'')`, which is `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`. We just need to ensure balanceHash is properly returned as HashZero on this case, and then the message which caused that issue will be properly verified the same as is done in Raiden Core.
This includes regression tests.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. With receiving disabled, make a transfer from a Raiden Python node
2. The transfer will be received but the protocol won't proceed
3. Let it expire, and check the `LockExpired` message is properly handled.
