### PR TITLE
Fix estimateGas errors on concurrent channelOpen + deposit not being properly handled

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#1637] Fix depositToUDC failing if services already have withdrawn some fees
 - [#1651] Fix PFS being disabled if passed an undefined default config
 - [#1690] Fix LockExpired with empty balanceHash verification
+- [#1698] Fix estimateGas errors on channelOpen not properly being handled
 
 ### Added
 - [#1421] Adds support for withdrawing tokens from the UDC
@@ -29,6 +30,7 @@
 [#1649]: https://github.com/raiden-network/light-client/pull/1649
 [#1651]: https://github.com/raiden-network/light-client/issues/1651
 [#1690]: https://github.com/raiden-network/light-client/issues/1690
+[#1698]: https://github.com/raiden-network/light-client/issues/1698
 [#1701]: https://github.com/raiden-network/light-client/pull/1701
 
 ## [0.9.0] - 2020-05-28


### PR DESCRIPTION
Fixes #1698

**Short description**
So far, `channelOpenEpic` was only checking errors on receipt, i.e. after tx was sent and mined. But ethers v4 is helpful by first estimating gas for a tx without `gasLimit` set, and will throw before submitting (i.e. on tx promise) if a tx would aways fail. This is very good as it saves gas by not even sending a failing tx (e.g. because of not enough funds, as on the linked issue). This, however, makes the tx sending promise to reject, and we weren't handling this properly for approve/setTotalDeposit transactions on openChannel. This PR fixes this, and also split from it and `channelDepositEpic` a function which constructs an observable which performs the deposit, deduplicating the logic while still allowing it to be done in parallel with channelOpen (on channelOpen), or standalone on channelDeposit.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. There are proper unit and e2e test to check this functionality is still working
2. To test the fix, trigger the bug, and check despite `channelDeposit.failure`, channelOpen still resolves correctly
