### PR TITLE
Adjust modifiers and add some properties to RaidenChannel & RaidenTransfer interfaces

### DIFF
--- a/raiden-cli/src/utils/channels.ts
+++ b/raiden-cli/src/utils/channels.ts
@@ -26,17 +26,16 @@ export function filterChannels(
   return filteredChannels;
 }
 
-/* eslint-disable @typescript-eslint/camelcase */
 export function transformSdkChannelFormatToApi(channel: RaidenChannel): ApiChannel {
   return {
-    channel_identifier: channel.id ?? 0, // FIXME: old "bug" in the SDK
+    channel_identifier: channel.id,
     token_network_address: channel.tokenNetwork,
     partner_address: channel.partner,
     token_address: channel.token,
     balance: channel.balance.toString(),
     total_deposit: channel.ownDeposit.toString(),
     state: channel.state,
-    settle_timeout: channel.settleTimeout ?? 0,
+    settle_timeout: channel.settleTimeout,
     reveal_timeout: 0, // FIXME: Not defined here. Python client handles reveal timeout differently,
   };
 }

--- a/raiden-dapp/src/components/navigation/Channels.vue
+++ b/raiden-dapp/src/components/navigation/Channels.vue
@@ -110,7 +110,7 @@ export default class Channels extends Mixins(NavigationMixin) {
     const { expanded, channel } = payload;
     if (expanded) {
       this.selectedChannel = channel;
-      this.expanded = { [channel.id ?? -1]: true };
+      this.expanded = { [channel.id]: true };
     } else {
       this.selectedChannel = null;
       const updates = { ...this.expanded };

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -18,6 +18,8 @@
 - [#1610] Updates smart contracts to v0.37.0 (Alderaan)
 - [#837] Changes the action tags from camel to path format. This change affects the event types exposed through the public API.
 - [#1649] Have constant error messages and codes in public Raiden API.
+- [#1657] Expose RaidenChannel's id,settleTimeout,openBlock as required properties
+- [#1708] Expose RaidenTransfer's secret as optional property
 
 [#837]: https://github.com/raiden-network/light-client/issues/837
 [#1421]: https://github.com/raiden-network/light-client/issues/1421
@@ -28,8 +30,10 @@
 [#1642]: https://github.com/raiden-network/light-client/issues/1642
 [#1649]: https://github.com/raiden-network/light-client/pull/1649
 [#1651]: https://github.com/raiden-network/light-client/issues/1651
+[#1657]: https://github.com/raiden-network/light-client/issues/1657
 [#1690]: https://github.com/raiden-network/light-client/issues/1690
 [#1701]: https://github.com/raiden-network/light-client/pull/1701
+[#1708]: https://github.com/raiden-network/light-client/issues/1708
 
 ## [0.9.0] - 2020-05-28
 ### Added

--- a/raiden-ts/src/channels/state.ts
+++ b/raiden-ts/src/channels/state.ts
@@ -104,9 +104,9 @@ export interface RaidenChannel {
   // "distributable" capacity of channel, sum of own total deposit and balance (which as usually
   // negative, decreases capacity)
   capacity: BigNumber;
-  id?: number;
-  settleTimeout?: number;
-  openBlock?: number;
+  id: number;
+  settleTimeout: number;
+  openBlock: number;
   closeBlock?: number;
 }
 

--- a/raiden-ts/src/transfers/state.ts
+++ b/raiden-ts/src/transfers/state.ts
@@ -148,4 +148,5 @@ export interface RaidenTransfer {
    * False if transfer still has pending actions (even if success status is already known)
    */
   completed: boolean;
+  secret?: Secret;
 }

--- a/raiden-ts/src/transfers/utils.ts
+++ b/raiden-ts/src/transfers/utils.ts
@@ -184,6 +184,7 @@ export function raidenTransfer(state: TransferState): RaidenTransfer {
     changedAt,
     success,
     completed,
+    secret: state.secret?.[1]?.value,
   };
 }
 


### PR DESCRIPTION
Fixes #1657 
Fixes #1708 

**Short description**
`RaidenChannel`'s `id`, `settleTimeout` and `openBlock` are marked as required and therefore always defined
`RaidenTransfer`'s `secret` is added as optional property, and'll hold transfer's secret whenever we know it (usually true for sent transfers)

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Nothing to test, mostly types and public data adjustments
