### PR TITLE
dApp: Serialized error messages for logs

### DIFF
--- a/raiden-dapp/src/utils/logstore.ts
+++ b/raiden-dapp/src/utils/logstore.ts
@@ -89,10 +89,23 @@ export async function setupLogStore(
       return (...message: any[]): void => {
         rawMethod(...message);
         const filtered = filterMessage(message);
+
         if (!filtered) return;
+
+        const serializedFilteredMessage = filtered.map(message => {
+          if (message === 'object') {
+            JSON.stringify(message);
+          }
+          return message;
+        });
+
         db.put(
           collectionName,
-          { logger: loggerName, level: methodName, message },
+          {
+            logger: loggerName,
+            level: methodName,
+            message: serializedFilteredMessage
+          },
           Date.now()
         ).catch(() =>
           db.put(

--- a/raiden-dapp/src/utils/logstore.ts
+++ b/raiden-dapp/src/utils/logstore.ts
@@ -89,22 +89,13 @@ export async function setupLogStore(
       return (...message: any[]): void => {
         rawMethod(...message);
         const filtered = filterMessage(message);
-
         if (!filtered) return;
-
-        const serializedFilteredMessage = filtered.map(message => {
-          if (message === 'object') {
-            JSON.stringify(message);
-          }
-          return message;
-        });
-
         db.put(
           collectionName,
           {
             logger: loggerName,
             level: methodName,
-            message: serializedFilteredMessage
+            message: filtered
           },
           Date.now()
         ).catch(() =>


### PR DESCRIPTION
Fixes #1292 

**Short description**
These changes solve the issue with the errors not appearing in the logs. Let me know if this is the correct approach. I believe it makes more sense to add the code as part of the `serialize` function but I will let you @andrevmatos provide feedback first.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to the dApp.
2. Trigger an error, i.e. trying to receive transfers from a LC that does not have receiving enabled.
