### PR TITLE
sdk: Fix waiting for failed deposit on Raiden.openChannel

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#1651] Fix PFS being disabled if passed an undefined default config
 - [#1690] Fix LockExpired with empty balanceHash verification
 - [#1698] Fix estimateGas errors on channelOpen not properly being handled
+- [#1761] Fix deposit error on openChannel not rejecting promise
 
 ### Added
 - [#1374] Monitors MonitoringService contract and emit event when MS acts
@@ -41,6 +42,8 @@
 [#1701]: https://github.com/raiden-network/light-client/pull/1701
 [#1708]: https://github.com/raiden-network/light-client/issues/1708
 [#1705]: https://github.com/raiden-network/light-client/issues/1705
+[#1711]: https://github.com/raiden-network/light-client/pull/1711
+[#1761]: https://github.com/raiden-network/light-client/issues/1761
 
 ## [0.9.0] - 2020-05-28
 ### Added

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -615,9 +615,15 @@ export class Raiden {
 
     const meta = { tokenNetwork, partner };
     // wait for confirmation
-    const openPromise = asyncActionToPromise(channelOpen, meta, this.action$, false).then(
+    const openPromise = asyncActionToPromise(channelOpen, meta, this.action$, true).then(
       ({ txHash }) => txHash, // pluck txHash
     );
+    let depositPromise;
+    if (deposit) {
+      depositPromise = asyncActionToPromise(channelDeposit, meta, this.action$, true).then(
+        ({ txHash }) => txHash, // pluck txHash
+      );
+    }
 
     this.store.dispatch(channelOpen.request({ ...options, settleTimeout, deposit }, meta));
 
@@ -632,10 +638,8 @@ export class Raiden {
       .toPromise();
     onChange?.({ type: EventTypes.CONFIRMED, payload: { txHash: openTxHash } });
 
-    if (deposit) {
-      const depositTx = await asyncActionToPromise(channelDeposit, meta, this.action$, true).then(
-        ({ txHash }) => txHash, // pluck txHash
-      );
+    if (depositPromise) {
+      const depositTx = await depositPromise;
       onChange?.({ type: EventTypes.DEPOSITED, payload: { txHash: depositTx } });
     }
 


### PR DESCRIPTION
Fixes #1761 

**Short description**
The error can happen, it's expected (e.g. if not enough funds or gas), but we must catch it and reject the promise properly. This was being missed because the promise was created only after the deposit succeeds, which happen after the deposit failure already was emitted.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Test bug properly rejects the dialog.
