### PR TITLE
sdk: adjust monitor request epic default behavior

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [#1649] Have constant error messages and codes in public Raiden API.
 - [#1657] Expose RaidenChannel's id,settleTimeout,openBlock as required properties
 - [#1708] Expose RaidenTransfer's secret as optional property
+- [#1705] All transfers become monitored per default to make receiving transfers safe
 
 [#837]: https://github.com/raiden-network/light-client/issues/837
 [#1374]: https://github.com/raiden-network/light-client/issues/1374
@@ -39,6 +40,7 @@
 [#1698]: https://github.com/raiden-network/light-client/issues/1698
 [#1701]: https://github.com/raiden-network/light-client/pull/1701
 [#1708]: https://github.com/raiden-network/light-client/issues/1708
+[#1705]: https://github.com/raiden-network/light-client/issues/1705
 
 ## [0.9.0] - 2020-05-28
 ### Added

--- a/raiden-ts/src/epics.ts
+++ b/raiden-ts/src/epics.ts
@@ -14,7 +14,6 @@ import {
 import { MaxUint256 } from 'ethers/constants';
 import negate from 'lodash/negate';
 import unset from 'lodash/fp/unset';
-import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
 
 import { RaidenState } from './state';
@@ -51,9 +50,7 @@ function getConfig$(
             ? userConfig.caps
             : {
                 [Capabilities.NO_RECEIVE]: !(
-                  config.monitoringReward?.gt(0) &&
-                  config.monitoringReward.lte(udcBalance) &&
-                  !isEmpty(config.rateToSvt)
+                  config.monitoringReward?.gt(0) && config.monitoringReward.lte(udcBalance)
                 ),
                 ...config.caps, // default and user config overwrite runtime caps above
               };

--- a/raiden-ts/tests/unit/epics/monitor.spec.ts
+++ b/raiden-ts/tests/unit/epics/monitor.spec.ts
@@ -237,6 +237,19 @@ describe('monitorRequestEpic', () => {
     signerSpy.mockRestore();
   });
 
+  test('success: token without known rateToSvt gets monitored', async () => {
+    expect.assertions(1);
+
+    action$.next(raidenConfigUpdate({ rateToSvt: {} }));
+
+    const promise = monitorRequestEpic(action$, state$, depsMock).toPromise();
+    action$.next(udcDeposited(monitoringReward.mul(2) as UInt<32>));
+    await receiveTransfer(20);
+    setTimeout(() => action$.complete(), 50);
+
+    await expect(promise).resolves.toBeDefined();
+  });
+
   test('ignore: not enough udcBalance', async () => {
     expect.assertions(1);
 
@@ -303,21 +316,6 @@ describe('monitorRequestEpic', () => {
 
     // transfer <= monitoringReward isn't worth to be monitored
     await receiveTransfer(20, false);
-    setTimeout(() => action$.complete(), 50);
-
-    await expect(promise).resolves.toBeUndefined();
-  });
-
-  test('ignore: token without known rateToSvt', async () => {
-    expect.assertions(1);
-
-    action$.next(raidenConfigUpdate({ rateToSvt: {} }));
-
-    const promise = monitorRequestEpic(action$, state$, depsMock).toPromise();
-    action$.next(udcDeposited(monitoringReward.mul(2) as UInt<32>));
-
-    // transfer <= monitoringReward isn't worth to be monitored
-    await receiveTransfer(20);
     setTimeout(() => action$.complete(), 50);
 
     await expect(promise).resolves.toBeUndefined();

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -528,8 +528,7 @@ describe('transport epic', () => {
     );
     await expect(promise).resolves.toBeUndefined();
     expect(matrix.setAvatarUrl).toHaveBeenCalledTimes(1);
-    // noReceive is dynamic
-    expect(matrix.setAvatarUrl).toHaveBeenCalledWith('noReceive,noDelivery,webRTC');
+    expect(matrix.setAvatarUrl).toHaveBeenCalledWith('noDelivery,webRTC');
 
     promise = matrixUpdateCapsEpic(action$, state$, depsMock).toPromise();
     action$.next(


### PR DESCRIPTION
Fixes #1705

**Short description**

Well, basically just execute what got described in the linked issue.

I failed to find a way how I can force the own balance to become zero for the new case to skip the monitor request. Please **help**.


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [x] Change has been manually tested by the reviewer (dApp) 
