### PR TITLE
dapp: Fix non-informative error message on SDK's wrapped errors

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -10,11 +10,13 @@
 ### Fixed
 
 - [#1579] Removes minting references when detected network is mainnet.
+- [#1756] Fix non-informative error message on SDK's wrapped errors
 
 ### Changed
 - [#1610] Adds alderaan compatibility.
 - [#1540] Adds title to channels list to clarify that only channels for the selected token display.
 
+[#1756]: https://github.com/raiden-network/light-client/issues/1756
 [#1610]: https://github.com/raiden-network/light-client/issues/1610
 [#1540]: https://github.com/raiden-network/light-client/issues/1540
 [#1579]: https://github.com/raiden-network/light-client/issues/1579

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -279,37 +279,21 @@ export default class RaidenService {
     const raiden = this.raiden;
     progressUpdater(1, 3);
 
-    try {
-      await raiden.openChannel(token, partner, { deposit: amount }, e =>
-        e.type === EventTypes.OPENED ? progressUpdater(2, 3) : ''
-      );
-    } catch (e) {
-      throw new ChannelOpenFailed(e);
-    }
+    await raiden.openChannel(token, partner, { deposit: amount }, e =>
+      e.type === EventTypes.OPENED ? progressUpdater(2, 3) : ''
+    );
   }
 
   async closeChannel(token: string, partner: string) {
-    try {
-      await this.raiden.closeChannel(token, partner);
-    } catch (e) {
-      throw new ChannelCloseFailed(e);
-    }
+    await this.raiden.closeChannel(token, partner);
   }
 
   async deposit(token: string, partner: string, amount: BigNumber) {
-    try {
-      await this.raiden.depositChannel(token, partner, amount);
-    } catch (e) {
-      throw new ChannelDepositFailed(e);
-    }
+    await this.raiden.depositChannel(token, partner, amount);
   }
 
   async settleChannel(token: string, partner: string) {
-    try {
-      await this.raiden.settleChannel(token, partner);
-    } catch (e) {
-      throw new ChannelSettleFailed(e);
-    }
+    await this.raiden.settleChannel(token, partner);
   }
 
   async fetchTokenData(tokens: string[]): Promise<void> {
@@ -330,17 +314,13 @@ export default class RaidenService {
     paths: RaidenPaths,
     paymentId: BigNumber
   ) {
-    try {
-      const key = await this.raiden.transfer(token, target, amount, {
-        paymentId,
-        paths
-      });
+    const key = await this.raiden.transfer(token, target, amount, {
+      paymentId,
+      paths
+    });
 
-      // Wait for transaction to be completed
-      await this.raiden.waitTransfer(key);
-    } catch (e) {
-      throw new TransferFailed(e);
-    }
+    // Wait for transaction to be completed
+    await this.raiden.waitTransfer(key);
   }
 
   async findRoutes(
@@ -483,16 +463,6 @@ export default class RaidenService {
   }
 }
 
-export class ChannelSettleFailed extends Error {}
-
-export class ChannelCloseFailed extends Error {}
-
-export class ChannelOpenFailed extends Error {}
-
-export class ChannelDepositFailed extends Error {}
-
 export class EnsResolveFailed extends Error {}
-
-export class TransferFailed extends Error {}
 
 export class RaidenInitializationFailed extends Error {}


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #1756 

**Short description**
Wrapping errors as previously done on the RaidenService doesn't work, since passing Error objects to an `Error` constructur gets it serialized as unhelpful `"[object Object]"` string.
This fixes the error by exposing the original instance, as expected by `ErrorMessage.vue` component. If it's a known error, expected message is shown. Otherwise, the much more informative original message is shown.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Try to trigger the bug, as described