### PR TITLE
Fix PFSFeeUpdates not being sent and preventing mediation

### DIFF
--- a/raiden-ts/src/transport/epics/init.ts
+++ b/raiden-ts/src/transport/epics/init.ts
@@ -78,6 +78,7 @@ function joinGlobalRooms(config: RaidenConfig, matrix: MatrixClient): Observable
           }),
         ]);
         matrix.store.storeRoom(room);
+        matrix.emit('Room', room);
         return room;
       }),
     ),

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -774,21 +774,21 @@ describe('transport epic', () => {
     );
 
     test(
-      'do not leave discovery room',
+      'do not leave global room',
       fakeSchedulers((advance) => {
         expect.assertions(2);
 
         const roomId = `!discoveryRoomId:${matrixServer}`,
           state$ = of(state),
-          name = `#raiden_${depsMock.network.name}_discovery:${matrixServer}`;
+          roomAlias = `#raiden_${depsMock.network.name}_discovery:${matrixServer}`;
 
         matrix.getRoom.mockReturnValueOnce({
           roomId,
-          name,
+          name: undefined,
           getMember: jest.fn(),
           getJoinedMembers: jest.fn(() => []),
-          getCanonicalAlias: jest.fn(() => name),
-          getAliases: jest.fn(() => []),
+          getCanonicalAlias: jest.fn(() => null),
+          getAliases: jest.fn(() => [roomAlias]),
           currentState: {
             roomId,
             setStateEvents: jest.fn(),


### PR DESCRIPTION
Fixes #1777

**Description**
Fixes the described issue.
Additionally, this includes some very relevant improvements to debouncing behafor for `PFSCapacityUpdate` and `RequestMonitoring` epics. Instead of some absolute debouncing, now `pairwise` operator helps compare a channel state with the previous one. This allows debouncing **only** when a pending transfer gets reduced (meaning there's a big chance of it being completed on next seconds) and allowing us to save some signatures and messages/http roundtrips (original intent of the debounces), while being smarter about when a transfer got completed instead or a deposit was made, skipping the debounce timeout and acting right away. There're tests for these specific behaviors.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Check issue doens't happen when mediation is enabled
2. PFSCapacityUpdate and MonitoringRequest are performed immediatelly when a transfer succeeds or a deposit gets confirmed, and are debounced on transfer pending.
