### PR TITLE
dapp: Fixes duplicate withdrawn notification

### DIFF
--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -193,6 +193,9 @@ export default class RaidenService {
               value.payload.txHash
             );
           } else if (value.type === 'udc/withdrawn') {
+            if (!value.payload.confirmed) {
+              return;
+            }
             await this.notifyWithdrawal(
               value.meta.amount,
               value.payload.withdrawal

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -757,7 +757,8 @@ describe('RaidenService', () => {
     subject.next({
       type: 'udc/withdrawn',
       payload: {
-        withdrawal: parseEther('5')
+        withdrawal: parseEther('5'),
+        confirmed: true
       },
       meta: {
         amount: parseEther('5')


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

**Short description**
The withdrawn action is fired twice, once as normal and one as confirmed.

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
