### PR TITLE
Use tar.gz build artifacts compatible with buster docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,9 +193,9 @@ jobs:
             fi
       - run:
           name: Compress dapp
-          command: tar -cjf dapp.tar.bz2 dist
+          command: tar -czvf dapp.tar.gz dist
       - store_artifacts:
-          path: dapp.tar.bz2
+          path: dapp.tar.gz
       - persist_to_workspace:
           root: ~/src
           paths:

--- a/serve_pr/ci_dapp.sh
+++ b/serve_pr/ci_dapp.sh
@@ -30,8 +30,8 @@ for PIPELINE in $PIPELINES; do
     log "Pull Request: ${PULL}"
     PULLDIR="${PWD}/${PULL}"
     mkdir -p "${PULLDIR}"
-    OLDFILE="$PULLDIR/dapp.prev.tar.bz2"
-    OUTFILE="$PULLDIR/dapp.tar.bz2"
+    OLDFILE="$PULLDIR/dapp.prev.tar.gz"
+    OUTFILE="$PULLDIR/dapp.tar.gz"
     $CURL -L -o "$OUTFILE" -z "$OLDFILE" "$URL" && SUCCESS=1
     [[ "$SUCCESS" == 1 ]] && break
   done


### PR DESCRIPTION
**Short description**
Small PR to move build artifact to tar.gz, available on `buster` docker images (bz2 and xz aren't available out of the box).

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
