### PR TITLE
Disables button and modal when withdrawal is done

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -10,27 +10,28 @@
 
 ### Fixed
 
+- [#1788] Bug where button is displayed and modal not closing on UDC withdrawal
 - [#1781] Transparent dialog overlay for Firefox
 - [#1783] Minor visual alignments
 - [#1579] Removes minting references when detected network is mainnet.
-- [#1756] Fix non-informative error message on SDK's wrapped errors
 - [#1773] Fix performance issues of progress indicators
+- [#1756] Fix non-informative error message on SDK's wrapped errors
 
 ### Changed
 
 - [#1610] Adds alderaan compatibility.
 - [#1540] Adds title to channels list to clarify that only channels for the selected token display.
 
-[#1781]: https://github.com/raiden-network/light-client/issues/1781
+[#1788]: https://github.com/raiden-network/light-client/issues/1788
 [#1783]: https://github.com/raiden-network/light-client/issues/1783
 [#1756]: https://github.com/raiden-network/light-client/issues/1756
+[#1773]: https://github.com/raiden-network/light-client/issues/1773
 [#1610]: https://github.com/raiden-network/light-client/issues/1610
 [#1540]: https://github.com/raiden-network/light-client/issues/1540
 [#1579]: https://github.com/raiden-network/light-client/issues/1579
 [#1421]: https://github.com/raiden-network/light-client/issues/1421
 [#1374]: https://github.com/raiden-network/light-client/issues/1374
 [#168]: https://github.com/raiden-network/light-client/issues/168
-[#1773]: https://github.com/raiden-network/light-client/issues/1773
 
 ## [0.9.0] - 2020-05-28
 

--- a/raiden-dapp/src/components/dialogs/UdcWithdrawalDialog.vue
+++ b/raiden-dapp/src/components/dialogs/UdcWithdrawalDialog.vue
@@ -53,7 +53,7 @@
         </v-col>
       </v-row>
     </v-card-text>
-    <v-card-actions v-if="!error">
+    <v-card-actions v-if="!error && !isDone">
       <action-button
         :enabled="isValid"
         :text="$t('general.buttons.confirm')"
@@ -112,6 +112,7 @@ export default class UdcWithdrawalDialog extends Vue {
     this.isDone = true;
     setTimeout(() => {
       this.isDone = false;
+      this.cancel();
     }, 5000);
   }
 

--- a/raiden-dapp/tests/unit/components/dialogs/udc-withdrawal-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/dialogs/udc-withdrawal-dialog.spec.ts
@@ -76,4 +76,23 @@ describe('UdcWithdrawalDialog.vue', function() {
     wrapper.setData({ amount: '10' });
     expect((wrapper.vm as any).isValid).toBe(true);
   });
+
+  describe('with timers', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    test('emits cancel after done', async () => {
+      jest.useFakeTimers();
+      wrapper.setData({ amount: '10' });
+      await (wrapper.vm as any).planWithdraw();
+      jest.advanceTimersByTime(5000);
+      expect(wrapper.emitted('cancel')).toBeTruthy();
+      jest.useRealTimers();
+    });
+  });
 });


### PR DESCRIPTION
Fixes #1788

**Short description**
Makes sure the button is hidden once the withdrawal is confirmed and closes the dialog on the UDC screen.


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [x] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to the dApp and withdraw tokens from the UDC screen.

