### PR TITLE
Refactor TokenNetwork events fetching

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#1690] Fix LockExpired with empty balanceHash verification
 - [#1698] Fix estimateGas errors on channelOpen not properly being handled
 - [#1761] Fix deposit error on openChannel not rejecting promise
+- [#1787] Fix TokenNetwork monitoring losing events
 
 ### Added
 - [#1374] Monitors MonitoringService contract and emit event when MS acts
@@ -25,6 +26,7 @@
 - [#1657] Expose RaidenChannel's id,settleTimeout,openBlock as required properties
 - [#1708] Expose RaidenTransfer's secret as optional property
 - [#1705] All transfers become monitored per default to make receiving transfers safe
+- [#1822] Refactor and optimize TokenNetwork events monitoring: one filter per Tokennetwork
 
 [#837]: https://github.com/raiden-network/light-client/issues/837
 [#1374]: https://github.com/raiden-network/light-client/issues/1374
@@ -44,6 +46,8 @@
 [#1705]: https://github.com/raiden-network/light-client/issues/1705
 [#1711]: https://github.com/raiden-network/light-client/pull/1711
 [#1761]: https://github.com/raiden-network/light-client/issues/1761
+[#1787]: https://github.com/raiden-network/light-client/issues/1787
+[#1822]: https://github.com/raiden-network/light-client/pull/1822
 
 ## [0.9.0] - 2020-05-28
 ### Added

--- a/raiden-ts/src/channels/actions.ts
+++ b/raiden-ts/src/channels/actions.ts
@@ -28,6 +28,7 @@ export const tokenMonitored = createAction(
     }),
     t.partial({
       fromBlock: t.number,
+      toBlock: t.number,
     }),
   ]),
 );
@@ -60,12 +61,12 @@ export namespace channelOpen {
 }
 
 /* Channel with meta:ChannelId + payload.id should be monitored */
-export const channelMonitor = createAction(
-  'channel/monitor',
-  t.intersection([t.type({ id: t.number }), t.partial({ fromBlock: t.number })]),
+export const channelMonitored = createAction(
+  'channel/monitored',
+  t.type({ id: t.number }),
   ChannelId,
 );
-export interface channelMonitor extends ActionType<typeof channelMonitor> {}
+export interface channelMonitored extends ActionType<typeof channelMonitored> {}
 
 export const channelDeposit = createAsyncAction(
   ChannelId,

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -554,11 +554,9 @@ export class Raiden {
    */
   public async monitorToken(token: string): Promise<Address> {
     assert(Address.is(token), [ErrorCodes.DTA_INVALID_ADDRESS, { token }], this.log.info);
-    const alreadyMonitoredTokens = this.state.tokens;
-    if (token in alreadyMonitoredTokens) return alreadyMonitoredTokens[token];
-    const tokenNetwork = (await this.deps.registryContract.token_to_token_networks(
-      token,
-    )) as Address;
+    let tokenNetwork = this.state.tokens[token];
+    if (tokenNetwork) return tokenNetwork;
+    tokenNetwork = (await this.deps.registryContract.token_to_token_networks(token)) as Address;
     assert(
       tokenNetwork && tokenNetwork !== AddressZero,
       ErrorCodes.RDN_UNKNOWN_TOKEN_NETWORK,

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -435,7 +435,7 @@ export const pfsCapacityUpdateEpic = (
  * PFSFeeUpdate to path_finding global room, so PFSs can pick us for mediation
  * TODO: Currently, we always send Zero fees; we should send correct fee data from config
  *
- * @param action$ - Observable of channelMonitor actions
+ * @param action$ - Observable of channelMonitored actions
  * @param state$ - Observable of RaidenStates
  * @param deps - Raiden epic dependencies
  * @param deps.log - Logger instance

--- a/raiden-ts/src/transport/epics/presence.ts
+++ b/raiden-ts/src/transport/epics/presence.ts
@@ -32,7 +32,7 @@ import { RaidenState } from '../../state';
 import { getUserPresence } from '../../utils/matrix';
 import { pluckDistinct } from '../../utils/rx';
 import { matrixPresence } from '../actions';
-import { channelMonitor } from '../../channels/actions';
+import { channelMonitored } from '../../channels/actions';
 import { parseCaps, stringifyCaps } from '../utils';
 
 // unavailable just means the user didn't do anything over a certain amount of time, but they're
@@ -256,7 +256,7 @@ export const matrixMonitorChannelPresenceEpic = (
   action$: Observable<RaidenAction>,
 ): Observable<matrixPresence.request> =>
   action$.pipe(
-    filter(channelMonitor.is),
+    filter(channelMonitored.is),
     map((action) => matrixPresence.request(undefined, { address: action.meta.partner })),
   );
 

--- a/raiden-ts/src/transport/epics/rooms.ts
+++ b/raiden-ts/src/transport/epics/rooms.ts
@@ -28,7 +28,7 @@ import { Address, isntNil } from '../../utils/types';
 import { isActionOf } from '../../utils/actions';
 import { RaidenEpicDeps } from '../../types';
 import { RaidenAction } from '../../actions';
-import { channelMonitor } from '../../channels/actions';
+import { channelMonitored } from '../../channels/actions';
 import { messageSend, messageReceived } from '../../messages/actions';
 import { transferSigned } from '../../transfers/actions';
 import { RaidenState } from '../../state';
@@ -104,7 +104,7 @@ function inviteLoop$(
  * Create room (if needed) for a transfer's target, channel's partner or, as a fallback, for any
  * recipient of a messageSend.request action
  *
- * @param action$ - Observable of transferSigned|channelMonitor|messageSend.request actions
+ * @param action$ - Observable of transferSigned|channelMonitored|messageSend.request actions
  * @param state$ - Observable of RaidenStates
  * @param deps - RaidenEpicDeps members
  * @param deps.address - Our address
@@ -122,7 +122,7 @@ export const matrixCreateRoomEpic = (
   action$.pipe(
     // ensure there's a room for address of interest for each of these actions
     // matrixRoomLeave ensures a new room is created if all we had are forgotten/left
-    filter(isActionOf([transferSigned, channelMonitor, messageSend.request, matrixRoomLeave])),
+    filter(isActionOf([transferSigned, channelMonitored, messageSend.request, matrixRoomLeave])),
     map((action) => {
       let peer;
       switch (action.type) {
@@ -138,7 +138,7 @@ export const matrixCreateRoomEpic = (
           )
             peer = action.payload.message.initiator;
           break;
-        case channelMonitor.type:
+        case channelMonitored.type:
           peer = action.meta.partner;
           break;
         default:

--- a/raiden-ts/src/utils/rx.ts
+++ b/raiden-ts/src/utils/rx.ts
@@ -1,4 +1,4 @@
-import { Observable, OperatorFunction, from } from 'rxjs';
+import { Observable, OperatorFunction, pairs } from 'rxjs';
 import { pluck, distinctUntilChanged, mergeMap, scan, filter } from 'rxjs/operators';
 import { isntNil } from './types';
 
@@ -70,7 +70,7 @@ export function distinctRecordValues<R>(
   return (input: Observable<Record<string, R>>): Observable<[string, R]> =>
     input.pipe(
       distinctUntilChanged(),
-      mergeMap((map) => from(Object.entries(map))),
+      mergeMap((map) => pairs<R>(map)),
       /* this scan stores a reference to each [key,value] in 'acc', and emit as 'changed' iff it
        * changes from last time seen. It relies on value references changing only if needed */
       scan<[string, R], { acc: { [k: string]: R }; changed?: [string, R] }>(

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -482,6 +482,8 @@ describe('Raiden', () => {
       raiden.state$.subscribe((state) => (raidenState = state));
       raiden.start();
 
+      await provider.mine(5);
+
       // ensure after hot boot, state is rehydrated and contains (only) previous token
       expect(raidenState).toBeDefined();
       expect(raidenState!.tokens).toEqual({ [token]: tokenNetwork });
@@ -633,11 +635,13 @@ describe('Raiden', () => {
       await expect(raiden.monitorToken(token)).resolves.toBe(tokenNetwork);
 
       await expect(promise).resolves.toEqual(
-        tokenMonitored({
-          fromBlock: expect.any(Number),
-          token: token as Address,
-          tokenNetwork: tokenNetwork as Address,
-        }),
+        tokenMonitored(
+          expect.objectContaining({
+            fromBlock: expect.any(Number),
+            token: token as Address,
+            tokenNetwork: tokenNetwork as Address,
+          }),
+        ),
       );
 
       // while partner is not yet initialized, open a channel with them
@@ -654,11 +658,13 @@ describe('Raiden', () => {
       // promise1, contrary to promise, should resolve at initialization, upon first scan
       // detects tokenNetwork as being of interest for having a channel with parner
       await expect(promise1).resolves.toEqual(
-        tokenMonitored({
-          fromBlock: expect.any(Number),
-          token: token as Address,
-          tokenNetwork: tokenNetwork as Address,
-        }),
+        tokenMonitored(
+          expect.objectContaining({
+            fromBlock: expect.any(Number),
+            token: token as Address,
+            tokenNetwork: tokenNetwork as Address,
+          }),
+        ),
       );
 
       raiden1.stop();

--- a/raiden-ts/tests/unit/actions.spec.ts
+++ b/raiden-ts/tests/unit/actions.spec.ts
@@ -2,7 +2,7 @@ import * as t from 'io-ts';
 import { from } from 'rxjs';
 import { bigNumberify } from 'ethers/utils';
 
-import { channelDeposit, channelMonitor } from 'raiden-ts/channels/actions';
+import { channelDeposit, channelMonitored } from 'raiden-ts/channels/actions';
 import { RaidenError, ErrorCodec, ErrorCodes } from 'raiden-ts/utils/error';
 import { Address, UInt, decode } from 'raiden-ts/utils/types';
 import {
@@ -19,12 +19,11 @@ import { ConfirmableAction } from 'raiden-ts/actions';
 describe('action factories not tested in reducers.spec.ts', () => {
   const tokenNetwork = '0x0000000000000000000000000000000000020001' as Address,
     partner = '0x0000000000000000000000000000000000000020' as Address;
-  test('channelMonitor', () => {
-    const id = 12,
-      fromBlock = 5123;
-    expect(channelMonitor({ id, fromBlock }, { tokenNetwork, partner })).toEqual({
-      type: channelMonitor.type,
-      payload: { id, fromBlock },
+  test('channelMonitored', () => {
+    const id = 12;
+    expect(channelMonitored({ id }, { tokenNetwork, partner })).toEqual({
+      type: channelMonitored.type,
+      payload: { id },
       meta: { tokenNetwork, partner },
     });
   });

--- a/raiden-ts/tests/unit/epics/path.spec.ts
+++ b/raiden-ts/tests/unit/epics/path.spec.ts
@@ -13,7 +13,7 @@ import {
   channelOpen,
   channelDeposit,
   channelClose,
-  channelMonitor,
+  channelMonitored,
 } from 'raiden-ts/channels/actions';
 import { raidenConfigUpdate, RaidenAction } from 'raiden-ts/actions';
 import { matrixPresence } from 'raiden-ts/transport/actions';
@@ -1282,7 +1282,7 @@ describe('PFS: pfsFeeUpdateEpic', () => {
       txHash,
     } = epicFixtures(depsMock));
     state$ = depsMock.latest$.pipe(pluck('state'));
-    action = channelMonitor({ id: channelId }, { tokenNetwork, partner });
+    action = channelMonitored({ id: channelId }, { tokenNetwork, partner });
 
     [
       raidenConfigUpdate({
@@ -1313,7 +1313,7 @@ describe('PFS: pfsFeeUpdateEpic', () => {
     depsMock.latest$.complete();
   });
 
-  test('success: send PFSFeeUpdate to global pfsRoom on channelMonitor', async () => {
+  test('success: send PFSFeeUpdate to global pfsRoom on channelMonitored', async () => {
     expect.assertions(1);
 
     const promise = pfsFeeUpdateEpic(action$, state$, depsMock).toPromise();

--- a/raiden-ts/tests/unit/epics/raiden.spec.ts
+++ b/raiden-ts/tests/unit/epics/raiden.spec.ts
@@ -14,9 +14,15 @@ import {
 import { defaultAbiCoder } from 'ethers/utils/abi-coder';
 
 import { raidenShutdown } from 'raiden-ts/actions';
-import { newBlock, tokenMonitored, channelMonitor, channelOpen } from 'raiden-ts/channels/actions';
+import {
+  newBlock,
+  tokenMonitored,
+  channelMonitored,
+  channelOpen,
+} from 'raiden-ts/channels/actions';
 import { ShutdownReason } from 'raiden-ts/constants';
 import { RaidenError, ErrorCodes } from 'raiden-ts/utils/error';
+import { first, pluck } from 'rxjs/operators';
 
 const partner = makeAddress();
 
@@ -29,18 +35,7 @@ describe('raiden init epics', () => {
     expect(raiden.output).toContainEqual(newBlock({ blockNumber: expect.any(Number) }));
   });
 
-  test('init previous tokenMonitored', async () => {
-    expect.assertions(2);
-    const raiden = await makeRaiden(undefined, false);
-    // change initial state before starting
-    raiden.store.dispatch(tokenMonitored({ token, tokenNetwork }));
-    expect(raiden.store.getState().tokens).toEqual({ [token]: tokenNetwork });
-    await raiden.start();
-    await waitBlock();
-    expect(raiden.output).toContainEqual(tokenMonitored({ token, tokenNetwork }));
-  });
-
-  test('init tokenMonitored with scanned tokenNetwork', async () => {
+  test('init tokenMonitored with scanned tokenNetwork, retryAsync$ retry', async () => {
     expect.assertions(3);
     const raiden = await makeRaiden(undefined, false);
     const { registryContract } = raiden.deps;
@@ -71,13 +66,23 @@ describe('raiden init epics', () => {
               raiden.address,
               null,
             ),
+            data: defaultAbiCoder.encode(['uint256'], [settleTimeout]),
           }),
         ];
       }
       return [];
     });
+
+    // ensure one getLogs error doesn't fail and is retried by retryAsync$
+    raiden.deps.provider.getLogs.mockRejectedValueOnce(new Error('network error;'));
+    const promise = raiden.deps.latest$
+      .pipe(pluck('action'), first(tokenMonitored.is))
+      .toPromise();
+
     await raiden.start();
     await waitBlock();
+    // since we put some delay on retryAsync$, we need to wait
+    await promise;
 
     expect(raiden.output).toContainEqual(
       tokenMonitored({ token, tokenNetwork, fromBlock: expect.any(Number) }),
@@ -113,7 +118,7 @@ describe('raiden init epics', () => {
     );
     await raiden.start();
 
-    expect(raiden.output).toContainEqual(channelMonitor({ id }, meta));
+    expect(raiden.output).toContainEqual(channelMonitored({ id }, meta));
   });
 
   test('ShutdownReason.ACCOUNT_CHANGED', async () => {
@@ -161,133 +166,6 @@ describe('raiden init epics', () => {
 
     expect(raiden.started).toBe(false);
     expect(raiden.output[raiden.output.length - 1]).toEqual(raidenShutdown({ reason: error }));
-  });
-});
-
-describe('tokenMonitoredEpic', () => {
-  const settleTimeoutEncoded = defaultAbiCoder.encode(['uint256'], [settleTimeout]);
-
-  test('first tokenMonitored with past$ ChannelOpened event', async () => {
-    expect.assertions(1);
-
-    const raiden = await makeRaiden();
-    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
-
-    raiden.deps.provider.getLogs.mockImplementation(async ({ address, topics }) => {
-      if (
-        address === tokenNetwork &&
-        topics?.[0] === tokenNetworkContract.interface.events.ChannelOpened.topic
-      )
-        return [
-          makeLog({
-            transactionHash: txHash,
-            blockNumber: openBlock,
-            filter: tokenNetworkContract.filters.ChannelOpened(id, partner, raiden.address, null),
-            data: settleTimeoutEncoded,
-          }),
-        ];
-      return [];
-    });
-
-    raiden.store.dispatch(
-      tokenMonitored({
-        token,
-        tokenNetwork,
-        fromBlock: 2,
-      }),
-    );
-    await waitBlock();
-
-    expect(raiden.output).toContainEqual(
-      channelOpen.success(
-        {
-          id,
-          token,
-          settleTimeout,
-          isFirstParticipant: false,
-          txHash,
-          txBlock: openBlock,
-          confirmed: undefined,
-        },
-        { tokenNetwork, partner },
-      ),
-    );
-  });
-
-  test('already tokenMonitored with new$ ChannelOpened event', async () => {
-    expect.assertions(1);
-
-    const raiden = await makeRaiden(undefined, false);
-    raiden.store.dispatch(tokenMonitored({ token, tokenNetwork }));
-    await raiden.start();
-
-    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
-
-    raiden.deps.provider.emit(
-      tokenNetworkContract.filters.ChannelOpened(null, null, null, null),
-      makeLog({
-        transactionHash: txHash,
-        blockNumber: openBlock,
-        filter: tokenNetworkContract.filters.ChannelOpened(id, raiden.address, partner, null),
-        data: settleTimeoutEncoded,
-      }),
-    );
-    await waitBlock();
-
-    expect(raiden.output).toContainEqual(
-      channelOpen.success(
-        {
-          id,
-          token,
-          settleTimeout,
-          isFirstParticipant: true,
-          txHash,
-          txBlock: openBlock,
-          confirmed: undefined,
-        },
-        { tokenNetwork, partner },
-      ),
-    );
-  });
-
-  test("ensure multiple tokenMonitored don't produce duplicated events", async () => {
-    expect.assertions(2);
-
-    const raiden = await makeRaiden();
-    for (let i = 0; i < 16; i++) raiden.store.dispatch(tokenMonitored({ token, tokenNetwork }));
-
-    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
-
-    raiden.deps.provider.emit(
-      tokenNetworkContract.filters.ChannelOpened(null, null, null, null),
-      makeLog({
-        transactionHash: txHash,
-        blockNumber: openBlock,
-        filter: tokenNetworkContract.filters.ChannelOpened(id, raiden.address, partner, null),
-        data: settleTimeoutEncoded,
-      }),
-    );
-    await waitBlock();
-
-    expect(raiden.output).toContainEqual(
-      channelOpen.success(
-        {
-          id,
-          token,
-          settleTimeout,
-          isFirstParticipant: true,
-          txHash,
-          txBlock: openBlock,
-          confirmed: undefined,
-        },
-        { tokenNetwork, partner },
-      ),
-    );
-    expect(
-      raiden.output.filter(
-        (action) => channelOpen.success.is(action) && action.payload.confirmed === undefined,
-      ),
-    ).toHaveLength(1);
   });
 });
 

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -11,7 +11,7 @@ import { verifyMessage, BigNumber } from 'ethers/utils';
 
 import { RaidenAction, raidenConfigUpdate } from 'raiden-ts/actions';
 import { raidenReducer } from 'raiden-ts/reducer';
-import { channelMonitor } from 'raiden-ts/channels/actions';
+import { channelMonitored } from 'raiden-ts/channels/actions';
 import {
   matrixPresence,
   matrixRoom,
@@ -267,9 +267,9 @@ describe('transport epic', () => {
   });
 
   describe('matrixMonitorChannelPresenceEpic', () => {
-    test('channelMonitor triggers matrixPresence.request', async () => {
+    test('channelMonitored triggers matrixPresence.request', async () => {
       const action$ = of<RaidenAction>(
-        channelMonitor({ id: channelId }, { tokenNetwork, partner }),
+        channelMonitored({ id: channelId }, { tokenNetwork, partner }),
       );
       const promise = matrixMonitorChannelPresenceEpic(action$).toPromise();
       await expect(promise).resolves.toEqual(


### PR DESCRIPTION
Fix #1787 
Fix #1780 
Should fix #1792 

**Short description**
Complete rewrite of TokenNetwork events monitoring logic.
This should not have drawbacks, and UX shouldn't be changed (besides things just working™)

Before:
- `tokenMonitoredEpic` was responsible for monitoring ChannelOpened events, was stateful on which blocks it had already seen and couldn't recover it network errors made it lose events (issue 1780 & 1787)
  - it was also inneficient because although it did only 1 getLogs call, it was too wide (any ChannelOpened event with anyone) and filtered client-side, could be thousands of events on first launch e.g. on mainnet
- `channelMonitoredEpic` then, for each channel, did a getLogs call on every startup (narrowed by channelId) and kept 1 filter

Now:
- `channelEventsEpic`: a single epic per TokenNetwork
  - 2-3 getLogs on each startup, but which are ranged from latest seen event blockNumber, and are strictly limited to channels of interest (with us), so even on initial sync, won't need to fetch thousands of irrelevant channels as before
  - 1 single filter per TokenNetwork (for all channels), only on new blocks it's a catch-all filter (filtering client-side), which can't be too many events but are more performant on number of network requests required
  - If network issues which can't be detected makes it not get some logs, it'll scan again from the narrowest safe range possible (since latest event seen), and will pick up any missed event

Costs per TokenNetwork monitored (N is number of channels):
Before: `(1 + N) * (getLogs, filters)` (plus first TN getLogs could be very expensive)
Now: `2..3 * getLogs + 1 * filter` (all getLogs are as specific as possible)


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Not much to say, just test past and new events are detected
