### PR TITLE
Transparent overlay instead of blurred in Firefox

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 
+- [#1781] Transparent dialog overlay for Firefox
 - [#1783] Minor visual alignments
 - [#1579] Removes minting references when detected network is mainnet.
 - [#1756] Fix non-informative error message on SDK's wrapped errors
@@ -18,6 +19,7 @@
 - [#1610] Adds alderaan compatibility.
 - [#1540] Adds title to channels list to clarify that only channels for the selected token display.
 
+[#1781]: https://github.com/raiden-network/light-client/issues/1781
 [#1783]: https://github.com/raiden-network/light-client/issues/1783
 [#1756]: https://github.com/raiden-network/light-client/issues/1756
 [#1610]: https://github.com/raiden-network/light-client/issues/1610

--- a/raiden-dapp/src/components/overlays/BlurredOverlay.vue
+++ b/raiden-dapp/src/components/overlays/BlurredOverlay.vue
@@ -37,4 +37,10 @@ export default class BlurredOverlay extends Vue {
     z-index: 101;
   }
 }
+
+@supports (-moz-appearance: none) {
+  .blurred-overlay {
+    background-color: rgba($card-background, 0.7);
+  }
+}
 </style>


### PR DESCRIPTION
Fixes #1781 

**Short description**
Since there is no good workaround for replacing ```backdrop-filter``` and since it is expected for Firefox to eventually enable ```backdrop-filter``` by default, we are going with a temporary solution where the overlay is slightly transparent in Firefox as opposed to blurry.
<img width="894" alt="Screenshot 2020-06-29 at 15 28 31" src="https://user-images.githubusercontent.com/43838780/86012538-62f17d00-ba1e-11ea-8840-610bcfcb91c3.png">



**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to the dApp and open any dialog.
