### PR TITLE
sdk: Fix nonce race when open+approve concurrently with Wallet

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#1698] Fix estimateGas errors on channelOpen not properly being handled
 - [#1761] Fix deposit error on openChannel not rejecting promise
 - [#1787] Fix TokenNetwork monitoring losing events
+- [#1830] Fix a nonce race when openining + depositing concurrently
 
 ### Added
 - [#1374] Monitors MonitoringService contract and emit event when MS acts
@@ -49,6 +50,7 @@
 [#1761]: https://github.com/raiden-network/light-client/issues/1761
 [#1787]: https://github.com/raiden-network/light-client/issues/1787
 [#1822]: https://github.com/raiden-network/light-client/pull/1822
+[#1830]: https://github.com/raiden-network/light-client/issues/1830
 [#1832]: https://github.com/raiden-network/light-client/pull/1832
 
 ## [0.9.0] - 2020-05-28

--- a/raiden-ts/tests/unit/epics/channels.spec.ts
+++ b/raiden-ts/tests/unit/epics/channels.spec.ts
@@ -411,7 +411,9 @@ describe('channelDepositEpic', () => {
       channelDeposit.failure(expect.any(Error), { tokenNetwork, partner: partner.address }),
     );
     expect(tokenContract.functions.approve).toHaveBeenCalledTimes(1);
-    expect(tokenContract.functions.approve).toHaveBeenCalledWith(tokenNetwork, deposit);
+    expect(tokenContract.functions.approve).toHaveBeenCalledWith(tokenNetwork, deposit, {
+      nonce: undefined,
+    });
   });
 
   test('setTotalDeposit tx fails', async () => {


### PR DESCRIPTION
Fixes #1830

**Short description**
See https://github.com/raiden-network/light-client/issues/1830#issuecomment-651249481

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Bug: test it doesn't happen anymore
