### PR TITLE
dapp: prevent unintended/automatic unloading/stop

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#1579] Removes minting references when detected network is mainnet.
 - [#1773] Fix performance issues of progress indicators
 - [#1756] Fix non-informative error message on SDK's wrapped errors
+- [#1805] Fix unintended automatic stop of Raiden Service by web-browser
 
 ### Changed
 
@@ -35,6 +36,7 @@
 [#1421]: https://github.com/raiden-network/light-client/issues/1421
 [#1374]: https://github.com/raiden-network/light-client/issues/1374
 [#168]: https://github.com/raiden-network/light-client/issues/168
+[#1805]: https://github.com/raiden-network/light-client/issues/1805
 
 ## [0.9.0] - 2020-05-28
 

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -216,7 +216,12 @@ export default class RaidenService {
 
         this.store.commit('network', raiden.network);
 
-        window.addEventListener('beforeunload', () => this.raiden.stop());
+        /* istanbul ignore next */
+        window.addEventListener('beforeunload', (event) => {
+          event.preventDefault();
+          return ''; // Some engines like Chrome expect this.
+        });
+
         raiden.start();
         this.store.commit('balance', await this.getBalance());
         if (subkey) {


### PR DESCRIPTION
Fixes #1805

**Short description**

There were issues when the web-browser automatically unloads the dApp.
Especially Firefox seem to do this for memory optimization if the tab
was unused for a longer period. This leads to a stop of the Raiden
service and the user needs to reconnect. This gets prevented now.

NOTE: This feature/fix is incredibly hard to test, because it is now
reliable reproducible and costs a takes long. But long term test
attempts (over 40h) seem to show that the unload preventing
functionality works.

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Open the dApp and connect to it
2. Turn the tab of the web-browser inactive
3. Wait for a long time (hours)
4. Check that the dApp is still loaded and not the initial connection screen get shown
