### PR TITLE
Try to fix deposit error and show proper error dialog on dApp

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#1773] Fix performance issues of progress indicators
 - [#1756] Fix non-informative error message on SDK's wrapped errors
 - [#1805] Fix unintended automatic stop of Raiden Service by web-browser
+- [#1876] Show error message on Channels screen if an exception occurs
 
 ### Changed
 
@@ -37,6 +38,7 @@
 [#1374]: https://github.com/raiden-network/light-client/issues/1374
 [#168]: https://github.com/raiden-network/light-client/issues/168
 [#1805]: https://github.com/raiden-network/light-client/issues/1805
+[#1876]: https://github.com/raiden-network/light-client/pull/1876
 
 ## [0.9.0] - 2020-05-28
 

--- a/raiden-dapp/src/components/channels/ChannelDialogs.vue
+++ b/raiden-dapp/src/components/channels/ChannelDialogs.vue
@@ -3,7 +3,7 @@
     v-if="channel && action === 'close'"
     :identifier="channel.id"
     :positive-action="$t('confirmation.buttons.close')"
-    :visible="action === 'close'"
+    :visible="visible"
     @confirm="close()"
     @cancel="dismiss()"
   >
@@ -18,7 +18,7 @@
     v-else-if="channel && action === 'settle'"
     :identifier="channel.id"
     :positive-action="$t('confirmation.buttons.settle')"
-    :visible="action === 'settle'"
+    :visible="visible"
     @confirm="settle()"
     @cancel="dismiss()"
   >
@@ -37,7 +37,7 @@
     v-else-if="channel && action === 'deposit'"
     :identifier="channel.id"
     :token="token(channel.token)"
-    :visible="action === 'deposit'"
+    :visible="visible"
     :loading="depositInProgress"
     :done="false"
     @depositTokens="deposit($event)"
@@ -72,6 +72,7 @@ export default class ChannelDialogs extends Vue {
   token!: (address: string) => Token;
 
   depositInProgress = false;
+  visible = true;
 
   @Emit()
   message(_message: string) {}
@@ -81,38 +82,46 @@ export default class ChannelDialogs extends Vue {
     this.depositInProgress = false;
   }
 
+  @Emit()
+  error(_error: Error) {}
+
   async deposit(deposit: BigNumber) {
     const { token, partner } = this.channel!;
     try {
       this.depositInProgress = true;
       await this.$raiden.deposit(token, partner, deposit);
-      this.dismiss();
       this.message(this.$t('channel-list.messages.deposit.success') as string);
     } catch (e) {
       this.message(this.$t('channel-list.messages.deposit.failure') as string);
+      this.error(e);
     }
+    this.dismiss();
   }
 
   async close() {
     const { token, partner } = this.channel!;
-    this.dismiss();
+    this.visible = false;
     try {
       await this.$raiden.closeChannel(token, partner);
       this.message(this.$t('channel-list.messages.close.success') as string);
     } catch (e) {
       this.message(this.$t('channel-list.messages.close.failure') as string);
+      this.error(e);
     }
+    this.dismiss();
   }
 
   async settle() {
     const { token, partner } = this.channel!;
-    this.dismiss();
+    this.visible = false;
     try {
       await this.$raiden.settleChannel(token, partner);
       this.message(this.$t('channel-list.messages.settle.success') as string);
     } catch (e) {
       this.message(this.$t('channel-list.messages.settle.failure') as string);
+      this.error(e);
     }
+    this.dismiss();
   }
 }
 </script>

--- a/raiden-dapp/src/components/navigation/Channels.vue
+++ b/raiden-dapp/src/components/navigation/Channels.vue
@@ -73,25 +73,28 @@
       :channel="selectedChannel"
       @dismiss="action = null"
       @message="showMessage($event)"
+      @error="error = $event"
     ></channel-dialogs>
+    <error-dialog :error="error" @dismiss="error = null" />
   </div>
 </template>
 
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator';
 import { mapGetters } from 'vuex';
-import { ChannelState, RaidenChannel } from 'raiden-ts';
+import { ChannelState, RaidenChannel, RaidenError } from 'raiden-ts';
 import ListHeader from '@/components/ListHeader.vue';
 import { Token } from '@/model/types';
 import AddressUtils from '@/utils/address-utils';
 import NavigationMixin from '@/mixins/navigation-mixin';
 import ChannelList from '@/components/channels/ChannelList.vue';
 import ChannelDialogs from '@/components/channels/ChannelDialogs.vue';
+import ErrorDialog from '@/components/dialogs/ErrorDialog.vue';
 import { ChannelAction } from '@/types';
 import Filters from '@/filters';
 
 @Component({
-  components: { ChannelDialogs, ListHeader, ChannelList },
+  components: { ChannelDialogs, ListHeader, ChannelList, ErrorDialog },
   computed: {
     ...mapGetters(['channels']),
   },
@@ -101,6 +104,7 @@ export default class Channels extends Mixins(NavigationMixin) {
   snackbar: boolean = false;
   channels!: (address: string) => RaidenChannel[];
   action: ChannelAction | null = null;
+  error: Error | RaidenError | null = null;
 
   selectedChannel: RaidenChannel | null = null;
   expanded: { [id: number]: boolean } = {};

--- a/raiden-dapp/tests/unit/components/channels/channels-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/channels/channels-dialog.spec.ts
@@ -108,7 +108,6 @@ describe('ChannelDialogs.vue', () => {
       expect(messageEvent).toBeTruthy();
       const [firstMessageArg] = messageEvent?.shift();
       expect(firstMessageArg).toEqual('channel-list.messages.deposit.failure');
-      expect(wrapper.emitted('dismiss')).toBeUndefined();
     });
   });
 

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#1761] Fix deposit error on openChannel not rejecting promise
 - [#1787] Fix TokenNetwork monitoring losing events
 - [#1830] Fix a nonce race when openining + depositing concurrently
+- [#1848] Fix a Metamask error by retry on deposit
 
 ### Added
 - [#1374] Monitors MonitoringService contract and emit event when MS acts
@@ -52,6 +53,7 @@
 [#1822]: https://github.com/raiden-network/light-client/pull/1822
 [#1830]: https://github.com/raiden-network/light-client/issues/1830
 [#1832]: https://github.com/raiden-network/light-client/pull/1832
+[#1848]: https://github.com/raiden-network/light-client/issues/1848
 
 ## [0.9.0] - 2020-05-28
 ### Added


### PR DESCRIPTION
Fixes #1848 

**Short description**
The error seems to be caused either by a Metamask internal error or by a temporary error due to Metamask still having an outdated view of the blockchain upon transaction.
@agatsoh Please, test if the issue still occurs on this PR. Additionally, also make sure you have enough ETH on your main account to pay for the transactions, and also make sure to either restart the browser or disable-reenable Metamask if you switch Networks or Accounts, I've seen people commenting about some instances of similar issues caused by unexpected errors on Metamask which fixed themselves upon this reload cycle. 

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. @agatsoh to check if the issue still happen on this PR
