### PR TITLE
cli: Fix not filtering payments also per initiator

### DIFF
--- a/raiden-cli/src/utils/payments.ts
+++ b/raiden-cli/src/utils/payments.ts
@@ -11,7 +11,7 @@ export function transformSdkTransferToApiPayment(transfer: RaidenTransfer): ApiP
     token_address: transfer.token,
     amount: transfer.value.toString(),
     identifier: transfer.paymentId.toString(),
-    secret: '', // FIXME: must be first exposed by SDK (#1708)
+    secret: transfer.secret ?? '',
     secret_hash: transfer.secrethash,
     log_time: transfer.changedAt.toISOString(),
   };


### PR DESCRIPTION
Fixes #1841 

**Short description**
Payments filter was considering only `target`. For received transfers, the target are us, and we want to filter per `initiator` instead. Also fix a small fixme in code to expose `secret`.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Test the endpoint behaves as described as expected in the issue
