### PR TITLE
Feature/sdk check target presence for mediated transfers

### DIFF
--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -449,7 +449,6 @@ export default class RaidenService {
     amount: BigNumber,
     raidenPFS?: RaidenPFS
   ): Promise<RaidenPaths> {
-    await this.raiden.getAvailability(target);
     return await this.raiden.findRoutes(token, target, amount, {
       pfs: raidenPFS,
     });

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -394,15 +394,6 @@ describe('RaidenService', () => {
     });
 
     describe('findRoutes', () => {
-      test('rejects when it cannot find routes: no availability', async () => {
-        const raidenError = new RaidenError(ErrorCodes.PFS_TARGET_OFFLINE);
-        raiden.getAvailability = jest.fn().mockRejectedValue(raidenError);
-
-        await expect(
-          raidenService.findRoutes(AddressZero, AddressZero, One)
-        ).rejects.toEqual(raidenError);
-      });
-
       test('rejects when it cannot find routes: no routes', async () => {
         const error = new Error('no path');
         raiden.getAvailability = jest.fn().mockResolvedValue(AddressZero);

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [#1701] Allow parameter decoding to throw and log customized errors
 - [#1701] Add and extend error codes for user parameter validation for open channel
 - [#1711] Add and extend error codes for user parameter validation for transfer
+- [#1835] The presence knowledge for a payment routes target is secured automatically
 
 ### Changed
 - [#837] Changes the action tags from camel to path format. This change affects the event types exposed through the public API.
@@ -55,6 +56,7 @@
 [#1822]: https://github.com/raiden-network/light-client/pull/1822
 [#1830]: https://github.com/raiden-network/light-client/issues/1830
 [#1832]: https://github.com/raiden-network/light-client/pull/1832
+[#1835]: https://github.com/raiden-network/light-client/pull/1835
 [#1848]: https://github.com/raiden-network/light-client/issues/1848
 
 ## [0.9.0] - 2020-05-28

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -777,7 +777,7 @@ export class Raiden {
    * transfer. Any following transfer state change will be notified through this observable.
    *
    * @param token - Token address on currently configured token network registry
-   * @param target - Target address (must be getAvailability before)
+   * @param target - Target address
    * @param value - Amount to try to transfer
    * @param options - Optional parameters for transfer:
    * @param options.paymentId - payment identifier, a random one will be generated if missing</li>
@@ -931,7 +931,7 @@ export class Raiden {
    * Else, if no route can be found, promise is rejected with respective error.
    *
    * @param token - Token address on currently configured token network registry
-   * @param target - Target address (must be getAvailability before)
+   * @param target - Target address
    * @param value - Minimum capacity required on routes
    * @param options - Optional parameters
    * @param options.pfs - Use this PFS instead of configured or automatically choosen ones
@@ -963,7 +963,7 @@ export class Raiden {
    * single-element array of Paths
    *
    * @param token - Token address on currently configured token network registry
-   * @param target - Target address (must be getAvailability before)
+   * @param target - Target address
    * @param value - Minimum capacity required on route
    * @returns Promise to a [Raiden]Paths array containing the single, direct route, or undefined
    */

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -762,13 +762,6 @@ describe('Raiden', () => {
       ).rejects.toThrowError(/Invalid path parameter./i);
     });
 
-    test('target not available', async () => {
-      expect.assertions(1);
-      await expect(raiden.transfer(token, partner, 21)).rejects.toThrowError(
-        ErrorCodes.PFS_TARGET_OFFLINE,
-      );
-    });
-
     describe('partner online', () => {
       // partner's client instance
       let raiden1: Raiden;

--- a/raiden-ts/tests/unit/epics/path.spec.ts
+++ b/raiden-ts/tests/unit/epics/path.spec.ts
@@ -206,16 +206,81 @@ describe('PFS: pathFindServiceEpic', () => {
     );
   });
 
-  test('success request missing matrix presence of target', async () => {
+  test('fail on failing matrix presence request', async () => {
+    expect.assertions(1);
+
+    const value = bigNumberify(100) as UInt<32>;
+    const matrixError = new Error('Unspecific matrix error for testing purpose');
+    const promise = pathFindServiceEpic(action$, state$, depsMock).pipe(toArray()).toPromise();
+
+    [
+      pathFind.request({}, { tokenNetwork, target: partner, value }),
+      matrixPresence.failure(matrixError, { address: partner }),
+    ].forEach((a) => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject([
+      matrixPresence.request(undefined, { address: partner }),
+      pathFind.failure(matrixError, {
+        tokenNetwork,
+        target: partner,
+        value,
+      }),
+    ]);
+  });
+
+  test('fail on successful matrix presence request but target unavailable', async () => {
     expect.assertions(1);
 
     const value = bigNumberify(100) as UInt<32>;
     const promise = pathFindServiceEpic(action$, state$, depsMock).pipe(toArray()).toPromise();
-    action$.next(pathFind.request({}, { tokenNetwork, target, value }));
-    setTimeout(() => action$.complete(), 50);
+
+    [
+      pathFind.request({}, { tokenNetwork, target: partner, value }),
+      matrixPresence.success(
+        { userId: partnerUserId, available: false, ts: Date.now() },
+        { address: partner },
+      ),
+    ].forEach((a) => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
 
     await expect(promise).resolves.toMatchObject([
-      matrixPresence.request(undefined, { address: target }),
+      matrixPresence.request(undefined, { address: partner }),
+      pathFind.failure(
+        expect.objectContaining({
+          message: ErrorCodes.PFS_TARGET_OFFLINE,
+          details: { target: partner },
+        }),
+        {
+          tokenNetwork,
+          target: partner,
+          value,
+        },
+      ),
+    ]);
+  });
+
+  test('success on successful matrix presence request and target available', async () => {
+    expect.assertions(1);
+
+    const value = bigNumberify(100) as UInt<32>;
+    const promise = pathFindServiceEpic(action$, state$, depsMock).pipe(toArray()).toPromise();
+
+    [
+      pathFind.request({}, { tokenNetwork, target: partner, value }),
+      matrixPresence.success(
+        { userId: partnerUserId, available: true, ts: Date.now() },
+        { address: partner },
+      ),
+    ].forEach((a) => action$.next(a));
+    setTimeout(() => action$.complete(), 10);
+
+    await expect(promise).resolves.toMatchObject([
+      matrixPresence.request(undefined, { address: partner }),
+      pathFind.success(
+        { paths: [{ path: [partner], fee: Zero as Int<32> }] },
+        { tokenNetwork, target: partner, value },
+      ),
     ]);
   });
 

--- a/raiden-ts/tests/unit/epics/path.spec.ts
+++ b/raiden-ts/tests/unit/epics/path.spec.ts
@@ -206,6 +206,19 @@ describe('PFS: pathFindServiceEpic', () => {
     );
   });
 
+  test('success request missing matrix presence of target', async () => {
+    expect.assertions(1);
+
+    const value = bigNumberify(100) as UInt<32>;
+    const promise = pathFindServiceEpic(action$, state$, depsMock).pipe(toArray()).toPromise();
+    action$.next(pathFind.request({}, { tokenNetwork, target, value }));
+    setTimeout(() => action$.complete(), 50);
+
+    await expect(promise).resolves.toMatchObject([
+      matrixPresence.request(undefined, { address: target }),
+    ]);
+  });
+
   test('success provided route', async () => {
     expect.assertions(1);
 


### PR DESCRIPTION
Fixes #1835

**Short description**

Before validating a route for a mediated transfer the `pathFindServiceEpic` first makes sure that the presence of the routes target is actually known. Before a missing presence lead to the assumption that the target is not available. The workaround so far was to do a manual presence request by the user before doing a transfer.

_Attention:_
The epic for touched for this feature was too huge when starting to work on it. It was kinda part of this PR to first refactor its code to reduce the complexity of each single function and improve the code quality especially in regards of readability. This was necessary to do this extension without loosing the overview. After all would have this changes break the _codeclimate_ rules. I may have taken this refactoring quite far. I recommend to review the commits individually. So the actual main implementation of this feature is within a single commit and is better to understand when looking at it focused. Sorry for the inconvenience. 

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
