### PR TITLE
sdk: try to fix integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
       - attach_workspace: *attach_options
       - run:
           name: Restore dependencies
-          command: pnpm install --prefer-frozen-lockfile
+          command: pnpm install --prefer-frozen-lockfile && pnpm run build --filter raiden-ts
       - run:
           name: Run integration tests
           command: source /etc/profile.d/smartcontracts.sh && pnpm run test:integration --filter raiden-ts -- --ci --runInBand --reporters=default --reporters=jest-junit

--- a/raiden-ts/tests/integration/integration.spec.ts
+++ b/raiden-ts/tests/integration/integration.spec.ts
@@ -10,7 +10,7 @@ import { filter } from 'rxjs/operators';
 import { Signer, Wallet } from 'ethers';
 import { RaidenPaths } from 'raiden-ts/services/types';
 
-jest.setTimeout(80000);
+jest.setTimeout(120000);
 
 const ethBalance = '100000000000000000000000';
 const tttBalance = '1000000000000000000000';
@@ -73,13 +73,12 @@ describe('integration', () => {
   });
 
   afterAll((done) => {
-    raiden.stop();
     raiden.events$.pipe(filter((value) => value.type === 'raiden/shutdown')).subscribe(done);
+    raiden.stop();
   });
 
   test('account is funded', async () => {
-    const balance = await raiden.getBalance(raiden.address);
-    expect(balance.eq(bigNumberify(ethBalance))).toBe(true);
+    await expect(raiden.getBalance(raiden.address)).resolves.toEqual(bigNumberify(ethBalance));
   });
 
   describe('mediated transfer', () => {


### PR DESCRIPTION
Fixes #

**Short description**
Nightly integration tests are failing because `pnpm` doesn't seem to be building SDK on `prepare`. So, fix it by explicitly calling the build script, and also make some of the tests failures more descriptive.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Just let it run tonight
