### PR TITLE
sdk: accept falsy paymentId parameters

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#1787] Fix TokenNetwork monitoring losing events
 - [#1830] Fix a nonce race when openining + depositing concurrently
 - [#1848] Fix a Metamask error by retry on deposit
+- [#1882] Fix paymentId gets ignored when being falsie (e.g. `0`)
 
 ### Added
 - [#249] Add withdraw functionality
@@ -56,6 +57,7 @@
 [#1830]: https://github.com/raiden-network/light-client/issues/1830
 [#1832]: https://github.com/raiden-network/light-client/pull/1832
 [#1848]: https://github.com/raiden-network/light-client/issues/1848
+[#1882]: https://github.com/raiden-network/light-client/issues/1882
 
 ## [0.9.0] - 2020-05-28
 ### Added

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -809,9 +809,10 @@ export class Raiden {
     assert(tokenNetwork, ErrorCodes.RDN_UNKNOWN_TOKEN_NETWORK, this.log.info);
 
     const decodedValue = decode(UInt(32), value, ErrorCodes.DTA_INVALID_AMOUNT, this.log.info);
-    const paymentId = options.paymentId
-      ? decode(UInt(8), options.paymentId, ErrorCodes.DTA_INVALID_PAYMENT_ID, this.log.info)
-      : makePaymentId();
+    const paymentId =
+      options.paymentId !== undefined
+        ? decode(UInt(8), options.paymentId, ErrorCodes.DTA_INVALID_PAYMENT_ID, this.log.info)
+        : makePaymentId();
     const paths = !options.paths
       ? undefined
       : decode(Paths, options.paths, ErrorCodes.DTA_INVALID_PATH, this.log.info);


### PR DESCRIPTION
Fixes #1882

@andrevmatos I did not add a test, but still extended the changelog. :stuck_out_tongue_winking_eye: 
After all a user detected this problem for him, so I think this entry is not completely worthless. :wink: 
