### PR TITLE
infra: improvements to renovate config, enable masterIssue

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,17 +8,21 @@
       "packagePatterns": [
         "*"
       ],
-      "groupName": "all dependencies",
-      "groupSlug": "all"
+      "updateTypes": ["minor", "patch"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "schedule": ["after 8am on thursday"],
+      "lockFileMaintenance": { "enabled": true }
+    },
+    {
+      "updateTypes": ["major"],
+      "masterIssueApproval": true
     }
   ],
+  "masterIssue": true,
   "labels": ["dependencies"],
-  "lockFileMaintenance": { "enabled": true },
-  "schedule": ["after 8am on thursday"],
-  "prConcurrentLimit": 15,
-  "prHourlyLimit": 5,
   "reviewers": ["team:raiden-network/light-client"],
   "reviewersSampleSize": 1,
-  "rangeStrategy": "pin",
+  "rangeStrategy": "bump",
   "timezone": "Europe/Berlin"
 }


### PR DESCRIPTION

Improvements over #1868 

**Short description**
Groups only minor-patch updates, use a [Master Issue](https://renovatebot.com/blog/master-issue) for individual major updates management.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Renovate's config only work from `master` branch, so we need to merge it to test
2.
