### PR TITLE
infra: renovate: include lockFileMaintenance in minor group update

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
       "packagePatterns": [
         "*"
       ],
-      "updateTypes": ["minor", "patch"],
+      "updateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance", "rollback", "bump"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
       "schedule": ["after 8am on thursday"],


### PR DESCRIPTION
Follow up of #1890 

**Short description**
`lockFileMaintainance` and other update types were missing. This adds everything non-major to the group.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
