### PR TITLE
infra: add '--no-git-checks' to pnpm publish command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
       - run:
           name: Publish on npm
-          command: pnpm publish --filter raiden-ts
+          command: pnpm publish --no-git-checks --filter raiden-ts
 
   integration_tests:
     executor: integration-executor


### PR DESCRIPTION
**Short description**
Since [pnpm 5.0.0-rc2](https://github.com/pnpm/pnpm/releases/tag/v5.0.0-rc.2), `pnpm publish` defaults to enabling a `git-checks` option, which fails if current repository is not on master branch, up-to-date and clean. Meanwhile, CircleCI's default `checkout` step detaches `HEAD` to ensure it stays in sync with the current `$CIRCLECI_SHA1` commit.
This causes the [publishing to fail](https://app.circleci.com/pipelines/github/raiden-network/light-client/6083/workflows/21472886-0490-467e-b3db-85565af74704/jobs/37593) on the automatic CircleCI's `publish_artifact` step:
```sh
#!/bin/bash -eo pipefail 
pnpm publish --filter raiden-ts 
 ERROR  Command failed with exit code 128: git symbolic-ref --short HEAD
 fatal: ref HEAD is not a symbolic ref
 
 at makeError                  ../../../usr/local/lib/node_modules/pnpm/lib/node_modules/execa/lib/error.js:59                                 error = new Error(messag…
 at handlePromise              ../../../usr/local/lib/node_modules/pnpm/lib/node_modules/execa/index.js:114                                    const returnedError = ma…
 at processTicksAndRejections  internal/process/task_queues.js:97                                                                                                       
 at getCurrentBranch           ../../../usr/local/lib/node_modules/pnpm/lib/node_modules/@pnpm/plugin-commands-publishing/lib/gitChecks.js:17  const { stdout } = await…
 at handler [as publish]       ../../../usr/local/lib/node_modules/pnpm/lib/node_modules/@pnpm/plugin-commands-publishing/lib/publish.js:89    if (await gitChecks_1.ge…
  
Exited with code exit status 1 
CircleCI received exit code 1 
```

The fix consists in disabling these checks to ensure the publishing works on CircleCI too.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Wait for next release (since the linked one was published manually) and check if it succeeds
