### PR TITLE
cli: make GET /payments params optional

### DIFF
--- a/raiden-cli/src/utils/validation.ts
+++ b/raiden-cli/src/utils/validation.ts
@@ -18,6 +18,16 @@ export function validateAddressParameter(
   }
 }
 
+export function validateOptionalAddressParameter(
+  this: string,
+  request: Request,
+  response: Response,
+  next: NextFunction,
+) {
+  if (!request.params[this]) next();
+  else validateAddressParameter.call(this, request, response, next);
+}
+
 export function isInvalidParameterError(error: RaidenError): boolean {
   return [
     ErrorCodes.DTA_NEGATIVE_NUMBER,


### PR DESCRIPTION
Fixes #1880 
Part of #1691 

**Short description**
First of a series of PRs to improve CLI to make it compatible with SP, to try to use it for stress tests.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Check /payments and /payments/<token> routes behave as expected
