### PR TITLE
cli: implement channel deposit, close, settle and fix some issues with channels interface

### DIFF
--- a/raiden-cli/src/app.ts
+++ b/raiden-cli/src/app.ts
@@ -1,4 +1,4 @@
-import express, { Express, Request, Response, NextFunction, Errback } from 'express';
+import express, { Express, Request, Response, NextFunction } from 'express';
 import createError from 'http-errors';
 import logger from 'morgan';
 import { Cli } from './types';
@@ -10,13 +10,12 @@ function notFoundHandler(_request: Request, _response: Response, next: NextFunct
 
 function internalErrorHandler(
   this: Cli,
-  error: Errback,
+  error: Error,
   _request: Request,
   _response: Response,
   next: NextFunction,
 ) {
-  this.log.error(error);
-  next(createError(500, 'Internal Raiden node error'));
+  next(createError(500, error.message));
 }
 
 export function makeApp(this: Cli): Express {

--- a/raiden-cli/src/routes/channels.ts
+++ b/raiden-cli/src/routes/channels.ts
@@ -1,17 +1,13 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import { first } from 'rxjs/operators';
-import { ErrorCodes, RaidenError } from 'raiden-ts';
+import { first, pluck } from 'rxjs/operators';
+import { ErrorCodes, RaidenError, isntNil } from 'raiden-ts';
 import { Cli } from '../types';
 import {
-  validateAddressParameter,
   isInvalidParameterError,
   isTransactionWouldFailError,
+  validateOptionalAddressParameter,
 } from '../utils/validation';
-import {
-  flattenChannelDictionary,
-  transformSdkChannelFormatToApi,
-  filterChannels,
-} from '../utils/channels';
+import { flattenChannelDictionary, transformSdkChannelFormatToApi } from '../utils/channels';
 
 function isConflictError(error: RaidenError): boolean {
   return (
@@ -20,46 +16,39 @@ function isConflictError(error: RaidenError): boolean {
   );
 }
 
-async function getAllChannels(this: Cli, _request: Request, response: Response) {
-  const channelDictionary = await this.raiden.channels$.pipe(first()).toPromise();
-  const channelList = flattenChannelDictionary(channelDictionary);
-  const formattedChannels = channelList.map((channel) => transformSdkChannelFormatToApi(channel));
-  response.json(formattedChannels);
-}
-
-async function getChannelsForToken(this: Cli, request: Request, response: Response) {
-  const channelDictionary = await this.raiden.channels$.pipe(first()).toPromise();
-  const channelList = flattenChannelDictionary(channelDictionary);
-  const filteredChannels = filterChannels(channelList, request.params.tokenAddress);
-  const formattedChannels = filteredChannels.map((channel) =>
-    transformSdkChannelFormatToApi(channel),
-  );
-  response.json(formattedChannels);
-}
-
-async function getChannelsForTokenAndPartner(this: Cli, request: Request, response: Response) {
-  const channelDictionary = await this.raiden.channels$.pipe(first()).toPromise();
-  const channel = channelDictionary[request.params.tokenAddress]?.[request.params.partnerAddress];
-
-  if (channel) {
-    response.json(transformSdkChannelFormatToApi(channel));
+async function getChannels(this: Cli, request: Request, response: Response) {
+  const channelsDict = await this.raiden.channels$.pipe(first()).toPromise();
+  const token: string | undefined = request.params.tokenAddress;
+  const partner: string | undefined = request.params.partnerAddress;
+  if (token && partner) {
+    const channel = channelsDict[token]?.[partner];
+    if (channel) {
+      response.json(transformSdkChannelFormatToApi(channel));
+    } else {
+      response.status(404).send('The channel does not exist');
+    }
   } else {
-    response.status(404).send('The channel does not exist');
+    let channelsList = flattenChannelDictionary(channelsDict);
+    if (token) channelsList = channelsList.filter((channel) => channel.token === token);
+    if (partner) channelsList = channelsList.filter((channel) => channel.token === partner);
+    response.json(channelsList.map(transformSdkChannelFormatToApi));
   }
 }
 
 async function openChannel(this: Cli, request: Request, response: Response, next: NextFunction) {
+  const token: string = request.body.token_address;
+  const partner: string = request.body.partner_address;
   try {
     // TODO: We ignore the provided `reveal_timeout` until #1656 provides
     // a better solution.
-    await this.raiden.openChannel(request.body.token_address, request.body.partner_address, {
+    await this.raiden.openChannel(token, partner, {
       settleTimeout: request.body.settle_timeout,
       deposit: request.body.total_deposit,
     });
-    const channelDictionary = await this.raiden.channels$.pipe(first()).toPromise();
-    const newChannel =
-      channelDictionary[request.body.token_address]?.[request.body.partner_address];
-    response.status(201).json(transformSdkChannelFormatToApi(newChannel));
+    const channel = await this.raiden.channels$
+      .pipe(pluck(token, partner), first(isntNil))
+      .toPromise();
+    response.status(201).json(transformSdkChannelFormatToApi(channel));
   } catch (error) {
     if (isInvalidParameterError(error)) {
       response.status(400).send(error.message);
@@ -76,19 +65,11 @@ async function openChannel(this: Cli, request: Request, response: Response, next
 export function makeChannelsRouter(this: Cli): Router {
   const router = Router();
 
-  router.get('/', getAllChannels.bind(this));
-
   router.get(
-    '/:tokenAddress',
-    validateAddressParameter.bind('tokenAddress'),
-    getChannelsForToken.bind(this),
-  );
-
-  router.get(
-    '/:tokenAddress/:partnerAddress',
-    validateAddressParameter.bind('tokenAddress'),
-    validateAddressParameter.bind('partnerAddress'),
-    getChannelsForTokenAndPartner.bind(this),
+    '/:tokenAddress?/:partnerAddress?',
+    validateOptionalAddressParameter.bind('tokenAddress'),
+    validateOptionalAddressParameter.bind('partnerAddress'),
+    getChannels.bind(this),
   );
 
   router.put('/', openChannel.bind(this));

--- a/raiden-cli/src/routes/channels.ts
+++ b/raiden-cli/src/routes/channels.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { first, pluck } from 'rxjs/operators';
-import { ErrorCodes, RaidenError, isntNil } from 'raiden-ts';
-import { Cli } from '../types';
+import { ErrorCodes, isntNil, ChannelState } from 'raiden-ts';
+import { Cli, ApiChannelState } from '../types';
 import {
   isInvalidParameterError,
   isTransactionWouldFailError,
@@ -9,10 +9,22 @@ import {
 } from '../utils/validation';
 import { flattenChannelDictionary, transformSdkChannelFormatToApi } from '../utils/channels';
 
-function isConflictError(error: RaidenError): boolean {
+function isConflictError(error: Error): boolean {
   return (
     [ErrorCodes.RDN_UNKNOWN_TOKEN_NETWORK, ErrorCodes.CNL_INVALID_STATE].includes(error.message) ||
     isTransactionWouldFailError(error)
+  );
+}
+
+function isInsuficientFundsError(error: { message: string; code?: string | number }): boolean {
+  return (
+    error.code === 'INSUFFICIENT_FUNDS' ||
+    [
+      ErrorCodes.DTA_INVALID_AMOUNT,
+      ErrorCodes.DTA_INVALID_DEPOSIT,
+      ErrorCodes.CNL_WITHDRAW_AMOUNT_TOO_LOW,
+      ErrorCodes.CNL_WITHDRAW_AMOUNT_TOO_HIGH,
+    ].includes(error.message)
   );
 }
 
@@ -52,7 +64,91 @@ async function openChannel(this: Cli, request: Request, response: Response, next
   } catch (error) {
     if (isInvalidParameterError(error)) {
       response.status(400).send(error.message);
-    } else if (error.code === 'INSUFFICIENT_FUNDS') {
+    } else if (isInvalidParameterError(error)) {
+      response.status(402).send(error.message);
+    } else if (isConflictError(error)) {
+      response.status(409).send(error.message);
+    } else {
+      next(error);
+    }
+  }
+}
+
+const allowedUpdateKeys = new Set(['state', 'total_deposit', 'total_withdraw']);
+function validateChannelUpdateBody(request: Request, response: Response, next: NextFunction) {
+  const intersec = Object.keys(request.body).filter((k) => allowedUpdateKeys.has(k));
+  if (intersec.length < 1)
+    return response
+      .status(400)
+      .send('one of "state" | "total_deposit" | "total_withdraw" operations required');
+  else if (intersec.length > 1)
+    return response
+      .status(409)
+      .send('more than one of "state" | "total_deposit" | "total_withdraw" requested');
+  if (
+    request.body.state &&
+    ![ApiChannelState.closed, ApiChannelState.settled].includes(request.body.state)
+  )
+    return response
+      .status(400)
+      .send('invalid "state" requested: must be one of "closed" | "settled"');
+  return next();
+}
+
+async function updateChannel(this: Cli, request: Request, response: Response, next: NextFunction) {
+  const token: string = request.params.tokenAddress;
+  const partner: string = request.params.partnerAddress;
+  try {
+    let channel = await this.raiden.channels$.pipe(first(), pluck(token, partner)).toPromise();
+    if (!channel) return response.status(404).send('channel not found');
+    if (request.body.state) {
+      if (request.body.state === ApiChannelState.closed) {
+        await this.raiden.closeChannel(token, partner);
+        channel = await this.raiden.channels$
+          .pipe(
+            pluck(token, partner),
+            first((channel) =>
+              [ChannelState.closed, ChannelState.settleable, ChannelState.settling].includes(
+                channel.state,
+              ),
+            ),
+          )
+          .toPromise();
+      } else if (request.body.state === ApiChannelState.settled) {
+        const promise = this.raiden.settleChannel(token, partner);
+        channel = await this.raiden.channels$.pipe(pluck(token, partner), first()).toPromise();
+        await promise;
+      }
+    } else if (request.body.total_deposit) {
+      await this.raiden.depositChannel(
+        token,
+        partner,
+        channel.ownDeposit.sub(request.body.total_deposit).mul(-1),
+      );
+      channel = await this.raiden.channels$
+        .pipe(
+          pluck(token, partner),
+          first((channel) => channel.ownDeposit.gte(request.body.total_deposit)),
+        )
+        .toPromise();
+    } else if (request.body.total_withdraw) {
+      await this.raiden.withdrawChannel(
+        token,
+        partner,
+        channel.ownWithdraw.sub(request.body.total_withdraw).mul(-1),
+      );
+      channel = await this.raiden.channels$
+        .pipe(
+          pluck(token, partner),
+          first((channel) => channel.ownWithdraw.gte(request.body.total_withdraw)),
+        )
+        .toPromise();
+    }
+    response.status(200).json(transformSdkChannelFormatToApi(channel));
+  } catch (error) {
+    if (isInvalidParameterError(error)) {
+      response.status(400).send(error.message);
+    } else if (isInsuficientFundsError(error)) {
       response.status(402).send(error.message);
     } else if (isConflictError(error)) {
       response.status(409).send(error.message);
@@ -74,9 +170,13 @@ export function makeChannelsRouter(this: Cli): Router {
 
   router.put('/', openChannel.bind(this));
 
-  router.patch('/:tokenAddress/:partnerAddress', (_request: Request, response: Response) => {
-    response.status(404).send('Not implemented yet');
-  });
+  router.patch(
+    '/:tokenAddress/:partnerAddress',
+    validateOptionalAddressParameter.bind('tokenAddress'),
+    validateOptionalAddressParameter.bind('partnerAddress'),
+    validateChannelUpdateBody,
+    updateChannel.bind(this),
+  );
 
   return router;
 }

--- a/raiden-cli/src/types.ts
+++ b/raiden-cli/src/types.ts
@@ -27,15 +27,16 @@ export enum ApiChannelState {
 
 // Data structures as exchanged over the API
 export interface ApiChannel {
-  channel_identifier: number;
+  channel_identifier: string;
   token_network_address: string;
   partner_address: string;
   token_address: string;
   balance: string;
   total_deposit: string;
+  total_withdraw: string;
   state: ApiChannelState;
-  settle_timeout: number;
-  reveal_timeout: number;
+  settle_timeout: string;
+  reveal_timeout: string;
 }
 
 export enum ApiPaymentEvents {

--- a/raiden-cli/src/types.ts
+++ b/raiden-cli/src/types.ts
@@ -19,6 +19,12 @@ export interface Cli {
   server?: Server;
 }
 
+export enum ApiChannelState {
+  opened = 'opened',
+  closed = 'closed',
+  settled = 'settled',
+}
+
 // Data structures as exchanged over the API
 export interface ApiChannel {
   channel_identifier: number;
@@ -27,7 +33,7 @@ export interface ApiChannel {
   token_address: string;
   balance: string;
   total_deposit: string;
-  state: string;
+  state: ApiChannelState;
   settle_timeout: number;
   reveal_timeout: number;
 }

--- a/raiden-cli/src/utils/channels.ts
+++ b/raiden-cli/src/utils/channels.ts
@@ -36,8 +36,9 @@ export function transformSdkChannelFormatToApi(channel: RaidenChannel): ApiChann
     token_address: channel.token,
     balance: channel.balance.toString(),
     total_deposit: channel.ownDeposit.toString(),
+    total_withdraw: channel.ownWithdraw.toString(),
     state: transformSdkChannelStateToApi(channel.state),
     settle_timeout: channel.settleTimeout,
-    reveal_timeout: 0, // FIXME: Not defined here. Python client handles reveal timeout differently,
+    reveal_timeout: 50, // FIXME: Not defined here. Python client handles reveal timeout differently,
   };
 }

--- a/raiden-cli/src/utils/channels.ts
+++ b/raiden-cli/src/utils/channels.ts
@@ -9,7 +9,7 @@ export function flattenChannelDictionary(channelDict: RaidenChannels): RaidenCha
   );
 }
 
-function transformSdkChannelStateToApi(state: ChannelState): ApiChannelState {
+function transformChannelStateForApi(state: ChannelState): ApiChannelState {
   let apiState;
   switch (state) {
     case ChannelState.open:
@@ -28,7 +28,7 @@ function transformSdkChannelStateToApi(state: ChannelState): ApiChannelState {
   return apiState;
 }
 
-export function transformSdkChannelFormatToApi(channel: RaidenChannel): ApiChannel {
+export function transformChannelFormatForApi(channel: RaidenChannel): ApiChannel {
   return {
     channel_identifier: channel.id.toString(),
     token_network_address: channel.tokenNetwork,
@@ -37,7 +37,7 @@ export function transformSdkChannelFormatToApi(channel: RaidenChannel): ApiChann
     balance: channel.capacity.toString(),
     total_deposit: channel.ownDeposit.toString(),
     total_withdraw: channel.ownWithdraw.toString(),
-    state: transformSdkChannelStateToApi(channel.state),
+    state: transformChannelStateForApi(channel.state),
     settle_timeout: channel.settleTimeout.toString(),
     reveal_timeout: '50', // FIXME: Not defined here. Python client handles reveal timeout differently,
   };

--- a/raiden-cli/src/utils/channels.ts
+++ b/raiden-cli/src/utils/channels.ts
@@ -30,15 +30,15 @@ function transformSdkChannelStateToApi(state: ChannelState): ApiChannelState {
 
 export function transformSdkChannelFormatToApi(channel: RaidenChannel): ApiChannel {
   return {
-    channel_identifier: channel.id,
+    channel_identifier: channel.id.toString(),
     token_network_address: channel.tokenNetwork,
     partner_address: channel.partner,
     token_address: channel.token,
-    balance: channel.balance.toString(),
+    balance: channel.capacity.toString(),
     total_deposit: channel.ownDeposit.toString(),
     total_withdraw: channel.ownWithdraw.toString(),
     state: transformSdkChannelStateToApi(channel.state),
-    settle_timeout: channel.settleTimeout,
-    reveal_timeout: 50, // FIXME: Not defined here. Python client handles reveal timeout differently,
+    settle_timeout: channel.settleTimeout.toString(),
+    reveal_timeout: '50', // FIXME: Not defined here. Python client handles reveal timeout differently,
   };
 }

--- a/raiden-cli/src/utils/channels.ts
+++ b/raiden-cli/src/utils/channels.ts
@@ -9,23 +9,6 @@ export function flattenChannelDictionary(channelDict: RaidenChannels): RaidenCha
   );
 }
 
-export function filterChannels(
-  channels: RaidenChannel[],
-  tokenAddress?: string,
-  partnerAddress?: string,
-): RaidenChannel[] {
-  let filteredChannels = channels;
-
-  if (tokenAddress) {
-    filteredChannels = filteredChannels.filter((channel) => channel.token === tokenAddress);
-  }
-  if (partnerAddress) {
-    filteredChannels = filteredChannels.filter((channel) => channel.token === partnerAddress);
-  }
-
-  return filteredChannels;
-}
-
 export function transformSdkChannelFormatToApi(channel: RaidenChannel): ApiChannel {
   return {
     channel_identifier: channel.id,

--- a/raiden-cli/src/utils/validation.ts
+++ b/raiden-cli/src/utils/validation.ts
@@ -53,5 +53,5 @@ export function isInvalidParameterError(error: RaidenError): boolean {
  * insufficient tokens funds for depositing.
  */
 export function isTransactionWouldFailError(error: Error): boolean {
-  return /gas required exceeds allowance .* or always failing transaction/.test(error.message);
+  return /always failing transaction/.test(error.message);
 }

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -670,7 +670,7 @@ export class Raiden {
     assert(tokenNetwork, ErrorCodes.RDN_UNKNOWN_TOKEN_NETWORK, this.log.info);
     assert(!subkey || this.deps.main, ErrorCodes.RDN_SUBKEY_NOT_SET, this.log.info);
 
-    const deposit = decode(UInt(32), amount);
+    const deposit = decode(UInt(32), amount, ErrorCodes.DTA_INVALID_DEPOSIT, this.log.info);
     const meta = { tokenNetwork, partner };
     const promise = asyncActionToPromise(channelDeposit, meta, this.action$, true).then(
       ({ txHash }) => txHash,


### PR DESCRIPTION
Part of #1692 

**Short description**
Extend the channel part of the CLI:
- `balance` field contains what is called `capacity` on the SDK, i.e. the amount which can still be transferred on the channel
- `state` contains a different set of strings: `opened`, `closed`, `settled`, so we need to adapt our more descriptive state to these
- all numbes are serialized as strings, including small ones like `id`, `settleTimeout` and `revealTimeout`
- implement `PATCH` method on the channels endpoint:
  - body with `{ "state": "closed"|"settled" }` respectively closes and settles the channel
  - body with `{ "total_deposit": "<number>" }` deposits amout which takes the total deposit to the requested amount
  - body with `{ "total_withdral": "<number>" }` withdraws amount which brings total withdraw to the requested amount

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Test calling actions on a channel with the respective PATCH on the API
