### PR TITLE
cli: implement /tokens endpoints

### DIFF
--- a/raiden-cli/src/routes/tokens.ts
+++ b/raiden-cli/src/routes/tokens.ts
@@ -1,20 +1,52 @@
 import { Router, Request, Response } from 'express';
+import { first } from 'rxjs/operators';
+
 import { Cli } from '../types';
+import { validateAddressParameter } from '../utils/validation';
+
+async function getAllTokens(this: Cli, _request: Request, response: Response) {
+  response.json(await this.raiden.getTokenList());
+}
+
+async function getTokenNetwork(this: Cli, request: Request, response: Response) {
+  // Attention: this also enables monitoring token
+  try {
+    response.json(await this.raiden.monitorToken(request.params.tokenAddress));
+  } catch (error) {
+    response.status(404).send(error.message);
+  }
+}
+
+async function getTokenPartners(this: Cli, request: Request, response: Response) {
+  const token: string = request.params.tokenAddress;
+  const channelsDict = await this.raiden.channels$.pipe(first()).toPromise();
+  const baseUrl = request.baseUrl.replace(/\/\w+$/, '');
+  if (!(token in channelsDict)) response.status(404).send('Unknown token or no partner');
+  else
+    response.json(
+      Object.values(channelsDict[token]).map((channel) => ({
+        partner_address: channel.partner,
+        channel: `${baseUrl}/channels/${token}/${channel.partner}`,
+      })),
+    );
+}
 
 export function makeTokensRouter(this: Cli): Router {
   const router = Router();
 
-  router.get('/', function (_request: Request, response: Response): void {
-    response.status(404).send('Not implemented yet');
-  });
+  router.get('/', getAllTokens.bind(this));
 
-  router.get('/:tokenAddress', (_request: Request, response: Response) => {
-    response.status(404).send('Not implemented yet');
-  });
+  router.get(
+    '/:tokenAddress',
+    validateAddressParameter.bind('tokenAddress'),
+    getTokenNetwork.bind(this),
+  );
 
-  router.get('/:tokenAddress/partners', (_request: Request, response: Response) => {
-    response.status(404).send('Not implemented yet');
-  });
+  router.get(
+    '/:tokenAddress/partners',
+    validateAddressParameter.bind('tokenAddress'),
+    getTokenPartners.bind(this),
+  );
 
   router.put('/:tokenAddress', (_request: Request, response: Response) => {
     response.status(404).send('Not implemented yet');

--- a/raiden-cli/src/routes/tokens.ts
+++ b/raiden-cli/src/routes/tokens.ts
@@ -21,14 +21,12 @@ async function getTokenPartners(this: Cli, request: Request, response: Response)
   const token: string = request.params.tokenAddress;
   const channelsDict = await this.raiden.channels$.pipe(first()).toPromise();
   const baseUrl = request.baseUrl.replace(/\/\w+$/, '');
-  if (!(token in channelsDict)) response.status(404).send('Unknown token or no partner');
-  else
-    response.json(
-      Object.values(channelsDict[token]).map((channel) => ({
-        partner_address: channel.partner,
-        channel: `${baseUrl}/channels/${token}/${channel.partner}`,
-      })),
-    );
+  response.json(
+    Object.values(channelsDict[token] ?? {}).map((channel) => ({
+      partner_address: channel.partner,
+      channel: `${baseUrl}/channels/${token}/${channel.partner}`,
+    })),
+  );
 }
 
 export function makeTokensRouter(this: Cli): Router {


### PR DESCRIPTION
Part of #1692 

**Short description**
Title.
Only deploying token networks is left, since it's not supported by the SDK yet (#1576)

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Test the respective endpoints are working properly in the CLI