### PR TITLE
sdk: check token balance before trying to deposit

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,16 +1,16 @@
 # Changelog
 
 ## [Unreleased]
-
 ### Fixed
 
 ### Added
 
 ### Changed
+- [#1905] Fail early if not enough tokens to deposit
 
+[#1905]: https://github.com/raiden-network/light-client/issues/1905
 
 ## [0.10.0] - 2020-07-13
-
 ### Fixed
 - [#1514] Fix handling of expired LockedTransfer and WithdrawRequest
 - [#1607] Fix settling when one side closes/updates with outdated BalanceProof

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -1286,7 +1286,9 @@ export class Raiden {
   }
 
   public async planUdcWithdraw(value: BigNumberish): Promise<Hash> {
-    const meta = { amount: bigNumberify(value) as UInt<32> };
+    const meta = {
+      amount: decode(UInt(32), value, ErrorCodes.DTA_INVALID_AMOUNT, this.log.error),
+    };
     const promise = asyncActionToPromise(udcWithdraw, meta, this.action$, true).then(
       ({ txHash }) => txHash!,
     );

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -1337,7 +1337,7 @@ describe('Raiden', () => {
     await expect(sub.openChannel(token, partner, { subkey: true })).resolves.toMatch(/^0x/);
     // first deposit fails, as subkey has only 200 tokens settled from previous channel
     await expect(sub.depositChannel(token, partner, 300, { subkey: true })).rejects.toThrow(
-      'revert',
+      ErrorCodes.RDN_INSUFFICIENT_BALANCE,
     );
     await expect(sub.depositChannel(token, partner, 80, { subkey: true })).resolves.toMatch(/^0x/);
 

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -813,6 +813,7 @@ export async function makeRaiden(
       }
       tokenContract.functions.approve.mockResolvedValue(makeTransaction());
       tokenContract.functions.allowance.mockResolvedValue(Zero);
+      tokenContract.functions.balanceOf.mockResolvedValue(parseEther('1000'));
       return tokenContract;
     },
   );


### PR DESCRIPTION
Fixes #1905 

**Short description**
Title.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Check you get an early `ErrorCodes.RDN_INSUFFICIENT_BALANCE` error if you try to deposit more than you have of balance