### PR TITLE
sdk: option to allow mint to specific address with mintFor

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -4,11 +4,13 @@
 ### Fixed
 
 ### Added
+- [#1910] Add option to `mint` tokens for any address
 
 ### Changed
 - [#1905] Fail early if not enough tokens to deposit
 
 [#1905]: https://github.com/raiden-network/light-client/issues/1905
+[#1910]: https://github.com/raiden-network/light-client/pull/1910
 
 ## [0.10.0] - 2020-07-13
 ### Fixed

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -1187,7 +1187,9 @@ describe('Raiden', () => {
 
     test('should return transaction if minted successfully', async () => {
       expect.assertions(1);
-      await expect(raiden.mint(token, 50)).resolves.toMatch(/^0x[0-9a-fA-F]{64}$/);
+      await expect(raiden.mint(token, 50, { to: raiden.address })).resolves.toMatch(
+        /^0x[0-9a-fA-F]{64}$/,
+      );
     });
   });
 


### PR DESCRIPTION
Needed for `_testing`'s mint functionality of #1692 

**Short description**
Add an optional param to specificy the beneficiary of the `mint` transaction.

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
