### PR TITLE
cli: implement /_testing endpoint for minting tokens

### DIFF
--- a/raiden-cli/src/routes/api.v1.ts
+++ b/raiden-cli/src/routes/api.v1.ts
@@ -16,7 +16,7 @@ export function makeApiV1Router(this: Cli): Router {
   router.use('/pending_transfers', makePendingTransfersRouter.call(this));
   router.use('/connections', makeConnectionsRouter.call(this));
   router.use('/payments', makePaymentsRouter.call(this));
-  router.use('/testing', makeTestingRouter.call(this));
+  router.use('/_testing', makeTestingRouter.call(this));
 
   router.get('/version', (_request: Request, response: Response) => {
     response.json({ version: Raiden.version });

--- a/raiden-cli/src/routes/testing.ts
+++ b/raiden-cli/src/routes/testing.ts
@@ -1,12 +1,31 @@
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
+import { ErrorCodes } from 'raiden-ts';
+import { validateAddressParameter } from '../utils/validation';
 import { Cli } from '../types';
+
+async function mintTokens(this: Cli, request: Request, response: Response, next: NextFunction) {
+  try {
+    const transactionHash = await this.raiden.mint(
+      request.params.tokenAddress,
+      request.body.value,
+      { to: request.body.to },
+    );
+    response.json({ transaction_hash: transactionHash });
+  } catch (error) {
+    if ([ErrorCodes.DTA_INVALID_ADDRESS, ErrorCodes.DTA_INVALID_AMOUNT].includes(error.message))
+      response.status(400).send(error.message);
+    else next(error);
+  }
+}
 
 export function makeTestingRouter(this: Cli): Router {
   const router = Router();
 
-  router.get('/tokens/:tokenAddress/mint', (_request: Request, response: Response) => {
-    response.status(404).send('Not implemented yet');
-  });
+  router.post(
+    '/tokens/:tokenAddress/mint',
+    validateAddressParameter.bind('tokenAddress'),
+    mintTokens.bind(this),
+  );
 
   return router;
 }


### PR DESCRIPTION
Based on top of #1910 
Part of #1692 

**Short description**
Implements minting tokens from the CLI API.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
