### PR TITLE
sdk,cli: expose contracts info in SDK and provide /contracts endpoint in CLI

### DIFF
--- a/raiden-cli/src/routes/api.v1.ts
+++ b/raiden-cli/src/routes/api.v1.ts
@@ -19,15 +19,24 @@ export function makeApiV1Router(this: Cli): Router {
   router.use('/testing', makeTestingRouter.call(this));
 
   router.get('/version', (_request: Request, response: Response) => {
+    response.json({ version: Raiden.version });
+  });
+
+  router.get('/contracts', (_request: Request, response: Response) => {
+    const contracts = this.raiden.contractsInfo;
     response.json({
-      version: Raiden.version,
+      contracts_version: Raiden.contractVersion,
+      token_network_registry_address: contracts.TokenNetworkRegistry.address,
+      secret_registry_address: contracts.SecretRegistry.address,
+      service_registry_address: contracts.ServiceRegistry.address,
+      user_deposit_address: contracts.UserDeposit.address,
+      monitoring_service_address: contracts.MonitoringService.address,
+      one_to_n_address: '',
     });
   });
 
   router.get('/address', (_request: Request, response: Response) => {
-    response.json({
-      our_address: this.raiden.address,
-    });
+    response.json({ our_address: this.raiden.address });
   });
 
   router.get('/status', (_request: Request, response: Response) => {

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -5,12 +5,14 @@
 
 ### Added
 - [#1910] Add option to `mint` tokens for any address
+- [#1913] Added `contractsInfo` getter holding current contracts info
 
 ### Changed
 - [#1905] Fail early if not enough tokens to deposit
 
 [#1905]: https://github.com/raiden-network/light-client/issues/1905
 [#1910]: https://github.com/raiden-network/light-client/pull/1910
+[#1913]: https://github.com/raiden-network/light-client/pull/1913
 
 ## [0.10.0] - 2020-07-13
 ### Fixed
@@ -227,8 +229,8 @@
 - Update message packing and signature to confront with Alderaan format.
 - Optimize past event scanning.
 - Make transfer parameters consistent with openChannel.
-- Update previous transfer initialization to monitor pending transfers. 
-- Update the transfer mechanism to accept transfers that are reduced up to 10% due to fees. 
+- Update previous transfer initialization to monitor pending transfers.
+- Update the transfer mechanism to accept transfers that are reduced up to 10% due to fees.
 - Increase time before leaving unknown rooms.
 - Reduce the minimum settle timeout to 20.
 - Remove fee field from LockedTransfer to comply with raiden-py.
@@ -255,7 +257,7 @@
 - Add monitoring for transfers based on secret hash.
 
 ### Changed
-- Change transfer api return secret hash. 
+- Change transfer api return secret hash.
 
 ## [0.1] - 2019-08-21
 ### Added

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -487,6 +487,15 @@ export class Raiden {
   }
 
   /**
+   * Returns the Smart Contracts addresses and deployment blocks
+   *
+   * @returns Smart Contracts info
+   */
+  get contractsInfo(): ContractsInfo {
+    return this.deps.contractsInfo;
+  }
+
+  /**
    * Update Raiden Config with a partial (shallow) object
    *
    * @param config - Partial object containing keys and values to update in config

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -264,6 +264,21 @@ describe('Raiden', () => {
     expect(raiden.network).toEqual(await provider.getNetwork());
   });
 
+  test('contractVersion', async () => {
+    expect.assertions(1);
+    expect(Raiden.contractVersion).toMatch(/.+/);
+  });
+
+  test('contractsInfo', async () => {
+    expect.assertions(1);
+    expect(raiden.contractsInfo).toMatchObject({
+      TokenNetworkRegistry: {
+        address: expect.stringMatching(/0x[0-9a-f]{40}/i),
+        block_number: expect.any(Number),
+      },
+    });
+  });
+
   test('getBlockNumber', async () => {
     expect.assertions(1);
     await expect(raiden.getBlockNumber()).resolves.toBeGreaterThanOrEqual(


### PR DESCRIPTION
Part of #1692 

**Short description**
Implements `/contracts` endpoint. Still undocumented on spec, but offered by python API.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
