### PR TITLE
cli: add naive connections manager endpoints

### DIFF
--- a/raiden-cli/src/routes/connections.ts
+++ b/raiden-cli/src/routes/connections.ts
@@ -1,20 +1,133 @@
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
+import { first } from 'rxjs/operators';
+import { ChannelState, isntNil } from 'raiden-ts';
+
+import {
+  validateAddressParameter,
+  isConflictError,
+  isInsuficientFundsError,
+  isInvalidParameterError,
+} from '../utils/validation';
 import { Cli } from '../types';
+
+export interface ApiConnection {
+  channels: string;
+  sum_deposits: string;
+  funds: string;
+}
+
+export interface ApiTokenConnections {
+  [token: string]: ApiConnection;
+}
+
+async function getConnections(this: Cli, _request: Request, response: Response) {
+  const channelsDict = await this.raiden.channels$.pipe(first()).toPromise();
+  const connections = Object.entries(channelsDict).reduce<ApiTokenConnections>(
+    (connections, [token, partnerChannel]) => ({
+      ...connections,
+      [token]: Object.values(partnerChannel).reduce<ApiConnection>(
+        ({ channels, funds }, { ownDeposit, ownWithdraw }) => {
+          const deposits = ownDeposit.sub(ownWithdraw).add(funds).toString();
+          return {
+            channels: (+channels + 1).toString(),
+            sum_deposits: deposits,
+            funds: deposits,
+          };
+        },
+        { channels: '0', sum_deposits: '0', funds: '0' },
+      ),
+    }),
+    {},
+  );
+  response.json(connections);
+}
+
+/**
+ * Naive connection manager: only supports connecting to a single hardcoded hub
+ * We don't want to improve this (for now), since SDK doesn't have the concept of connection
+ * manager; it may change when we have proper auto-pilot (#211); before that, this dummy
+ * implementation should enough to make WebUI work with it
+ */
+async function connectTokenNetwork(
+  this: Cli,
+  request: Request,
+  response: Response,
+  next: NextFunction,
+) {
+  if (request.body.initial_channel_target && request.body.initial_channel_target != 1)
+    return response.status(409).send('CLI only supports managing connection with one hub');
+  if (request.body.joinable_funds_target && request.body.joinable_funds_target != 1)
+    return response.status(409).send('CLI only supports allocating whole funds');
+  const token: string = request.params.tokenAddress;
+  try {
+    const channelsDict = await this.raiden.channels$.pipe(first()).toPromise();
+    const hub = await this.raiden.resolveName('hub.raiden.eth');
+    const channel = channelsDict[token]?.[hub];
+    if (!channel) {
+      await this.raiden.openChannel(token, hub, {
+        deposit: request.body.funds,
+      });
+    } else if (
+      request.body.funds &&
+      channel.ownDeposit.sub(channel.ownWithdraw).lt(request.body.funds)
+    ) {
+      // if channel exists but allocated funds are lower than requested, deposit difference
+      // amount = funds - (ownDeposit - ownWithdraw) = ((ownDeposit - ownWithdraw) - funds) * -1
+      const amount = channel.ownDeposit.sub(channel.ownWithdraw).sub(request.body.funds).mul(-1);
+      await this.raiden.depositChannel(token, hub, amount);
+    }
+    response.status(204);
+  } catch (error) {
+    if (isInvalidParameterError(error)) response.status(400).send(error.message);
+    else if (isInsuficientFundsError(error)) response.status(402).send(error.message);
+    else if (isConflictError(error)) response.status(409).send(error.message);
+    else next(error);
+  }
+}
+
+/**
+ * Closes all closeable channels in a token network
+ * TODO: implement auto-settle (see discussion at #237)
+ */
+async function disconnectTokenNetwork(this: Cli, request: Request, response: Response) {
+  const token: string = request.params.tokenAddress;
+  const channelsDict = await this.raiden.channels$.pipe(first()).toPromise();
+  if (!channelsDict[token]) return response.status(404).send('No channels on tokenNetwork');
+  const closeableChannels = Object.values(channelsDict[token]).filter((channel) =>
+    [ChannelState.open, ChannelState.closing].includes(channel.state),
+  );
+  const promises: Promise<string | undefined>[] = [];
+  for (let i = 0; i < closeableChannels.length; i++) {
+    // if more than one channel to close, wait 1s between each call to avoid nonce races
+    if (i > 0) await new Promise((resolve) => setTimeout(resolve, 1000));
+    const channel = closeableChannels[i];
+    promises.push(
+      this.raiden.closeChannel(token, channel.partner).then(
+        () => channel.partner,
+        () => undefined,
+      ),
+    );
+  }
+  const partners: string[] = (await Promise.all(promises)).filter(isntNil);
+  response.json(partners);
+}
 
 export function makeConnectionsRouter(this: Cli): Router {
   const router = Router();
 
-  router.get('/', function (_request: Request, response: Response): void {
-    response.send('All connections');
-  });
+  router.get('/', getConnections.bind(this));
 
-  router.put('/:tokenAddress', (_request: Request, response: Response) => {
-    response.status(404).send('Not implemented yet');
-  });
+  router.put(
+    '/:tokenAddress',
+    validateAddressParameter.bind('tokenAddress'),
+    connectTokenNetwork.bind(this),
+  );
 
-  router.delete('/:tokenAddress', (_request: Request, response: Response) => {
-    response.status(404).send('Not implemented yet');
-  });
+  router.delete(
+    '/:tokenAddress',
+    validateAddressParameter.bind('tokenAddress'),
+    disconnectTokenNetwork.bind(this),
+  );
 
   return router;
 }

--- a/raiden-cli/src/routes/payments.ts
+++ b/raiden-cli/src/routes/payments.ts
@@ -7,6 +7,7 @@ import {
   validateAddressParameter,
   isInvalidParameterError,
   validateOptionalAddressParameter,
+  isInsuficientFundsError,
 } from '../utils/validation';
 
 export enum ApiPaymentEvent {
@@ -91,6 +92,8 @@ async function doTransfer(this: Cli, request: Request, response: Response, next:
   } catch (error) {
     if (isInvalidParameterError(error)) {
       response.status(400).send(error.message);
+    } else if (isInsuficientFundsError(error)) {
+      response.status(402).send(error.message);
     } else if (isConflictError(error)) {
       const pfsErrorDetail = error.details?.errors ? ` (${error.details.errors})` : '';
       response.status(409).send(error.message + pfsErrorDetail);

--- a/raiden-cli/src/utils/validation.ts
+++ b/raiden-cli/src/utils/validation.ts
@@ -55,3 +55,24 @@ export function isInvalidParameterError(error: RaidenError): boolean {
 export function isTransactionWouldFailError(error: Error): boolean {
   return /always failing transaction/.test(error.message);
 }
+
+export function isConflictError(error: Error): boolean {
+  return (
+    [ErrorCodes.RDN_UNKNOWN_TOKEN_NETWORK, ErrorCodes.CNL_INVALID_STATE].includes(error.message) ||
+    isTransactionWouldFailError(error)
+  );
+}
+
+export function isInsuficientFundsError(error: {
+  message: string;
+  code?: string | number;
+}): boolean {
+  return (
+    error.code === 'INSUFFICIENT_FUNDS' ||
+    [
+      ErrorCodes.RDN_INSUFFICIENT_BALANCE,
+      ErrorCodes.CNL_WITHDRAW_AMOUNT_TOO_LOW,
+      ErrorCodes.CNL_WITHDRAW_AMOUNT_TOO_HIGH,
+    ].includes(error.message)
+  );
+}


### PR DESCRIPTION
Part of #1692 

**Short description**
- GET will return the connected TokenNetworks; as it's a dummy implementation, it has no notion of allocated funds, so the funds and deposits are just the sum of channel's deposits
- PUT works by connecting with a single hardcoded hub (currently, `hub.raiden.eth`, as suggested by dApp)
- DELETE does work as intended by closing all channels in a tokenNetwork, although auto-settling is still pending

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
