### PR TITLE
sdk: Add option to fetch all contracts addresses from UserDeposit address alone

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 
 ### Added
+- [#703] Add option to fetch all contracts addresses from UserDeposit address alone
 - [#1910] Add option to `mint` tokens for any address
 - [#1913] Added `contractsInfo` getter holding current contracts info
 - [#1824] Expose channel settle actions as events
@@ -11,6 +12,7 @@
 ### Changed
 - [#1905] Fail early if not enough tokens to deposit
 
+[#703]: https://github.com/raiden-network/light-client/issues/703
 [#1905]: https://github.com/raiden-network/light-client/issues/1905
 [#1910]: https://github.com/raiden-network/light-client/pull/1910
 [#1913]: https://github.com/raiden-network/light-client/pull/1913

--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -358,7 +358,6 @@ export async function fetchContractsInfo(
 ): Promise<ContractsInfo> {
   const userDepositContract = UserDepositFactory.connect(userDeposit, provider);
 
-  const oneToN = (await userDepositContract.one_to_n_address()) as Address;
   const monitoringService = (await userDepositContract.msc_address()) as Address;
   const monitoringServiceContract = MonitoringServiceFactory.connect(monitoringService, provider);
 
@@ -376,12 +375,10 @@ export async function fetchContractsInfo(
     fromBlock: 1,
     toBlock: 'latest',
   });
-  let firstBlock = 0;
-  for (const { blockNumber } of logs) {
-    if (blockNumber) {
-      firstBlock = firstBlock ? Math.min(firstBlock, blockNumber) : blockNumber;
-    }
-  }
+  const logBlocks = logs.map((log) => log.blockNumber).filter(isntNil);
+  const firstBlock = logBlocks.length ? Math.min(...logBlocks) : 0;
+
+  const oneToN = (await userDepositContract.one_to_n_address()) as Address;
 
   return {
     TokenNetworkRegistry: { address: tokenNetworkRegistry, block_number: firstBlock },

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -345,7 +345,10 @@ export class Raiden {
     } else if (typeof contractsOrUserDepositAddress === 'string') {
       // if an Address is provided, use it as UserDeposit contract address entrypoint and fetch
       // all contracts from there
-      assert(Address.is(contractsOrUserDepositAddress), ErrorCodes.DTA_INVALID_ADDRESS);
+      assert(Address.is(contractsOrUserDepositAddress), [
+        ErrorCodes.DTA_INVALID_ADDRESS,
+        { contractsOrUserDepositAddress },
+      ]);
       contracts = await fetchContractsInfo(provider, contractsOrUserDepositAddress);
     } else {
       contracts = contractsOrUserDepositAddress;

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -27,9 +27,7 @@ import { fromFetch } from 'rxjs/fetch';
 import { Event } from 'ethers/contract';
 import { BigNumber, bigNumberify, toUtf8Bytes, verifyMessage, concat } from 'ethers/utils';
 import { Two, Zero, MaxUint256, WeiPerEther } from 'ethers/constants';
-import memoize from 'lodash/memoize';
 
-import { UserDeposit } from '../contracts/UserDeposit';
 import { RaidenAction } from '../actions';
 import { RaidenState } from '../state';
 import { RaidenEpicDeps, Latest } from '../types';
@@ -61,11 +59,6 @@ import {
 import { channelCanRoute, pfsInfo, pfsListInfo, packIOU, signIOU } from './utils';
 import { IOU, LastIOUResults, PathResults, Paths, PFS } from './types';
 
-const oneToNAddress = memoize(
-  async (userDepositContract: UserDeposit) =>
-    userDepositContract.functions.one_to_n_address() as Promise<Address>,
-);
-
 /**
  * Codec for PFS API returned error
  *
@@ -94,7 +87,7 @@ function makeTimestamp(time?: Date): string {
 function fetchLastIou$(
   pfs: PFS,
   tokenNetwork: Address,
-  { address, signer, network, userDepositContract, latest$, config$ }: RaidenEpicDeps,
+  { address, signer, network, contractsInfo, latest$, config$ }: RaidenEpicDeps,
 ): Observable<IOU> {
   return defer(() => {
     const timestamp = makeTimestamp(),
@@ -121,7 +114,7 @@ function fetchLastIou$(
           receiver: pfs.address,
           chain_id: bigNumberify(network.chainId) as UInt<32>,
           amount: Zero as UInt<32>,
-          one_to_n_address: await oneToNAddress(userDepositContract),
+          one_to_n_address: contractsInfo.OneToN.address,
           expiration_block: bigNumberify(blockNumber).add(2 * 10 ** 5) as UInt<32>,
         }; // return empty/zeroed IOU
       }

--- a/raiden-ts/src/state.ts
+++ b/raiden-ts/src/state.ts
@@ -153,6 +153,7 @@ export const initialState = makeInitialState({
     UserDeposit: { address: AddressZero as Address, block_number: 0 },
     SecretRegistry: { address: AddressZero as Address, block_number: 0 },
     MonitoringService: { address: AddressZero as Address, block_number: 0 },
+    OneToN: { address: AddressZero as Address, block_number: 0 },
   },
 });
 

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -30,6 +30,7 @@ export interface ContractsInfo {
   UserDeposit: Info;
   SecretRegistry: Info;
   MonitoringService: Info;
+  OneToN: Info;
 }
 
 export interface Latest {

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -156,7 +156,7 @@ describe('Raiden', () => {
   });
 
   test('create from other params and RaidenState', async () => {
-    expect.assertions(13);
+    expect.assertions(14);
 
     const raiden0State = await raiden.state$.pipe(first()).toPromise();
     raiden.stop();
@@ -222,6 +222,7 @@ describe('Raiden', () => {
                 UserDeposit: { address: partner as Address, block_number: 2 },
                 SecretRegistry: { address: partner as Address, block_number: 3 },
                 MonitoringService: { address: partner as Address, block_number: 3 },
+                OneToN: { address: partner as Address, block_number: 3 },
               },
               address: accounts[1] as Address,
             },
@@ -232,15 +233,42 @@ describe('Raiden', () => {
       ),
     ).rejects.toThrow(/Mismatch between network or registry address and loaded state/i);
 
-    // success when using address of account on provider and initial state
+    // success when using address of account on provider and initial state,
+    // and pass UserDeposit address to fetch contracts info from
     const raiden1 = await Raiden.create(
       provider,
       accounts[1],
       makeInitialState({ network, contractsInfo, address: accounts[1] as Address }, { config }),
-      contractsInfo,
+      contractsInfo.UserDeposit.address,
       config,
     );
     expect(raiden1).toBeInstanceOf(Raiden);
+    expect(raiden1.contractsInfo).toMatchObject({
+      TokenNetworkRegistry: {
+        address: contractsInfo.TokenNetworkRegistry.address,
+        block_number: expect.any(Number),
+      },
+      ServiceRegistry: {
+        address: contractsInfo.ServiceRegistry.address,
+        block_number: expect.any(Number),
+      },
+      UserDeposit: {
+        address: contractsInfo.UserDeposit.address,
+        block_number: expect.any(Number),
+      },
+      SecretRegistry: {
+        address: contractsInfo.SecretRegistry.address,
+        block_number: expect.any(Number),
+      },
+      MonitoringService: {
+        address: contractsInfo.MonitoringService.address,
+        block_number: expect.any(Number),
+      },
+      OneToN: {
+        address: contractsInfo.OneToN.address,
+        block_number: expect.any(Number),
+      },
+    });
 
     // test Raiden.started, not yet started
     expect(raiden1.started).toBeUndefined();

--- a/raiden-ts/tests/unit/epics/mediate.spec.ts
+++ b/raiden-ts/tests/unit/epics/mediate.spec.ts
@@ -1,4 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { raidenEpicDeps } from '../mocks';
+import { epicFixtures } from '../fixtures';
+
 import { bigNumberify } from 'ethers/utils';
 import { Zero, One } from 'ethers/constants';
 import { of } from 'rxjs';
@@ -24,9 +27,6 @@ import {
   getLocksroot,
 } from 'raiden-ts/transfers/utils';
 import { Direction } from 'raiden-ts/transfers/state';
-
-import { epicFixtures } from '../fixtures';
-import { raidenEpicDeps } from '../mocks';
 
 describe('mediate transfers', () => {
   let depsMock: ReturnType<typeof raidenEpicDeps>;

--- a/raiden-ts/tests/unit/epics/receive.spec.ts
+++ b/raiden-ts/tests/unit/epics/receive.spec.ts
@@ -1,4 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { raidenEpicDeps, makeSignature, makeLog } from '../mocks';
+import { epicFixtures } from '../fixtures';
+
 import { bigNumberify, BigNumber } from 'ethers/utils';
 import { Zero, One, HashZero } from 'ethers/constants';
 import { of, EMPTY } from 'rxjs';
@@ -52,9 +55,6 @@ import {
   getLocksroot,
 } from 'raiden-ts/transfers/utils';
 import { Direction } from 'raiden-ts/transfers/state';
-
-import { epicFixtures } from '../fixtures';
-import { raidenEpicDeps, makeSignature, makeLog } from '../mocks';
 import { pluckDistinct } from 'raiden-ts/utils/rx';
 
 describe('receive transfers', () => {

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -459,9 +459,7 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
     jest.spyOn(userDepositContract.functions, func as keyof UserDeposit['functions']);
   }
 
-  userDepositContract.functions.one_to_n_address.mockResolvedValue(
-    '0x0A0000000000000000000000000000000000000a',
-  );
+  userDepositContract.functions.one_to_n_address.mockResolvedValue(oneToNAddress);
   userDepositContract.functions.balances.mockResolvedValue(parseEther('5'));
   userDepositContract.functions.total_deposit.mockResolvedValue(parseEther('5'));
   userDepositContract.functions.effectiveBalance.mockResolvedValue(parseEther('5'));
@@ -508,6 +506,10 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
       },
       MonitoringService: {
         address: monitoringServiceContract.address as Address,
+        block_number: 102,
+      },
+      OneToN: {
+        address: oneToNAddress,
         block_number: 102,
       },
     },
@@ -881,6 +883,10 @@ export async function makeRaiden(
     },
     MonitoringService: {
       address: monitoringServiceContract.address as Address,
+      block_number: 102,
+    },
+    OneToN: {
+      address: oneToNAddress,
       block_number: 102,
     },
   };

--- a/raiden-ts/tests/unit/reducers.spec.ts
+++ b/raiden-ts/tests/unit/reducers.spec.ts
@@ -83,6 +83,7 @@ describe('raidenReducer', () => {
           UserDeposit: { address: AddressZero as Address, block_number: 0 },
           SecretRegistry: { address: AddressZero as Address, block_number: 0 },
           MonitoringService: { address: AddressZero as Address, block_number: 0 },
+          OneToN: { address: AddressZero as Address, block_number: 0 },
         },
       },
       { blockNumber: 1337 },


### PR DESCRIPTION
Fixes #703

**Short description**
Supports using `UserDeposit` contract's address as entrypoint to fetch all other addresses from it.
Deployment block for all contracts is set to oldest TokenNetwork registration event, as it's used only as lowerbound for events fetching.
Also, adds `OneToN` contract to `ContractsInfo` type, which completes it with all relevant deployed contracts.
The previous default way for feeding `contractsInfo` from the JSON generated deployment files is kept for backwards compatibility and efficiency, since it doesn't require the associated network requests.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
