### PR TITLE
sdk: fix `fromEthersEvent` ranges fetching in case of temporary connectivity loss

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
+- [#1923] Fix `fromEthersEvent` ranges fetching in case of temporary connectivity loss
 
 ### Added
 - [#1910] Add option to `mint` tokens for any address
@@ -15,6 +16,7 @@
 [#1910]: https://github.com/raiden-network/light-client/pull/1910
 [#1913]: https://github.com/raiden-network/light-client/pull/1913
 [#1824]: https://github.com/raiden-network/light-client/issues/1824
+[#1923]: https://github.com/raiden-network/light-client/issues/1923
 
 ## [0.10.0] - 2020-07-13
 ### Fixed

--- a/raiden-ts/tests/unit/epics/monitor.spec.ts
+++ b/raiden-ts/tests/unit/epics/monitor.spec.ts
@@ -1,5 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { raidenEpicDeps, makeLog, makeAddress, makeHash, makeRaidens, waitBlock } from '../mocks';
+import {
+  raidenEpicDeps,
+  makeLog,
+  makeAddress,
+  makeHash,
+  makeRaidens,
+  waitBlock,
+  providersEmit,
+} from '../mocks';
 import { epicFixtures, tokenNetwork, ensureChannelIsOpen, id } from '../fixtures';
 
 import { bigNumberify, BigNumberish, defaultAbiCoder } from 'ethers/utils';
@@ -336,21 +344,12 @@ test('msMonitorNewBPEpic', async () => {
   const monitoringService = makeAddress();
   const nonce = Two as UInt<8>;
   const txHash = makeHash();
-  const txBlock = 68;
 
   // emit a NewBalanceProofReceived event
-  raiden.deps.provider.emit(
-    monitoringServiceContract.filters.NewBalanceProofReceived(
-      null,
-      null,
-      null,
-      null,
-      null,
-      raiden.address,
-    ),
+  await providersEmit(
+    {},
     makeLog({
       transactionHash: txHash,
-      blockNumber: txBlock,
       filter: monitoringServiceContract.filters.NewBalanceProofReceived(
         null,
         null,
@@ -365,8 +364,8 @@ test('msMonitorNewBPEpic', async () => {
       ),
     }),
   );
-
   await waitBlock();
+
   expect(raiden.output).toContainEqual(
     msBalanceProofSent({
       tokenNetwork,
@@ -376,8 +375,8 @@ test('msMonitorNewBPEpic', async () => {
       nonce,
       monitoringService,
       txHash,
-      txBlock,
-      confirmed: true,
+      txBlock: expect.any(Number),
+      confirmed: undefined,
     }),
   );
 });


### PR DESCRIPTION
Fixes #1923 
Follow-up of #1832 

**Short description**
This PR fixes the issue by using a `fromBlock` queue, instead of a single value, so we always keep track of "_[range]_ successful requests in the past", and can proceed with the correct ranges even in case of connectivity loss or exceptions thrown.
Also, the queue is only walked over (i.e. popping the front we just queried, pushing to the back the new block for future range request) if the request didn't throw, allowing us to safely ignore any network error/exception thrown while scanning ranges and retrying the previous `fromBlock` when a new `block` event is emitted, which indicates connectivity was restored.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Disconnect the browser from internet while dApp is connected and monitoring some channel/tokenNetwork
2. Do some transaction which would show up on an event (e.g. a deposit on partner)
3. Wait more than 5 blocks after transaction, then connect back to internet
4. See event got picked up properly, network failures didn't error/shutdown the SDK
