### PR TITLE
dApp: Clear newBlocks entries from logs, split by account, redact accessTokens and secrets

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -10,9 +10,13 @@
 - [#1824] Listen to channel settle events and push notifications for them
 
 ### Changed
+- [#1265] Reduce logs size by hiding superfluous actions entries
+- [#1875] Redact sensitive information (transport's accessToken, transfer's secrets) from logs
 
+[#1265]: https://github.com/raiden-network/light-client/issues/1265
 [#1786]: https://github.com/raiden-network/light-client/issues/1786
 [#1824]: https://github.com/raiden-network/light-client/issues/1824
+[#1875]: https://github.com/raiden-network/light-client/issues/1875
 
 ## [0.10.0] - 2020-07-13
 

--- a/raiden-dapp/src/components/account/AccountContent.vue
+++ b/raiden-dapp/src/components/account/AccountContent.vue
@@ -179,7 +179,11 @@ export default class AccountContent extends Mixins(NavigationMixin) {
   /* istanbul ignore next */
   async downloadLogs() {
     const [lastTime, content] = await getLogsFromStore();
-    const filename = `raiden_${new Date(lastTime).toISOString()}.log`;
+    let account = '';
+    try {
+      account = `${await this.$raiden.getAccount()}_`;
+    } catch (err) {}
+    const filename = `raiden_${account}${new Date(lastTime).toISOString()}.log`;
     const file = new File([content], filename, { type: 'text/plain' });
     const url = URL.createObjectURL(file);
     const el = document.createElement('a');

--- a/raiden-dapp/src/utils/logstore.ts
+++ b/raiden-dapp/src/utils/logstore.ts
@@ -1,14 +1,16 @@
 import logging from 'loglevel';
 import { openDB, DBSchema, IDBPDatabase } from 'idb';
 
-const collectionName = 'logs';
+const storeName = 'logs';
+let lastBlockNumber: number | undefined = undefined;
 
 interface RaidenDB extends DBSchema {
-  [collectionName]: {
+  [storeName]: {
     value: {
       logger: string;
       level: string;
       message: any[];
+      block?: number;
     };
     key: number;
     indexes: {
@@ -37,7 +39,13 @@ function serializeError(e: Error): string {
 /* istanbul ignore next */
 function filterMessage(message: any[]) {
   if (message[0] === '%c prev state') return;
+  if (message[0]?.startsWith?.('action %c')) return;
   if (message[0] === '—— log end ——') return;
+  const blockNumber: number | undefined = message[2]?.payload?.blockNumber;
+  if (blockNumber) {
+    lastBlockNumber = blockNumber; // set lastBlockNumber and skip newBlock action
+    return;
+  }
   message = message.map((e) =>
     e instanceof Error
       ? serializeError(e)
@@ -64,19 +72,29 @@ function serialize(e: any): string {
   }
 }
 
-/* istanbul ignore next */
-export async function setupLogStore(
-  dbName = 'raiden',
-  additionalLoggers: string[] = ['matrix']
-): Promise<void> {
-  if (typeof db !== 'undefined') return;
+async function setupDb(dbName: string) {
+  if (db?.name === dbName) return;
   db = await openDB<RaidenDB>(dbName, 1, {
     upgrade(db) {
-      const logsStore = db.createObjectStore(collectionName);
+      const logsStore = db.createObjectStore(storeName);
       logsStore.createIndex('by-logger', 'logger');
       logsStore.createIndex('by-level', 'level');
     },
   });
+}
+
+const loggerRe = /^raiden:(0x[0-9a-f]{40})$/i;
+async function setDbForLogger(loggerName: string) {
+  if (!loggerRe.test(loggerName)) return;
+  await setupDb(loggerName);
+}
+
+/* istanbul ignore next */
+export async function setupLogStore(
+  additionalLoggers: string[] = ['matrix']
+): Promise<void> {
+  if (typeof db !== 'undefined') return;
+  await setupDb('raiden'); // init database, for startup logs
 
   for (const log of [logging, ...additionalLoggers.map(logging.getLogger)]) {
     const origFactory = log.methodFactory;
@@ -86,25 +104,28 @@ export async function setupLogStore(
       loggerName: string
     ): logging.LoggingMethod => {
       const rawMethod = origFactory(methodName, level, loggerName);
+      setDbForLogger(loggerName);
       return (...message: any[]): void => {
         rawMethod(...message);
         const filtered = filterMessage(message);
         if (!filtered) return;
         db.put(
-          collectionName,
+          storeName,
           {
             logger: loggerName,
             level: methodName,
             message: filtered,
+            ...(lastBlockNumber ? { block: lastBlockNumber } : {}),
           },
           Date.now()
         ).catch(() =>
           db.put(
-            collectionName,
+            storeName,
             {
               logger: loggerName,
               level: methodName,
               message: message.map(serialize),
+              ...(lastBlockNumber ? { block: lastBlockNumber } : {}),
             },
             Date.now()
           )
@@ -116,16 +137,26 @@ export async function setupLogStore(
 
 export async function getLogsFromStore(): Promise<[number, string]> {
   let content = '';
-  let cursor = await db.transaction(collectionName).store.openCursor();
+  let cursor = await db.transaction(storeName).store.openCursor();
   let lastTime = Date.now();
+  let first = true;
   while (cursor) {
-    const { logger, level, message } = cursor.value;
+    const { logger, level, message, block } = cursor.value;
     const line = message
       .map((m) => (typeof m === 'string' ? m : JSON.stringify(m)))
       .join(' ');
     lastTime = +cursor.key;
     const time = new Date(cursor.key).toISOString();
-    content += `${time} @ ${logger} [${level}] \t=> ${line}\n`;
+    const blockStr = block ? ` #${block}` : ''; // don't print block if there's none
+    // most (usually all) entries have loggerName == dbName == `raiden:<address>`
+    // in this case, we print the loggerName only once and omit later to save space
+    let loggerStr;
+    if (logger === db.name && !first) loggerStr = '';
+    else {
+      loggerStr = ` @ ${logger}`;
+      first = false;
+    }
+    content += `${time}${blockStr}${loggerStr} [${level}] \t=> ${line}\n`;
     cursor = await cursor.continue();
   }
   return [lastTime, content];


### PR DESCRIPTION
Fixes #1265 
Fixes #1875 

**Short description**
A few logging improvements for dApp's logs:
- `newBlock` actions are filtered from logs; instead, its blockNumber is saved, and upon next _more important_ actions, it's included after timestamp
- Remove logger name from every line, saving ~50 chars per line; it's printed on first action and omitted later
- Logs are split per session account; while disconnected, you download logs only from initialization (before account/address is availble); and connected, you download from the session/account you're on
- Address is added to the name of the downloaded log file, to ease identification
- Redact transport's `accessToken` and transfer's `secret` from every downloaded log line (security)

Example:
```
2020-07-20T21:47:48.490Z @ raiden:0xd8fc6Df26689B63E7B3008B32cBd7205d48FAB3c [info] 	=> %c action     {"type":"channel/monitored","payload":{"id":2421},"meta":{"tokenNetwork":"0x3EA2a1fED7FdEf300DA19E97092Ce8FdF8bf66A3","partner":"0x1F916ab5cf1B30B22f24Ebf435f53Ee665344Acf"}}
2020-07-20T21:47:48.494Z [info] 	=> %c action     {"type":"channel/monitored","payload":{"id":4684},"meta":{"tokenNetwork":"0x3EA2a1fED7FdEf300DA19E97092Ce8FdF8bf66A3","partner":"0x48a25Cd810ada615E85975535E67A8125da8d993"}}
2020-07-20T21:47:48.500Z [info] 	=> %c action     {"type":"matrix/presence/request","meta":{"address":"0x1F916ab5cf1B30B22f24Ebf435f53Ee665344Acf"}}
2020-07-20T21:47:48.505Z [info] 	=> %c action     {"type":"matrix/presence/request","meta":{"address":"0x48a25Cd810ada615E85975535E67A8125da8d993"}}
2020-07-20T21:47:48.511Z [info] 	=> %c action     {"type":"raiden/config/update","payload":{}}
2020-07-20T21:47:48.583Z #3081688 [info] 	=> %c action     {"type":"token/monitored","payload":{"token":"0x59105441977ecD9d805A4f5b060E34676F50F806","tokenNetwork":"0x3EA2a1fED7FdEf300DA19E97092Ce8FdF8bf66A3","fromBlock":3079675,"toBlock":3081688}}
2020-07-20T21:47:48.586Z #3081688 [info] 	=> %c action     {"type":"token/monitored","payload":{"token":"0xC563388e2e2fdD422166eD5E76971D11eD37A466","tokenNetwork":"0x812650FB6Acdf9dD47E631cBB5518B32FFD4D129","fromBlock":2942510,"toBlock":3081688}}
2020-07-20T21:47:48.923Z #3081688 [info] 	=> %c action     {"type":"udc/deposited","payload":{"_hex":"0x01236efcbcbb340000"}}
2020-07-20T21:47:49.269Z #3081688 [info] 	=> %c action     {"type":"matrix/setup","payload":{"server":"https://transport.demo001.env.raiden.network","setup":{"userId":"@0xd8fc6df26689b63e7b3008b32cbd7205d48fab3c:transport.demo001.env.raiden.network","accessToken":"<redacted>","deviceId":"RAIDEN","displayName":"0x0e8630b6161689eb5df51179ee72aef69604510b1d5868622961be637818448e1a5cc6fd3133291a2898470b4b322c34d6aaab5d4d3887b934b5cb523f7aa61d1c"}}}

```

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to an account
2. Download logs and see it doesn't include `block/new` actions and have the improved format and redactions.
