### PR TITLE
sdk: wait contract to catch up with just mined udcWithdraw plan tx

### DIFF
--- a/raiden-ts/tests/unit/epics/udc.spec.ts
+++ b/raiden-ts/tests/unit/epics/udc.spec.ts
@@ -35,6 +35,12 @@ describe('udcWithdraw', () => {
       0: amount,
       1: withdrawBlock,
     });
+    raiden.deps.userDepositContract.functions.withdraw_plans.mockResolvedValueOnce({
+      amount: Zero,
+      withdraw_block: Zero,
+      0: Zero,
+      1: Zero,
+    });
     const planTx = makeTransaction(1);
     raiden.deps.userDepositContract.functions.planWithdraw.mockResolvedValue(planTx);
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -46,6 +52,7 @@ describe('udcWithdraw', () => {
     raiden.store.dispatch(udcWithdraw.request(undefined, { amount: amount as UInt<32> }));
 
     await waitBlock(raiden.deps.provider.blockNumber + confirmationBlocks);
+    await waitBlock();
     expect(raiden.output).toContainEqual(
       udcWithdraw.success(
         {


### PR DESCRIPTION
Fixes a very small issue detected while testing #1934 

**Short description**
After `assertTx` for the planned withdraw, we right away called `withdraw_plans` function from UDC. Since the plan tx was just mined, it happens that this function could still be returning falsy values, which made `block` payload param on success action to go as `0`, which then made it not be properly waited and the effective `withdraw` to be sent after the plan completed.
This fixes it by retrying `withdraw_plans` each new block until it catches up with the just mined withdraw plan.
The planned withdraw would always be picked up anyway after a restart, so it's not even worth a changelog entry or its own issue.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Test UDC withdraw
