### PR TITLE
sdk: emit logs upon confirmation from fromEthersEvent

### DIFF
--- a/raiden-ts/src/transfers/epics/withdraw.ts
+++ b/raiden-ts/src/transfers/epics/withdraw.ts
@@ -191,6 +191,7 @@ export const withdrawSendTxEpic = (
             {
               txHash: receipt.transactionHash,
               txBlock: receipt.blockNumber,
+              // no sensitive value in payload, let confirmationEpic confirm it
               confirmed: undefined,
             },
             action.meta,

--- a/raiden-ts/tests/unit/epics/send.spec.ts
+++ b/raiden-ts/tests/unit/epics/send.spec.ts
@@ -1910,12 +1910,12 @@ describe('monitorSecretRegistryEpic', () => {
         data: secret, // non-indexed secret
       }),
     );
-    await waitBlock();
-    await waitBlock(raiden.deps.provider.blockNumber + raiden.config.confirmationBlocks + 1);
+    await waitBlock(txBlock);
+    await waitBlock(txBlock + raiden.config.confirmationBlocks + 1);
 
     expect(raiden.output).toContainEqual(
       transferSecretRegister.success(
-        { secret, txHash, txBlock, confirmed: undefined },
+        { secret, txHash, txBlock, confirmed: true },
         { direction: Direction.SENT, secrethash },
       ),
     );

--- a/raiden-ts/tests/unit/fixtures.ts
+++ b/raiden-ts/tests/unit/fixtures.ts
@@ -9,7 +9,6 @@ import {
   waitBlock,
   providersEmit,
   makeLog,
-  sleep,
 } from './mocks';
 
 import { Subject } from 'rxjs';
@@ -245,7 +244,6 @@ export async function ensureChannelIsOpen([raiden, partner]: [
     }),
   );
   await waitBlock(openBlock);
-  await sleep(raiden.deps.provider.pollingInterval);
   await waitBlock(openBlock + confirmationBlocks + 1); // confirmation
   assert(getChannel(raiden, partner), 'Raiden channel not open');
   assert(getChannel(partner, raiden), 'Partner channel not open');
@@ -285,7 +283,6 @@ export async function ensureChannelIsDeposited(
     getChannel(partner, raiden).partner.deposit.lt(totalDeposit)
   ) {
     await waitBlock();
-    await sleep(raiden.deps.provider.pollingInterval);
   }
 }
 
@@ -314,7 +311,6 @@ export async function ensureChannelIsClosed([raiden, partner]: [
     }),
   );
   await waitBlock(closeBlock);
-  await sleep(raiden.deps.provider.pollingInterval);
   await waitBlock(closeBlock + confirmationBlocks + 1); // confirmation
   assert(closedStates.includes(getChannel(raiden, partner)?.state), 'Raiden channel not closed');
   assert(closedStates.includes(getChannel(partner, raiden)?.state), 'Partner channel not closed');
@@ -347,7 +343,6 @@ export async function ensureChannelIsSettled([raiden, partner]: [
     }),
   );
   await waitBlock(settleBlock);
-  await sleep(raiden.deps.provider.pollingInterval);
   await waitBlock(settleBlock + confirmationBlocks + 1); // confirmation
   assert(!getChannel(raiden, partner), 'Raiden channel not settled');
   assert(!getChannel(partner, raiden), 'Partner channel not settled');

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -687,6 +687,7 @@ const serviceRegistryAddress = makeAddress();
 const svtAddress = makeAddress();
 const oneToNAddress = makeAddress();
 const udcAddress = makeAddress();
+const pollingInterval = 10;
 
 /**
  * Create a mock of a Raiden client for epics
@@ -704,7 +705,7 @@ export async function makeRaiden(
   const network: Network = { name: 'testnet', chainId: 1337 };
   const { JsonRpcProvider } = jest.requireActual('ethers/providers');
   const provider = new JsonRpcProvider() as jest.Mocked<JsonRpcProvider>;
-  provider.pollingInterval = 10;
+  provider.pollingInterval = pollingInterval;
   const signer = (wallet ?? makeWallet()).connect(provider);
   const address = signer.address as Address;
   const log = logging.getLogger(`raiden:${address}`);
@@ -1013,7 +1014,7 @@ export async function makeRaidens(length: number, start = true): Promise<MockedR
  * @param ms - milliseconds to wait
  * @returns Promise to void
  */
-export async function sleep(ms = 10): Promise<void> {
+export async function sleep(ms = pollingInterval): Promise<void> {
   return new Promise((resolve) => setTimeout(() => process.nextTick(resolve), ms));
 }
 
@@ -1029,6 +1030,7 @@ export async function providersEmit(eventName: EventType, ...args: any[]): Promi
     mockedClients.map((r) => new Promise((resolve) => r.deps.provider.once(eventName, resolve))),
   );
   mockedClients.forEach((r) => r.deps.provider.emit(eventName, ...args));
+  await sleep(); // fromEthersEvent needs to debounce emits
   await promise;
 }
 


### PR DESCRIPTION
Fixes #1936 

**Short description**
The problem with our previous confirmation logic was that it only took into account the `txHash` and at most updated a reorged `txBlock`: any pending action payload which depended on values which could change on reorgs (main example is `channel_identifier`, which currently depends strictly on tx order, since it's a nonce number) would get out-of-date and both the unconfirmed and its confirmed reemission would be inconsistent with the blockchain. This was actually witnessed upon stress testing on BF6 scenario on SP, which opens several channels on different clients simultaneously, and a reorg changed the order of the `openChannel` transactions on block and made a totally inconsistent state.

The fix keeps the previous `confirmationEpic`, but which should be used only for ConfirmableActions which have values/payloads which don't depend on order or reorgs of blocks/events on-chain. But now, the main way to confirm a log/event/action is through the same `fromEthersEvent` + `map(logToContractEvent)` utilities, which knows how to re-decode reorged events
- `fromEthersEvent` will watch double the range as before (`2 * confirmationBlocks`)
  - the higher half is for unconfirmed logs/events, as before, and the lower half is dedicated for confirmed logs;
  - unconfirmed logs can be emitted multiple times, in order to update their representation on `pendingTxs` state
  - confirmed actions are emitted as confirmed only once, and may replace the values with the confirmed counterparts; the `afterLogBlock` cleanup only takes place on this 'confirmed' part, to allow unconfirmed actions to be re-fetched
  - it can be used to query from a specific block in the past, taking the role previously with `getEventsStream`, in a sorted and standardized way
- `pendingTxs` reducer now deduplicate ConfirmableActions per action type and `txHash`, ensuring re-emitted unconfirmed actions are updated on state, which may make any depending unconfirmed action also be updated (e.g. deposits over unconfirmed channel)
- `makeDeposit$` function now needs to wait upon `openChannel` tx is confirmed, since it requires the `channelId` which only "stabilizes" after confirmation; `approve` side can still be done in parallel

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Check bug doesn't happen
2. Possible only once we can run BF6 scenario
