### PR TITLE
sdk: Fix nonce conflict issues with concurrent transactions

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - [#1923] Fix `fromEthersEvent` ranges fetching in case of temporary connectivity loss
+- [#1952] Fix nonce conflict issues with concurrent transactions
 
 ### Added
 - [#703] Add option to fetch all contracts addresses from UserDeposit address alone
@@ -14,11 +15,12 @@
 - [#1905] Fail early if not enough tokens to deposit
 
 [#703]: https://github.com/raiden-network/light-client/issues/703
+[#1824]: https://github.com/raiden-network/light-client/issues/1824
 [#1905]: https://github.com/raiden-network/light-client/issues/1905
 [#1910]: https://github.com/raiden-network/light-client/pull/1910
 [#1913]: https://github.com/raiden-network/light-client/pull/1913
-[#1824]: https://github.com/raiden-network/light-client/issues/1824
 [#1923]: https://github.com/raiden-network/light-client/issues/1923
+[#1952]: https://github.com/raiden-network/light-client/issues/1952
 
 ## [0.10.0] - 2020-07-13
 ### Fixed

--- a/raiden-ts/src/channels/utils.ts
+++ b/raiden-ts/src/channels/utils.ts
@@ -201,11 +201,12 @@ export const txNonceErrors: readonly string[] = [
   'nonce is too low',
   'nonce has already been used',
   'already known',
+  'Transaction with the same hash was already imported',
 ];
 export const txFailErrors: readonly string[] = ['always failing transaction'];
 
 /**
- * Re-subscribe/retry a transaction observable if a recoverable error is emitted
+ * RxJS pipeable operator to re-subscribe/retry a transaction observable on recoverable errors
  *
  * For this to work, the input$ transaction observable must be re-subscribable:
  * e.g. a promise wrapped in a `defer` callback.


### PR DESCRIPTION
Fixes #1952 

**Short description**
Implements the alternative approach described in the issue.
BF6 scenario pass fully with it.
BF1 passes the channel opening step which was failing and was base for the creation of the issue.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Test scenarios