### PR TITLE
cli: script compatible with raiden's command line parameters

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ importers:
     dependencies:
       '@types/http-errors': 1.8.0
       '@types/morgan': 1.9.1
+      cors: 2.8.5
       ethers: 4.0.47
       express: 4.17.1
       http-errors: 1.8.0
@@ -46,6 +47,7 @@ importers:
       '@types/yargs': ^15.0.5
       '@typescript-eslint/eslint-plugin': ^3.7.0
       '@typescript-eslint/parser': ^3.7.0
+      cors: ^2.8.5
       eslint: ^7.5.0
       eslint-config-prettier: ^6.11.0
       eslint-plugin-import: ^2.22.0
@@ -2370,7 +2372,7 @@ packages:
       jest-resolve: 26.1.0_jest-resolve@26.1.0
       jest-resolve-dependencies: 26.1.0
       jest-runner: 26.1.0_canvas@2.6.1
-      jest-runtime: 26.1.0_canvas@2.6.1
+      jest-runtime: 26.1.0
       jest-snapshot: 26.1.0
       jest-util: 26.1.0
       jest-validate: 26.1.0
@@ -7372,7 +7374,6 @@ packages:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
-    dev: true
     engines:
       node: '>= 0.10'
     resolution:
@@ -12292,7 +12293,7 @@ packages:
       jest-environment-jsdom: 26.1.0_canvas@2.6.1
       jest-environment-node: 26.1.0
       jest-get-type: 26.0.0
-      jest-jasmine2: 26.1.0_canvas@2.6.1
+      jest-jasmine2: 26.1.0
       jest-regex-util: 26.0.0
       jest-resolve: 26.1.0_jest-resolve@26.1.0
       jest-util: 26.1.0
@@ -12567,32 +12568,6 @@ packages:
       canvas: '*'
     resolution:
       integrity: sha512-1IPtoDKOAG+MeBrKvvuxxGPJb35MTTRSDglNdWWCndCB3TIVzbLThRBkwH9P081vXLgiJHZY8Bz3yzFS803xqQ==
-  /jest-jasmine2/26.1.0_canvas@2.6.1:
-    dependencies:
-      '@babel/traverse': 7.10.5
-      '@jest/environment': 26.1.0
-      '@jest/source-map': 26.1.0
-      '@jest/test-result': 26.1.0
-      '@jest/types': 26.1.0
-      chalk: 4.1.0
-      co: 4.6.0
-      expect: 26.1.0
-      is-generator-fn: 2.1.0
-      jest-each: 26.1.0
-      jest-matcher-utils: 26.1.0
-      jest-message-util: 26.1.0
-      jest-runtime: 26.1.0_canvas@2.6.1
-      jest-snapshot: 26.1.0
-      jest-util: 26.1.0
-      pretty-format: 26.1.0
-      throat: 5.0.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-1IPtoDKOAG+MeBrKvvuxxGPJb35MTTRSDglNdWWCndCB3TIVzbLThRBkwH9P081vXLgiJHZY8Bz3yzFS803xqQ==
   /jest-junit/11.0.1:
     dependencies:
       mkdirp: 1.0.4
@@ -12856,7 +12831,7 @@ packages:
       jest-config: 26.1.0_canvas@2.6.1
       jest-docblock: 26.0.0
       jest-haste-map: 26.1.0
-      jest-jasmine2: 26.1.0_canvas@2.6.1
+      jest-jasmine2: 26.1.0
       jest-leak-detector: 26.1.0
       jest-message-util: 26.1.0
       jest-resolve: 26.1.0_jest-resolve@26.1.0
@@ -15280,7 +15255,6 @@ packages:
     resolution:
       integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
   /object-assign/4.1.1:
-    dev: true
     engines:
       node: '>=0.10.0'
     resolution:
@@ -19510,7 +19484,7 @@ packages:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.1.0_canvas@2.6.1
+      jest: 26.1.0
       jest-util: 26.1.0
       json5: 2.1.3
       lodash.memoize: 4.1.2

--- a/raiden-cli/package.json
+++ b/raiden-cli/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@types/http-errors": "^1.8.0",
     "@types/morgan": "^1.9.1",
+    "cors": "^2.8.5",
     "ethers": "^4.0.47",
     "express": "^4.17.1",
     "http-errors": "^1.8.0",

--- a/raiden-cli/raiden.sh
+++ b/raiden-cli/raiden.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+RAIDEN="$( dirname $0 )/build/raiden.js"
+[ -e "$RAIDEN" ] || RAIDEN="$( dirname $0 )/build/raiden.bundle.js"
+
+exec node "$RAIDEN" "$@"

--- a/raiden-cli/src/app.ts
+++ b/raiden-cli/src/app.ts
@@ -1,4 +1,5 @@
 import express, { Express, Request, Response, NextFunction } from 'express';
+import cors from 'cors';
 import createError from 'http-errors';
 import logger from 'morgan';
 import { Cli } from './types';
@@ -18,9 +19,10 @@ function internalErrorHandler(
   next(createError(500, error.message));
 }
 
-export function makeApp(this: Cli): Express {
+export function makeApp(this: Cli, corsOrigin?: string): Express {
   const app = express();
   app.use(express.json());
+  if (corsOrigin) app.use(cors({ origin: corsOrigin }));
   app.use(
     logger(
       ':remote-addr - :remote-user ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"',

--- a/raiden-cli/src/cli.ts
+++ b/raiden-cli/src/cli.ts
@@ -3,10 +3,23 @@ import { Logger, getLogger } from 'loglevel';
 import { makeApp } from './app';
 import { Cli } from './types';
 
-export async function makeCli(raiden: Raiden, port: number, log?: Logger): Promise<Cli> {
+export function makeCli(
+  raiden: Raiden,
+  endpoint?: number | string,
+  log?: Logger,
+  corsOrigin?: string,
+): Cli {
   log = log ?? getLogger(`cli:${raiden.address}`);
   const cli: Cli = { log, raiden };
-  cli.app = makeApp.call(cli);
-  cli.server = cli.app.listen(port, () => log!.info(`Server started at port: ${port}`));
+  if (endpoint) {
+    cli.app = makeApp.call(cli, corsOrigin);
+    let host: string, port: number | string;
+    if (typeof endpoint === 'number') [host, port] = ['127.0.0.1', endpoint];
+    else [host, port] = endpoint.split(':');
+    cli.server = cli.app.listen(+port, host, () =>
+      log!.info(`Server started at: http://${host}:${port}`),
+    );
+    cli.server.setTimeout(3.6e6); // 1h
+  }
   return cli;
 }

--- a/raiden-cli/src/cli.ts
+++ b/raiden-cli/src/cli.ts
@@ -5,18 +5,18 @@ import { Cli } from './types';
 
 export function makeCli(
   raiden: Raiden,
-  endpoint?: number | string,
+  endpoint?: readonly [string, number],
   log?: Logger,
   corsOrigin?: string,
 ): Cli {
   log = log ?? getLogger(`cli:${raiden.address}`);
   const cli: Cli = { log, raiden };
   if (endpoint) {
+    const [, port] = endpoint;
+    let [host] = endpoint;
+    host = host || '127.0.0.1';
     cli.app = makeApp.call(cli, corsOrigin);
-    let host: string, port: number | string;
-    if (typeof endpoint === 'number') [host, port] = ['127.0.0.1', endpoint];
-    else [host, port] = endpoint.split(':');
-    cli.server = cli.app.listen(+port, host, () =>
+    cli.server = cli.app.listen(port, host, () =>
       log!.info(`Server started at: http://${host}:${port}`),
     );
     cli.server.setTimeout(3.6e6); // 1h

--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -104,7 +104,7 @@ async function main() {
     ...DEFAULT_RAIDEN_CONFIG,
     ...argv.config,
   });
-  const cli = await makeCli(raiden, argv.port);
+  const cli = makeCli(raiden, argv.port);
   registerShutdownHooks.call(cli);
   cli.raiden.start();
 }

--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -104,7 +104,7 @@ async function main() {
     ...DEFAULT_RAIDEN_CONFIG,
     ...argv.config,
   });
-  const cli = makeCli(raiden, argv.port);
+  const cli = makeCli(raiden, ['127.0.0.1', argv.port]);
   registerShutdownHooks.call(cli);
   cli.raiden.start();
 }

--- a/raiden-cli/src/raiden.ts
+++ b/raiden-cli/src/raiden.ts
@@ -1,0 +1,213 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import inquirer from 'inquirer';
+import yargs from 'yargs';
+import { LocalStorage } from 'node-localstorage';
+import { Wallet } from 'ethers';
+import { Raiden, Address, RaidenConfig } from 'raiden-ts';
+import { Cli } from './types';
+import { makeCli } from './cli';
+import { setupLoglevel } from './utils/logging';
+import DEFAULT_RAIDEN_CONFIG from './config.json';
+
+function parseArguments() {
+  return yargs
+    .usage('Usage: $0')
+    .options({
+      datadir: {
+        type: 'string',
+        default: './storage',
+        desc: 'Dir path where to store state',
+      },
+      configFile: {
+        type: 'string',
+        desc: 'JSON file path containing config object',
+        coerce: path.resolve,
+      },
+      keystorePath: {
+        type: 'string',
+        default: './',
+        desc: 'Path for ethereum keystore directory',
+        coerce: path.resolve,
+      },
+      address: {
+        type: 'string',
+        demandOption: true,
+        desc: 'Address of private key to use',
+        check: Address.is,
+      },
+      passwordFile: {
+        type: 'string',
+        desc: 'Path for text file containing password for keystore file',
+        coerce: path.resolve,
+      },
+      userDepositContractAddress: {
+        type: 'string',
+        desc: "Address of UserDeposit contract to use as contract's entrypoint",
+        check: Address.is,
+      },
+      defaultRevealTimeout: {
+        type: 'number',
+        default: 50,
+        desc: 'Default transfer reveal timeout',
+      },
+      defaultSettleTimeout: {
+        type: 'number',
+        default: 500,
+        desc: 'Default channel settle timeout',
+      },
+      ethRpcEndpoint: {
+        type: 'string',
+        default: 'http://127.0.0.1:8545',
+        desc: 'Ethereum JSON RPC node endpoint to use for blockchain interaction',
+      },
+      matrixServer: {
+        type: 'string',
+        default: 'auto',
+        desc: 'URL of Matrix Transport server',
+      },
+      rpc: {
+        type: 'boolean',
+        default: true,
+        desc: 'Start with or without the RPC server',
+      },
+      rpccorsdomain: {
+        type: 'string',
+        default: 'http://localhost:*/*',
+        desc: 'Comma separated list of domains to accept cross origin requests.',
+      },
+      apiAddress: {
+        type: 'string',
+        default: '127.0.0.1:5001',
+        desc: 'host:port to bind to and listen for API requests',
+      },
+      routingMode: {
+        choices: ['pfs', 'local', 'private'] as const,
+        default: 'pfs',
+        desc: 'Anything else than "pfs" disables mediated transfers',
+      },
+      pathfindingServiceAddress: {
+        type: 'string',
+        default: 'auto',
+        desc: 'Force a given PFS to be used; "auto" selects cheapest registered on-chain',
+      },
+      enableMonitoring: {
+        type: 'boolean',
+        default: true,
+        desc: "By default, enables monitoring if there's a UDC deposit",
+      },
+    })
+    .env('RAIDEN')
+    .help().argv;
+}
+
+async function askUserForPassword(): Promise<string> {
+  const userInput = await inquirer.prompt<{ password: string }>([
+    { type: 'password', name: 'password', message: 'Private Key Password:', mask: '*' },
+  ]);
+  return userInput.password;
+}
+
+async function getWallet(
+  keystoreDir: string,
+  address: string,
+  passwordFile?: string,
+): Promise<Wallet> {
+  let password;
+  if (!passwordFile) password = await askUserForPassword();
+  else password = (await fs.readFile(passwordFile, 'utf-8')).split('\n').shift()!;
+  let jsonStr;
+  for (const filename of await fs.readdir(keystoreDir)) {
+    if (!(filename.startsWith('UTC-') || filename.endsWith('.json'))) continue;
+    try {
+      jsonStr = await fs.readFile(path.join(keystoreDir, filename), 'utf-8');
+      const jsonContent = JSON.parse(jsonStr);
+      const jsonAddr = jsonContent?.['address'];
+      if (!jsonAddr || !address.toLowerCase().endsWith(jsonAddr.toLowerCase())) throw '';
+      break;
+    } catch (e) {
+      jsonStr = undefined;
+      continue;
+    }
+  }
+  if (!jsonStr) throw new Error(`Could not find keystore file for "${address}"`);
+  return await Wallet.fromEncryptedJson(jsonStr, password);
+}
+
+function createLocalStorage(name: string): LocalStorage {
+  const localStorage = new LocalStorage(name);
+  Object.assign(globalThis, { localStorage });
+  return localStorage;
+}
+
+function shutdownServer(this: Cli): void {
+  if (this.server?.listening) {
+    this.log.info('Closing server...');
+    this.server.close();
+  }
+}
+
+function unrefTimeout(timeout: number | NodeJS.Timeout) {
+  if (typeof timeout === 'number') return;
+  timeout.unref();
+}
+
+function shutdownRaiden(this: Cli): void {
+  if (this.raiden.started) {
+    this.log.info('Stopping raiden...');
+    this.raiden.stop();
+    // force-exit at most 5s after stopping raiden
+    unrefTimeout(setTimeout(() => process.exit(0), 5000));
+  } else {
+    process.exit(1);
+  }
+}
+
+function registerShutdownHooks(this: Cli): void {
+  // raiden shutdown triggers server shutdown
+  this.raiden.state$.subscribe(undefined, shutdownServer.bind(this), shutdownServer.bind(this));
+  process.on('SIGINT', shutdownRaiden.bind(this));
+  process.on('SIGTERM', shutdownRaiden.bind(this));
+}
+
+async function main() {
+  setupLoglevel();
+  const argv = parseArguments();
+  const wallet = await getWallet(argv.keystorePath, argv.address, argv.passwordFile);
+  const localStorage = createLocalStorage(argv.datadir);
+
+  let config: Partial<RaidenConfig> = DEFAULT_RAIDEN_CONFIG;
+  if (argv.configFile)
+    config = { ...config, ...JSON.parse(await fs.readFile(argv.configFile, 'utf-8')) };
+  config = {
+    ...config,
+    revealTimeout: argv.defaultRevealTimeout,
+    settleTimeout: argv.defaultSettleTimeout,
+  };
+  if (argv.matrixServer !== 'auto') config = { ...config, matrixServer: argv.matrixServer };
+  if (argv.routingMode !== 'pfs') config = { ...config, pfs: null };
+  else if (argv.pathfindingServiceAddress !== 'auto')
+    config = { ...config, pfs: argv.pathfindingServiceAddress };
+  if (!argv.enableMonitoring) config = { ...config, monitoringReward: null };
+
+  const raiden = await Raiden.create(
+    argv.ethRpcEndpoint,
+    wallet.privateKey,
+    localStorage,
+    argv.userDepositContractAddress,
+    config,
+  );
+  const cli = makeCli(
+    raiden,
+    argv.rpc ? argv.apiAddress : undefined,
+    undefined,
+    argv.rpccorsdomain,
+  );
+  registerShutdownHooks.call(cli);
+  cli.raiden.start();
+}
+
+main().catch((err) => {
+  console.error('Main error:', err);
+  process.exit(2);
+});

--- a/raiden-cli/src/routes/channels.ts
+++ b/raiden-cli/src/routes/channels.ts
@@ -199,9 +199,17 @@ async function updateChannel(this: Cli, request: Request, response: Response, ne
     if (request.body.state) {
       channel = await updateChannelState.call(this, channel, request.body.state);
     } else if (request.body.total_deposit) {
-      channel = await updateChannelDeposit.call(this, channel, request.body.total_deposit);
+      channel = await updateChannelDeposit.call(
+        this,
+        channel,
+        request.body.total_deposit.toString(),
+      );
     } else if (request.body.total_withdraw) {
-      channel = await updateChannelWithdraw.call(this, channel, request.body.total_withdraw);
+      channel = await updateChannelWithdraw.call(
+        this,
+        channel,
+        request.body.total_withdraw.toString(),
+      );
     }
     response.status(200).json(transformChannelFormatForApi(channel));
   } catch (error) {
@@ -210,7 +218,7 @@ async function updateChannel(this: Cli, request: Request, response: Response, ne
     } else if (isInsuficientFundsError(error)) {
       response.status(402).send(error.message);
     } else if (isConflictError(error)) {
-      response.status(409).send(error.message);
+      response.status(409).json({ message: error.message });
     } else {
       next(error);
     }

--- a/raiden-cli/src/routes/payments.ts
+++ b/raiden-cli/src/routes/payments.ts
@@ -96,7 +96,7 @@ async function doTransfer(this: Cli, request: Request, response: Response, next:
       response.status(402).send(error.message);
     } else if (isConflictError(error)) {
       const pfsErrorDetail = error.details?.errors ? ` (${error.details.errors})` : '';
-      response.status(409).send(error.message + pfsErrorDetail);
+      response.status(409).json({ message: error.message, details: pfsErrorDetail });
     } else {
       next(error);
     }

--- a/raiden-cli/webpack.config.js
+++ b/raiden-cli/webpack.config.js
@@ -1,14 +1,17 @@
 const path = require('path');
 
 module.exports = {
-  entry: './src/index.ts',
+  entry: {
+    main: './src/index.ts',
+    raiden: './src/raiden.ts',
+  },
   target: 'node',
   mode: 'production',
   // devtool: 'inline-source-map',
   devtool: 'cheap-source-map',
   output: {
     path: path.resolve(__dirname, 'build'),
-    filename: 'bundle.js',
+    filename: '[name].bundle.js',
   },
   stats: {
     // Ignore warnings due to yarg's dynamic module loading


### PR DESCRIPTION
Fixes #1691 
Fixes #1412 

**Short description**
Together with #1953 , this enables CLI to start running scenarios from [Scenario Player](https://github.com/raiden-network/scenario-player), which helps us test and proves compliance with Raiden Network.

To run a scenario with this:
- after building either normal or bundled version of CLI..
- copy a scenario (e.g. [BF6](https://github.com/raiden-network/raiden/blob/develop/raiden/tests/scenarios/bf6_stress_hub_node.yaml)), edit it and add the line `raiden_version: /path/to/raiden.sh` under `nodes:`, to tell it to use LC CLI's script (included, but can be changed as needed)
- run the scenario player with the usual parameters, and see the magic happen =)

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Above
