### PR TITLE
sdk: don't request PFS if there's no suitable channel

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Changed
 - [#1905] Fail early if not enough tokens to deposit
+- [#1958] Transfers can fail before requesting PFS if there's no viable channel
 
 [#703]: https://github.com/raiden-network/light-client/issues/703
 [#1824]: https://github.com/raiden-network/light-client/issues/1824
@@ -21,6 +22,7 @@
 [#1913]: https://github.com/raiden-network/light-client/pull/1913
 [#1923]: https://github.com/raiden-network/light-client/issues/1923
 [#1952]: https://github.com/raiden-network/light-client/issues/1952
+[#1958]: https://github.com/raiden-network/light-client/issues/1958
 
 ## [0.10.0] - 2020-07-13
 ### Fixed

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -432,7 +432,7 @@ export class Raiden {
   public stop(): void {
     // start still can't be called again, but turns this.started to false
     // this.epicMiddleware is set to null by latest$'s complete callback
-    this.store.dispatch(raidenShutdown({ reason: ShutdownReason.STOP }));
+    if (this.started) this.store.dispatch(raidenShutdown({ reason: ShutdownReason.STOP }));
   }
 
   /**

--- a/raiden-ts/tests/e2e/provider.ts
+++ b/raiden-ts/tests/e2e/provider.ts
@@ -26,7 +26,7 @@ export class TestProvider extends Web3Provider {
     super(
       web3 ??
         ganache.provider({
-          total_accounts: 3,
+          total_accounts: 5,
           default_balance_ether: 5,
           seed: 'testrpc_provider',
           network_id: 1338,


### PR DESCRIPTION
Fixes #1958 
Fixes #1948 

**Short description**
Adds a simple `assert` to fail early if there's no channel which could handle the transfer.

**BF1** passes after this fix:

![Screenshot_20200724_223951](https://user-images.githubusercontent.com/587021/88461221-10b64700-ce78-11ea-9175-f466292d2346.png)


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. BF1 passes
