### PR TITLE
sdk,cli: expose and use transfer's lockTimeout

### DIFF
--- a/raiden-cli/src/routes/payments.ts
+++ b/raiden-cli/src/routes/payments.ts
@@ -77,12 +77,11 @@ function getPayments(this: Cli, request: Request, response: Response) {
 
 async function doTransfer(this: Cli, request: Request, response: Response, next: NextFunction) {
   try {
-    // TODO: We ignore the provided `lock_timeout` until #1710 provides a better solution
     const transferKey = await this.raiden.transfer(
       request.params.tokenAddress,
       request.params.targetAddress,
       request.body.amount,
-      { paymentId: request.body.identifier },
+      { paymentId: request.body.identifier, lockTimeout: request.body.lock_timeout },
     );
     await this.raiden.waitTransfer(transferKey);
     const newTransfer = await this.raiden.transfers$

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Added
 - [#703] Add option to fetch all contracts addresses from UserDeposit address alone
+- [#1710] Add option specify transfer's lock timeout
 - [#1910] Add option to `mint` tokens for any address
 - [#1913] Added `contractsInfo` getter holding current contracts info
 - [#1824] Expose channel settle actions as events
@@ -16,6 +17,7 @@
 - [#1958] Transfers can fail before requesting PFS if there's no viable channel
 
 [#703]: https://github.com/raiden-network/light-client/issues/703
+[#1710]: https://github.com/raiden-network/light-client/issues/1710
 [#1824]: https://github.com/raiden-network/light-client/issues/1824
 [#1905]: https://github.com/raiden-network/light-client/issues/1905
 [#1910]: https://github.com/raiden-network/light-client/pull/1910

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Added
 - [#703] Add option to fetch all contracts addresses from UserDeposit address alone
-- [#1710] Add option specify transfer's lock timeout
+- [#1710] Add option to specify a transfer's lock timeout
 - [#1910] Add option to `mint` tokens for any address
 - [#1913] Added `contractsInfo` getter holding current contracts info
 - [#1824] Expose channel settle actions as events

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -810,6 +810,7 @@ export class Raiden {
    *     Is ignored if paths were already provided. If neither are set and config.pfs is not
    *     disabled (null), use it if set or if undefined (auto mode), fetches the best
    *     PFS from ServiceRegistry and automatically fetch routes from it.</li>
+   * @param options.lockTimeout - Specify a lock timeout for transfer; default is 2 * revealTimeout
    * @returns A promise to transfer's unique key (id) when it's accepted
    */
   public async transfer(
@@ -822,6 +823,7 @@ export class Raiden {
       secrethash?: string;
       paths?: RaidenPaths;
       pfs?: RaidenPFS;
+      lockTimeout?: number;
     } = {},
   ): Promise<string> {
     assert(Address.is(token), [ErrorCodes.DTA_INVALID_ADDRESS, { token }], this.log.info);
@@ -840,6 +842,9 @@ export class Raiden {
     const pfs = !options.pfs
       ? undefined
       : decode(PFS, options.pfs, ErrorCodes.DTA_INVALID_PFS, this.log.info);
+    const expiration = !options.lockTimeout
+      ? undefined
+      : this.state.blockNumber + options.lockTimeout;
 
     assert(
       options.secret === undefined || Secret.is(options.secret),
@@ -909,6 +914,7 @@ export class Raiden {
                     paths,
                     paymentId,
                     secret,
+                    expiration,
                   },
                   { secrethash, direction: Direction.SENT },
                 ),

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -842,6 +842,7 @@ export class Raiden {
     const pfs = !options.pfs
       ? undefined
       : decode(PFS, options.pfs, ErrorCodes.DTA_INVALID_PFS, this.log.info);
+    // if undefined, default expiration is calculated at locked's [[makeAndSignTransfer$]]
     const expiration = !options.lockTimeout
       ? undefined
       : this.state.blockNumber + options.lockTimeout;

--- a/raiden-ts/tests/e2e/raiden.spec.ts
+++ b/raiden-ts/tests/e2e/raiden.spec.ts
@@ -868,6 +868,14 @@ describe('Raiden', () => {
         expect(transfers[key].status).toBe(RaidenTransferStatus.pending);
       });
 
+      test('fail: invalid lockTimeout', async () => {
+        expect.assertions(2);
+
+        await expect(raiden.transfer(token, partner, 23, { lockTimeout: 1 })).rejects.toThrowError(
+          'expiration',
+        );
+      });
+
       test('success: auto pfs route', async () => {
         expect.assertions(7);
 


### PR DESCRIPTION
Fixes #1710 

**Short description**
Title

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Test CLI honors `lock_timeout` param
