### PR TITLE
dApp: always use hash mode on router

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -10,11 +10,13 @@
 - [#1824] Listen to channel settle events and push notifications for them
 
 ### Changed
+- [#1931] dApp always uses hash mode on router
 - [#1769] Updated UDC deposit dialog for testnet
 - [#1768] Updated UDC screen
 - [#1265] Reduce logs size by hiding superfluous actions entries
 - [#1875] Redact sensitive information (transport's accessToken, transfer's secrets) from logs
 
+[#1931]: https://github.com/raiden-network/light-client/issues/1931
 [#1769]: https://github.com/raiden-network/light-client/issues/1769
 [#1768]: https://github.com/raiden-network/light-client/issues/1768
 [#1265]: https://github.com/raiden-network/light-client/issues/1265

--- a/raiden-dapp/src/router/index.ts
+++ b/raiden-dapp/src/router/index.ts
@@ -8,7 +8,7 @@ Vue.use(Router);
 
 /* istanbul ignore next */
 const router = new Router({
-  mode: process.env.NODE_ENV === 'production' ? 'history' : 'hash',
+  mode: 'hash',
   base: process.env.BASE_URL,
   routes: [
     {


### PR DESCRIPTION
Fixes #1931  

**Short description**
Changed the router mode to always be set as `hash`.


**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
