### PR TITLE
Rename VUE_APP_TRANSPORT and support VUE_APP_MATRIX_LIST_URL envvar

### DIFF
--- a/raiden-dapp/.env.development
+++ b/raiden-dapp/.env.development
@@ -1,4 +1,4 @@
 VUE_APP_PFS=https://pfs.demo001.env.raiden.network
-VUE_APP_TRANSPORT=https://transport.demo001.env.raiden.network
+VUE_APP_MATRIX_SERVER=https://transport.demo001.env.raiden.network
 VUE_APP_HUB=hub.raiden.eth
 VUE_APP_ALLOW_MAINNET=true

--- a/raiden-dapp/.env.e2e
+++ b/raiden-dapp/.env.e2e
@@ -2,6 +2,6 @@ VUE_APP_CONFIGURATION_URL=./e2e.json
 VUE_APP_DEPLOYMENT_INFO=./deployment_private_net.json
 VUE_APP_DEPLOYMENT_SERVICES_INFO=./deployment_services_private_net.json
 VUE_APP_PFS=http://localhost:6000
-VUE_APP_TRANSPORT=http://localhost
+VUE_APP_MATRIX_SERVER=http://localhost
 NODE_ENV=development
 E2E=true

--- a/raiden-dapp/.env.ghpages
+++ b/raiden-dapp/.env.ghpages
@@ -1,5 +1,5 @@
 NODE_ENV=production
 VUE_APP_PFS=https://pfs.demo001.env.raiden.network
-VUE_APP_TRANSPORT=https://transport.demo001.env.raiden.network
+VUE_APP_MATRIX_SERVER=https://transport.demo001.env.raiden.network
 VUE_APP_HUB=hub.raiden.eth
 VUE_APP_ALLOW_MAINNET=false

--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [#1786] Introduces snackbar display for notifications
 - [#1824] Listen to channel settle events and push notifications for them
+- [#2002] Add support to VUE_APP_MATRIX_LIST_URL transpile-time env var
 
 ### Changed
 - [#1931] dApp always uses hash mode on router
@@ -23,6 +24,7 @@
 [#1786]: https://github.com/raiden-network/light-client/issues/1786
 [#1824]: https://github.com/raiden-network/light-client/issues/1824
 [#1875]: https://github.com/raiden-network/light-client/issues/1875
+[#2002]: https://github.com/raiden-network/light-client/issues/2002
 
 ## [0.10.0] - 2020-07-13
 

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -49,7 +49,8 @@ export default class RaidenService {
         {
           pfsSafetyMargin: 1.1,
           pfs: process.env.VUE_APP_PFS,
-          matrixServer: process.env.VUE_APP_TRANSPORT,
+          matrixServer: process.env.VUE_APP_MATRIX_SERVER,
+          matrixServerLookup: process.env.VUE_APP_MATRIX_LIST_URL,
         },
         subkey
       );


### PR DESCRIPTION
Fixes #2002 

**Short description**
- Rename `VUE_APP_TRANSPORT` to `VUE_APP_MATRIX_SERVER` to avoid conflict with previous var
- Add `VUE_APP_MATRIX_LIST_URL`:
  - passed to SDK's `matrixServerLookup` config
  - Has less priority than `VUE_APP_MATRIX_SERVER`, so make sure that's unset if one wants to iterate over the list in case of the first server isn't responding properly
  - Should be set to a URL ofa file containing a yaml-like list of servers, e.g.: `https://raw.githubusercontent.com/raiden-network/raiden-service-bundle/master/known_servers.main.yaml`

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
