### PR TITLE
Fix getLogs ranges, some confirmations instances and past logs sorting

### DIFF
--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -513,22 +513,21 @@ export const channelEventsEpic = (
         withLatestFrom(state$),
         mergeMap(([[token, tokenNetwork], state]) => {
           // fromBlock is latest on-chain event seen for this contract, or registry deployment block +1
-          const fromBlock =
-            Object.values(state.channels)
-              .concat(Object.values(state.oldChannels))
-              .filter((channel) => channel.tokenNetwork === tokenNetwork)
-              .reduce(
-                (acc, channel) =>
-                  Math.max(
-                    acc,
-                    'settleBlock' in channel
-                      ? channel.settleBlock
-                      : 'closeBlock' in channel
-                      ? channel.closeBlock
-                      : channel.openBlock,
-                  ),
-                deps.contractsInfo.TokenNetworkRegistry.block_number,
-              ) + 1;
+          const fromBlock = Object.values(state.channels)
+            .concat(Object.values(state.oldChannels))
+            .filter((channel) => channel.tokenNetwork === tokenNetwork)
+            .reduce(
+              (acc, channel) =>
+                Math.max(
+                  acc,
+                  'settleBlock' in channel
+                    ? channel.settleBlock
+                    : 'closeBlock' in channel
+                    ? channel.closeBlock
+                    : channel.openBlock,
+                ),
+              deps.contractsInfo.TokenNetworkRegistry.block_number,
+            );
 
           // notifies when past events fetching completes
           const pastDone$ = new AsyncSubject<true>();

--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -46,7 +46,7 @@ import { RaidenAction, raidenShutdown, ConfirmableAction } from '../actions';
 import { RaidenState } from '../state';
 import { ShutdownReason } from '../constants';
 import { chooseOnchainAccount, getContractWithSigner } from '../helpers';
-import { Address, Hash, UInt, Signature, isntNil, HexString } from '../utils/types';
+import { Address, Hash, UInt, Signature, isntNil, HexString, last } from '../utils/types';
 import { isActionOf } from '../utils/actions';
 import { pluckDistinct, distinctRecordValues, retryAsync$ } from '../utils/rx';
 import { fromEthersEvent, getNetwork, logToContractEvent } from '../utils/ethers';
@@ -281,7 +281,7 @@ function mapChannelEventsToAction(
           (c) => c.tokenNetwork === tokenNetwork && c.id === id,
         );
 
-        const event = args[args.length - 1] as Event;
+        const event = last(args);
         const topic = event.topics?.[0];
         const txHash = event.transactionHash! as Hash;
         const txBlock = event.blockNumber!;
@@ -442,8 +442,8 @@ function fetchPastChannelEvents$(
           const allEvents = [...openEvents, ...otherEvents];
           return from(
             sortBy(allEvents, [
-              (args) => (args.pop() as Event)?.blockNumber,
-              (args) => (args.pop() as Event)?.transactionIndex,
+              (args) => last(args).blockNumber,
+              (args) => last(args).transactionIndex,
             ]),
           );
         }),

--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -440,7 +440,12 @@ function fetchPastChannelEvents$(
             )
             .filter(isntNil);
           const allEvents = [...openEvents, ...otherEvents];
-          return from(sortBy(allEvents, (args) => (args[args.length - 1] as Event).blockNumber));
+          return from(
+            sortBy(allEvents, [
+              (args) => (args.pop() as Event)?.blockNumber,
+              (args) => (args.pop() as Event)?.transactionIndex,
+            ]),
+          );
         }),
       );
     }),

--- a/raiden-ts/src/transfers/epics/secret.ts
+++ b/raiden-ts/src/transfers/epics/secret.ts
@@ -313,9 +313,10 @@ export const monitorSecretRegistryEpic = (
     filter(
       ([[secrethash, , { blockNumber }], { sent, received }]) =>
         // emits only if lock didn't expire yet
-        (secrethash in sent && sent[secrethash].transfer[1].lock.expiration.gte(blockNumber!)) ||
-        (secrethash in received &&
-          received[secrethash].transfer[1].lock.expiration.gte(blockNumber!)),
+        !!blockNumber &&
+        ((secrethash in sent && sent[secrethash].transfer[1].lock.expiration.gte(blockNumber)) ||
+          (secrethash in received &&
+            received[secrethash].transfer[1].lock.expiration.gte(blockNumber))),
     ),
     mergeMap(function* ([
       [secrethash, secret, event],
@@ -339,7 +340,7 @@ export const monitorSecretRegistryEpic = (
             secret,
             txHash: event.transactionHash! as Hash,
             txBlock: event.blockNumber!,
-            confirmed: event.blockNumber! + confirmationBlocks <= blockNumber,
+            confirmed: event.blockNumber! + confirmationBlocks <= blockNumber ? true : undefined,
           },
           { secrethash, direction },
         );

--- a/raiden-ts/src/utils/types.ts
+++ b/raiden-ts/src/utils/types.ts
@@ -276,3 +276,39 @@ export const instanceOf: <C extends Newable>(C: C) => t.Type<InstanceType<C>> = 
       t.identity,
     ),
 );
+
+/**
+ * Infer type of last element of a tuple or array
+ * Currently supports tuples of up to 9 elements before falling back to array's inference
+ *
+ * FIXME: may be simplified with variadic tuple types from TypeScript 4.0
+ */
+export type Last<T extends any[]> = T extends [any, any, any, any, any, any, any, any, infer L]
+  ? L
+  : T extends [any, any, any, any, any, any, any, infer L]
+  ? L
+  : T extends [any, any, any, any, any, any, infer L]
+  ? L
+  : T extends [any, any, any, any, any, infer L]
+  ? L
+  : T extends [any, any, any, any, infer L]
+  ? L
+  : T extends [any, any, any, infer L]
+  ? L
+  : T extends [any, any, infer L]
+  ? L
+  : T extends [any, infer L]
+  ? L
+  : T extends [infer L]
+  ? L
+  : T[number] | undefined;
+
+/**
+ * Like lodash's last, but properly infer return type when argument is a tuple
+ *
+ * @param arr - Tuple or array to get last element from
+ * @returns Last element from arr
+ */
+export function last<T extends any[]>(arr: T): Last<T> {
+  return arr[arr.length - 1];
+}

--- a/raiden-ts/tests/e2e/provider.ts
+++ b/raiden-ts/tests/e2e/provider.ts
@@ -10,7 +10,7 @@ import { ContractFactory } from 'ethers/contract';
 import { parseUnits, ParamType } from 'ethers/utils';
 
 import { ContractsInfo } from 'raiden-ts/types';
-import { Address } from 'raiden-ts/utils/types';
+import { Address, last } from 'raiden-ts/utils/types';
 import { TokenNetworkRegistry } from 'raiden-ts/contracts/TokenNetworkRegistry';
 import { CustomToken } from 'raiden-ts/contracts/CustomToken';
 import { ServiceRegistry } from 'raiden-ts/contracts/ServiceRegistry';
@@ -78,7 +78,7 @@ export class TestProvider extends Web3Provider {
 
   public async deployRegistry(): Promise<ContractsInfo> {
     const accounts = await this.listAccounts();
-    const address = accounts[accounts.length - 1],
+    const address = last(accounts)!,
       signer = this.getSigner(address);
 
     const secretRegistryContract = (await new ContractFactory(
@@ -212,7 +212,7 @@ export class TestProvider extends Web3Provider {
     tokenNetwork: string;
   }> {
     const accounts = await this.listAccounts();
-    const signer = this.getSigner(accounts[accounts.length - 1]);
+    const signer = this.getSigner(last(accounts)!);
 
     const registryContract = TokenNetworkRegistryFactory.connect(
       info.TokenNetworkRegistry.address,

--- a/raiden-ts/tests/unit/epics/channels.spec.ts
+++ b/raiden-ts/tests/unit/epics/channels.spec.ts
@@ -218,7 +218,7 @@ describe('channelEventsEpic', () => {
         // ensure already confirmed channel also got into scanned channelIds set
         expect.arrayContaining([id - 1, id].map((i) => defaultAbiCoder.encode(['uint256'], [i]))),
       ],
-      fromBlock: openBlock - 4,
+      fromBlock: openBlock - 5,
       toBlock: expect.any(Number),
     });
   });
@@ -334,11 +334,9 @@ describe('channelEventsEpic', () => {
 
     const [raiden, partner] = await makeRaidens(2);
     const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
-
     await ensureChannelIsClosed([raiden, partner]);
-    raiden.store.dispatch(channelMonitored({ id }, { tokenNetwork, partner: partner.address }));
-    await waitBlock(settleBlock);
 
+    await waitBlock(settleBlock);
     const settleHash = makeHash();
     await providersEmit(
       getChannelEventsFilter(tokenNetworkContract),
@@ -350,6 +348,7 @@ describe('channelEventsEpic', () => {
       }),
     );
     await waitBlock();
+    await sleep(2 * raiden.config.pollingInterval);
 
     expect(raiden.output).toContainEqual(
       channelSettle.success(

--- a/raiden-ts/tests/unit/epics/path.spec.ts
+++ b/raiden-ts/tests/unit/epics/path.spec.ts
@@ -1519,7 +1519,7 @@ describe('PFS: pfsServiceRegistryMonitorEpic', () => {
         data: expiringSoonEncoded,
       }),
     );
-    await waitBlock();
+    await waitBlock(raiden.deps.provider.blockNumber + raiden.config.confirmationBlocks + 1);
 
     await expect(
       raiden.deps.latest$

--- a/raiden-ts/tests/unit/epics/raiden.spec.ts
+++ b/raiden-ts/tests/unit/epics/raiden.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../fixtures';
 
 import { defaultAbiCoder } from 'ethers/utils/abi-coder';
+import { first, pluck } from 'rxjs/operators';
 
 import { raidenShutdown } from 'raiden-ts/actions';
 import {
@@ -22,7 +23,7 @@ import {
 } from 'raiden-ts/channels/actions';
 import { ShutdownReason } from 'raiden-ts/constants';
 import { RaidenError, ErrorCodes } from 'raiden-ts/utils/error';
-import { first, pluck } from 'rxjs/operators';
+import { last } from 'raiden-ts/utils/types';
 
 const partner = makeAddress();
 
@@ -134,7 +135,7 @@ describe('raiden init epics', () => {
     await raiden.deps.latest$.toPromise(); // raidenShutdown completes subjects
 
     expect(raiden.started).toBe(false);
-    expect(raiden.output[raiden.output.length - 1]).toEqual(
+    expect(last(raiden.output)).toEqual(
       raidenShutdown({ reason: ShutdownReason.ACCOUNT_CHANGED }),
     );
   });
@@ -149,7 +150,7 @@ describe('raiden init epics', () => {
     await raiden.deps.latest$.toPromise(); // raidenShutdown completes subjects
 
     expect(raiden.started).toBe(false);
-    expect(raiden.output[raiden.output.length - 1]).toEqual(
+    expect(last(raiden.output)).toEqual(
       raidenShutdown({ reason: ShutdownReason.NETWORK_CHANGED }),
     );
   });
@@ -165,7 +166,7 @@ describe('raiden init epics', () => {
     await raiden.deps.latest$.toPromise(); // raidenShutdown completes subjects
 
     expect(raiden.started).toBe(false);
-    expect(raiden.output[raiden.output.length - 1]).toEqual(raidenShutdown({ reason: error }));
+    expect(last(raiden.output)).toEqual(raidenShutdown({ reason: error }));
   });
 });
 


### PR DESCRIPTION
Fixes #2004
Fixes #2007

Plus some small improvements on confirmations logs handling, and a `last` utility function with proper type inference for the returned last tuple element.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Tests pass
