### PR TITLE
dApp: fixes icons not visiblie in Firefox bug

### DIFF
--- a/raiden-dapp/src/components/channels/ChannelList.vue
+++ b/raiden-dapp/src/components/channels/ChannelList.vue
@@ -39,7 +39,11 @@
               :disabled="channel.state !== 'open' || busy"
               @click="action(['deposit', channel])"
             >
-              <v-img max-width="25px" :src="require('@/assets/deposit.svg')" />
+              <v-img
+                width="27"
+                height="25px"
+                :src="require('@/assets/deposit.svg')"
+              />
               <span class="action-title">
                 {{ $t('channel-actions.deposit') }}
               </span>
@@ -52,7 +56,8 @@
               @click="action(['withdraw', channel])"
             >
               <v-img
-                max-width="25px"
+                width="27px"
+                height="25px"
                 :src="require('@/assets/withdrawal.svg')"
               />
               <span class="action-title">


### PR DESCRIPTION
Fixes #1932 

**Short description**
Now also Firefox users can enjoy the beautiful icons for deposit and withdrawal in the channels list.
<img width="682" alt="Screenshot 2020-07-31 at 13 43 39" src="https://user-images.githubusercontent.com/43838780/89031965-dcd59880-d333-11ea-92f8-a4dfd216179b.png">


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to the dApp on Firefox and make sure you have a channel open.
2. Go to the channels screen and you should see the icons.
