### PR TITLE
dApp: displays "Amount" placeholder on open channel input field

### DIFF
--- a/raiden-dapp/src/components/navigation/OpenChannel.vue
+++ b/raiden-dapp/src/components/navigation/OpenChannel.vue
@@ -11,6 +11,7 @@
           v-model="deposit"
           :token="token"
           :max="token.balance"
+          :placeholder="$t('transfer.amount-placeholder')"
           limit
         ></amount-input>
       </v-col>


### PR DESCRIPTION
Fixes #2015 

**Short description**
Displays a placeholder text in the input field for the open channel screen.
<img width="601" alt="Screenshot 2020-07-31 at 14 19 32" src="https://user-images.githubusercontent.com/43838780/89034248-e281ad00-d338-11ea-883a-60d24923ec24.png">

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to the dApp, select a token, and proceed to open a channel with a hub.

