### PR TITLE
Fix ERC20 token approval

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#1952] Fix nonce conflict issues with concurrent transactions
 - [#1997] Fix matrix rate-limiting logins when many nodes are started in parallel
 - [#1998] Fix events reverted due to a reorg still getting confirmed
+- [#2010] Fix multiple approve on secure ERC20 tokens, like RDN
 
 ### Added
 - [#703] Add option to fetch all contracts addresses from UserDeposit address alone
@@ -17,6 +18,7 @@
 ### Changed
 - [#1905] Fail early if not enough tokens to deposit
 - [#1958] Transfers can fail before requesting PFS if there's no viable channel
+- [#2010] Token.approve defaults to MaxUint256, so only one approval is needed per token; set config.minimumAllowance to Zero to fallback to strict deposit values
 - [#2019] Use exponential back-off strategy for protocol messages retries
 
 [#703]: https://github.com/raiden-network/light-client/issues/703
@@ -30,6 +32,7 @@
 [#1958]: https://github.com/raiden-network/light-client/issues/1958
 [#1997]: https://github.com/raiden-network/light-client/issues/1997
 [#1998]: https://github.com/raiden-network/light-client/issues/1998
+[#2010]: https://github.com/raiden-network/light-client/issues/2010
 [#2019]: https://github.com/raiden-network/light-client/issues/2019
 
 ## [0.10.0] - 2020-07-13

--- a/raiden-ts/src/channels/utils.ts
+++ b/raiden-ts/src/channels/utils.ts
@@ -13,7 +13,7 @@ import logging from 'loglevel';
 
 import { RaidenState } from '../state';
 import { RaidenEpicDeps } from '../types';
-import { UInt, Address, Hash, Int } from '../utils/types';
+import { UInt, Address, Hash, Int, bnMax } from '../utils/types';
 import { RaidenError } from '../utils/error';
 import { distinctRecordValues } from '../utils/rx';
 import { MessageType } from '../messages/types';
@@ -49,11 +49,6 @@ export function channelUniqueKey<
   )
 >(channel: C): ChannelUniqueKey {
   return `${channel.id}#${channelKey(channel)}`;
-}
-
-// get the biggest UInt BigNumber from an array, or Zero if empty
-function bnMax<T extends UInt>(...args: T[]): T {
-  return args.reduce((a, b) => (b.gt(a) ? b : a), Zero as T);
 }
 
 /**

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -1,5 +1,6 @@
 import * as t from 'io-ts';
 import { Network, parseEther } from 'ethers/utils';
+import { MaxUint256 } from 'ethers/constants';
 
 import { Capabilities } from './constants';
 import { Address, UInt } from './utils/types';
@@ -40,6 +41,9 @@ const RTCIceServer = t.type({ urls: t.union([t.string, t.array(t.string)]) });
  * - rateToSvt - Exchange rate between tokens and SVT, in wei: e.g. rate[TKN]=2e18 => 1TKN = 2SVT
  * - pollingInterval - Interval at which to poll ETH provider for new blocks/events (milliseconds)
  *      Honored only at start time
+ * - minimumAllowance - Minimum value to call `approve` on tokens; default to MaxUint256, so
+ *      approving tokens should be needed only once, trusting TokenNetwork's & UDC contracts;
+ *      Set to Zero to fallback to approving the strictly needed deposit amounts
  * - matrixServer? - Specify a matrix server to use.
  * - subkey? - When using subkey, this sets the behavior when { subkey } option isn't explicitly
  *             set in on-chain method calls. false (default) = use main key; true = use subkey
@@ -71,6 +75,7 @@ export const RaidenConfig = t.readonly(
       fallbackIceServers: t.array(RTCIceServer),
       rateToSvt: t.record(t.string, UInt(32)),
       pollingInterval: t.number,
+      minimumAllowance: UInt(32),
     }),
     t.partial({
       matrixServer: t.string,
@@ -121,6 +126,7 @@ export function makeDefaultConfig(
     fallbackIceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
     rateToSvt: {},
     pollingInterval: 5000,
+    minimumAllowance: MaxUint256 as UInt<32>,
     ...overwrites,
   };
 }

--- a/raiden-ts/src/epics.ts
+++ b/raiden-ts/src/epics.ts
@@ -24,7 +24,7 @@ import { Capabilities } from './constants';
 import { pluckDistinct } from './utils/rx';
 import { getPresences$ } from './transport/utils';
 import { rtcChannel } from './transport/actions';
-import { pfsListUpdated, udcDeposited } from './services/actions';
+import { pfsListUpdated, udcDeposit } from './services/actions';
 import { Address, UInt } from './utils/types';
 import { isActionOf } from './utils/actions';
 
@@ -79,8 +79,8 @@ export function getLatest$(
   { defaultConfig, log, provider }: Pick<RaidenEpicDeps, 'defaultConfig' | 'log' | 'provider'>,
 ): Observable<Latest> {
   const udcBalance$ = action$.pipe(
-    filter(udcDeposited.is),
-    pluck('payload'),
+    filter(udcDeposit.success.is),
+    pluck('meta', 'totalDeposit'),
     // starts with max, to prevent receiving starting as disabled before actual balance is fetched
     startWith(MaxUint256 as UInt<32>),
   );

--- a/raiden-ts/src/errors.json
+++ b/raiden-ts/src/errors.json
@@ -84,6 +84,7 @@
   "DTA_INVALID_PATH": "Invalid path parameter.",
   "DTA_INVALID_PFS": "Invalid path finding service parameter.",
 
+  "UDC_DEPOSIT_OUTDATED": "The UDC contains a target balance different than requested deposit",
   "UDC_PLAN_WITHDRAW_FAILED" : "An error occurred while planning to withdraw from the User Deposit contract.",
   "UDC_PLAN_WITHDRAW_GT_ZERO" : "The planned withdraw amount has to be greater than zero.",
   "UDC_PLAN_WITHDRAW_EXCEEDS_AVAILABLE" : "The planned withdraw amount exceeds the total amount available for withdrawing.",

--- a/raiden-ts/src/services/actions.ts
+++ b/raiden-ts/src/services/actions.ts
@@ -24,7 +24,6 @@ export const pathFind = createAsyncAction(
   t.partial({ paths: Paths, pfs: t.union([PFS, t.null]) }),
   t.type({ paths: Paths }),
 );
-
 export namespace pathFind {
   export interface request extends ActionType<typeof pathFind.request> {}
   export interface success extends ActionType<typeof pathFind.success> {}
@@ -43,8 +42,22 @@ export interface iouPersist extends ActionType<typeof iouPersist> {}
 export const iouClear = createAction('iou/clear', undefined, ServiceId);
 export interface iouClear extends ActionType<typeof iouClear> {}
 
-export const udcDeposited = createAction('udc/deposited', UInt(32));
-export interface udcDeposited extends ActionType<typeof udcDeposited> {}
+export const udcDeposit = createAsyncAction(
+  t.type({ totalDeposit: UInt(32) }),
+  'udc/deposit/request',
+  'udc/deposit/success',
+  'udc/deposit/failure',
+  t.intersection([t.type({ deposit: UInt(32) }), t.partial({ subkey: t.boolean })]),
+  t.union([
+    t.undefined,
+    t.type({ txHash: Hash, txBlock: t.number, confirmed: t.union([t.undefined, t.boolean]) }),
+  ]),
+);
+export namespace udcDeposit {
+  export interface request extends ActionType<typeof udcDeposit.request> {}
+  export interface success extends ActionType<typeof udcDeposit.success> {}
+  export interface failure extends ActionType<typeof udcDeposit.failure> {}
+}
 
 const UdcWithdrawId = t.type({
   amount: UInt(32),

--- a/raiden-ts/src/utils/actions.ts
+++ b/raiden-ts/src/utils/actions.ts
@@ -530,7 +530,7 @@ export async function asyncActionToPromise<
       map((action) => {
         if (asyncAction.failure.is(action))
           throw action.payload as ActionType<AAC['failure']>['payload'];
-        else if (action.payload.confirmed === false)
+        else if (action.payload?.confirmed === false)
           throw new RaidenError(ErrorCodes.RDN_TRANSACTION_REORG, {
             transactionHash: action.payload.txHash!,
           });

--- a/raiden-ts/src/utils/types.ts
+++ b/raiden-ts/src/utils/types.ts
@@ -312,3 +312,13 @@ export type Last<T extends any[]> = T extends [any, any, any, any, any, any, any
 export function last<T extends any[]>(arr: T): Last<T> {
   return arr[arr.length - 1];
 }
+
+/**
+ * Math.max for BigNumbers
+ *
+ * @param args - Parameters to compare, must have at least one element
+ * @returns Maxium of parameters as per BigNumber's lt comparison
+ */
+export function bnMax<T extends BigNumber>(...args: [T, ...T[]]): T {
+  return args.reduce((a, b) => (a.lt(b) ? b : a));
+}

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -462,6 +462,9 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
   userDepositContract.functions.one_to_n_address.mockResolvedValue(oneToNAddress);
   userDepositContract.functions.balances.mockResolvedValue(parseEther('5'));
   userDepositContract.functions.total_deposit.mockResolvedValue(parseEther('5'));
+  userDepositContract.functions.deposit.mockResolvedValue(
+    makeTransaction(undefined, { to: userDepositContract.address }),
+  );
   userDepositContract.functions.effectiveBalance.mockResolvedValue(parseEther('5'));
   userDepositContract.functions.withdraw_plans.mockResolvedValue({
     amount: Zero,
@@ -717,9 +720,9 @@ export async function makeRaiden(
   jest.spyOn(provider, 'listenerCount');
   jest.spyOn(provider, 'getNetwork').mockImplementation(async () => provider.network);
   jest.spyOn(provider, 'resolveName').mockImplementation(async (addressOrName) => addressOrName);
-  jest.spyOn(provider, 'send').mockImplementation(async (method) => {
+  jest.spyOn(provider, 'send').mockImplementation(async (method, params?: any[]) => {
     if (method === 'net_version') return network.chainId;
-    throw new Error(`provider.send called: "${method}"`);
+    throw new Error(`provider.send called: "${method}" => ${JSON.stringify(params)}`);
   });
   jest
     .spyOn(provider, 'getCode')
@@ -773,7 +776,13 @@ export async function makeRaiden(
     signer,
   ) as MockedContract<TokenNetworkRegistry>;
   for (const func in registryContract.functions) {
-    jest.spyOn(registryContract.functions, func as keyof TokenNetworkRegistry['functions']);
+    jest
+      .spyOn(registryContract.functions, func as keyof TokenNetworkRegistry['functions'])
+      .mockImplementation(async (...params: any[]) => {
+        throw new Error(
+          `TokenNetworkRegistry: tried to call "${func}" with params ${JSON.stringify(params)}`,
+        );
+      });
   }
   registryContract.functions.token_to_token_networks.mockImplementation(async () => makeAddress());
 
@@ -783,7 +792,15 @@ export async function makeRaiden(
         TokenNetwork
       >;
       for (const func in tokenNetworkContract.functions) {
-        jest.spyOn(tokenNetworkContract.functions, func as keyof TokenNetwork['functions']);
+        jest
+          .spyOn(tokenNetworkContract.functions, func as keyof TokenNetwork['functions'])
+          .mockImplementation(async (...params: any[]) => {
+            throw new Error(
+              `TokenNetwork[${address}]: tried to call "${func}" with params ${JSON.stringify(
+                params,
+              )}`,
+            );
+          });
       }
       tokenNetworkContract.functions.getChannelParticipantInfo.mockResolvedValue([
         Zero,
@@ -794,15 +811,27 @@ export async function makeRaiden(
         HashZero,
         Zero,
       ]);
-      tokenNetworkContract.functions.openChannel.mockResolvedValue(makeTransaction());
-      tokenNetworkContract.functions.setTotalDeposit.mockResolvedValue(makeTransaction());
-      tokenNetworkContract.functions.setTotalWithdraw.mockResolvedValue(makeTransaction());
-      tokenNetworkContract.functions.closeChannel.mockResolvedValue(makeTransaction());
-      tokenNetworkContract.functions.updateNonClosingBalanceProof.mockResolvedValue(
-        makeTransaction(),
+      tokenNetworkContract.functions.openChannel.mockResolvedValue(
+        makeTransaction(undefined, { to: address }),
       );
-      tokenNetworkContract.functions.settleChannel.mockResolvedValue(makeTransaction());
-      tokenNetworkContract.functions.unlock.mockResolvedValue(makeTransaction());
+      tokenNetworkContract.functions.setTotalDeposit.mockResolvedValue(
+        makeTransaction(undefined, { to: address }),
+      );
+      tokenNetworkContract.functions.setTotalWithdraw.mockResolvedValue(
+        makeTransaction(undefined, { to: address }),
+      );
+      tokenNetworkContract.functions.closeChannel.mockResolvedValue(
+        makeTransaction(undefined, { to: address }),
+      );
+      tokenNetworkContract.functions.updateNonClosingBalanceProof.mockResolvedValue(
+        makeTransaction(undefined, { to: address }),
+      );
+      tokenNetworkContract.functions.settleChannel.mockResolvedValue(
+        makeTransaction(undefined, { to: address }),
+      );
+      tokenNetworkContract.functions.unlock.mockResolvedValue(
+        makeTransaction(undefined, { to: address }),
+      );
       return tokenNetworkContract;
     },
   );
@@ -813,9 +842,17 @@ export async function makeRaiden(
         HumanStandardToken
       >;
       for (const func in tokenContract.functions) {
-        jest.spyOn(tokenContract.functions, func as keyof HumanStandardToken['functions']);
+        jest
+          .spyOn(tokenContract.functions, func as keyof HumanStandardToken['functions'])
+          .mockImplementation(async (...params: any[]) => {
+            throw new Error(
+              `Token[${address}]: tried to call "${func}" with params ${JSON.stringify(params)}`,
+            );
+          });
       }
-      tokenContract.functions.approve.mockResolvedValue(makeTransaction());
+      tokenContract.functions.approve.mockResolvedValue(
+        makeTransaction(undefined, { to: address }),
+      );
       tokenContract.functions.allowance.mockResolvedValue(Zero);
       tokenContract.functions.balanceOf.mockResolvedValue(parseEther('1000'));
       return tokenContract;
@@ -827,7 +864,13 @@ export async function makeRaiden(
     signer,
   ) as MockedContract<ServiceRegistry>;
   for (const func in serviceRegistryContract.functions) {
-    jest.spyOn(serviceRegistryContract.functions, func as keyof ServiceRegistry['functions']);
+    jest
+      .spyOn(serviceRegistryContract.functions, func as keyof ServiceRegistry['functions'])
+      .mockImplementation(async (...params: any[]) => {
+        throw new Error(
+          `ServiceRegistry: tried to call "${func}" with params ${JSON.stringify(params)}`,
+        );
+      });
   }
   serviceRegistryContract.functions.token.mockResolvedValue(svtAddress);
   serviceRegistryContract.functions.urls.mockImplementation(async () => 'https://pfs.raiden.test');
@@ -836,8 +879,15 @@ export async function makeRaiden(
     UserDeposit
   >;
   for (const func in userDepositContract.functions) {
-    jest.spyOn(userDepositContract.functions, func as keyof UserDeposit['functions']);
+    jest
+      .spyOn(userDepositContract.functions, func as keyof UserDeposit['functions'])
+      .mockImplementation(async (...params: any[]) => {
+        throw new Error(
+          `UserDeposit: tried to call "${func}" with params ${JSON.stringify(params)}`,
+        );
+      });
   }
+  userDepositContract.functions.token.mockResolvedValue(svtAddress);
   userDepositContract.functions.one_to_n_address.mockResolvedValue(oneToNAddress);
   userDepositContract.functions.balances.mockResolvedValue(parseEther('5'));
   userDepositContract.functions.total_deposit.mockResolvedValue(parseEther('5'));
@@ -854,7 +904,13 @@ export async function makeRaiden(
   >;
 
   for (const func in secretRegistryContract.functions) {
-    jest.spyOn(secretRegistryContract.functions, func as keyof SecretRegistry['functions']);
+    jest
+      .spyOn(secretRegistryContract.functions, func as keyof SecretRegistry['functions'])
+      .mockImplementation(async (...params: any[]) => {
+        throw new Error(
+          `SecretRegistry: tried to call "${func}" with params ${JSON.stringify(params)}`,
+        );
+      });
   }
 
   const monitoringServiceContract = MonitoringServiceFactory.connect(
@@ -863,7 +919,13 @@ export async function makeRaiden(
   ) as MockedContract<MonitoringService>;
 
   for (const func in monitoringServiceContract.functions) {
-    jest.spyOn(monitoringServiceContract.functions, func as keyof MonitoringService['functions']);
+    jest
+      .spyOn(monitoringServiceContract.functions, func as keyof MonitoringService['functions'])
+      .mockImplementation(async (...params: any[]) => {
+        throw new Error(
+          `MonitoringService: tried to call "${func}" with params ${JSON.stringify(params)}`,
+        );
+      });
   }
 
   const contractsInfo: ContractsInfo = {


### PR DESCRIPTION
Fixes #2010 
Fixes UDC deposit part of #1908 

**Short description**
This makes 2 important changes:
- To approve before depositing (both for `depositChannel` and `depositToUDC`), if the current allowance is less than required to deposit but different than `0`, we must first set it to `0` then set the needed allowance; this is a requirement on secure ERC20 contracts like RDN
- To avoid the double transactions as above, we now default to approving `MaxUint256` (i.e. a very big number), trusting the `spender` (i.e. `TokenNetwork` contract and `UserDeposit` contract, respectively); this way, only an `approve` per token is needed, and the following deposits can happen without the need to mine `approve` again
  - If a user isn't confortable with the above, they can either set `config.minimumAllowance` to a small value, like `Zero`, which will make it default to the strictly requested `deposit` amount, and/or, on Metamask's prompt (per `approve` transaction), simply set the `allowance` to any desired amount (as long as it's greater than or equal the requested `deposit`, or else the `deposit` tx will fail)

Additionally, this also refactor the `depositToUDC` logic, which was on the public `Raiden` class, to its own epic, and interact with it through `udcDeposit` async actions.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Test the default requested `approve` is now a very big number
2. Test editing allowance on Metamask and setting it to a value greater than the requested deposit will succeed (don't forget to also increase a little the `gasLimit`), but on the next deposit, it'll be required to first `approve(0)` and then the new value, which still defaults to a very big number
