### PR TITLE
Implement autoSettle option and epic and set it on cli

### DIFF
--- a/raiden-cli/src/config.json
+++ b/raiden-cli/src/config.json
@@ -4,6 +4,8 @@
   "pfsSafetyMargin": 1.1,
   "caps": {
     "noDelivery": true,
+    "noReceive": false,
+    "noMediate": false,
     "webRTC": true
   },
   "autoSettle": true

--- a/raiden-cli/src/config.json
+++ b/raiden-cli/src/config.json
@@ -5,5 +5,6 @@
   "caps": {
     "noDelivery": true,
     "webRTC": true
-  }
+  },
+  "autoSettle": true
 }

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#2010] Fix multiple approve on secure ERC20 tokens, like RDN
 
 ### Added
+- [#237] Add autoSettle config (off by default) to allow auto-settling settleable channels
 - [#703] Add option to fetch all contracts addresses from UserDeposit address alone
 - [#1710] Add option to specify a transfer's lock timeout
 - [#1910] Add option to `mint` tokens for any address
@@ -21,6 +22,7 @@
 - [#2010] Token.approve defaults to MaxUint256, so only one approval is needed per token; set config.minimumAllowance to Zero to fallback to strict deposit values
 - [#2019] Use exponential back-off strategy for protocol messages retries
 
+[#237]: https://github.com/raiden-network/light-client/issues/237
 [#703]: https://github.com/raiden-network/light-client/issues/703
 [#1710]: https://github.com/raiden-network/light-client/issues/1710
 [#1824]: https://github.com/raiden-network/light-client/issues/1824

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -44,6 +44,7 @@ const RTCIceServer = t.type({ urls: t.union([t.string, t.array(t.string)]) });
  * - minimumAllowance - Minimum value to call `approve` on tokens; default to MaxUint256, so
  *      approving tokens should be needed only once, trusting TokenNetwork's & UDC contracts;
  *      Set to Zero to fallback to approving the strictly needed deposit amounts
+ * - autoSettle - Whether to channelSettle.request settleable channels automatically
  * - matrixServer? - Specify a matrix server to use.
  * - subkey? - When using subkey, this sets the behavior when { subkey } option isn't explicitly
  *             set in on-chain method calls. false (default) = use main key; true = use subkey
@@ -76,6 +77,7 @@ export const RaidenConfig = t.readonly(
       rateToSvt: t.record(t.string, UInt(32)),
       pollingInterval: t.number,
       minimumAllowance: UInt(32),
+      autoSettle: t.boolean,
     }),
     t.partial({
       matrixServer: t.string,
@@ -127,6 +129,7 @@ export function makeDefaultConfig(
     rateToSvt: {},
     pollingInterval: 5000,
     minimumAllowance: MaxUint256 as UInt<32>,
+    autoSettle: false,
     ...overwrites,
   };
 }

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -567,9 +567,9 @@ function makeMonitoringRequest$({
   config$,
 }: RaidenEpicDeps) {
   return ([, channel]: [Channel, Channel]) => {
-    const { partnerUnlocked, ownDeposit } = channelAmounts(channel);
+    const { partnerUnlocked } = channelAmounts(channel);
     // give up early if nothing to lose
-    if (partnerUnlocked.isZero() || ownDeposit.isZero()) return EMPTY;
+    if (partnerUnlocked.isZero()) return EMPTY;
 
     return combineLatest([latest$, config$]).pipe(
       // combineLatest + filter ensures it'll pass if anything here changes


### PR DESCRIPTION
Fixes #1964 
Fixes #1965 
Fixes #1966 
Fixes #1967 
Fixes #1817 by monitoring non-deposited but received channels, while still honoring `rateToSvt`, if set
Implements `autoSettle` part of #237 

**Short description**
- `autoSettle` config added, default to `false`, set to `true` on CLI
- `channelAutoSettleEpic` is a new epic which monitors that config and, if `true` and a channel becomes settleable, waits between 1 and 2 times `confirmationBlocks` and, if the channel didn't get settled by partner nor user, automatically dispatches a `channelSettle.request`
- CLI is set to also always disable `noReceive` and `noMediate` capability, in order to **comply** with Raiden behavior, by sending and receiving transfers even if there's no UDC deposited to back MS reward (currently, condition to auto-enabling receiving)

With all the above, all MS scenarios are currently passing; image from MS2-4 as examples:

![Screenshot_20200731_175015](https://user-images.githubusercontent.com/587021/89090759-63fa2f00-d37b-11ea-95c1-e42588debdd0.png)
![Screenshot_20200731_202607](https://user-images.githubusercontent.com/587021/89090746-55ac1300-d37b-11ea-821b-8ca3be566b38.png)
![Screenshot_20200731_214133](https://user-images.githubusercontent.com/587021/89090764-6bb9d380-d37b-11ea-85a3-ce3da6c854e8.png)

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Run MS1-4
