### PR TITLE
Exponential back-off strategy for delays between protocol messages retries

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Changed
 - [#1905] Fail early if not enough tokens to deposit
 - [#1958] Transfers can fail before requesting PFS if there's no viable channel
+- [#2019] Use exponential back-off strategy for protocol messages retries
 
 [#703]: https://github.com/raiden-network/light-client/issues/703
 [#1710]: https://github.com/raiden-network/light-client/issues/1710
@@ -29,6 +30,7 @@
 [#1958]: https://github.com/raiden-network/light-client/issues/1958
 [#1997]: https://github.com/raiden-network/light-client/issues/1997
 [#1998]: https://github.com/raiden-network/light-client/issues/1998
+[#2019]: https://github.com/raiden-network/light-client/issues/2019
 
 ## [0.10.0] - 2020-07-13
 ### Fixed

--- a/raiden-ts/src/messages/actions.ts
+++ b/raiden-ts/src/messages/actions.ts
@@ -12,7 +12,7 @@ export const messageSend = createAsyncAction(
   'message/send/success',
   'message/send/failure',
   t.type({ message: t.union([t.string, Signed(Message)]) }),
-  undefined,
+  t.union([t.undefined, t.type({ via: t.string })]),
 );
 export namespace messageSend {
   export interface request extends ActionType<typeof messageSend.request> {}

--- a/raiden-ts/src/transport/epics/helpers.ts
+++ b/raiden-ts/src/transport/epics/helpers.ts
@@ -142,8 +142,8 @@ export function waitMemberAndSend$(
     }),
     take(1), // use first room/user which meets all requirements/filters above
     mergeMap((via) =>
-      defer(
-        () =>
+      defer<Promise<void>>(
+        async () =>
           typeof via === 'string'
             ? matrix.sendEvent(via, type, content, '') // via room
             : via.send(content.body), // via RTC channel

--- a/raiden-ts/src/transport/epics/messages.ts
+++ b/raiden-ts/src/transport/epics/messages.ts
@@ -11,7 +11,6 @@ import {
   switchMap,
   take,
   takeUntil,
-  mapTo,
   tap,
 } from 'rxjs/operators';
 import find from 'lodash/find';
@@ -81,7 +80,7 @@ export const matrixMessageSendEpic = (
             { log, latest$, config$ },
             true, // alowRtc
           ).pipe(
-            mapTo(messageSend.success(undefined, action.meta)),
+            map((via) => messageSend.success({ via }, action.meta)),
             catchError((err) => {
               log.error('messageSend error', err, action.meta);
               return of(messageSend.failure(err, action.meta));

--- a/raiden-ts/src/utils/rx.ts
+++ b/raiden-ts/src/utils/rx.ts
@@ -69,7 +69,7 @@ export function distinctRecordValues<R>(
  * Operator to repeat-subscribe an input observable until a notifier emits
  *
  * @param notifier - Notifier observable to stop repeating
- * @param delayMs - Delay between retries; in milliseconds, or an Iterator of delays
+ * @param delayMs - Delay between retries or an Iterator of delays; in milliseconds
  * @returns Monotype operator function
  */
 export function repeatUntil<T>(

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -946,7 +946,7 @@ describe('transport epic', () => {
       setTimeout(() => action$.complete(), 100);
 
       await expect(promise).resolves.toMatchObject(
-        messageSend.success(undefined, {
+        messageSend.success(expect.anything(), {
           address: partner,
           msgId: signed.message_identifier.toString(),
         }),


### PR DESCRIPTION
Fixes #2019 

**Short description**
retry utilities also accept an `Iterator<number>` for the delay, and will wait each yielded value between retries; a `exponentialBackoff` generator utility is provided, and used for the protocol messages retries, starting with `config.pollingInterval = 5s`, and increasing this delay by 40% on each iteration up to the maximum value, which we set by default as `2 * httpTimeout = 60s`
This is an optimization, since first retries can get a message accepted (if partner synced to accept the message) sooner than a constant value, like before

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. MS4 can trigger reject a message sometimes due to partner not yet having confirmed the deposit
2. Check the transfer message is retried in 5s instead of 30s, and accepted
