### PR TITLE
dapp: restore hash mode of router

### DIFF
--- a/raiden-dapp/src/router/index.ts
+++ b/raiden-dapp/src/router/index.ts
@@ -189,7 +189,7 @@ export function globalNavigationGuard(
 Vue.use(Router);
 
 const router = new Router({
-  mode: process.env.NODE_ENV === 'production' ? 'history' : 'hash',
+  mode: 'hash',
   base: process.env.BASE_URL,
   routes,
 });


### PR DESCRIPTION
For some reason this must have been lost while resolving merge conflicts
in the router. Even the author thinks to remember it was protected.

**Sorry!!**