### PR TITLE
dApp: Prevents access to state download dialog when connected

### DIFF
--- a/raiden-dapp/src/views/account/BackupState.vue
+++ b/raiden-dapp/src/views/account/BackupState.vue
@@ -36,6 +36,7 @@
         <template #activator="{ on }">
           <div v-on="isConnected ? on : null">
             <v-list-item
+              :disabled="isConnected"
               class="backup-state__buttons__upload-state"
               @click="uploadState = true"
             >


### PR DESCRIPTION
Fixes #1827 

**Short description**
Makes sure that user cannot access upload state dialog once connected.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to the dApp and navigate to the `Backup state` menu on the account screen.
2. Try to click the button for uploading state.
