### PR TITLE
Change disclaimer acceptance text

### DIFF
--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -5,7 +5,7 @@
       " Privacy warning: Please be aware, that by using the Raiden Client, among others your Ethereum address, channels, channel deposits, settlements and the Ethereum address of your channel counterparty will be stored on the Ethereum chain, i.e. on servers of Ethereum node operators and ergo are to a certain extent publicly available. The same might also be stored on systems of parties running Raiden nodes connected to the same token network. Data present in the Ethereum chain is very unlikely to be able to be changed, removed or deleted from the public arena.",
       " Also be aware, that data on individual Raiden token transfers will be made available via the Matrix protocol to the recipient, intermediating nodes of a specific transfer as well as to the Matrix server operators, see Raiden Transport Specification."
     ],
-    "accept-checkbox": "I agree to the Privacy Policy, Disclaimer and Imprint",
+    "accept-checkbox": "I have read, understood and hereby accept the above disclaimer and privacy warning",
     "persist-checkbox": "Don't display this message on start up",
     "accept-button": "Accept"
   },


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes # (no issue created)

**Short description**
The disclaimer acceptance text has been changed to `I have read, understood and hereby accept the above disclaimer and privacy warning` to align with the Raiden Python client (see https://github.com/raiden-network/raiden/blob/84eb30b7a5122a94d8ed01a31def7ff3b6c4f414/raiden/ui/cli.py#L604-L605)

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Open the dApp
