### PR TITLE
0.10.0 -> v0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "light-client",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Raiden Light Client monorepo",
   "author": "brainbot labs est.",
   "private": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,17 +14,17 @@ importers:
       morgan: 1.10.0
       node-localstorage: 2.1.6
       raiden-ts: 'link:../raiden-ts'
-      rxjs: 6.6.0
+      rxjs: 6.6.2
       wrtc: 0.4.6
       yargs: 15.4.1
     devDependencies:
       '@types/express': 4.17.7
       '@types/inquirer': 7.3.0
-      '@types/node': 14.0.24
+      '@types/node': 14.0.27
       '@types/node-localstorage': 1.3.0
       '@types/yargs': 15.0.5
-      '@typescript-eslint/eslint-plugin': 3.7.0_a7d792035c43f2b80bcf395c5516fe5c
-      '@typescript-eslint/parser': 3.7.0_eslint@7.5.0+typescript@3.9.7
+      '@typescript-eslint/eslint-plugin': 3.8.0_ca0faf4066da35843277552e510770b3
+      '@typescript-eslint/parser': 3.8.0_eslint@7.5.0+typescript@3.9.7
       eslint: 7.5.0
       eslint-config-prettier: 6.11.0_eslint@7.5.0
       eslint-plugin-import: 2.22.0_eslint@7.5.0
@@ -35,18 +35,18 @@ importers:
       symbol-observable: 1.2.0
       ts-loader: 8.0.1_typescript@3.9.7
       typescript: 3.9.7
-      webpack: 4.43.0_webpack@4.43.0
-      webpack-cli: 3.3.12_webpack@4.43.0
+      webpack: 4.44.1_7d74d9f6ceb0e540c1e44d9709220c58
+      webpack-cli: 3.3.12_webpack@4.44.1
     specifiers:
       '@types/express': ^4.17.7
       '@types/http-errors': ^1.8.0
       '@types/inquirer': ^7.3.0
       '@types/morgan': ^1.9.1
-      '@types/node': ^14.0.24
+      '@types/node': ^14.0.27
       '@types/node-localstorage': ^1.3.0
       '@types/yargs': ^15.0.5
-      '@typescript-eslint/eslint-plugin': ^3.7.0
-      '@typescript-eslint/parser': ^3.7.0
+      '@typescript-eslint/eslint-plugin': ^3.7.1
+      '@typescript-eslint/parser': ^3.7.1
       cors: ^2.8.5
       eslint: ^7.5.0
       eslint-config-prettier: ^6.11.0
@@ -63,11 +63,11 @@ importers:
       node-pre-gyp: ^0.15.0
       prettier: ^2.0.5
       raiden-ts: '*'
-      rxjs: ^6.6.0
+      rxjs: ^6.6.2
       symbol-observable: ^1.2.0
       ts-loader: ^8.0.1
       typescript: ^3.9.7
-      webpack: ^4.43.0
+      webpack: ^4.44.1
       webpack-cli: ^3.3.12
       wrtc: ^0.4.6
       yargs: ^15.4.1
@@ -81,37 +81,37 @@ importers:
       loglevel: 1.6.8
       raiden-ts: 'link:../raiden-ts'
       register-service-worker: 1.7.1
-      rxjs: 6.6.0
+      rxjs: 6.6.2
       tiny-async-pool: 1.1.0
       typeface-roboto: 0.0.75
       vue: 2.6.11
       vue-class-component: 7.2.5_vue@2.6.11
-      vue-i18n: 8.18.2
+      vue-i18n: 8.20.0
       vue-property-decorator: 9.0.0_ca358c81848ed432ed1021d8d24ee103
-      vue-qrcode-reader: 2.3.10
+      vue-qrcode-reader: 2.3.11
       vue-router: 3.3.4
       vue-virtual-scroller: 1.0.10_vue@2.6.11
-      vuetify: 2.3.6_vue@2.6.11
+      vuetify: 2.3.7_vue@2.6.11
       vuex: 3.5.1_vue@2.6.11
       vuex-persist: 2.2.0_vuex@3.5.1
     devDependencies:
-      '@babel/core': 7.10.5
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.10.4_@babel+core@7.10.5
-      '@babel/plugin-proposal-optional-chaining': 7.10.4_@babel+core@7.10.5
+      '@babel/core': 7.11.0
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-optional-chaining': 7.11.0_@babel+core@7.11.0
       '@cypress/code-coverage': 3.8.1
-      '@cypress/webpack-preprocessor': 5.4.2_4559467a1846d577798ec943bd48cad3
+      '@cypress/webpack-preprocessor': 5.4.2_acb184a748c2af9056ceb32896700615
       '@kazupon/vue-i18n-loader': 0.5.0
-      '@mdi/font': 5.3.45
+      '@mdi/font': 5.4.55
       '@namics/stylelint-bem': 6.3.1_stylelint@13.6.1
-      '@testing-library/jest-dom': 5.11.1
-      '@types/jest': 26.0.6
+      '@testing-library/jest-dom': 5.11.2
+      '@types/jest': 26.0.8
       '@types/lodash': 4.14.158
       '@types/tiny-async-pool': 1.0.0
       '@types/vue-i18n': 7.0.0
       '@types/webpack': 4.41.21
-      '@typescript-eslint/eslint-plugin': 3.7.0_a7d792035c43f2b80bcf395c5516fe5c
-      '@typescript-eslint/parser': 3.7.0_eslint@7.5.0+typescript@3.9.7
-      '@vue/cli': 4.4.6_@babel+core@7.10.5
+      '@typescript-eslint/eslint-plugin': 3.8.0_ca0faf4066da35843277552e510770b3
+      '@typescript-eslint/parser': 3.8.0_eslint@7.5.0+typescript@3.9.7
+      '@vue/cli': 4.4.6_@babel+core@7.11.0
       '@vue/cli-plugin-babel': 4.4.6_@vue+cli-service@4.4.6
       '@vue/cli-plugin-e2e-cypress': 4.4.6_b25395b3b3842d7e71fbbc19c94aff40
       '@vue/cli-plugin-eslint': 4.4.6_b25395b3b3842d7e71fbbc19c94aff40
@@ -122,59 +122,59 @@ importers:
       '@vue/cli-plugin-vuex': 4.4.6_@vue+cli-service@4.4.6
       '@vue/cli-service': 4.4.6_12cff5d04a7b84a4e22ef665d8d21340
       '@vue/eslint-config-prettier': 6.0.0_8686e156d8c56f93371cc3c0b70b3d57
-      '@vue/eslint-config-typescript': 5.0.2_0793fcc7a1108934102a0610919e9b48
+      '@vue/eslint-config-typescript': 5.0.2_40f844fffa9af343ee9319c3bf0f9252
       '@vue/test-utils': 1.0.3_d81dac297579cfd5597855dabf60f13b
-      babel-core: 7.0.0-bridge.0_@babel+core@7.10.5
+      babel-core: 7.0.0-bridge.0_@babel+core@7.11.0
       babel-eslint: 10.1.0_eslint@7.5.0
-      babel-loader: 8.1.0_13c776b87d2822e76e5e552d0872621e
+      babel-loader: 8.1.0_eb1461431efd5a396fc2100c302053ae
       canvas: 2.6.1
-      copy-webpack-plugin: 6.0.3_webpack@4.43.0
+      copy-webpack-plugin: 6.0.3_webpack@4.44.1
       eslint: 7.5.0
       eslint-import-resolver-alias: 1.1.2_eslint-plugin-import@2.22.0
       eslint-plugin-import: 2.22.0_eslint@7.5.0
-      eslint-plugin-jsdoc: 30.0.3_eslint@7.5.0
+      eslint-plugin-jsdoc: 30.2.0_eslint@7.5.0
       eslint-plugin-prettier: 3.1.4_eslint@7.5.0
       eslint-plugin-vue: 6.2.2_eslint@7.5.0
       eslint-plugin-vue-i18n: 0.3.0_eslint@7.5.0
-      eslint-plugin-vuetify: 1.0.0-beta.7_eslint@7.5.0+vuetify@2.3.6
+      eslint-plugin-vuetify: 1.0.0-beta.7_eslint@7.5.0+vuetify@2.3.7
       flush-promises: 1.0.2
-      jest: 26.1.0_canvas@2.6.1
-      jest-junit: 11.0.1
+      jest: 26.2.2_canvas@2.6.1
+      jest-junit: 11.1.0
       material-design-icons-iconfont: 5.0.1
       nyc: 15.1.0
       sass: 1.26.10
-      sass-loader: 9.0.2_sass@1.26.10+webpack@4.43.0
-      source-map-loader: 1.0.1_webpack@4.43.0
+      sass-loader: 9.0.2_sass@1.26.10+webpack@4.44.1
+      source-map-loader: 1.0.1_webpack@4.44.1
       stylelint: 13.6.1
       stylelint-config-recommended-scss: 4.2.0_10e17cd3bd594037572f86f9e2baa954
       stylelint-scss: 3.18.0_stylelint@13.6.1
       symbol-observable: 1.2.0
-      ts-jest: 26.1.3_jest@26.1.0+typescript@3.9.7
+      ts-jest: 26.1.4_jest@26.2.2+typescript@3.9.7
       tslib: 2.0.0
       typescript: 3.9.7
       vue-cli-plugin-i18n: 1.0.1
-      vue-cli-plugin-vuetify: 2.0.7_639642eb3bb4815112acddb1c405f875
+      vue-cli-plugin-vuetify: 2.0.7_fb9579d217c5c7127396de9c5445c080
       vue-jest: 3.0.6_64ba5b21466dd6d31604ca8f3ce0789b
       vue-template-compiler: 2.6.11
-      vuetify-loader: 1.6.0_6a58f05bac33018dc577282d418e9eb8
-      webpack: 4.43.0_webpack@4.43.0
+      vuetify-loader: 1.6.0_9463ea465103b1f409e4954823843e27
+      webpack: 4.44.1_webpack@4.44.1
     specifiers:
-      '@babel/core': ^7.10.5
+      '@babel/core': ^7.11.0
       '@babel/plugin-proposal-nullish-coalescing-operator': ^7.10.4
-      '@babel/plugin-proposal-optional-chaining': ^7.10.4
+      '@babel/plugin-proposal-optional-chaining': ^7.11.0
       '@cypress/code-coverage': ^3.8.1
       '@cypress/webpack-preprocessor': ^5.4.2
       '@kazupon/vue-i18n-loader': ^0.5.0
-      '@mdi/font': ^5.3.45
+      '@mdi/font': ^5.4.55
       '@namics/stylelint-bem': ^6.3.1
-      '@testing-library/jest-dom': ^5.11.1
-      '@types/jest': ^26.0.6
+      '@testing-library/jest-dom': ^5.11.2
+      '@types/jest': ^26.0.8
       '@types/lodash': ^4.14.158
       '@types/tiny-async-pool': ^1.0.0
       '@types/vue-i18n': ^7.0.0
       '@types/webpack': ^4.41.21
-      '@typescript-eslint/eslint-plugin': ^3.7.0
-      '@typescript-eslint/parser': ^3.7.0
+      '@typescript-eslint/eslint-plugin': ^3.7.1
+      '@typescript-eslint/parser': ^3.7.1
       '@vue/cli': ^4.4.6
       '@vue/cli-plugin-babel': ^4.4.6
       '@vue/cli-plugin-e2e-cypress': ^4.4.6
@@ -197,7 +197,7 @@ importers:
       eslint: ^7.5.0
       eslint-import-resolver-alias: ^1.1.2
       eslint-plugin-import: ^2.22.0
-      eslint-plugin-jsdoc: ^30.0.3
+      eslint-plugin-jsdoc: ^30.1.0
       eslint-plugin-prettier: ^3.1.4
       eslint-plugin-vue: ^6.2.2
       eslint-plugin-vue-i18n: ^0.3.0
@@ -206,15 +206,15 @@ importers:
       ethers: ^4.0.47
       flush-promises: ^1.0.2
       idb: ^5.0.4
-      jest: ^26.1.0
-      jest-junit: ^11.0.1
+      jest: ^26.2.2
+      jest-junit: ^11.1.0
       lodash: ^4.17.19
       loglevel: ^1.6.8
       material-design-icons-iconfont: ^5.0.1
       nyc: ^15.1.0
       raiden-ts: '*'
       register-service-worker: ^1.7.1
-      rxjs: ^6.6.0
+      rxjs: ^6.6.2
       sass: ^1.26.10
       sass-loader: ^9.0.2
       source-map-loader: ^1.0.1
@@ -223,7 +223,7 @@ importers:
       stylelint-scss: ^3.18.0
       symbol-observable: ^1.2.0
       tiny-async-pool: ^1.1.0
-      ts-jest: ^26.1.3
+      ts-jest: ^26.1.4
       tslib: ^2.0.0
       typeface-roboto: ^0.0.75
       typescript: ^3.9.7
@@ -231,18 +231,18 @@ importers:
       vue-class-component: ^7.2.5
       vue-cli-plugin-i18n: ^1.0.1
       vue-cli-plugin-vuetify: ^2.0.7
-      vue-i18n: ^8.18.2
+      vue-i18n: ^8.20.0
       vue-jest: ^3.0.6
       vue-property-decorator: ^9.0.0
-      vue-qrcode-reader: ^2.3.10
+      vue-qrcode-reader: ^2.3.11
       vue-router: ^3.3.4
       vue-template-compiler: ^2.6.11
       vue-virtual-scroller: ^1.0.10
-      vuetify: ^2.3.6
+      vuetify: ^2.3.7
       vuetify-loader: ^1.6.0
       vuex: ^3.5.1
       vuex-persist: ^2.2.0
-      webpack: ^4.43.0
+      webpack: ^4.44.1
   raiden-ts:
     dependencies:
       abort-controller: 3.0.0
@@ -253,17 +253,17 @@ importers:
       lodash: 4.17.19
       loglevel: 1.6.8
       lossless-json: 1.0.4
-      matrix-js-sdk: 7.1.0
+      matrix-js-sdk: 8.0.0
       redux: 4.0.5
       redux-logger: 3.0.6
-      redux-observable: 1.2.0_redux@4.0.5+rxjs@6.6.0
-      rxjs: 6.6.0
+      redux-observable: 1.2.0_redux@4.0.5+rxjs@6.6.2
+      rxjs: 6.6.2
       wrtc: 0.4.6
     devDependencies:
       '@typechain/ethers-v4': 1.0.0_ethers@4.0.47+typechain@2.0.0
       '@types/events': 3.0.0
       '@types/isomorphic-fetch': 0.0.35
-      '@types/jest': 26.0.6
+      '@types/jest': 26.0.8
       '@types/lodash': 4.14.158
       '@types/lossless-json': 1.0.0
       '@types/matrix-js-sdk': 5.1.2
@@ -271,25 +271,25 @@ importers:
       '@types/node-localstorage': 1.3.0
       '@types/redux-logger': 3.0.8
       '@types/tiny-async-pool': 1.0.0
-      '@typescript-eslint/eslint-plugin': 3.7.0_a7d792035c43f2b80bcf395c5516fe5c
-      '@typescript-eslint/parser': 3.7.0_eslint@7.5.0+typescript@3.9.7
+      '@typescript-eslint/eslint-plugin': 3.8.0_ca0faf4066da35843277552e510770b3
+      '@typescript-eslint/parser': 3.8.0_eslint@7.5.0+typescript@3.9.7
       eslint: 7.5.0
       eslint-config-prettier: 6.11.0_eslint@7.5.0
       eslint-plugin-import: 2.22.0_eslint@7.5.0
-      eslint-plugin-jsdoc: 30.0.3_eslint@7.5.0
+      eslint-plugin-jsdoc: 30.2.0_eslint@7.5.0
       eslint-plugin-prettier: 3.1.4_eslint@7.5.0+prettier@2.0.5
       ganache-cli: 6.9.1
-      jest: 26.1.0
-      jest-junit: 11.0.1
+      jest: 26.2.2
+      jest-junit: 11.1.0
       memdown: 5.1.0
       node-localstorage: 2.1.6
       node-pre-gyp: 0.15.0
       prettier: 2.0.5
       rimraf: 3.0.2
-      rxjs-marbles: 6.0.1_rxjs@6.6.0
+      rxjs-marbles: 6.0.1_rxjs@6.6.2
       symbol-observable: 1.2.0
       tiny-async-pool: 1.1.0
-      ts-jest: 26.1.3_jest@26.1.0+typescript@3.9.7
+      ts-jest: 26.1.4_jest@26.2.2+typescript@3.9.7
       typechain: 2.0.0_typescript@3.9.7
       typedoc: 0.17.8_typescript@3.9.7
       typedoc-plugin-markdown: 2.3.1_typedoc@0.17.8
@@ -299,7 +299,7 @@ importers:
       '@typechain/ethers-v4': ^1.0.0
       '@types/events': ^3.0.0
       '@types/isomorphic-fetch': ^0.0.35
-      '@types/jest': ^26.0.6
+      '@types/jest': ^26.0.8
       '@types/lodash': ^4.14.158
       '@types/lossless-json': ^1.0.0
       '@types/matrix-js-sdk': ^5.1.2
@@ -307,25 +307,25 @@ importers:
       '@types/node-localstorage': ^1.3.0
       '@types/redux-logger': ^3.0.8
       '@types/tiny-async-pool': ^1.0.0
-      '@typescript-eslint/eslint-plugin': ^3.7.0
-      '@typescript-eslint/parser': ^3.7.0
+      '@typescript-eslint/eslint-plugin': ^3.7.1
+      '@typescript-eslint/parser': ^3.7.1
       abort-controller: ^3.0.0
       eslint: ^7.5.0
       eslint-config-prettier: ^6.11.0
       eslint-plugin-import: ^2.22.0
-      eslint-plugin-jsdoc: ^30.0.3
+      eslint-plugin-jsdoc: ^30.1.0
       eslint-plugin-prettier: ^3.1.4
       ethers: ^4.0.47
       fp-ts: ^2.7.1
       ganache-cli: ^6.9.1
       io-ts: ^2.2.9
       isomorphic-fetch: ^2.2.1
-      jest: ^26.1.0
-      jest-junit: ^11.0.1
+      jest: ^26.2.2
+      jest-junit: ^11.1.0
       lodash: ^4.17.19
       loglevel: ^1.6.8
       lossless-json: ^1.0.4
-      matrix-js-sdk: ^7.1.0
+      matrix-js-sdk: ^8.0.0
       memdown: ^5.1.0
       node-localstorage: ^2.1.6
       node-pre-gyp: ^0.15.0
@@ -334,11 +334,11 @@ importers:
       redux-logger: ^3.0.6
       redux-observable: ^1.2.0
       rimraf: ^3.0.2
-      rxjs: ^6.6.0
+      rxjs: ^6.6.2
       rxjs-marbles: ^6.0.1
       symbol-observable: ^1.2.0
       tiny-async-pool: ^1.1.0
-      ts-jest: ^26.1.3
+      ts-jest: ^26.1.4
       typechain: ^2.0.0
       typedoc: ^0.17.8
       typedoc-plugin-markdown: ^2.3.1
@@ -464,7 +464,7 @@ packages:
       '@babel/parser': 7.10.5
       '@babel/template': 7.10.4
       '@babel/traverse': 7.10.5
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
       convert-source-map: 1.7.0
       debug: 4.1.1
       gensync: 1.0.0-beta.1
@@ -478,6 +478,29 @@ packages:
       node: '>=6.9.0'
     resolution:
       integrity: sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==
+  /@babel/core/7.11.0:
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      '@babel/generator': 7.11.0
+      '@babel/helper-module-transforms': 7.11.0
+      '@babel/helpers': 7.10.4
+      '@babel/parser': 7.11.0
+      '@babel/template': 7.10.4
+      '@babel/traverse': 7.11.0
+      '@babel/types': 7.11.0
+      convert-source-map: 1.7.0
+      debug: 4.1.1
+      gensync: 1.0.0-beta.1
+      json5: 2.1.3
+      lodash: 4.17.19
+      resolve: 1.17.0
+      semver: 5.7.1
+      source-map: 0.5.7
+    dev: true
+    engines:
+      node: '>=6.9.0'
+    resolution:
+      integrity: sha512-mkLq8nwaXmDtFmRkQ8ED/eA2CnVw4zr7dCztKalZXBvdK5EeNUAesrrwUqjQEzFgomJssayzB0aqlOsP1vGLqg==
   /@babel/core/7.4.5:
     dependencies:
       '@babel/code-frame': 7.10.4
@@ -510,12 +533,20 @@ packages:
       integrity: sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==
   /@babel/generator/7.10.5:
     dependencies:
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
       jsesc: 2.5.2
       source-map: 0.5.7
     dev: true
     resolution:
       integrity: sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==
+  /@babel/generator/7.11.0:
+    dependencies:
+      '@babel/types': 7.11.0
+      jsesc: 2.5.2
+      source-map: 0.5.7
+    dev: true
+    resolution:
+      integrity: sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==
   /@babel/helper-annotate-as-pure/7.10.4:
     dependencies:
       '@babel/types': 7.10.5
@@ -557,9 +588,36 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==
+  /@babel/helper-compilation-targets/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/compat-data': 7.10.5
+      '@babel/core': 7.11.0
+      browserslist: 4.13.0
+      invariant: 2.2.4
+      levenary: 1.1.1
+      semver: 5.7.1
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==
   /@babel/helper-create-class-features-plugin/7.10.5_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-function-name': 7.10.4
+      '@babel/helper-member-expression-to-functions': 7.10.5
+      '@babel/helper-optimise-call-expression': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.10.4
+      '@babel/helper-split-export-declaration': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==
+  /@babel/helper-create-class-features-plugin/7.10.5_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-function-name': 7.10.4
       '@babel/helper-member-expression-to-functions': 7.10.5
       '@babel/helper-optimise-call-expression': 7.10.4
@@ -588,6 +646,17 @@ packages:
   /@babel/helper-create-regexp-features-plugin/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-regex': 7.10.5
+      regexpu-core: 4.7.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-2/hu58IEPKeoLF45DBwx3XFqsbCXmkdAay4spVr2x0jYgRxrSNp+ePwvSsy9g6YSaNDcKIQVPXk1Ov8S2edk2g==
+  /@babel/helper-create-regexp-features-plugin/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-annotate-as-pure': 7.10.4
       '@babel/helper-regex': 7.10.5
       regexpu-core: 4.7.0
@@ -626,13 +695,13 @@ packages:
     dependencies:
       '@babel/helper-get-function-arity': 7.10.4
       '@babel/template': 7.10.4
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==
   /@babel/helper-get-function-arity/7.10.4:
     dependencies:
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
@@ -644,13 +713,13 @@ packages:
       integrity: sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==
   /@babel/helper-member-expression-to-functions/7.10.5:
     dependencies:
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==
   /@babel/helper-module-imports/7.10.4:
     dependencies:
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==
@@ -659,16 +728,28 @@ packages:
       '@babel/helper-module-imports': 7.10.4
       '@babel/helper-replace-supers': 7.10.4
       '@babel/helper-simple-access': 7.10.4
-      '@babel/helper-split-export-declaration': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
       '@babel/template': 7.10.4
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
       lodash: 4.17.19
     dev: true
     resolution:
       integrity: sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==
+  /@babel/helper-module-transforms/7.11.0:
+    dependencies:
+      '@babel/helper-module-imports': 7.10.4
+      '@babel/helper-replace-supers': 7.10.4
+      '@babel/helper-simple-access': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
+      '@babel/template': 7.10.4
+      '@babel/types': 7.11.0
+      lodash: 4.17.19
+    dev: true
+    resolution:
+      integrity: sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==
   /@babel/helper-optimise-call-expression/7.10.4:
     dependencies:
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==
@@ -696,24 +777,36 @@ packages:
     dependencies:
       '@babel/helper-member-expression-to-functions': 7.10.5
       '@babel/helper-optimise-call-expression': 7.10.4
-      '@babel/traverse': 7.10.5
-      '@babel/types': 7.10.5
+      '@babel/traverse': 7.11.0
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==
   /@babel/helper-simple-access/7.10.4:
     dependencies:
       '@babel/template': 7.10.4
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==
+  /@babel/helper-skip-transparent-expression-wrappers/7.11.0:
+    dependencies:
+      '@babel/types': 7.11.0
+    dev: true
+    resolution:
+      integrity: sha512-0XIdiQln4Elglgjbwo9wuJpL/K7AGCY26kmEt0+pRP0TAj4jjyNq1MjoRvikrTVqKcx4Gysxt4cXvVFXP/JO2Q==
   /@babel/helper-split-export-declaration/7.10.4:
     dependencies:
       '@babel/types': 7.10.5
     dev: true
     resolution:
       integrity: sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==
+  /@babel/helper-split-export-declaration/7.11.0:
+    dependencies:
+      '@babel/types': 7.11.0
+    dev: true
+    resolution:
+      integrity: sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==
   /@babel/helper-validator-identifier/7.10.4:
     dev: true
     resolution:
@@ -730,8 +823,8 @@ packages:
   /@babel/helpers/7.10.4:
     dependencies:
       '@babel/template': 7.10.4
-      '@babel/traverse': 7.10.5
-      '@babel/types': 7.10.5
+      '@babel/traverse': 7.11.0
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==
@@ -750,12 +843,30 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==
+  /@babel/parser/7.11.0:
+    dev: true
+    engines:
+      node: '>=6.0.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==
   /@babel/plugin-proposal-async-generator-functions/7.10.5_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-remap-async-to-generator': 7.10.4
       '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.10.5
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-cNMCVezQbrRGvXJwm9fu/1sJj9bHdGAgKodZdLqOQIpfoH3raqmRPBM17+lh7CzhiKRRBrGtZL9WcjxSoGYUSg==
+  /@babel/plugin-proposal-async-generator-functions/7.10.5_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-remap-async-to-generator': 7.10.4
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -776,6 +887,16 @@ packages:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==
+  /@babel/plugin-proposal-class-properties/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -813,11 +934,31 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==
+  /@babel/plugin-proposal-dynamic-import/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.11.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==
   /@babel/plugin-proposal-json-strings/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.10.5
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==
+  /@babel/plugin-proposal-json-strings/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -843,11 +984,31 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==
+  /@babel/plugin-proposal-nullish-coalescing-operator/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.11.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==
   /@babel/plugin-proposal-numeric-separator/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.10.5
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==
+  /@babel/plugin-proposal-numeric-separator/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -859,6 +1020,17 @@ packages:
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.10.5
       '@babel/plugin-transform-parameters': 7.10.5_@babel+core@7.10.5
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==
+  /@babel/plugin-proposal-object-rest-spread/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-transform-parameters': 7.10.5_@babel+core@7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -895,6 +1067,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==
+  /@babel/plugin-proposal-optional-catch-binding/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.11.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-LflT6nPh+GK2MnFiKDyLiqSqVHkQnVf7hdoAvyTnnKj9xB3docGRsdPuxp6qqqW19ifK3xgc9U5/FwrSaCNX5g==
   /@babel/plugin-proposal-optional-catch-binding/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -915,6 +1097,27 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ZIhQIEeavTgouyMSdZRap4VPPHqJJ3NEs2cuHs5p0erH+iz6khB0qfgU8g7UuJkG88+fBMy23ZiU+nuHvekJeQ==
+  /@babel/plugin-proposal-optional-chaining/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.11.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ZIhQIEeavTgouyMSdZRap4VPPHqJJ3NEs2cuHs5p0erH+iz6khB0qfgU8g7UuJkG88+fBMy23ZiU+nuHvekJeQ==
+  /@babel/plugin-proposal-optional-chaining/7.11.0_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-skip-transparent-expression-wrappers': 7.11.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.11.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==
   /@babel/plugin-proposal-private-methods/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
@@ -925,10 +1128,32 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==
+  /@babel/plugin-proposal-private-methods/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-wh5GJleuI8k3emgTg5KkJK6kHNsGEr0uBTDBuQUBJwckk9xs1ez79ioheEVVxMLyPscB0LfkbVHslQqIzWV6Bw==
   /@babel/plugin-proposal-unicode-property-regex/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    engines:
+      node: '>=4'
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-H+3fOgPnEXFL9zGYtKQe4IDOPKYlZdF1kqFDQRRb8PK4B8af1vAGK04tF5iQAAsui+mHNBQSAtd2/ndEDe9wuA==
+  /@babel/plugin-proposal-unicode-property-regex/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     engines:
@@ -952,6 +1177,15 @@ packages:
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
+  /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -985,6 +1219,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==
+  /@babel/plugin-syntax-class-properties/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==
   /@babel/plugin-syntax-decorators/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
@@ -997,6 +1240,15 @@ packages:
   /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
+  /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -1024,6 +1276,15 @@ packages:
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
+  /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -1075,6 +1336,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
+  /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
@@ -1084,9 +1354,27 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
+  /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
+  /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -1111,6 +1399,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
+  /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1129,9 +1426,27 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
+  /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
   /@babel/plugin-syntax-top-level-await/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==
+  /@babel/plugin-syntax-top-level-await/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -1156,6 +1471,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==
+  /@babel/plugin-transform-arrow-functions/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==
   /@babel/plugin-transform-arrow-functions/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1168,6 +1492,17 @@ packages:
   /@babel/plugin-transform-async-to-generator/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-module-imports': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-remap-async-to-generator': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-F6nREOan7J5UXTLsDsZG3DXmZSVofr2tGNwfdrVwkDWHfQckbQXnXSPfD7iO+c/2HGqycwyLST3DnZ16n+cBJQ==
+  /@babel/plugin-transform-async-to-generator/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-module-imports': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-remap-async-to-generator': 7.10.4
@@ -1196,6 +1531,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==
+  /@babel/plugin-transform-block-scoped-functions/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==
   /@babel/plugin-transform-block-scoped-functions/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1214,6 +1558,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6Ycw3hjpQti0qssQcA6AMSFDHeNJ++R6dIMnpRqUjFeBBTmTDPa8zgF90OVfTvAo11mXZTlVUViY1g8ffrURLg==
+  /@babel/plugin-transform-block-scoping/7.10.5_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-6Ycw3hjpQti0qssQcA6AMSFDHeNJ++R6dIMnpRqUjFeBBTmTDPa8zgF90OVfTvAo11mXZTlVUViY1g8ffrURLg==
   /@babel/plugin-transform-block-scoping/7.10.5_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1226,6 +1579,22 @@ packages:
   /@babel/plugin-transform-classes/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-define-map': 7.10.5
+      '@babel/helper-function-name': 7.10.4
+      '@babel/helper-optimise-call-expression': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.10.4
+      '@babel/helper-split-export-declaration': 7.10.4
+      globals: 11.12.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==
+  /@babel/plugin-transform-classes/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-annotate-as-pure': 7.10.4
       '@babel/helper-define-map': 7.10.5
       '@babel/helper-function-name': 7.10.4
@@ -1264,6 +1633,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==
+  /@babel/plugin-transform-computed-properties/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==
   /@babel/plugin-transform-computed-properties/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1276,6 +1654,15 @@ packages:
   /@babel/plugin-transform-destructuring/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==
+  /@babel/plugin-transform-destructuring/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -1301,6 +1688,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==
+  /@babel/plugin-transform-dotall-regex/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ZEAVvUTCMlMFAbASYSVQoxIbHm2OkG2MseW6bV2JjIygOjdVv8tuxrCTzj1+Rynh7ODb8GivUy7dzEXzEhuPaA==
   /@babel/plugin-transform-dotall-regex/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1320,6 +1717,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==
+  /@babel/plugin-transform-duplicate-keys/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-GL0/fJnmgMclHiBTTWXNlYjYsA7rDrtsazHG6mglaGSTh0KsrW04qml+Bbz9FL0LcJIRwBWL5ZqlNHKTkU3xAA==
   /@babel/plugin-transform-duplicate-keys/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1332,6 +1738,16 @@ packages:
   /@babel/plugin-transform-exponentiation-operator/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==
+  /@babel/plugin-transform-exponentiation-operator/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
@@ -1368,6 +1784,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
+  /@babel/plugin-transform-for-of/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
   /@babel/plugin-transform-for-of/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1380,6 +1805,16 @@ packages:
   /@babel/plugin-transform-function-name/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-function-name': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==
+  /@babel/plugin-transform-function-name/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-function-name': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
@@ -1406,6 +1841,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==
+  /@babel/plugin-transform-literals/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==
   /@babel/plugin-transform-literals/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1418,6 +1862,15 @@ packages:
   /@babel/plugin-transform-member-expression-literals/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==
+  /@babel/plugin-transform-member-expression-literals/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -1444,6 +1897,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==
+  /@babel/plugin-transform-modules-amd/7.10.5_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-module-transforms': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+      babel-plugin-dynamic-import-node: 2.3.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-elm5uruNio7CTLFItVC/rIzKLfQ17+fX7EVz5W0TMgIHFo1zY0Ozzx+lgwhL4plzl8OzVn6Qasx5DeEFyoNiRw==
   /@babel/plugin-transform-modules-amd/7.10.5_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1458,6 +1922,18 @@ packages:
   /@babel/plugin-transform-modules-commonjs/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-module-transforms': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-simple-access': 7.10.4
+      babel-plugin-dynamic-import-node: 2.3.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==
+  /@babel/plugin-transform-modules-commonjs/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-module-transforms': 7.10.5
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-simple-access': 7.10.4
@@ -1491,6 +1967,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==
+  /@babel/plugin-transform-modules-systemjs/7.10.5_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-hoist-variables': 7.10.4
+      '@babel/helper-module-transforms': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+      babel-plugin-dynamic-import-node: 2.3.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-f4RLO/OL14/FP1AEbcsWMzpbUz6tssRaeQg11RH1BP/XnPpRoVwgeYViMFacnkaw4k4wjRSjn3ip1Uw9TaXuMw==
   /@babel/plugin-transform-modules-systemjs/7.10.5_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1506,6 +1994,16 @@ packages:
   /@babel/plugin-transform-modules-umd/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-module-transforms': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-mohW5q3uAEt8T45YT7Qc5ws6mWgJAaL/8BfWD9Dodo1A3RKWli8wTS+WiQ/knF+tXlPirW/1/MqzzGfCExKECA==
+  /@babel/plugin-transform-modules-umd/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-module-transforms': 7.10.5
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
@@ -1532,6 +2030,15 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==
+  /@babel/plugin-transform-named-capturing-groups-regex/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.11.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    resolution:
+      integrity: sha512-V6LuOnD31kTkxQPhKiVYzYC/Jgdq53irJC/xBSmqcNcqFGV+PER4l6rU5SH2Vl7bH9mLDHcc0+l9HUOe4RNGKA==
   /@babel/plugin-transform-named-capturing-groups-regex/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1550,6 +2057,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==
+  /@babel/plugin-transform-new-target/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-YXwWUDAH/J6dlfwqlWsztI2Puz1NtUAubXhOPLQ5gjR/qmQ5U96DY4FQO8At33JN4XPBhrjB8I4eMmLROjjLjw==
   /@babel/plugin-transform-new-target/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1562,6 +2078,16 @@ packages:
   /@babel/plugin-transform-object-super/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-replace-supers': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==
+  /@babel/plugin-transform-object-super/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-replace-supers': 7.10.4
     dev: true
@@ -1589,6 +2115,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==
+  /@babel/plugin-transform-parameters/7.10.5_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-get-function-arity': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==
   /@babel/plugin-transform-parameters/7.10.5_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1602,6 +2138,15 @@ packages:
   /@babel/plugin-transform-property-literals/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==
+  /@babel/plugin-transform-property-literals/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -1667,6 +2212,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==
+  /@babel/plugin-transform-regenerator/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      regenerator-transform: 0.14.5
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-3thAHwtor39A7C04XucbMg17RcZ3Qppfxr22wYzZNcVIkPHfpM9J0SO8zuCV6SZa265kxBJSrfKTvDCYqBFXGw==
   /@babel/plugin-transform-regenerator/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1679,6 +2233,15 @@ packages:
   /@babel/plugin-transform-reserved-words/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-hGsw1O6Rew1fkFbDImZIEqA8GoidwTAilwCyWqLBM9f+e/u/sQMQu7uX6dyokfOayRuuVfKOW4O7HvaBWM+JlQ==
+  /@babel/plugin-transform-reserved-words/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -1727,6 +2290,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==
+  /@babel/plugin-transform-shorthand-properties/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==
   /@babel/plugin-transform-shorthand-properties/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1745,6 +2317,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-1e/51G/Ni+7uH5gktbWv+eCED9pP8ZpRhZB3jOaI3mmzfvJTWHkuyYTv0Z5PYtyM+Tr2Ccr9kUdQxn60fI5WuQ==
+  /@babel/plugin-transform-spread/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-1e/51G/Ni+7uH5gktbWv+eCED9pP8ZpRhZB3jOaI3mmzfvJTWHkuyYTv0Z5PYtyM+Tr2Ccr9kUdQxn60fI5WuQ==
   /@babel/plugin-transform-spread/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1757,6 +2338,16 @@ packages:
   /@babel/plugin-transform-sticky-regex/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-regex': 7.10.5
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Ddy3QZfIbEV0VYcVtFDCjeE4xwVTJWTmUtorAJkn6u/92Z/nWJNV+mILyqHKrUxXYKA2EoCilgoPePymKL4DvQ==
+  /@babel/plugin-transform-sticky-regex/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-regex': 7.10.5
     dev: true
@@ -1784,6 +2375,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==
+  /@babel/plugin-transform-template-literals/7.10.5_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-annotate-as-pure': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==
   /@babel/plugin-transform-template-literals/7.10.5_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1797,6 +2398,15 @@ packages:
   /@babel/plugin-transform-typeof-symbol/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==
+  /@babel/plugin-transform-typeof-symbol/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -1832,10 +2442,29 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==
+  /@babel/plugin-transform-unicode-escapes/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-y5XJ9waMti2J+e7ij20e+aH+fho7Wb7W8rNuu72aKRwCHFqQdhkdU2lo3uZ9tQuboEJcUFayXdARhcxLQ3+6Fg==
   /@babel/plugin-transform-unicode-regex/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.10.5
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-wNfsc4s8N2qnIwpO/WP2ZiSyjfpTamT2C9V9FDH/Ljub9zw6P3SjkXcFmc0RQUt96k2fmIvtla2MMjgTwIAC+A==
+  /@babel/plugin-transform-unicode-regex/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-create-regexp-features-plugin': 7.10.4_@babel+core@7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -1913,6 +2542,78 @@ packages:
       '@babel/plugin-transform-unicode-escapes': 7.10.4_@babel+core@7.10.5
       '@babel/plugin-transform-unicode-regex': 7.10.4_@babel+core@7.10.5
       '@babel/preset-modules': 0.1.3_@babel+core@7.10.5
+      '@babel/types': 7.10.5
+      browserslist: 4.13.0
+      core-js-compat: 3.6.5
+      invariant: 2.2.4
+      levenary: 1.1.1
+      semver: 5.7.1
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-tcmuQ6vupfMZPrLrc38d0sF2OjLT3/bZ0dry5HchNCQbrokoQi4reXqclvkkAT5b+gWc23meVWpve5P/7+w/zw==
+  /@babel/preset-env/7.10.4_@babel+core@7.11.0:
+    dependencies:
+      '@babel/compat-data': 7.10.5
+      '@babel/core': 7.11.0
+      '@babel/helper-compilation-targets': 7.10.4_@babel+core@7.11.0
+      '@babel/helper-module-imports': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-proposal-async-generator-functions': 7.10.5_@babel+core@7.11.0
+      '@babel/plugin-proposal-class-properties': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-dynamic-import': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-json-strings': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-numeric-separator': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-object-rest-spread': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-optional-catch-binding': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-optional-chaining': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-private-methods': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.11.0
+      '@babel/plugin-syntax-class-properties': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.11.0
+      '@babel/plugin-syntax-top-level-await': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-arrow-functions': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-async-to-generator': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-block-scoped-functions': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-block-scoping': 7.10.5_@babel+core@7.11.0
+      '@babel/plugin-transform-classes': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-computed-properties': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-destructuring': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-duplicate-keys': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-exponentiation-operator': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-for-of': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-function-name': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-literals': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-member-expression-literals': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-modules-amd': 7.10.5_@babel+core@7.11.0
+      '@babel/plugin-transform-modules-commonjs': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-modules-systemjs': 7.10.5_@babel+core@7.11.0
+      '@babel/plugin-transform-modules-umd': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-new-target': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-object-super': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-parameters': 7.10.5_@babel+core@7.11.0
+      '@babel/plugin-transform-property-literals': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-regenerator': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-reserved-words': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-shorthand-properties': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-spread': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-sticky-regex': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-template-literals': 7.10.5_@babel+core@7.11.0
+      '@babel/plugin-transform-typeof-symbol': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-unicode-escapes': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-unicode-regex': 7.10.4_@babel+core@7.11.0
+      '@babel/preset-modules': 0.1.3_@babel+core@7.11.0
       '@babel/types': 7.10.5
       browserslist: 4.13.0
       core-js-compat: 3.6.5
@@ -2003,6 +2704,19 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==
+  /@babel/preset-modules/0.1.3_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.11.0
+      '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.11.0
+      '@babel/types': 7.10.5
+      esutils: 2.0.3
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==
   /@babel/preset-react/7.0.0_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -2060,25 +2774,39 @@ packages:
   /@babel/template/7.10.4:
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@babel/parser': 7.10.5
-      '@babel/types': 7.10.5
+      '@babel/parser': 7.11.0
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
   /@babel/traverse/7.10.5:
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@babel/generator': 7.10.5
+      '@babel/generator': 7.11.0
       '@babel/helper-function-name': 7.10.4
-      '@babel/helper-split-export-declaration': 7.10.4
-      '@babel/parser': 7.10.5
-      '@babel/types': 7.10.5
+      '@babel/helper-split-export-declaration': 7.11.0
+      '@babel/parser': 7.11.0
+      '@babel/types': 7.11.0
       debug: 4.1.1
       globals: 11.12.0
       lodash: 4.17.19
     dev: true
     resolution:
       integrity: sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==
+  /@babel/traverse/7.11.0:
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      '@babel/generator': 7.11.0
+      '@babel/helper-function-name': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
+      '@babel/parser': 7.11.0
+      '@babel/types': 7.11.0
+      debug: 4.1.1
+      globals: 11.12.0
+      lodash: 4.17.19
+    dev: true
+    resolution:
+      integrity: sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==
   /@babel/types/7.10.4:
     dependencies:
       '@babel/helper-validator-identifier': 7.10.4
@@ -2095,6 +2823,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==
+  /@babel/types/7.11.0:
+    dependencies:
+      '@babel/helper-validator-identifier': 7.10.4
+      lodash: 4.17.19
+      to-fast-properties: 2.0.0
+    dev: true
+    resolution:
+      integrity: sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==
   /@bcoe/v8-coverage/0.2.3:
     dev: true
     resolution:
@@ -2159,14 +2895,14 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=
-  /@cypress/webpack-preprocessor/5.4.2_4559467a1846d577798ec943bd48cad3:
+  /@cypress/webpack-preprocessor/5.4.2_acb184a748c2af9056ceb32896700615:
     dependencies:
-      '@babel/core': 7.10.5
-      babel-loader: 8.1.0_13c776b87d2822e76e5e552d0872621e
+      '@babel/core': 7.11.0
+      babel-loader: 8.1.0_eb1461431efd5a396fc2100c302053ae
       bluebird: 3.7.1
       debug: 4.1.1
       lodash: 4.17.19
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.1
@@ -2270,18 +3006,19 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==
-  /@jest/console/26.1.0:
+  /@jest/console/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
       chalk: 4.1.0
-      jest-message-util: 26.1.0
-      jest-util: 26.1.0
+      jest-message-util: 26.2.0
+      jest-util: 26.2.0
       slash: 3.0.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-+0lpTHMd/8pJp+Nd4lyip+/Iyf2dZJvcCqrlkeZQoQid+JlThA4M9vxHtheyrQ99jJTMQam+es4BcvZ5W5cC3A==
+      integrity: sha512-mXQfx3nSLwiHm1i7jbu+uvi+vvpVjNGzIQYLCfsat9rapC+MJkS4zBseNrgJE0vU921b3P67bQzhduphjY3Tig==
   /@jest/core/24.9.0:
     dependencies:
       '@jest/console': 24.9.0
@@ -2317,30 +3054,31 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==
-  /@jest/core/26.1.0:
+  /@jest/core/26.2.2:
     dependencies:
-      '@jest/console': 26.1.0
-      '@jest/reporters': 26.1.0
-      '@jest/test-result': 26.1.0
-      '@jest/transform': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/console': 26.2.0
+      '@jest/reporters': 26.2.2
+      '@jest/test-result': 26.2.0
+      '@jest/transform': 26.2.2
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
       ansi-escapes: 4.3.1
       chalk: 4.1.0
       exit: 0.1.2
       graceful-fs: 4.2.4
-      jest-changed-files: 26.1.0
-      jest-config: 26.1.0
-      jest-haste-map: 26.1.0
-      jest-message-util: 26.1.0
+      jest-changed-files: 26.2.0
+      jest-config: 26.2.2
+      jest-haste-map: 26.2.2
+      jest-message-util: 26.2.0
       jest-regex-util: 26.0.0
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
-      jest-resolve-dependencies: 26.1.0
-      jest-runner: 26.1.0
-      jest-runtime: 26.1.0
-      jest-snapshot: 26.1.0
-      jest-util: 26.1.0
-      jest-validate: 26.1.0
-      jest-watcher: 26.1.0
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-resolve-dependencies: 26.2.2
+      jest-runner: 26.2.2
+      jest-runtime: 26.2.2
+      jest-snapshot: 26.2.2
+      jest-util: 26.2.0
+      jest-validate: 26.2.0
+      jest-watcher: 26.2.0
       micromatch: 4.0.2
       p-each-series: 2.1.0
       rimraf: 3.0.2
@@ -2352,31 +3090,32 @@ packages:
     peerDependencies:
       canvas: '*'
     resolution:
-      integrity: sha512-zyizYmDJOOVke4OO/De//aiv8b07OwZzL2cfsvWF3q9YssfpcKfcnZAwDY8f+A76xXSMMYe8i/f/LPocLlByfw==
-  /@jest/core/26.1.0_canvas@2.6.1:
+      integrity: sha512-UwA8gNI8aeV4FHGfGAUfO/DHjrFVvlBravF1Tm9Kt6qFE+6YHR47kFhgdepOFpADEKstyO+MVdPvkV6/dyt9sA==
+  /@jest/core/26.2.2_canvas@2.6.1:
     dependencies:
-      '@jest/console': 26.1.0
-      '@jest/reporters': 26.1.0
-      '@jest/test-result': 26.1.0
-      '@jest/transform': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/console': 26.2.0
+      '@jest/reporters': 26.2.2
+      '@jest/test-result': 26.2.0
+      '@jest/transform': 26.2.2
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
       ansi-escapes: 4.3.1
       chalk: 4.1.0
       exit: 0.1.2
       graceful-fs: 4.2.4
-      jest-changed-files: 26.1.0
-      jest-config: 26.1.0_canvas@2.6.1
-      jest-haste-map: 26.1.0
-      jest-message-util: 26.1.0
+      jest-changed-files: 26.2.0
+      jest-config: 26.2.2_canvas@2.6.1
+      jest-haste-map: 26.2.2
+      jest-message-util: 26.2.0
       jest-regex-util: 26.0.0
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
-      jest-resolve-dependencies: 26.1.0
-      jest-runner: 26.1.0_canvas@2.6.1
-      jest-runtime: 26.1.0
-      jest-snapshot: 26.1.0
-      jest-util: 26.1.0
-      jest-validate: 26.1.0
-      jest-watcher: 26.1.0
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-resolve-dependencies: 26.2.2
+      jest-runner: 26.2.2_canvas@2.6.1
+      jest-runtime: 26.2.2
+      jest-snapshot: 26.2.2
+      jest-util: 26.2.0
+      jest-validate: 26.2.0
+      jest-watcher: 26.2.0
       micromatch: 4.0.2
       p-each-series: 2.1.0
       rimraf: 3.0.2
@@ -2388,7 +3127,7 @@ packages:
     peerDependencies:
       canvas: '*'
     resolution:
-      integrity: sha512-zyizYmDJOOVke4OO/De//aiv8b07OwZzL2cfsvWF3q9YssfpcKfcnZAwDY8f+A76xXSMMYe8i/f/LPocLlByfw==
+      integrity: sha512-UwA8gNI8aeV4FHGfGAUfO/DHjrFVvlBravF1Tm9Kt6qFE+6YHR47kFhgdepOFpADEKstyO+MVdPvkV6/dyt9sA==
   /@jest/environment/24.9.0:
     dependencies:
       '@jest/fake-timers': 24.9.0
@@ -2400,16 +3139,17 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==
-  /@jest/environment/26.1.0:
+  /@jest/environment/26.2.0:
     dependencies:
-      '@jest/fake-timers': 26.1.0
-      '@jest/types': 26.1.0
-      jest-mock: 26.1.0
+      '@jest/fake-timers': 26.2.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
+      jest-mock: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-86+DNcGongbX7ai/KE/S3/NcUVZfrwvFzOOWX/W+OOTvTds7j07LtC+MgGydH5c8Ri3uIrvdmVgd1xFD5zt/xA==
+      integrity: sha512-oCgp9NmEiJ5rbq9VI/v/yYLDpladAAVvFxZgNsnJxOETuzPZ0ZcKKHYjKYwCtPOP1WCrM5nmyuOhMStXFGHn+g==
   /@jest/fake-timers/24.9.0:
     dependencies:
       '@jest/types': 24.9.0
@@ -2420,28 +3160,29 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==
-  /@jest/fake-timers/26.1.0:
+  /@jest/fake-timers/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       '@sinonjs/fake-timers': 6.0.1
-      jest-message-util: 26.1.0
-      jest-mock: 26.1.0
-      jest-util: 26.1.0
+      '@types/node': 14.0.27
+      jest-message-util: 26.2.0
+      jest-mock: 26.2.0
+      jest-util: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-Y5F3kBVWxhau3TJ825iuWy++BAuQzK/xEa+wD9vDH3RytW9f2DbMVodfUQC54rZDX3POqdxCgcKdgcOL0rYUpA==
-  /@jest/globals/26.1.0:
+      integrity: sha512-45Gfe7YzYTKqTayBrEdAF0qYyAsNRBzfkV0IyVUm3cx7AsCWlnjilBM4T40w7IXT5VspOgMPikQlV0M6gHwy/g==
+  /@jest/globals/26.2.0:
     dependencies:
-      '@jest/environment': 26.1.0
-      '@jest/types': 26.1.0
-      expect: 26.1.0
+      '@jest/environment': 26.2.0
+      '@jest/types': 26.2.0
+      expect: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-MKiHPNaT+ZoG85oMaYUmGHEqu98y3WO2yeIDJrs2sJqHhYOy3Z6F7F/luzFomRQ8SQ1wEkmahFAz2291Iv8EAw==
+      integrity: sha512-Hoc6ScEIPaym7RNytIL2ILSUWIGKlwEv+JNFof9dGYOdvPjb2evEURSslvCMkNuNg1ECEClTE8PH7ULlMJntYA==
   /@jest/reporters/24.9.0:
     dependencies:
       '@jest/environment': 24.9.0
@@ -2470,13 +3211,13 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==
-  /@jest/reporters/26.1.0:
+  /@jest/reporters/26.2.2:
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
-      '@jest/console': 26.1.0
-      '@jest/test-result': 26.1.0
-      '@jest/transform': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/console': 26.2.0
+      '@jest/test-result': 26.2.0
+      '@jest/transform': 26.2.2
+      '@jest/types': 26.2.0
       chalk: 4.1.0
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -2487,10 +3228,10 @@ packages:
       istanbul-lib-report: 3.0.0
       istanbul-lib-source-maps: 4.0.0
       istanbul-reports: 3.0.2
-      jest-haste-map: 26.1.0
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
-      jest-util: 26.1.0
-      jest-worker: 26.1.0
+      jest-haste-map: 26.2.2
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-util: 26.2.0
+      jest-worker: 26.2.1
       slash: 3.0.0
       source-map: 0.6.1
       string-length: 4.0.1
@@ -2502,7 +3243,7 @@ packages:
     optionalDependencies:
       node-notifier: 7.0.2
     resolution:
-      integrity: sha512-SVAysur9FOIojJbF4wLP0TybmqwDkdnFxHSPzHMMIYyBtldCW9gG+Q5xWjpMFyErDiwlRuPyMSJSU64A67Pazg==
+      integrity: sha512-7854GPbdFTAorWVh+RNHyPO9waRIN6TcvCezKVxI1khvFq9YjINTW7J3WU+tbR038Ynn6WjYred6vtT0YmIWVQ==
   /@jest/source-map/24.9.0:
     dependencies:
       callsites: 3.1.0
@@ -2533,17 +3274,17 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==
-  /@jest/test-result/26.1.0:
+  /@jest/test-result/26.2.0:
     dependencies:
-      '@jest/console': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/console': 26.2.0
+      '@jest/types': 26.2.0
       '@types/istanbul-lib-coverage': 2.0.3
       collect-v8-coverage: 1.0.1
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-Xz44mhXph93EYMA8aYDz+75mFbarTV/d/x0yMdI3tfSRs/vh4CqSxgzVmCps1fPkHDCtn0tU8IH9iCKgGeGpfw==
+      integrity: sha512-kgPlmcVafpmfyQEu36HClK+CWI6wIaAWDHNxfQtGuKsgoa2uQAYdlxjMDBEa3CvI40+2U3v36gQF6oZBkoKatw==
   /@jest/test-sequencer/24.9.0:
     dependencies:
       '@jest/test-result': 24.9.0
@@ -2555,34 +3296,34 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==
-  /@jest/test-sequencer/26.1.0:
+  /@jest/test-sequencer/26.2.2:
     dependencies:
-      '@jest/test-result': 26.1.0
+      '@jest/test-result': 26.2.0
       graceful-fs: 4.2.4
-      jest-haste-map: 26.1.0
-      jest-runner: 26.1.0
-      jest-runtime: 26.1.0
+      jest-haste-map: 26.2.2
+      jest-runner: 26.2.2
+      jest-runtime: 26.2.2
     dev: true
     engines:
       node: '>= 10.14.2'
     peerDependencies:
       canvas: '*'
     resolution:
-      integrity: sha512-Z/hcK+rTq56E6sBwMoQhSRDVjqrGtj1y14e2bIgcowARaIE1SgOanwx6gvY4Q9gTKMoZQXbXvptji+q5GYxa6Q==
-  /@jest/test-sequencer/26.1.0_canvas@2.6.1:
+      integrity: sha512-SliZWon5LNqV/lVXkeowSU6L8++FGOu3f43T01L1Gv6wnFDP00ER0utV9jyK9dVNdXqfMNCN66sfcyar/o7BNw==
+  /@jest/test-sequencer/26.2.2_canvas@2.6.1:
     dependencies:
-      '@jest/test-result': 26.1.0
+      '@jest/test-result': 26.2.0
       graceful-fs: 4.2.4
-      jest-haste-map: 26.1.0
-      jest-runner: 26.1.0_canvas@2.6.1
-      jest-runtime: 26.1.0_canvas@2.6.1
+      jest-haste-map: 26.2.2
+      jest-runner: 26.2.2_canvas@2.6.1
+      jest-runtime: 26.2.2
     dev: true
     engines:
       node: '>= 10.14.2'
     peerDependencies:
       canvas: '*'
     resolution:
-      integrity: sha512-Z/hcK+rTq56E6sBwMoQhSRDVjqrGtj1y14e2bIgcowARaIE1SgOanwx6gvY4Q9gTKMoZQXbXvptji+q5GYxa6Q==
+      integrity: sha512-SliZWon5LNqV/lVXkeowSU6L8++FGOu3f43T01L1Gv6wnFDP00ER0utV9jyK9dVNdXqfMNCN66sfcyar/o7BNw==
   /@jest/transform/24.9.0:
     dependencies:
       '@babel/core': 7.10.5
@@ -2606,18 +3347,18 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==
-  /@jest/transform/26.1.0:
+  /@jest/transform/26.2.2:
     dependencies:
       '@babel/core': 7.10.5
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       babel-plugin-istanbul: 6.0.0
       chalk: 4.1.0
       convert-source-map: 1.7.0
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.4
-      jest-haste-map: 26.1.0
+      jest-haste-map: 26.2.2
       jest-regex-util: 26.0.0
-      jest-util: 26.1.0
+      jest-util: 26.2.0
       micromatch: 4.0.2
       pirates: 4.0.1
       slash: 3.0.0
@@ -2627,7 +3368,7 @@ packages:
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-ICPm6sUXmZJieq45ix28k0s+d/z2E8CHDsq+WwtWI6kW8m7I8kPqarSEcUN86entHQ570ZBRci5OWaKL0wlAWw==
+      integrity: sha512-c1snhvi5wRVre1XyoO3Eef5SEWpuBCH/cEbntBUd9tI5sNYiBDmO0My/lc5IuuGYKp/HFIHV1eZpSx5yjdkhKw==
   /@jest/types/24.9.0:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
@@ -2660,6 +3401,18 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==
+  /@jest/types/26.2.0:
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.3
+      '@types/istanbul-reports': 1.1.2
+      '@types/node': 14.0.27
+      '@types/yargs': 15.0.5
+      chalk: 4.1.0
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    resolution:
+      integrity: sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==
   /@kazupon/vue-i18n-loader/0.5.0:
     dependencies:
       js-yaml: 3.14.0
@@ -2670,10 +3423,10 @@ packages:
       node: '>= 10'
     resolution:
       integrity: sha512-Tp2mXKemf9/RBhI9CW14JjR9oKjL2KH7tV6S0eKEjIBuQBAOFNuPJu3ouacmz9hgoXbNp+nusw3MVQmxZWFR9g==
-  /@mdi/font/5.3.45:
+  /@mdi/font/5.4.55:
     dev: true
     resolution:
-      integrity: sha512-SD5d2vHEKRvDCInZQFXOwiFpBlzpuZOiqwxKf6E+zCt7UDc52TUSrL0+TXqY57VQh/SnTpZVXM+Uvs21OdPFWg==
+      integrity: sha512-M+Wdcs4nZ4/Kid949fcI0DsnvHtpE6pwk6Hv8YJZDp+Zne7ZtYdIN0z73cvcANkbyNnY3ncScULGMIceNd0xxQ==
   /@mrmlnc/readdir-enhanced/2.2.1:
     dependencies:
       call-me-maybe: 1.0.1
@@ -3017,7 +3770,7 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
-  /@testing-library/jest-dom/5.11.1:
+  /@testing-library/jest-dom/5.11.2:
     dependencies:
       '@babel/runtime': 7.10.5
       '@types/testing-library__jest-dom': 5.9.1
@@ -3035,7 +3788,7 @@ packages:
       npm: '>=6'
       yarn: '>=1'
     resolution:
-      integrity: sha512-NHOHjDwyBoqM7mXjNLieSp/6vJ17DILzhNTw7+RarluaBkyWRzWgFj+d6xnd1adMBlwfQSeR2FWGTxHXCxeMSA==
+      integrity: sha512-s+rWJx+lanEGKqvOl4qJR0rGjCrxsEjj9qjxFlg4NV4/FRD7fnUUAWPHqwpyafNHfLYArs58FADgdn4UKmjFmw==
   /@typechain/ethers-v4/1.0.0_ethers@4.0.47+typechain@2.0.0:
     dependencies:
       ethers: 4.0.47
@@ -3062,8 +3815,8 @@ packages:
       integrity: sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
   /@types/babel__core/7.1.9:
     dependencies:
-      '@babel/parser': 7.10.5
-      '@babel/types': 7.10.5
+      '@babel/parser': 7.11.0
+      '@babel/types': 7.11.0
       '@types/babel__generator': 7.6.1
       '@types/babel__template': 7.0.2
       '@types/babel__traverse': 7.0.13
@@ -3072,20 +3825,20 @@ packages:
       integrity: sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==
   /@types/babel__generator/7.6.1:
     dependencies:
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==
   /@types/babel__template/7.0.2:
     dependencies:
-      '@babel/parser': 7.10.5
-      '@babel/types': 7.10.5
+      '@babel/parser': 7.11.0
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==
   /@types/babel__traverse/7.0.13:
     dependencies:
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==
@@ -3173,7 +3926,7 @@ packages:
       integrity: sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
   /@types/graceful-fs/4.1.3:
     dependencies:
-      '@types/node': 14.0.24
+      '@types/node': 14.0.27
     dev: true
     resolution:
       integrity: sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==
@@ -3228,13 +3981,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==
-  /@types/jest/26.0.6:
+  /@types/jest/26.0.8:
     dependencies:
       jest-diff: 25.5.0
       pretty-format: 25.5.0
     dev: true
     resolution:
-      integrity: sha512-XhJCNf+oPyA90jyPhOT3yZo6xR8R7auyUAibzRewPwbOb649AOPXX/JSjbafcbxJrxs/+BymBmHSETM8VpGMOw==
+      integrity: sha512-eo3VX9jGASSuv680D4VQ89UmuLZneNxv2MCZjfwlInav05zXVJTzfc//lavdV0GPwSxsXJTy2jALscB7Acqg0g==
   /@types/json-schema/7.0.5:
     dev: true
     resolution:
@@ -3331,6 +4084,10 @@ packages:
   /@types/node/14.0.24:
     resolution:
       integrity: sha512-btt/oNOiDWcSuI721MdL8VQGnjsKjlTMdrKyTcLCKeQp/n4AAMFJ961wMbp+09y8WuGPClDEv07RIItdXKIXAA==
+  /@types/node/14.0.27:
+    dev: true
+    resolution:
+      integrity: sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
   /@types/normalize-package-data/2.4.0:
     dev: true
     resolution:
@@ -3404,7 +4161,7 @@ packages:
       integrity: sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
   /@types/testing-library__jest-dom/5.9.1:
     dependencies:
-      '@types/jest': 26.0.6
+      '@types/jest': 26.0.8
     dev: true
     resolution:
       integrity: sha512-yYn5EKHO3MPEMSOrcAb1dLWY+68CG29LiXKsWmmpVHqoP5+ZRiAVLyUHvPNrO2dABDdUGZvavMsaGpWNjM6N2g==
@@ -3484,10 +4241,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
-  /@typescript-eslint/eslint-plugin/3.7.0_a7d792035c43f2b80bcf395c5516fe5c:
+  /@typescript-eslint/eslint-plugin/3.8.0_ca0faf4066da35843277552e510770b3:
     dependencies:
-      '@typescript-eslint/experimental-utils': 3.7.0_eslint@7.5.0+typescript@3.9.7
-      '@typescript-eslint/parser': 3.7.0_eslint@7.5.0+typescript@3.9.7
+      '@typescript-eslint/experimental-utils': 3.8.0_eslint@7.5.0+typescript@3.9.7
+      '@typescript-eslint/parser': 3.8.0_eslint@7.5.0+typescript@3.9.7
       debug: 4.1.1
       eslint: 7.5.0
       functional-red-black-tree: 1.0.1
@@ -3506,12 +4263,12 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-4OEcPON3QIx0ntsuiuFP/TkldmBGXf0uKxPQlGtS/W2F3ndYm8Vgdpj/woPJkzUc65gd3iR+qi3K8SDQP/obFg==
-  /@typescript-eslint/experimental-utils/3.7.0_eslint@7.5.0+typescript@3.9.7:
+      integrity: sha512-lFb4VCDleFSR+eo4Ew+HvrJ37ZH1Y9ZyE+qyP7EiwBpcCVxwmUc5PAqhShCQ8N8U5vqYydm74nss+a0wrrCErw==
+  /@typescript-eslint/experimental-utils/3.8.0_eslint@7.5.0+typescript@3.9.7:
     dependencies:
       '@types/json-schema': 7.0.5
-      '@typescript-eslint/types': 3.7.0
-      '@typescript-eslint/typescript-estree': 3.7.0_typescript@3.9.7
+      '@typescript-eslint/types': 3.8.0
+      '@typescript-eslint/typescript-estree': 3.8.0_typescript@3.9.7
       eslint: 7.5.0
       eslint-scope: 5.1.0
       eslint-utils: 2.1.0
@@ -3522,13 +4279,13 @@ packages:
       eslint: '*'
       typescript: '*'
     resolution:
-      integrity: sha512-xpfXXAfZqhhqs5RPQBfAFrWDHoNxD5+sVB5A46TF58Bq1hRfVROrWHcQHHUM9aCBdy9+cwATcvCbRg8aIRbaHQ==
-  /@typescript-eslint/parser/3.7.0_eslint@7.5.0+typescript@3.9.7:
+      integrity: sha512-o8T1blo1lAJE0QDsW7nSyvZHbiDzQDjINJKyB44Z3sSL39qBy5L10ScI/XwDtaiunoyKGLiY9bzRk4YjsUZl8w==
+  /@typescript-eslint/parser/3.8.0_eslint@7.5.0+typescript@3.9.7:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 3.7.0_eslint@7.5.0+typescript@3.9.7
-      '@typescript-eslint/types': 3.7.0
-      '@typescript-eslint/typescript-estree': 3.7.0_typescript@3.9.7
+      '@typescript-eslint/experimental-utils': 3.8.0_eslint@7.5.0+typescript@3.9.7
+      '@typescript-eslint/types': 3.8.0
+      '@typescript-eslint/typescript-estree': 3.8.0_typescript@3.9.7
       eslint: 7.5.0
       eslint-visitor-keys: 1.3.0
       typescript: 3.9.7
@@ -3542,17 +4299,17 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-2LZauVUt7jAWkcIW7djUc3kyW+fSarNEuM3RF2JdLHR9BfX/nDEnyA4/uWz0wseoWVZbDXDF7iF9Jc342flNqQ==
-  /@typescript-eslint/types/3.7.0:
+      integrity: sha512-u5vjOBaCsnMVQOvkKCXAmmOhyyMmFFf5dbkM3TIbg3MZ2pyv5peE4gj81UAbTHwTOXEwf7eCQTUMKrDl/+qGnA==
+  /@typescript-eslint/types/3.8.0:
     dev: true
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
-      integrity: sha512-reCaK+hyKkKF+itoylAnLzFeNYAEktB0XVfSQvf0gcVgpz1l49Lt6Vo9x4MVCCxiDydA0iLAjTF/ODH0pbfnpg==
-  /@typescript-eslint/typescript-estree/3.7.0_typescript@3.9.7:
+      integrity: sha512-8kROmEQkv6ss9kdQ44vCN1dTrgu4Qxrd2kXr10kz2NP5T8/7JnEfYNxCpPkArbLIhhkGLZV3aVMplH1RXQRF7Q==
+  /@typescript-eslint/typescript-estree/3.8.0_typescript@3.9.7:
     dependencies:
-      '@typescript-eslint/types': 3.7.0
-      '@typescript-eslint/visitor-keys': 3.7.0
+      '@typescript-eslint/types': 3.8.0
+      '@typescript-eslint/visitor-keys': 3.8.0
       debug: 4.1.1
       glob: 7.1.6
       is-glob: 4.0.1
@@ -3569,15 +4326,15 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-xr5oobkYRebejlACGr1TJ0Z/r0a2/HUf0SXqPvlgUMwiMqOCu/J+/Dr9U3T0IxpE5oLFSkqMx1FE/dKaZ8KsOQ==
-  /@typescript-eslint/visitor-keys/3.7.0:
+      integrity: sha512-MTv9nPDhlKfclwnplRNDL44mP2SY96YmPGxmMbMy6x12I+pERcxpIUht7DXZaj4mOKKtet53wYYXU0ABaiXrLw==
+  /@typescript-eslint/visitor-keys/3.8.0:
     dependencies:
       eslint-visitor-keys: 1.3.0
     dev: true
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
-      integrity: sha512-k5PiZdB4vklUpUX4NBncn5RBKty8G3ihTY+hqJsCdMuD0v4jofI5xuqwnVcWxfv6iTm2P/dfEa2wMUnsUY8ODw==
+      integrity: sha512-gfqQWyVPpT9NpLREXNR820AYwgz+Kr1GuF3nf1wxpHD6hdxI62tq03ToomFnDxY0m3pUB39IF7sil7D5TQexLA==
   /@vue/babel-helper-vue-jsx-merge-props/1.0.0:
     dev: true
     resolution:
@@ -3840,7 +4597,7 @@ packages:
       pnp-webpack-plugin: 1.6.4_typescript@3.9.7
       portfinder: 1.0.27
       postcss-loader: 3.0.0
-      sass-loader: 9.0.2_sass@1.26.10+webpack@4.43.0
+      sass-loader: 9.0.2_sass@1.26.10+webpack@4.44.1
       ssri: 7.1.0
       terser-webpack-plugin: 2.3.7_webpack@4.43.0
       thread-loader: 2.1.3_webpack@4.43.0
@@ -3942,9 +4699,9 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-9l67vb0J9iubf14Lj6aI8Fg9DPIgB9gCLbwQWVrFtoaDTapdbo0X6cf0zK1RNeN/5CrGa5baIntqsWwC1Iqlcw==
-  /@vue/cli/4.4.6_@babel+core@7.10.5:
+  /@vue/cli/4.4.6_@babel+core@7.11.0:
     dependencies:
-      '@babel/preset-env': 7.10.4_@babel+core@7.10.5
+      '@babel/preset-env': 7.10.4_@babel+core@7.11.0
       '@vue/cli-shared-utils': 4.4.6
       '@vue/cli-ui': 4.4.6
       '@vue/cli-ui-addon-webpack': 4.4.6
@@ -4013,10 +4770,10 @@ packages:
       prettier: '>= 1.13.0'
     resolution:
       integrity: sha512-wFQmv45c3ige5EA+ngijq40YpVcIkAy0Lihupnsnd1Dao5CBbPyfCzqtejFLZX1EwH/kCJdpz3t6s+5wd3+KxQ==
-  /@vue/eslint-config-typescript/5.0.2_0793fcc7a1108934102a0610919e9b48:
+  /@vue/eslint-config-typescript/5.0.2_40f844fffa9af343ee9319c3bf0f9252:
     dependencies:
-      '@typescript-eslint/eslint-plugin': 3.7.0_a7d792035c43f2b80bcf395c5516fe5c
-      '@typescript-eslint/parser': 3.7.0_eslint@7.5.0+typescript@3.9.7
+      '@typescript-eslint/eslint-plugin': 3.8.0_ca0faf4066da35843277552e510770b3
+      '@typescript-eslint/parser': 3.8.0_eslint@7.5.0+typescript@3.9.7
       eslint: 7.5.0
       eslint-plugin-vue: 6.2.2_eslint@7.5.0
       vue-eslint-parser: 7.1.0_eslint@7.5.0
@@ -4448,6 +5205,7 @@ packages:
     resolution:
       integrity: sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
   /aes-js/3.0.0:
+    dev: false
     resolution:
       integrity: sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=
   /agentkeepalive/2.2.0:
@@ -5447,6 +6205,14 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
+  /babel-core/7.0.0-bridge.0_@babel+core@7.11.0:
+    dependencies:
+      '@babel/core': 7.11.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
   /babel-eslint/10.1.0_eslint@7.5.0:
     dependencies:
       '@babel/code-frame': 7.10.4
@@ -5488,14 +6254,14 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==
-  /babel-jest/26.1.0_@babel+core@7.10.5:
+  /babel-jest/26.2.2_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
-      '@jest/transform': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/transform': 26.2.2
+      '@jest/types': 26.2.0
       '@types/babel__core': 7.1.9
       babel-plugin-istanbul: 6.0.0
-      babel-preset-jest: 26.1.0_@babel+core@7.10.5
+      babel-preset-jest: 26.2.0_@babel+core@7.10.5
       chalk: 4.1.0
       graceful-fs: 4.2.4
       slash: 3.0.0
@@ -5505,7 +6271,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-Nkqgtfe7j6PxLO6TnCQQlkMm8wdTdnIF8xrdpooHCuD5hXRzVEPbPneTJKknH5Dsv3L8ip9unHDAp48YQ54Dkg==
+      integrity: sha512-JmLuePHgA+DSOdOL8lPxCgD2LhPPm+rdw1vnxR73PpIrnmKCS2/aBhtkAcxQWuUcW2hBrH8MJ3LKXE7aWpNZyA==
   /babel-loader/8.1.0_13c776b87d2822e76e5e552d0872621e:
     dependencies:
       '@babel/core': 7.10.5
@@ -5515,6 +6281,23 @@ packages:
       pify: 4.0.1
       schema-utils: 2.7.0
       webpack: 4.43.0_webpack@4.43.0
+    dev: true
+    engines:
+      node: '>= 6.9'
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      webpack: '>=2'
+    resolution:
+      integrity: sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==
+  /babel-loader/8.1.0_eb1461431efd5a396fc2100c302053ae:
+    dependencies:
+      '@babel/core': 7.11.0
+      find-cache-dir: 2.1.0
+      loader-utils: 1.4.0
+      mkdirp: 0.5.5
+      pify: 4.0.1
+      schema-utils: 2.7.0
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     engines:
       node: '>= 6.9'
@@ -5572,17 +6355,17 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==
-  /babel-plugin-jest-hoist/26.1.0:
+  /babel-plugin-jest-hoist/26.2.0:
     dependencies:
       '@babel/template': 7.10.4
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
       '@types/babel__core': 7.1.9
       '@types/babel__traverse': 7.0.13
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-qhqLVkkSlqmC83bdMhM8WW4Z9tB+JkjqAqlbbohS9sJLT5Ha2vfzuKqg5yenXrAjOPG2YC0WiXdH3a9PvB+YYw==
+      integrity: sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==
   /babel-plugin-syntax-object-rest-spread/6.13.0:
     dev: true
     resolution:
@@ -5641,10 +6424,10 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==
-  /babel-preset-jest/26.1.0_@babel+core@7.10.5:
+  /babel-preset-jest/26.2.0_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
-      babel-plugin-jest-hoist: 26.1.0
+      babel-plugin-jest-hoist: 26.2.0
       babel-preset-current-node-syntax: 0.1.3_@babel+core@7.10.5
     dev: true
     engines:
@@ -5652,7 +6435,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-na9qCqFksknlEj5iSdw1ehMVR06LCCTkZLGKeEtxDDdhg8xpUF09m29Kvh1pRbZ07h7AQ5ttLYUwpXL4tO6w7w==
+      integrity: sha512-R1k8kdP3R9phYQugXeNnK/nvCGlBzG4m3EoIIukC80GXb6wCv2XiwPhK6K9MAkQcMszWBYvl2Wm+yigyXFQqXg==
   /babel-runtime/6.26.0:
     dependencies:
       core-js: 2.6.11
@@ -7324,7 +8107,7 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     resolution:
       integrity: sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==
-  /copy-webpack-plugin/6.0.3_webpack@4.43.0:
+  /copy-webpack-plugin/6.0.3_webpack@4.44.1:
     dependencies:
       cacache: 15.0.5
       fast-glob: 3.2.4
@@ -7336,7 +8119,7 @@ packages:
       p-limit: 3.0.2
       schema-utils: 2.7.0
       serialize-javascript: 4.0.0
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
       webpack-sources: 1.4.3
     dev: true
     engines:
@@ -8532,6 +9315,7 @@ packages:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+    dev: false
     resolution:
       integrity: sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
   /elliptic/6.5.3:
@@ -8546,6 +9330,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
+  /emittery/0.7.1:
+    dev: true
+    engines:
+      node: '>=10'
+    resolution:
+      integrity: sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==
   /emoji-regex/7.0.3:
     dev: true
     resolution:
@@ -8816,7 +9606,7 @@ packages:
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0
     resolution:
       integrity: sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==
-  /eslint-plugin-jsdoc/30.0.3_eslint@7.5.0:
+  /eslint-plugin-jsdoc/30.2.0_eslint@7.5.0:
     dependencies:
       comment-parser: 0.7.5
       debug: 4.1.1
@@ -8832,7 +9622,7 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0
     resolution:
-      integrity: sha512-EviSu0Hgc9Bhz00WhA6829KYC9BaP6JWoycOTA1xFxjQ/2XguRlB3r6nGNA/jkmMDQp5dTQ22s1kAJIaC+dE8Q==
+      integrity: sha512-gBC5Wp7vSgMBRiGtCfjCgRQ9Wzdus6Hc8WuDNetYxuJoJ5rDHQMkJzBZ0/Qdg3fFh2eIpM7EcJD0pbrYKPxKLw==
   /eslint-plugin-prettier/3.1.4_eslint@7.5.0:
     dependencies:
       eslint: 7.5.0
@@ -8890,12 +9680,12 @@ packages:
       eslint: ^5.0.0 || ^6.0.0
     resolution:
       integrity: sha512-Nhc+oVAHm0uz/PkJAWscwIT4ijTrK5fqNqz9QB1D35SbbuMG1uB6Yr5AJpvPSWg+WOw7nYNswerYh0kOk64gqQ==
-  /eslint-plugin-vuetify/1.0.0-beta.7_eslint@7.5.0+vuetify@2.3.6:
+  /eslint-plugin-vuetify/1.0.0-beta.7_eslint@7.5.0+vuetify@2.3.7:
     dependencies:
       eslint: 7.5.0
       eslint-plugin-vue: 6.2.2_eslint@7.5.0
       requireindex: 1.2.0
-      vuetify: 2.3.6_vue@2.6.11
+      vuetify: 2.3.7_vue@2.6.11
     dev: true
     peerDependencies:
       eslint: ^6.0.0 | ^7.0.0
@@ -9077,6 +9867,7 @@ packages:
       setimmediate: 1.0.4
       uuid: 2.0.1
       xmlhttprequest: 1.8.0
+    dev: false
     resolution:
       integrity: sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==
   /event-pubsub/4.3.0:
@@ -9328,19 +10119,19 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==
-  /expect/26.1.0:
+  /expect/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       ansi-styles: 4.2.1
       jest-get-type: 26.0.0
-      jest-matcher-utils: 26.1.0
-      jest-message-util: 26.1.0
+      jest-matcher-utils: 26.2.0
+      jest-message-util: 26.2.0
       jest-regex-util: 26.0.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-QbH4LZXDsno9AACrN9eM0zfnby9G+OsdNgZUohjg/P0mLy1O+/bzTAJGT6VSIjVCe8yKM6SzEl/ckEOFBT7Vnw==
+      integrity: sha512-8AMBQ9UVcoUXt0B7v+5/U5H6yiUR87L6eKCfjE3spx7Ya5lF+ebUo37MCFBML2OiLfkX1sxmQOZhIDonyVTkcw==
   /express-history-api-fallback/2.2.1:
     dev: true
     resolution:
@@ -9625,6 +10416,18 @@ packages:
       loader-utils: 1.4.0
       schema-utils: 2.7.0
       webpack: 4.43.0_webpack@4.43.0
+    dev: true
+    engines:
+      node: '>= 8.9.0'
+    peerDependencies:
+      webpack: ^4.0.0
+    resolution:
+      integrity: sha512-aKrYPYjF1yG3oX0kWRrqrSMfgftm7oJW5M+m4owoldH5C51C0RkIwB++JbRvEW3IU6/ZG5n8UvEcdgwOt2UOWA==
+  /file-loader/4.3.0_webpack@4.44.1:
+    dependencies:
+      loader-utils: 1.4.0
+      schema-utils: 2.7.0
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     engines:
       node: '>= 8.9.0'
@@ -10708,6 +11511,7 @@ packages:
     dependencies:
       ajv: 6.12.3
       har-schema: 2.0.0
+    deprecated: this library is no longer supported
     engines:
       node: '>=6'
     resolution:
@@ -10834,13 +11638,13 @@ packages:
     dependencies:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
+    dev: false
     resolution:
       integrity: sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==
   /hash.js/1.1.7:
     dependencies:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
-    dev: true
     resolution:
       integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
   /hasha/5.2.0:
@@ -10878,7 +11682,7 @@ packages:
       integrity: sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
   /hmac-drbg/1.0.1:
     dependencies:
-      hash.js: 1.1.3
+      hash.js: 1.1.7
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
     resolution:
@@ -12033,7 +12837,7 @@ packages:
       integrity: sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==
   /istanbul-lib-instrument/4.0.3:
     dependencies:
-      '@babel/core': 7.10.5
+      '@babel/core': 7.11.0
       '@istanbuljs/schema': 0.1.2
       istanbul-lib-coverage: 3.0.0
       semver: 6.3.0
@@ -12152,16 +12956,16 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==
-  /jest-changed-files/26.1.0:
+  /jest-changed-files/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       execa: 4.0.3
       throat: 5.0.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-HS5MIJp3B8t0NRKGMCZkcDUZo36mVRvrDETl81aqljT1S9tqiHRSpyoOvWg9ZilzZG9TDisDNaN1IXm54fLRZw==
+      integrity: sha512-+RyJb+F1K/XBLIYiL449vo5D+CvlHv29QveJUWNPXuUicyZcq+tf1wNxmmFeRvAU1+TzhwqczSjxnCCFt7+8iA==
   /jest-cli/24.9.0:
     dependencies:
       '@jest/core': 24.9.0
@@ -12183,19 +12987,19 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==
-  /jest-cli/26.1.0:
+  /jest-cli/26.2.2:
     dependencies:
-      '@jest/core': 26.1.0
-      '@jest/test-result': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/core': 26.2.2
+      '@jest/test-result': 26.2.0
+      '@jest/types': 26.2.0
       chalk: 4.1.0
       exit: 0.1.2
       graceful-fs: 4.2.4
       import-local: 3.0.2
       is-ci: 2.0.0
-      jest-config: 26.1.0
-      jest-util: 26.1.0
-      jest-validate: 26.1.0
+      jest-config: 26.2.2
+      jest-util: 26.2.0
+      jest-validate: 26.2.0
       prompts: 2.3.2
       yargs: 15.4.1
     dev: true
@@ -12205,20 +13009,20 @@ packages:
     peerDependencies:
       canvas: '*'
     resolution:
-      integrity: sha512-Imumvjgi3rU7stq6SJ1JUEMaV5aAgJYXIs0jPqdUnF47N/Tk83EXfmtvNKQ+SnFVI6t6mDOvfM3aA9Sg6kQPSw==
-  /jest-cli/26.1.0_canvas@2.6.1:
+      integrity: sha512-vVcly0n/ijZvdy6gPQiQt0YANwX2hLTPQZHtW7Vi3gcFdKTtif7YpI85F8R8JYy5DFSWz4x1OW0arnxlziu5Lw==
+  /jest-cli/26.2.2_canvas@2.6.1:
     dependencies:
-      '@jest/core': 26.1.0_canvas@2.6.1
-      '@jest/test-result': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/core': 26.2.2_canvas@2.6.1
+      '@jest/test-result': 26.2.0
+      '@jest/types': 26.2.0
       chalk: 4.1.0
       exit: 0.1.2
       graceful-fs: 4.2.4
       import-local: 3.0.2
       is-ci: 2.0.0
-      jest-config: 26.1.0_canvas@2.6.1
-      jest-util: 26.1.0
-      jest-validate: 26.1.0
+      jest-config: 26.2.2_canvas@2.6.1
+      jest-util: 26.2.0
+      jest-validate: 26.2.0
       prompts: 2.3.2
       yargs: 15.4.1
     dev: true
@@ -12228,7 +13032,7 @@ packages:
     peerDependencies:
       canvas: '*'
     resolution:
-      integrity: sha512-Imumvjgi3rU7stq6SJ1JUEMaV5aAgJYXIs0jPqdUnF47N/Tk83EXfmtvNKQ+SnFVI6t6mDOvfM3aA9Sg6kQPSw==
+      integrity: sha512-vVcly0n/ijZvdy6gPQiQt0YANwX2hLTPQZHtW7Vi3gcFdKTtif7YpI85F8R8JYy5DFSWz4x1OW0arnxlziu5Lw==
   /jest-config/24.9.0:
     dependencies:
       '@babel/core': 7.10.5
@@ -12253,60 +13057,60 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==
-  /jest-config/26.1.0:
+  /jest-config/26.2.2:
     dependencies:
       '@babel/core': 7.10.5
-      '@jest/test-sequencer': 26.1.0
-      '@jest/types': 26.1.0
-      babel-jest: 26.1.0_@babel+core@7.10.5
+      '@jest/test-sequencer': 26.2.2
+      '@jest/types': 26.2.0
+      babel-jest: 26.2.2_@babel+core@7.10.5
       chalk: 4.1.0
       deepmerge: 4.2.2
       glob: 7.1.6
       graceful-fs: 4.2.4
-      jest-environment-jsdom: 26.1.0
-      jest-environment-node: 26.1.0
+      jest-environment-jsdom: 26.2.0
+      jest-environment-node: 26.2.0
       jest-get-type: 26.0.0
-      jest-jasmine2: 26.1.0
+      jest-jasmine2: 26.2.2
       jest-regex-util: 26.0.0
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
-      jest-util: 26.1.0
-      jest-validate: 26.1.0
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-util: 26.2.0
+      jest-validate: 26.2.0
       micromatch: 4.0.2
-      pretty-format: 26.1.0
+      pretty-format: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     peerDependencies:
       canvas: '*'
     resolution:
-      integrity: sha512-ONTGeoMbAwGCdq4WuKkMcdMoyfs5CLzHEkzFOlVvcDXufZSaIWh/OXMLa2fwKXiOaFcqEw8qFr4VOKJQfn4CVw==
-  /jest-config/26.1.0_canvas@2.6.1:
+      integrity: sha512-2lhxH0y4YFOijMJ65usuf78m7+9/8+hAb1PZQtdRdgnQpAb4zP6KcVDDktpHEkspBKnc2lmFu+RQdHukUUbiTg==
+  /jest-config/26.2.2_canvas@2.6.1:
     dependencies:
       '@babel/core': 7.10.5
-      '@jest/test-sequencer': 26.1.0_canvas@2.6.1
-      '@jest/types': 26.1.0
-      babel-jest: 26.1.0_@babel+core@7.10.5
+      '@jest/test-sequencer': 26.2.2_canvas@2.6.1
+      '@jest/types': 26.2.0
+      babel-jest: 26.2.2_@babel+core@7.10.5
       chalk: 4.1.0
       deepmerge: 4.2.2
       glob: 7.1.6
       graceful-fs: 4.2.4
-      jest-environment-jsdom: 26.1.0_canvas@2.6.1
-      jest-environment-node: 26.1.0
+      jest-environment-jsdom: 26.2.0_canvas@2.6.1
+      jest-environment-node: 26.2.0
       jest-get-type: 26.0.0
-      jest-jasmine2: 26.1.0
+      jest-jasmine2: 26.2.2
       jest-regex-util: 26.0.0
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
-      jest-util: 26.1.0
-      jest-validate: 26.1.0
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-util: 26.2.0
+      jest-validate: 26.2.0
       micromatch: 4.0.2
-      pretty-format: 26.1.0
+      pretty-format: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     peerDependencies:
       canvas: '*'
     resolution:
-      integrity: sha512-ONTGeoMbAwGCdq4WuKkMcdMoyfs5CLzHEkzFOlVvcDXufZSaIWh/OXMLa2fwKXiOaFcqEw8qFr4VOKJQfn4CVw==
+      integrity: sha512-2lhxH0y4YFOijMJ65usuf78m7+9/8+hAb1PZQtdRdgnQpAb4zP6KcVDDktpHEkspBKnc2lmFu+RQdHukUUbiTg==
   /jest-diff/24.9.0:
     dependencies:
       chalk: 2.4.2
@@ -12329,17 +13133,17 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==
-  /jest-diff/26.1.0:
+  /jest-diff/26.2.0:
     dependencies:
       chalk: 4.1.0
       diff-sequences: 26.0.0
       jest-get-type: 26.0.0
-      pretty-format: 26.1.0
+      pretty-format: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-GZpIcom339y0OXznsEKjtkfKxNdg7bVbEofK8Q6MnevTIiR1jNhDWKhRX6X0SDXJlwn3dy59nZ1z55fLkAqPWg==
+      integrity: sha512-Wu4Aopi2nzCsHWLBlD48TgRy3Z7OsxlwvHNd1YSnHc7q1NJfrmyCPoUXrTIrydQOG5ApaYpsAsdfnMbJqV1/wQ==
   /jest-docblock/24.9.0:
     dependencies:
       detect-newline: 2.1.0
@@ -12368,18 +13172,18 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==
-  /jest-each/26.1.0:
+  /jest-each/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       chalk: 4.1.0
       jest-get-type: 26.0.0
-      jest-util: 26.1.0
-      pretty-format: 26.1.0
+      jest-util: 26.2.0
+      pretty-format: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-lYiSo4Igr81q6QRsVQq9LIkJW0hZcKxkIkHzNeTMPENYYDw/W/Raq28iJ0sLlNFYz2qxxeLnc5K2gQoFYlu2bA==
+      integrity: sha512-gHPCaho1twWHB5bpcfnozlc6mrMi+VAewVPNgmwf81x2Gzr6XO4dl+eOrwPWxbkYlgjgrYjWK2xgKnixbzH3Ew==
   /jest-environment-jsdom-fifteen/1.0.2_canvas@2.6.1:
     dependencies:
       '@jest/environment': 24.9.0
@@ -12406,13 +13210,14 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==
-  /jest-environment-jsdom/26.1.0:
+  /jest-environment-jsdom/26.2.0:
     dependencies:
-      '@jest/environment': 26.1.0
-      '@jest/fake-timers': 26.1.0
-      '@jest/types': 26.1.0
-      jest-mock: 26.1.0
-      jest-util: 26.1.0
+      '@jest/environment': 26.2.0
+      '@jest/fake-timers': 26.2.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
+      jest-mock: 26.2.0
+      jest-util: 26.2.0
       jsdom: 16.3.0
     dev: true
     engines:
@@ -12420,14 +13225,15 @@ packages:
     peerDependencies:
       canvas: '*'
     resolution:
-      integrity: sha512-dWfiJ+spunVAwzXbdVqPH1LbuJW/kDL+FyqgA5YzquisHqTi0g9hquKif9xKm7c1bKBj6wbmJuDkeMCnxZEpUw==
-  /jest-environment-jsdom/26.1.0_canvas@2.6.1:
+      integrity: sha512-sDG24+5M4NuIGzkI3rJW8XUlrpkvIdE9Zz4jhD8OBnVxAw+Y1jUk9X+lAOD48nlfUTlnt3lbAI3k2Ox+WF3S0g==
+  /jest-environment-jsdom/26.2.0_canvas@2.6.1:
     dependencies:
-      '@jest/environment': 26.1.0
-      '@jest/fake-timers': 26.1.0
-      '@jest/types': 26.1.0
-      jest-mock: 26.1.0
-      jest-util: 26.1.0
+      '@jest/environment': 26.2.0
+      '@jest/fake-timers': 26.2.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
+      jest-mock: 26.2.0
+      jest-util: 26.2.0
       jsdom: 16.3.0_canvas@2.6.1
     dev: true
     engines:
@@ -12435,7 +13241,7 @@ packages:
     peerDependencies:
       canvas: '*'
     resolution:
-      integrity: sha512-dWfiJ+spunVAwzXbdVqPH1LbuJW/kDL+FyqgA5YzquisHqTi0g9hquKif9xKm7c1bKBj6wbmJuDkeMCnxZEpUw==
+      integrity: sha512-sDG24+5M4NuIGzkI3rJW8XUlrpkvIdE9Zz4jhD8OBnVxAw+Y1jUk9X+lAOD48nlfUTlnt3lbAI3k2Ox+WF3S0g==
   /jest-environment-node/24.9.0:
     dependencies:
       '@jest/environment': 24.9.0
@@ -12448,18 +13254,19 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==
-  /jest-environment-node/26.1.0:
+  /jest-environment-node/26.2.0:
     dependencies:
-      '@jest/environment': 26.1.0
-      '@jest/fake-timers': 26.1.0
-      '@jest/types': 26.1.0
-      jest-mock: 26.1.0
-      jest-util: 26.1.0
+      '@jest/environment': 26.2.0
+      '@jest/fake-timers': 26.2.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
+      jest-mock: 26.2.0
+      jest-util: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-DNm5x1aQH0iRAe9UYAkZenuzuJ69VKzDCAYISFHQ5i9e+2Tbeu2ONGY7YStubCLH8a1wdKBgqScYw85+ySxqxg==
+      integrity: sha512-4M5ExTYkJ19efBzkiXtBi74JqKLDciEk4CEsp5tTjWGYMrlKFQFtwIVG3tW1OGE0AlXhZjuHPwubuRYY4j4uOw==
   /jest-get-type/24.9.0:
     dev: true
     engines:
@@ -12498,27 +13305,28 @@ packages:
       fsevents: 1.2.13
     resolution:
       integrity: sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==
-  /jest-haste-map/26.1.0:
+  /jest-haste-map/26.2.2:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       '@types/graceful-fs': 4.1.3
+      '@types/node': 14.0.27
       anymatch: 3.1.1
       fb-watchman: 2.0.1
       graceful-fs: 4.2.4
-      jest-serializer: 26.1.0
-      jest-util: 26.1.0
-      jest-worker: 26.1.0
+      jest-regex-util: 26.0.0
+      jest-serializer: 26.2.0
+      jest-util: 26.2.0
+      jest-worker: 26.2.1
       micromatch: 4.0.2
       sane: 4.1.0
       walker: 1.0.7
-      which: 2.0.2
     dev: true
     engines:
       node: '>= 10.14.2'
     optionalDependencies:
       fsevents: 2.1.3
     resolution:
-      integrity: sha512-WeBS54xCIz9twzkEdm6+vJBXgRBQfdbbXD0dk8lJh7gLihopABlJmIQFdWSDDtuDe4PRiObsjZSUjbJ1uhWEpA==
+      integrity: sha512-3sJlMSt+NHnzCB+0KhJ1Ut4zKJBiJOlbrqEYNdRQGlXTv8kqzZWjUKQRY3pkjmlf+7rYjAV++MQ4D6g4DhAyOg==
   /jest-jasmine2/24.9.0:
     dependencies:
       '@babel/traverse': 7.10.5
@@ -12542,24 +13350,25 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==
-  /jest-jasmine2/26.1.0:
+  /jest-jasmine2/26.2.2:
     dependencies:
-      '@babel/traverse': 7.10.5
-      '@jest/environment': 26.1.0
+      '@babel/traverse': 7.11.0
+      '@jest/environment': 26.2.0
       '@jest/source-map': 26.1.0
-      '@jest/test-result': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/test-result': 26.2.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
       chalk: 4.1.0
       co: 4.6.0
-      expect: 26.1.0
+      expect: 26.2.0
       is-generator-fn: 2.1.0
-      jest-each: 26.1.0
-      jest-matcher-utils: 26.1.0
-      jest-message-util: 26.1.0
-      jest-runtime: 26.1.0
-      jest-snapshot: 26.1.0
-      jest-util: 26.1.0
-      pretty-format: 26.1.0
+      jest-each: 26.2.0
+      jest-matcher-utils: 26.2.0
+      jest-message-util: 26.2.0
+      jest-runtime: 26.2.2
+      jest-snapshot: 26.2.2
+      jest-util: 26.2.0
+      pretty-format: 26.2.0
       throat: 5.0.0
     dev: true
     engines:
@@ -12567,8 +13376,8 @@ packages:
     peerDependencies:
       canvas: '*'
     resolution:
-      integrity: sha512-1IPtoDKOAG+MeBrKvvuxxGPJb35MTTRSDglNdWWCndCB3TIVzbLThRBkwH9P081vXLgiJHZY8Bz3yzFS803xqQ==
-  /jest-junit/11.0.1:
+      integrity: sha512-Q8AAHpbiZMVMy4Hz9j1j1bg2yUmPa1W9StBvcHqRaKa9PHaDUMwds8LwaDyzP/2fkybcTQE4+pTMDOG9826tEw==
+  /jest-junit/11.1.0:
     dependencies:
       mkdirp: 1.0.4
       strip-ansi: 5.2.0
@@ -12578,7 +13387,7 @@ packages:
     engines:
       node: '>=10.12.0'
     resolution:
-      integrity: sha512-stgc0mBoiSg/F9qWd4KkmR3K7Nk2u+M/dc1oup7gxz9mrzGcEaU2YL9/0QscVqqg3IOaA1P5ZXtozG/XR6j6nw==
+      integrity: sha512-c2LFOyKY7+ZxL5zSu+WHmHfsJ2wqbOpeYJ4Uu26yMhFxny2J2NQj6AVS7M+Eaxji9Q/oIDDK5tQy0DGzDp9xOw==
   /jest-leak-detector/24.9.0:
     dependencies:
       jest-get-type: 24.9.0
@@ -12588,15 +13397,15 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==
-  /jest-leak-detector/26.1.0:
+  /jest-leak-detector/26.2.0:
     dependencies:
       jest-get-type: 26.0.0
-      pretty-format: 26.1.0
+      pretty-format: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-dsMnKF+4BVOZwvQDlgn3MG+Ns4JuLv8jNvXH56bgqrrboyCbI1rQg6EI5rs+8IYagVcfVP2yZFKfWNZy0rK0Hw==
+      integrity: sha512-aQdzTX1YiufkXA1teXZu5xXOJgy7wZQw6OJ0iH5CtQlOETe6gTSocaYKUNui1SzQ91xmqEUZ/WRavg9FD82rtQ==
   /jest-matcher-utils/24.9.0:
     dependencies:
       chalk: 2.4.2
@@ -12619,17 +13428,17 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==
-  /jest-matcher-utils/26.1.0:
+  /jest-matcher-utils/26.2.0:
     dependencies:
       chalk: 4.1.0
-      jest-diff: 26.1.0
+      jest-diff: 26.2.0
       jest-get-type: 26.0.0
-      pretty-format: 26.1.0
+      pretty-format: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-PW9JtItbYvES/xLn5mYxjMd+Rk+/kIt88EfH3N7w9KeOrHWaHrdYPnVHndGbsFGRJ2d5gKtwggCvkqbFDoouQA==
+      integrity: sha512-2cf/LW2VFb3ayPHrH36ZDjp9+CAeAe/pWBAwsV8t3dKcrINzXPVxq8qMWOxwt5BaeBCx4ZupVGH7VIgB8v66vQ==
   /jest-message-util/24.9.0:
     dependencies:
       '@babel/code-frame': 7.10.4
@@ -12645,10 +13454,10 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==
-  /jest-message-util/26.1.0:
+  /jest-message-util/26.2.0:
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       '@types/stack-utils': 1.0.1
       chalk: 4.1.0
       graceful-fs: 4.2.4
@@ -12659,7 +13468,7 @@ packages:
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-dY0+UlldiAJwNDJ08SF0HdF32g9PkbF2NRK/+2iMPU40O6q+iSn1lgog/u0UH8ksWoPv0+gNq8cjhYO2MFtT0g==
+      integrity: sha512-g362RhZaJuqeqG108n1sthz5vNpzTNy926eNDszo4ncRbmmcMRIUAZibnd6s5v2XSBCChAxQtCoN25gnzp7JbQ==
   /jest-mock/24.9.0:
     dependencies:
       '@jest/types': 24.9.0
@@ -12668,14 +13477,15 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==
-  /jest-mock/26.1.0:
+  /jest-mock/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-1Rm8EIJ3ZFA8yCIie92UbxZWj9SuVmUGcyhLHyAhY6WI3NIct38nVcfOPWhJteqSn8V8e3xOMha9Ojfazfpovw==
+      integrity: sha512-XeC7yWtWmWByoyVOHSsE7NYsbXJLtJNgmhD7z4MKumKm6ET0si81bsSLbQ64L5saK3TgsHo2B/UqG5KNZ1Sp/Q==
   /jest-pnp-resolver/1.2.2_jest-resolve@24.9.0:
     dependencies:
       jest-resolve: 24.9.0_jest-resolve@24.9.0
@@ -12689,9 +13499,9 @@ packages:
         optional: true
     resolution:
       integrity: sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
-  /jest-pnp-resolver/1.2.2_jest-resolve@26.1.0:
+  /jest-pnp-resolver/1.2.2_jest-resolve@26.2.2:
     dependencies:
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
     dev: true
     engines:
       node: '>=6'
@@ -12724,16 +13534,16 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==
-  /jest-resolve-dependencies/26.1.0:
+  /jest-resolve-dependencies/26.2.2:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       jest-regex-util: 26.0.0
-      jest-snapshot: 26.1.0
+      jest-snapshot: 26.2.2
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-fQVEPHHQ1JjHRDxzlLU/buuQ9om+hqW6Vo928aa4b4yvq4ZHBtRSDsLdKQLuCqn5CkTVpYZ7ARh2fbA8WkRE6g==
+      integrity: sha512-S5vufDmVbQXnpP7435gr710xeBGUFcKNpNswke7RmFvDQtmqPjPVU/rCeMlEU0p6vfpnjhwMYeaVjKZAy5QYJA==
   /jest-resolve/24.9.0_jest-resolve@24.9.0:
     dependencies:
       '@jest/types': 24.9.0
@@ -12748,13 +13558,13 @@ packages:
       jest-resolve: '*'
     resolution:
       integrity: sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==
-  /jest-resolve/26.1.0_jest-resolve@26.1.0:
+  /jest-resolve/26.2.2_jest-resolve@26.2.2:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       chalk: 4.1.0
       graceful-fs: 4.2.4
-      jest-pnp-resolver: 1.2.2_jest-resolve@26.1.0
-      jest-util: 26.1.0
+      jest-pnp-resolver: 1.2.2_jest-resolve@26.2.2
+      jest-util: 26.2.0
       read-pkg-up: 7.0.1
       resolve: 1.17.0
       slash: 3.0.0
@@ -12764,7 +13574,7 @@ packages:
     peerDependencies:
       jest-resolve: '*'
     resolution:
-      integrity: sha512-KsY1JV9FeVgEmwIISbZZN83RNGJ1CC+XUCikf/ZWJBX/tO4a4NvA21YixokhdR9UnmPKKAC4LafVixJBrwlmfg==
+      integrity: sha512-ye9Tj/ILn/0OgFPE/3dGpQPUqt4dHwIocxt5qSBkyzxQD8PbL0bVxBogX2FHxsd3zJA7V2H/cHXnBnNyyT9YoQ==
   /jest-runner/24.9.0:
     dependencies:
       '@jest/console': 24.9.0
@@ -12791,25 +13601,26 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==
-  /jest-runner/26.1.0:
+  /jest-runner/26.2.2:
     dependencies:
-      '@jest/console': 26.1.0
-      '@jest/environment': 26.1.0
-      '@jest/test-result': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/console': 26.2.0
+      '@jest/environment': 26.2.0
+      '@jest/test-result': 26.2.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
       chalk: 4.1.0
+      emittery: 0.7.1
       exit: 0.1.2
       graceful-fs: 4.2.4
-      jest-config: 26.1.0
+      jest-config: 26.2.2
       jest-docblock: 26.0.0
-      jest-haste-map: 26.1.0
-      jest-jasmine2: 26.1.0
-      jest-leak-detector: 26.1.0
-      jest-message-util: 26.1.0
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
-      jest-runtime: 26.1.0
-      jest-util: 26.1.0
-      jest-worker: 26.1.0
+      jest-haste-map: 26.2.2
+      jest-leak-detector: 26.2.0
+      jest-message-util: 26.2.0
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-runtime: 26.2.2
+      jest-util: 26.2.0
+      jest-worker: 26.2.1
       source-map-support: 0.5.19
       throat: 5.0.0
     dev: true
@@ -12818,26 +13629,27 @@ packages:
     peerDependencies:
       canvas: '*'
     resolution:
-      integrity: sha512-elvP7y0fVDREnfqit0zAxiXkDRSw6dgCkzPCf1XvIMnSDZ8yogmSKJf192dpOgnUVykmQXwYYJnCx641uLTgcw==
-  /jest-runner/26.1.0_canvas@2.6.1:
+      integrity: sha512-/qb6ptgX+KQ+aNMohJf1We695kaAfuu3u3ouh66TWfhTpLd9WbqcF6163d/tMoEY8GqPztXPLuyG0rHRVDLxCA==
+  /jest-runner/26.2.2_canvas@2.6.1:
     dependencies:
-      '@jest/console': 26.1.0
-      '@jest/environment': 26.1.0
-      '@jest/test-result': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/console': 26.2.0
+      '@jest/environment': 26.2.0
+      '@jest/test-result': 26.2.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
       chalk: 4.1.0
+      emittery: 0.7.1
       exit: 0.1.2
       graceful-fs: 4.2.4
-      jest-config: 26.1.0_canvas@2.6.1
+      jest-config: 26.2.2_canvas@2.6.1
       jest-docblock: 26.0.0
-      jest-haste-map: 26.1.0
-      jest-jasmine2: 26.1.0
-      jest-leak-detector: 26.1.0
-      jest-message-util: 26.1.0
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
-      jest-runtime: 26.1.0_canvas@2.6.1
-      jest-util: 26.1.0
-      jest-worker: 26.1.0
+      jest-haste-map: 26.2.2
+      jest-leak-detector: 26.2.0
+      jest-message-util: 26.2.0
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-runtime: 26.2.2
+      jest-util: 26.2.0
+      jest-worker: 26.2.1
       source-map-support: 0.5.19
       throat: 5.0.0
     dev: true
@@ -12846,7 +13658,7 @@ packages:
     peerDependencies:
       canvas: '*'
     resolution:
-      integrity: sha512-elvP7y0fVDREnfqit0zAxiXkDRSw6dgCkzPCf1XvIMnSDZ8yogmSKJf192dpOgnUVykmQXwYYJnCx641uLTgcw==
+      integrity: sha512-/qb6ptgX+KQ+aNMohJf1We695kaAfuu3u3ouh66TWfhTpLd9WbqcF6163d/tMoEY8GqPztXPLuyG0rHRVDLxCA==
   /jest-runtime/24.9.0:
     dependencies:
       '@jest/console': 24.9.0
@@ -12878,31 +13690,31 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==
-  /jest-runtime/26.1.0:
+  /jest-runtime/26.2.2:
     dependencies:
-      '@jest/console': 26.1.0
-      '@jest/environment': 26.1.0
-      '@jest/fake-timers': 26.1.0
-      '@jest/globals': 26.1.0
+      '@jest/console': 26.2.0
+      '@jest/environment': 26.2.0
+      '@jest/fake-timers': 26.2.0
+      '@jest/globals': 26.2.0
       '@jest/source-map': 26.1.0
-      '@jest/test-result': 26.1.0
-      '@jest/transform': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/test-result': 26.2.0
+      '@jest/transform': 26.2.2
+      '@jest/types': 26.2.0
       '@types/yargs': 15.0.5
       chalk: 4.1.0
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.1.6
       graceful-fs: 4.2.4
-      jest-config: 26.1.0
-      jest-haste-map: 26.1.0
-      jest-message-util: 26.1.0
-      jest-mock: 26.1.0
+      jest-config: 26.2.2
+      jest-haste-map: 26.2.2
+      jest-message-util: 26.2.0
+      jest-mock: 26.2.0
       jest-regex-util: 26.0.0
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
-      jest-snapshot: 26.1.0
-      jest-util: 26.1.0
-      jest-validate: 26.1.0
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-snapshot: 26.2.2
+      jest-util: 26.2.0
+      jest-validate: 26.2.0
       slash: 3.0.0
       strip-bom: 4.0.0
       yargs: 15.4.1
@@ -12913,43 +13725,7 @@ packages:
     peerDependencies:
       canvas: '*'
     resolution:
-      integrity: sha512-1qiYN+EZLmG1QV2wdEBRf+Ci8i3VSfIYLF02U18PiUDrMbhfpN/EAMMkJtT02jgJUoaEOpHAIXG6zS3QRMzRmA==
-  /jest-runtime/26.1.0_canvas@2.6.1:
-    dependencies:
-      '@jest/console': 26.1.0
-      '@jest/environment': 26.1.0
-      '@jest/fake-timers': 26.1.0
-      '@jest/globals': 26.1.0
-      '@jest/source-map': 26.1.0
-      '@jest/test-result': 26.1.0
-      '@jest/transform': 26.1.0
-      '@jest/types': 26.1.0
-      '@types/yargs': 15.0.5
-      chalk: 4.1.0
-      collect-v8-coverage: 1.0.1
-      exit: 0.1.2
-      glob: 7.1.6
-      graceful-fs: 4.2.4
-      jest-config: 26.1.0_canvas@2.6.1
-      jest-haste-map: 26.1.0
-      jest-message-util: 26.1.0
-      jest-mock: 26.1.0
-      jest-regex-util: 26.0.0
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
-      jest-snapshot: 26.1.0
-      jest-util: 26.1.0
-      jest-validate: 26.1.0
-      slash: 3.0.0
-      strip-bom: 4.0.0
-      yargs: 15.4.1
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    hasBin: true
-    peerDependencies:
-      canvas: '*'
-    resolution:
-      integrity: sha512-1qiYN+EZLmG1QV2wdEBRf+Ci8i3VSfIYLF02U18PiUDrMbhfpN/EAMMkJtT02jgJUoaEOpHAIXG6zS3QRMzRmA==
+      integrity: sha512-a8VXM3DxCDnCIdl9+QucWFfQ28KdqmyVFqeKLigHdErtsx56O2ZIdQkhFSuP1XtVrG9nTNHbKxjh5XL1UaFDVQ==
   /jest-serializer-vue/2.0.2:
     dependencies:
       pretty: 2.0.0
@@ -12962,14 +13738,15 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==
-  /jest-serializer/26.1.0:
+  /jest-serializer/26.2.0:
     dependencies:
+      '@types/node': 14.0.27
       graceful-fs: 4.2.4
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-eqZOQG/0+MHmr25b2Z86g7+Kzd5dG9dhCiUoyUNJPgiqi38DqbDEOlHcNijyfZoj74soGBohKBZuJFS18YTJ5w==
+      integrity: sha512-V7snZI9IVmyJEu0Qy0inmuXgnMWDtrsbV2p9CRAcmlmPVwpC2ZM8wXyYpiugDQnwLHx0V4+Pnog9Exb3UO8M6Q==
   /jest-snapshot/24.9.0:
     dependencies:
       '@babel/types': 7.10.5
@@ -12990,28 +13767,28 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==
-  /jest-snapshot/26.1.0:
+  /jest-snapshot/26.2.2:
     dependencies:
       '@babel/types': 7.10.5
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       '@types/prettier': 2.0.2
       chalk: 4.1.0
-      expect: 26.1.0
+      expect: 26.2.0
       graceful-fs: 4.2.4
-      jest-diff: 26.1.0
+      jest-diff: 26.2.0
       jest-get-type: 26.0.0
-      jest-haste-map: 26.1.0
-      jest-matcher-utils: 26.1.0
-      jest-message-util: 26.1.0
-      jest-resolve: 26.1.0_jest-resolve@26.1.0
+      jest-haste-map: 26.2.2
+      jest-matcher-utils: 26.2.0
+      jest-message-util: 26.2.0
+      jest-resolve: 26.2.2_jest-resolve@26.2.2
       natural-compare: 1.4.0
-      pretty-format: 26.1.0
+      pretty-format: 26.2.0
       semver: 7.3.2
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-YhSbU7eMTVQO/iRbNs8j0mKRxGp4plo7sJ3GzOQ0IYjvsBiwg0T1o0zGQAYepza7lYHuPTrG5J2yDd0CE2YxSw==
+      integrity: sha512-NdjD8aJS7ePu268Wy/n/aR1TUisG0BOY+QOW4f6h46UHEKOgYmmkvJhh2BqdVZQ0BHSxTMt04WpCf9njzx8KtA==
   /jest-transform-stub/2.0.0:
     dev: true
     resolution:
@@ -13047,6 +13824,19 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-rNMOwFQevljfNGvbzNQAxdmXQ+NawW/J72dmddsK0E8vgxXCMtwQ/EH0BiWEIxh0hhMcTsxwAxINt7Lh46Uzbg==
+  /jest-util/26.2.0:
+    dependencies:
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
+      chalk: 4.1.0
+      graceful-fs: 4.2.4
+      is-ci: 2.0.0
+      micromatch: 4.0.2
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    resolution:
+      integrity: sha512-YmDwJxLZ1kFxpxPfhSJ0rIkiZOM0PQbRcfH0TzJOhqCisCAsI1WcmoQqO83My9xeVA2k4n+rzg2UuexVKzPpig==
   /jest-validate/24.9.0:
     dependencies:
       '@jest/types': 24.9.0
@@ -13060,19 +13850,19 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==
-  /jest-validate/26.1.0:
+  /jest-validate/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       camelcase: 6.0.0
       chalk: 4.1.0
       jest-get-type: 26.0.0
       leven: 3.1.0
-      pretty-format: 26.1.0
+      pretty-format: 26.2.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-WPApOOnXsiwhZtmkDsxnpye+XLb/tUISP+H6cHjfUIXvlG+eKwP+isnivsxlHCPaO9Q5wvbhloIBkdF3qUn+Nw==
+      integrity: sha512-8XKn3hM6VIVmLNuyzYLCPsRCT83o8jMZYhbieh4dAyKLc4Ypr36rVKC+c8WMpWkfHHpGnEkvWUjjIAyobEIY/Q==
   /jest-watch-typeahead/0.4.2:
     dependencies:
       ansi-escapes: 4.3.1
@@ -13099,19 +13889,20 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==
-  /jest-watcher/26.1.0:
+  /jest-watcher/26.2.0:
     dependencies:
-      '@jest/test-result': 26.1.0
-      '@jest/types': 26.1.0
+      '@jest/test-result': 26.2.0
+      '@jest/types': 26.2.0
+      '@types/node': 14.0.27
       ansi-escapes: 4.3.1
       chalk: 4.1.0
-      jest-util: 26.1.0
+      jest-util: 26.2.0
       string-length: 4.0.1
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-ffEOhJl2EvAIki613oPsSG11usqnGUzIiK7MMX6hE4422aXOcVEG3ySCTDFLn1+LZNXGPE8tuJxhp8OBJ1pgzQ==
+      integrity: sha512-674Boco4Joe0CzgKPL6K4Z9LgyLx+ZvW2GilbpYb8rFEUkmDGgsZdv1Hv5rxsRpb1HLgKUOL/JfbttRCuFdZXQ==
   /jest-worker/24.9.0:
     dependencies:
       merge-stream: 2.0.0
@@ -13130,15 +13921,16 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==
-  /jest-worker/26.1.0:
+  /jest-worker/26.2.1:
     dependencies:
+      '@types/node': 14.0.27
       merge-stream: 2.0.0
       supports-color: 7.1.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-Z9P5pZ6UC+kakMbNJn+tA2RdVdNX5WH1x+5UCBZ9MxIK24pjYtFt96fK+UwBTrjLYm232g1xz0L3eTh51OW+yQ==
+      integrity: sha512-+XcGMMJDTeEGncRb5M5Zq9P7K4sQ1sirhjdOxsN1462h6lFo9w59bl2LVQmdGEEeU3m+maZCkS2Tcc9SfCHO4A==
   /jest/24.9.0:
     dependencies:
       import-local: 2.0.0
@@ -13149,11 +13941,11 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==
-  /jest/26.1.0:
+  /jest/26.2.2:
     dependencies:
-      '@jest/core': 26.1.0
+      '@jest/core': 26.2.2
       import-local: 3.0.2
-      jest-cli: 26.1.0
+      jest-cli: 26.2.2
     dev: true
     engines:
       node: '>= 10.14.2'
@@ -13161,12 +13953,12 @@ packages:
     peerDependencies:
       canvas: '*'
     resolution:
-      integrity: sha512-LIti8jppw5BcQvmNJe4w2g1N/3V68HUfAv9zDVm7v+VAtQulGhH0LnmmiVkbNE4M4I43Bj2fXPiBGKt26k9tHw==
-  /jest/26.1.0_canvas@2.6.1:
+      integrity: sha512-EkJNyHiAG1+A8pqSz7cXttoVa34hOEzN/MrnJhYnfp5VHxflVcf2pu3oJSrhiy6LfIutLdWo+n6q63tjcoIeig==
+  /jest/26.2.2_canvas@2.6.1:
     dependencies:
-      '@jest/core': 26.1.0_canvas@2.6.1
+      '@jest/core': 26.2.2_canvas@2.6.1
       import-local: 3.0.2
-      jest-cli: 26.1.0_canvas@2.6.1
+      jest-cli: 26.2.2_canvas@2.6.1
     dev: true
     engines:
       node: '>= 10.14.2'
@@ -13174,7 +13966,7 @@ packages:
     peerDependencies:
       canvas: '*'
     resolution:
-      integrity: sha512-LIti8jppw5BcQvmNJe4w2g1N/3V68HUfAv9zDVm7v+VAtQulGhH0LnmmiVkbNE4M4I43Bj2fXPiBGKt26k9tHw==
+      integrity: sha512-EkJNyHiAG1+A8pqSz7cXttoVa34hOEzN/MrnJhYnfp5VHxflVcf2pu3oJSrhiy6LfIutLdWo+n6q63tjcoIeig==
   /js-beautify/1.11.0:
     dependencies:
       config-chain: 1.1.12
@@ -13207,6 +13999,7 @@ packages:
     resolution:
       integrity: sha1-NiITz4YPRo8BJfxslqvBdCUx+Ug=
   /js-sha3/0.5.7:
+    dev: false
     resolution:
       integrity: sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
   /js-sha3/0.8.0:
@@ -13239,7 +14032,7 @@ packages:
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.10.4_@babel+core@7.10.5
       '@babel/plugin-proposal-optional-chaining': 7.10.4_@babel+core@7.10.5
       '@babel/plugin-transform-modules-commonjs': 7.10.4_@babel+core@7.10.5
-      '@babel/preset-env': 7.10.4_@babel+core@7.10.5
+      '@babel/preset-env': 7.10.4_@babel+core@7.11.0
       '@babel/preset-flow': 7.10.4_@babel+core@7.10.5
       '@babel/preset-typescript': 7.10.4_@babel+core@7.10.5
       '@babel/register': 7.10.5_@babel+core@7.10.5
@@ -13493,6 +14286,7 @@ packages:
     resolution:
       integrity: sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
   /jsondiffpatch/0.3.11:
+    bundledDependencies: []
     dependencies:
       chalk: 2.4.2
       diff-match-patch: 1.0.5
@@ -14269,7 +15063,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==
-  /matrix-js-sdk/7.1.0:
+  /matrix-js-sdk/8.0.0:
     dependencies:
       '@babel/runtime': 7.10.5
       another-json: 0.2.0
@@ -14282,7 +15076,7 @@ packages:
       unhomoglyph: 1.0.6
     dev: false
     resolution:
-      integrity: sha512-Y+MdOfsVQRGx0KcwSdNtwsFNGWUF7Zi7wPxUSa050J8eBlbkXUNFAyuSWviLJ5pUwzmp9XMEKD9Cdv+tGZG1ww==
+      integrity: sha512-1p0Bv5My0+opkgqq9jGMa8myimGjiuGjzONR9o9i+VY/2hCaT67qIs3oNM3RI+c8sanijr3CHBaeo4tfyXzOuQ==
   /md5.js/1.3.5:
     dependencies:
       hash-base: 3.1.0
@@ -15190,11 +15984,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
-  /null-loader/3.0.0_webpack@4.43.0:
+  /null-loader/3.0.0_webpack@4.44.1:
     dependencies:
       loader-utils: 1.4.0
       schema-utils: 1.0.0
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     engines:
       node: '>= 8.9.0'
@@ -16646,9 +17440,9 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
-  /pretty-format/26.1.0:
+  /pretty-format/26.2.0:
     dependencies:
-      '@jest/types': 26.1.0
+      '@jest/types': 26.2.0
       ansi-regex: 5.0.0
       ansi-styles: 4.2.1
       react-is: 16.13.1
@@ -16656,7 +17450,7 @@ packages:
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==
+      integrity: sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==
   /pretty-time/1.1.0:
     dev: true
     engines:
@@ -17104,10 +17898,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-91VZZvMJjzyIYExEnPC69XeCdL8=
-  /redux-observable/1.2.0_redux@4.0.5+rxjs@6.6.0:
+  /redux-observable/1.2.0_redux@4.0.5+rxjs@6.6.2:
     dependencies:
       redux: 4.0.5
-      rxjs: 6.6.0
+      rxjs: 6.6.2
     dev: false
     peerDependencies:
       redux: '>=4 <5'
@@ -17617,10 +18411,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
-  /rxjs-marbles/6.0.1_rxjs@6.6.0:
+  /rxjs-marbles/6.0.1_rxjs@6.6.2:
     dependencies:
       fast-equals: 2.0.0
-      rxjs: 6.6.0
+      rxjs: 6.6.2
       rxjs-report-usage: 1.0.5
     dev: true
     peerDependencies:
@@ -17655,6 +18449,14 @@ packages:
       npm: '>=2.0.0'
     resolution:
       integrity: sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==
+  /rxjs/6.6.2:
+    dependencies:
+      tslib: 1.13.0
+    dev: false
+    engines:
+      npm: '>=2.0.0'
+    resolution:
+      integrity: sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==
   /safe-buffer/5.1.2:
     resolution:
       integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -17687,7 +18489,7 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==
-  /sass-loader/9.0.2_sass@1.26.10+webpack@4.43.0:
+  /sass-loader/9.0.2_sass@1.26.10+webpack@4.44.1:
     dependencies:
       klona: 1.1.2
       loader-utils: 2.0.0
@@ -17695,7 +18497,7 @@ packages:
       sass: 1.26.10
       schema-utils: 2.7.0
       semver: 7.3.2
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     engines:
       node: '>= 10.13.0'
@@ -17767,6 +18569,7 @@ packages:
     resolution:
       integrity: sha1-cV1bnMV3YPsivczDvvtb/gaxoxc=
   /scrypt-js/2.0.4:
+    dev: false
     resolution:
       integrity: sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==
   /sec/1.0.0:
@@ -17925,6 +18728,7 @@ packages:
     resolution:
       integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
   /setimmediate/1.0.4:
+    dev: false
     resolution:
       integrity: sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=
   /setimmediate/1.0.5:
@@ -18183,14 +18987,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
-  /source-map-loader/1.0.1_webpack@4.43.0:
+  /source-map-loader/1.0.1_webpack@4.44.1:
     dependencies:
       data-urls: 2.0.0
       iconv-lite: 0.5.2
       loader-utils: 2.0.0
       schema-utils: 2.7.0
       source-map: 0.6.1
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     engines:
       node: '>= 10.13.0'
@@ -19083,6 +19887,25 @@ packages:
       webpack: ^4.0.0
     resolution:
       integrity: sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==
+  /terser-webpack-plugin/1.4.4_webpack@4.44.1:
+    dependencies:
+      cacache: 12.0.4
+      find-cache-dir: 2.1.0
+      is-wsl: 1.1.0
+      schema-utils: 1.0.0
+      serialize-javascript: 3.1.0
+      source-map: 0.6.1
+      terser: 4.8.0
+      webpack: 4.44.1_7d74d9f6ceb0e540c1e44d9709220c58
+      webpack-sources: 1.4.3
+      worker-farm: 1.7.0
+    dev: true
+    engines:
+      node: '>= 6.9.0'
+    peerDependencies:
+      webpack: ^4.0.0
+    resolution:
+      integrity: sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==
   /terser-webpack-plugin/2.3.7_webpack@4.43.0:
     dependencies:
       cacache: 13.0.1
@@ -19479,12 +20302,12 @@ packages:
       jest: '>=24 <25'
     resolution:
       integrity: sha512-Hb94C/+QRIgjVZlJyiWwouYUF+siNJHJHknyspaOcZ+OQAIdFG/UrdQVXw/0B8Z3No34xkUXZJpOTy9alOWdVQ==
-  /ts-jest/26.1.3_jest@26.1.0+typescript@3.9.7:
+  /ts-jest/26.1.4_jest@26.2.2+typescript@3.9.7:
     dependencies:
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.1.0
+      jest: 26.2.2
       jest-util: 26.1.0
       json5: 2.1.3
       lodash.memoize: 4.1.2
@@ -19501,7 +20324,7 @@ packages:
       jest: '>=26 <27'
       typescript: '>=3.8 <4.0'
     resolution:
-      integrity: sha512-beUTSvuqR9SmKQEylewqJdnXWMVGJRFqSz2M8wKJe7GBMmLZ5zw6XXKSJckbHNMxn+zdB3guN2eOucSw2gBMnw==
+      integrity: sha512-Nd7diUX6NZWfWq6FYyvcIPR/c7GbEF75fH1R6coOp3fbNzbRJBZZAn0ueVS0r8r9ral1VcrpneAFAwB3TsVS1Q==
   /ts-loader/6.2.2_typescript@3.9.7:
     dependencies:
       chalk: 2.4.2
@@ -20206,6 +21029,7 @@ packages:
     resolution:
       integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
   /uuid/2.0.1:
+    dev: false
     resolution:
       integrity: sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=
   /uuid/3.4.0:
@@ -20377,13 +21201,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-sLo6YzudaWgn5dOMvrKixE5bb/onYGxcxm+0YexqoOx0QtR+7hZ/P5WPFBMM9v/2i1ec2YYe2PvKTBel7KE+tA==
-  /vue-cli-plugin-vuetify/2.0.7_639642eb3bb4815112acddb1c405f875:
+  /vue-cli-plugin-vuetify/2.0.7_fb9579d217c5c7127396de9c5445c080:
     dependencies:
-      null-loader: 3.0.0_webpack@4.43.0
-      sass-loader: 9.0.2_sass@1.26.10+webpack@4.43.0
+      null-loader: 3.0.0_webpack@4.44.1
+      sass-loader: 9.0.2_sass@1.26.10+webpack@4.44.1
       semver: 7.3.2
       shelljs: 0.8.4
-      vuetify-loader: 1.6.0_6a58f05bac33018dc577282d418e9eb8
+      vuetify-loader: 1.6.0_9463ea465103b1f409e4954823843e27
     dev: true
     peerDependencies:
       sass-loader: '*'
@@ -20445,11 +21269,16 @@ packages:
     resolution:
       integrity: sha512-+zwDKvle4KcfloXZnj5hF01ViKDiFr5RMx5507D7oyDXpSleRpekF5YHgZa/+Ra6Go68//z0Nya58J9tKFsCjw==
   /vue-i18n/8.18.2:
+    dev: true
     resolution:
       integrity: sha512-0X5nBTCZAVjlwcrPaYJwNs3iipBBTv0AUHwQUOa8yP3XbQGWKbRHqBb3OhCYtum/IHDD21d/df5Xd2VgyxbxfA==
+  /vue-i18n/8.20.0:
+    dev: false
+    resolution:
+      integrity: sha512-ZiAOoeR4d/JtKpbjipx3I80ey7cYG1ki5gQ7HwzWm4YFio9brA15BEYHjalEoBaEfzF5OBEZP+Y2MvAaWnyXXg==
   /vue-jest/3.0.6_64ba5b21466dd6d31604ca8f3ce0789b:
     dependencies:
-      babel-core: 7.0.0-bridge.0_@babel+core@7.10.5
+      babel-core: 7.0.0-bridge.0_@babel+core@7.11.0
       babel-plugin-transform-es2015-modules-commonjs: 6.26.2
       chalk: 2.4.2
       deasync: 0.1.20
@@ -20542,14 +21371,14 @@ packages:
       vue-class-component: '*'
     resolution:
       integrity: sha512-oegTNPItuHOkW0AP1MnbdNwkmyhfsUIIXvIRHpgC18tVoEo21/i6kItyeekjMs8JgZJeuHzsaTc/DZaJFH4IWQ==
-  /vue-qrcode-reader/2.3.10:
+  /vue-qrcode-reader/2.3.11:
     dependencies:
       callforth: 0.3.1
       core-js: 3.6.5
       vue: 2.6.11
     dev: false
     resolution:
-      integrity: sha512-mS+OhvpCe+cpAvW7Bd/EYo6jVCcguyIQwZw6kbKZ+vUX6NWQR4Ddnt8vDoZbtf5aAhlS0TjFl+pxUr11/l2OhQ==
+      integrity: sha512-5A/zeGpIG8ky1GHIv+L6QTlvyugilRmskQEOppa4+lQ4MVKLVeL55EYnnBw+YQ0N45LBVcUwBLr//AHjdfkmZA==
   /vue-resize/0.4.5_vue@2.6.11:
     dependencies:
       vue: 2.6.11
@@ -20656,13 +21485,13 @@ packages:
     requiresBuild: true
     resolution:
       integrity: sha512-buscwFfIqvCcUAaRdbBWENmCSBZzr510fch1BhQZwVaQy28mF8H6Mvb+UDdwHQ7jon0d9qauXs9M0k4XHIWviw==
-  /vuetify-loader/1.6.0_6a58f05bac33018dc577282d418e9eb8:
+  /vuetify-loader/1.6.0_9463ea465103b1f409e4954823843e27:
     dependencies:
-      file-loader: 4.3.0_webpack@4.43.0
+      file-loader: 4.3.0_webpack@4.44.1
       loader-utils: 1.4.0
       vue-template-compiler: 2.6.11
-      vuetify: 2.3.6_vue@2.6.11
-      webpack: 4.43.0_webpack@4.43.0
+      vuetify: 2.3.7_vue@2.6.11
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     peerDependencies:
       vue-template-compiler: ^2.6.10
@@ -20670,13 +21499,14 @@ packages:
       webpack: ^4.0.0
     resolution:
       integrity: sha512-1bx3YeZ712dT1+QMX+XSFlP0O5k5O5Ui9ysBBmUZ9bWkAEHWZJQI9soI+qG5qmeFxUC0L9QYMCIKP0hOL/pf3Q==
-  /vuetify/2.3.6_vue@2.6.11:
+  /vuetify/2.3.7_vue@2.6.11:
     dependencies:
       vue: 2.6.11
+    dev: false
     peerDependencies:
       vue: ^2.6.4
     resolution:
-      integrity: sha512-mnn5ijJOQf6o443A2ymKrwJAFjaloU0x1QJJArswHv+y2FsSp9obZ6KXDKuzxO6hdGt8VDt/p4S2Hs8A41kbOg==
+      integrity: sha512-9PNorMNNcn0okT78ZpN86qL5Zx4xu0yzcO2w1IdN3ECdbAP00rHe8CEYCThakwXGUuTZ8Iv7gAMDqH6zfxSMtA==
   /vuex-persist/2.2.0_vuex@3.5.1:
     dependencies:
       flatted: 2.0.2
@@ -20765,6 +21595,16 @@ packages:
       watchpack-chokidar2: 2.0.0
     resolution:
       integrity: sha512-ymVbbQP40MFTp+cNMvpyBpBtygHnPzPkHqoIwRRj/0B8KhqQwV8LaKjtbaxF2lK4vl8zN9wCxS46IFCU5K4W0g==
+  /watchpack/1.7.4:
+    dependencies:
+      graceful-fs: 4.2.4
+      neo-async: 2.6.2
+    dev: true
+    optionalDependencies:
+      chokidar: 3.4.1
+      watchpack-chokidar2: 2.0.0
+    resolution:
+      integrity: sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==
   /wbuf/1.7.3:
     dependencies:
       minimalistic-assert: 1.0.1
@@ -20829,7 +21669,7 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-K4EHiEg4WlP4w1rKXKpYWvX9cfGBERHCGP06ETSNV62XUIfOUg1DDRQpxyBsFYxZLKc4YUAI3iiCIvWoliheGA==
-  /webpack-cli/3.3.12_webpack@4.43.0:
+  /webpack-cli/3.3.12_webpack@4.44.1:
     dependencies:
       chalk: 2.4.2
       cross-spawn: 6.0.5
@@ -20841,7 +21681,7 @@ packages:
       loader-utils: 1.4.0
       supports-color: 6.1.0
       v8-compile-cache: 2.1.1
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_7d74d9f6ceb0e540c1e44d9709220c58
       yargs: 13.3.2
     dev: true
     engines:
@@ -20969,6 +21809,88 @@ packages:
       webpack: '*'
     resolution:
       integrity: sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==
+  /webpack/4.44.1_7d74d9f6ceb0e540c1e44d9709220c58:
+    dependencies:
+      '@webassemblyjs/ast': 1.9.0
+      '@webassemblyjs/helper-module-context': 1.9.0
+      '@webassemblyjs/wasm-edit': 1.9.0
+      '@webassemblyjs/wasm-parser': 1.9.0
+      acorn: 6.4.1
+      ajv: 6.12.3
+      ajv-keywords: 3.5.1_ajv@6.12.3
+      chrome-trace-event: 1.0.2
+      enhanced-resolve: 4.3.0
+      eslint-scope: 4.0.3
+      json-parse-better-errors: 1.0.2
+      loader-runner: 2.4.0
+      loader-utils: 1.4.0
+      memory-fs: 0.4.1
+      micromatch: 3.1.10
+      mkdirp: 0.5.5
+      neo-async: 2.6.2
+      node-libs-browser: 2.2.1
+      schema-utils: 1.0.0
+      tapable: 1.1.3
+      terser-webpack-plugin: 1.4.4_webpack@4.44.1
+      watchpack: 1.7.4
+      webpack-cli: 3.3.12_webpack@4.44.1
+      webpack-sources: 1.4.3
+    dev: true
+    engines:
+      node: '>=6.11.5'
+    hasBin: true
+    peerDependencies:
+      webpack: '*'
+      webpack-cli: '*'
+      webpack-command: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+      webpack-command:
+        optional: true
+    resolution:
+      integrity: sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==
+  /webpack/4.44.1_webpack@4.44.1:
+    dependencies:
+      '@webassemblyjs/ast': 1.9.0
+      '@webassemblyjs/helper-module-context': 1.9.0
+      '@webassemblyjs/wasm-edit': 1.9.0
+      '@webassemblyjs/wasm-parser': 1.9.0
+      acorn: 6.4.1
+      ajv: 6.12.3
+      ajv-keywords: 3.5.1_ajv@6.12.3
+      chrome-trace-event: 1.0.2
+      enhanced-resolve: 4.3.0
+      eslint-scope: 4.0.3
+      json-parse-better-errors: 1.0.2
+      loader-runner: 2.4.0
+      loader-utils: 1.4.0
+      memory-fs: 0.4.1
+      micromatch: 3.1.10
+      mkdirp: 0.5.5
+      neo-async: 2.6.2
+      node-libs-browser: 2.2.1
+      schema-utils: 1.0.0
+      tapable: 1.1.3
+      terser-webpack-plugin: 1.4.4_webpack@4.44.1
+      watchpack: 1.7.4
+      webpack: 4.44.1_webpack@4.44.1
+      webpack-sources: 1.4.3
+    dev: true
+    engines:
+      node: '>=6.11.5'
+    hasBin: true
+    peerDependencies:
+      webpack: '*'
+      webpack-cli: '*'
+      webpack-command: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+      webpack-command:
+        optional: true
+    resolution:
+      integrity: sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==
   /webpackbar/3.2.0_webpack@4.43.0:
     dependencies:
       ansi-escapes: 4.3.1
@@ -21413,6 +22335,7 @@ packages:
     resolution:
       integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
   /xmlhttprequest/1.8.0:
+    dev: false
     engines:
       node: '>=0.4.0'
     resolution:

--- a/raiden-cli/package.json
+++ b/raiden-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-cli",
-  "version": "0.1.0",
+  "version": "0.11.0",
   "description": "Raiden Light Client standalone command-line app",
   "main": "build/index.js",
   "scripts": {

--- a/raiden-cli/raiden
+++ b/raiden-cli/raiden
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 RAIDEN="$( dirname $0 )/build/raiden.js"
-[ -e "$RAIDEN" ] || RAIDEN="$( dirname $0 )/build/raiden.bundle.js"
+[ ! -e "$RAIDEN" ] && RAIDEN="$( dirname $0 )/build/raiden.bundle.js"
 
 exec node "$RAIDEN" "$@"

--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.11.0] - 2020-08-04
+
 ### Fixed
 
 ### Added
@@ -381,7 +383,9 @@
 - Add link to privacy policy.
 - Add basic transfer screen.
 
-[unreleased]: https://github.com/raiden-network/light-client/compare/v0.9.0...HEAD
+[unreleased]: https://github.com/raiden-network/light-client/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/raiden-network/light-client/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/raiden-network/light-client/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/raiden-network/light-client/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/raiden-network/light-client/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/raiden-network/light-client/compare/v0.6.0...v0.7.0

--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-dapp",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "description": "A dApp that showcases the Raiden Light Client sdk functionality",
   "author": "brainbot labs est.",

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [0.11.0] - 2020-08-04
 ### Fixed
 - [#1923] Fix `fromEthersEvent` ranges fetching in case of temporary connectivity loss
 - [#1952] Fix nonce conflict issues with concurrent transactions
@@ -297,7 +299,9 @@
 - Add protocol message implementation.
 
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/raiden-network/light-client/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/raiden-network/light-client/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/raiden-network/light-client/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/raiden-network/light-client/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/raiden-network/light-client/compare/v0.6.0...v0.7.0

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-ts",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Raiden Light Client Typescript/Javascript SDK",
   "main": "dist:cjs/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
**Short description**
- Bump to v0.11.0 version
- Rename the cli's `raiden.sh` script to `raiden` (in order for it to be able to be executed from the SP just adjusting the `PATH` env var)
- Sync CLI's version with the other packages (v.0.11.0)
