### PR TITLE
Using epics by name.

### DIFF
--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -1426,3 +1426,20 @@ export const confirmationEpic = (
       ),
     ),
   );
+
+export const ChannelsEpics = [
+  initNewBlockEpic,
+  initTokensRegistryEpic,
+  initMonitorProviderEpic,
+  channelEventsEpic,
+  channelMonitoredEpic,
+  channelOpenEpic,
+  channelDepositEpic,
+  channelCloseEpic,
+  channelUpdateEpic,
+  channelAutoSettleEpic,
+  channelSettleEpic,
+  channelSettleableEpic,
+  channelUnlockEpic,
+  confirmationEpic,
+];

--- a/raiden-ts/src/epics.ts
+++ b/raiden-ts/src/epics.ts
@@ -28,10 +28,10 @@ import { pfsListUpdated, udcDeposit } from './services/actions';
 import { Address, UInt } from './utils/types';
 import { isActionOf } from './utils/actions';
 
-import * as ChannelsEpics from './channels/epics';
-import * as TransportEpics from './transport/epics';
-import * as TransfersEpics from './transfers/epics';
-import * as ServicesEpics from './services/epics';
+import { ChannelsEpics } from './channels/epics';
+import { TransportEpics } from './transport/epics';
+import { TransfersEpics } from './transfers/epics';
+import { ServicesEpics } from './services/epics';
 
 // calculate dynamic config, based on default, user and udcBalance (for receiving caps)
 function getConfig$(
@@ -136,12 +136,7 @@ export function getLatest$(
   );
 }
 
-const RaidenEpics = {
-  ...ChannelsEpics,
-  ...TransportEpics,
-  ...TransfersEpics,
-  ...ServicesEpics,
-};
+const RaidenEpics = [...ChannelsEpics, ...TransportEpics, ...TransfersEpics, ...ServicesEpics];
 
 export const raidenRootEpic = (
   action$: Observable<RaidenAction>,
@@ -162,7 +157,7 @@ export const raidenRootEpic = (
     () => getLatest$(limitedAction$, limitedState$, deps).subscribe(deps.latest$),
     () =>
       // like combineEpics, but completes action$, state$ & output$ when a raidenShutdown goes through
-      from(Object.values(RaidenEpics)).pipe(
+      from(RaidenEpics).pipe(
         mergeMap((epic) => epic(limitedAction$, limitedState$, deps)),
         catchError((err) => {
           deps.log.error('Fatal error:', err);

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -1232,3 +1232,17 @@ function getCleanPath(path: readonly Address[], address: Address): readonly Addr
 function isNoRouteFoundError(error: PathError | undefined): boolean {
   return error?.error_code === 2201;
 }
+
+export const ServicesEpics = [
+  pathFindServiceEpic,
+  pfsCapacityUpdateEpic,
+  pfsFeeUpdateEpic,
+  pfsServiceRegistryMonitorEpic,
+  monitorUdcBalanceEpic,
+  udcDepositEpic,
+  monitorRequestEpic,
+  udcWithdrawRequestEpic,
+  udcCheckWithdrawPlannedEpic,
+  udcWithdrawPlannedEpic,
+  msMonitorNewBPEpic,
+];

--- a/raiden-ts/src/transfers/epics/close.ts
+++ b/raiden-ts/src/transfers/epics/close.ts
@@ -72,3 +72,5 @@ export const transferChannelClosedEpic = (
       ),
     ),
   );
+
+export const CloseEpics = [transferChannelClosedEpic];

--- a/raiden-ts/src/transfers/epics/expire.ts
+++ b/raiden-ts/src/transfers/epics/expire.ts
@@ -88,3 +88,5 @@ export const transferAutoExpireEpic = (
       autoExpire$(action$, state, config, blockNumber),
     ),
   );
+
+export const ExpireEpics = [transferAutoExpireEpic];

--- a/raiden-ts/src/transfers/epics/index.ts
+++ b/raiden-ts/src/transfers/epics/index.ts
@@ -1,10 +1,23 @@
-export * from './close';
-export * from './expire';
-export * from './locked';
-export * from './init';
-export * from './mediate';
-export * from './processed';
-export * from './refund';
-export * from './retry';
-export * from './secret';
-export * from './withdraw';
+import { CloseEpics } from './close';
+import { ExpireEpics } from './expire';
+import { LockedEpics } from './locked';
+import { InitEpics } from './init';
+import { MediateEpics } from './mediate';
+import { ProcessedEpics } from './processed';
+import { RefundEpics } from './refund';
+import { RetryEpics } from './retry';
+import { SecretEpics } from './secret';
+import { WithdrawEpics } from './withdraw';
+
+export const TransfersEpics = [
+  ...CloseEpics,
+  ...ExpireEpics,
+  ...LockedEpics,
+  ...InitEpics,
+  ...MediateEpics,
+  ...ProcessedEpics,
+  ...RefundEpics,
+  ...RetryEpics,
+  ...SecretEpics,
+  ...WithdrawEpics,
+];

--- a/raiden-ts/src/transfers/epics/init.ts
+++ b/raiden-ts/src/transfers/epics/init.ts
@@ -127,3 +127,5 @@ export const initQueuePendingReceivedEpic = (
       );
     }),
   );
+
+export const InitEpics = [initQueuePendingEnvelopeMessagesEpic, initQueuePendingReceivedEpic];

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -1094,3 +1094,5 @@ export const transferGenerateAndSignEnvelopeMessageEpic = (
     }),
   );
 };
+
+export const LockedEpics = [transferGenerateAndSignEnvelopeMessageEpic];

--- a/raiden-ts/src/transfers/epics/mediate.ts
+++ b/raiden-ts/src/transfers/epics/mediate.ts
@@ -63,3 +63,5 @@ export const transferMediateEpic = (
       ),
     ),
   );
+
+export const MediateEpics = [transferMediateEpic];

--- a/raiden-ts/src/transfers/epics/processed.ts
+++ b/raiden-ts/src/transfers/epics/processed.ts
@@ -202,3 +202,11 @@ export const transferReceivedReplyProcessedEpic = (
     }),
   );
 };
+
+export const ProcessedEpics = [
+  transferProcessedReceivedEpic,
+  transferProcessedSendEpic,
+  transferUnlockProcessedReceivedEpic,
+  transferExpireProcessedEpic,
+  transferReceivedReplyProcessedEpic,
+];

--- a/raiden-ts/src/transfers/epics/refund.ts
+++ b/raiden-ts/src/transfers/epics/refund.ts
@@ -60,3 +60,5 @@ export const transferRefundedEpic = (
       yield transfer.failure(new RaidenError(ErrorCodes.XFER_REFUNDED), meta);
     }),
   );
+
+export const RefundEpics = [transferRefundedEpic];

--- a/raiden-ts/src/transfers/epics/retry.ts
+++ b/raiden-ts/src/transfers/epics/retry.ts
@@ -286,3 +286,5 @@ export const transferRetryMessageEpic = (
     ),
   );
 };
+
+export const RetryEpics = [transferRetryMessageEpic];

--- a/raiden-ts/src/transfers/epics/secret.ts
+++ b/raiden-ts/src/transfers/epics/secret.ts
@@ -465,3 +465,14 @@ export const transferSecretRegisterEpic = (
       );
     }),
   );
+
+export const SecretEpics = [
+  transferSecretRequestedEpic,
+  transferSecretRevealEpic,
+  transferSecretRevealedEpic,
+  transferRequestUnlockEpic,
+  monitorSecretRegistryEpic,
+  transferSuccessOnSecretRegisteredEpic,
+  transferAutoRegisterEpic,
+  transferSecretRegisterEpic,
+];

--- a/raiden-ts/src/transfers/epics/withdraw.ts
+++ b/raiden-ts/src/transfers/epics/withdraw.ts
@@ -370,3 +370,12 @@ export const withdrawSendExpireMessageEpic = (
       );
     }),
   );
+
+export const WithdrawEpics = [
+  initWithdrawMessagesEpic,
+  withdrawSendRequestMessageEpic,
+  withdrawSendTxEpic,
+  withdrawMessageProcessedEpic,
+  autoWithdrawExpireEpic,
+  withdrawSendExpireMessageEpic,
+];

--- a/raiden-ts/src/transport/epics/index.ts
+++ b/raiden-ts/src/transport/epics/index.ts
@@ -1,5 +1,13 @@
-export * from './init';
-export * from './presence';
-export * from './rooms';
-export * from './messages';
-export * from './webrtc';
+import { InitEpics } from './init';
+import { PresenceEpics } from './presence';
+import { RoomsEpics } from './rooms';
+import { MessagesEpics } from './messages';
+import { WebRTCEpics } from './webrtc';
+
+export const TransportEpics = [
+  ...InitEpics,
+  ...PresenceEpics,
+  ...RoomsEpics,
+  ...MessagesEpics,
+  ...WebRTCEpics,
+];

--- a/raiden-ts/src/transport/epics/init.ts
+++ b/raiden-ts/src/transport/epics/init.ts
@@ -431,3 +431,5 @@ export const matrixShutdownEpic = (
     ),
     ignoreElements(), // dont re-emit action$, but keep it subscribed so finalize works
   );
+
+export const InitEpics = [initMatrixEpic, matrixShutdownEpic];

--- a/raiden-ts/src/transport/epics/messages.ts
+++ b/raiden-ts/src/transport/epics/messages.ts
@@ -276,3 +276,10 @@ export const deliveredEpic = (
     }),
   );
 };
+
+export const MessagesEpics = [
+  matrixMessageSendEpic,
+  matrixMessageGlobalSendEpic,
+  matrixMessageReceivedEpic,
+  deliveredEpic,
+];

--- a/raiden-ts/src/transport/epics/presence.ts
+++ b/raiden-ts/src/transport/epics/presence.ts
@@ -287,3 +287,10 @@ export const matrixUpdateCapsEpic = (
     ),
     ignoreElements(),
   );
+
+export const PresenceEpics = [
+  matrixMonitorPresenceEpic,
+  matrixPresenceUpdateEpic,
+  matrixMonitorChannelPresenceEpic,
+  matrixUpdateCapsEpic,
+];

--- a/raiden-ts/src/transport/epics/rooms.ts
+++ b/raiden-ts/src/transport/epics/rooms.ts
@@ -507,3 +507,14 @@ export const matrixMessageReceivedUpdateRoomEpic = (
     }),
     map(([action]) => matrixRoom({ roomId: action.payload.roomId! }, action.meta)),
   );
+
+export const RoomsEpics = [
+  matrixCreateRoomEpic,
+  matrixInviteEpic,
+  matrixHandleInvitesEpic,
+  matrixLeaveExcessRoomsEpic,
+  matrixLeaveUnknownRoomsEpic,
+  matrixCleanLeftRoomsEpic,
+  matrixCleanMissingRoomsEpic,
+  matrixMessageReceivedUpdateRoomEpic,
+];

--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -443,3 +443,5 @@ export const rtcConnectEpic = (
     groupBy((action) => action.meta.address),
     mergeMap((grouped$) => handlePresenceChange$(action$, grouped$, deps)),
   );
+
+export const WebRTCEpics = [rtcConnectEpic];


### PR DESCRIPTION
I'm opening the PR even though it is broken because I want to see if you guys want to merge something like this or not.

It is only a syntatic change, the only benefit is that one can run `grep CloseEpics` or so and see were the epic is being used. Not terribly useful but IMO it makes a bit easier to navigate through the codebase. Anyways, not merging this is also fine.