### PR TITLE
Make it explicit the requirement for ES2019/Node12 build

### DIFF
--- a/raiden-cli/package.json
+++ b/raiden-cli/package.json
@@ -79,7 +79,7 @@
       "SharedArrayBuffer": "readonly"
     },
     "parserOptions": {
-      "ecmaVersion": 2018,
+      "ecmaVersion": 2019,
       "sourceType": "module",
       "project": "./tsconfig.json"
     },

--- a/raiden-cli/tsconfig.json
+++ b/raiden-cli/tsconfig.json
@@ -1,14 +1,15 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2019",
     "module": "commonjs",
     "outDir": "./build",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "strict": true,
     "sourceMap": true,
     "allowJs": true,
-    "lib": ["es2015", "es2016", "es2017", "dom"],
+    "lib": ["ES2019", "dom"],
     "baseUrl": ".",
     "paths": {
       "matrix-js-sdk": ["node_modules/raiden-ts/node_modules/@types/matrix-js-sdk/index.d.ts"],

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- [#2049] Target ES2019 (NodeJS 12+) on SDK builds
 
 ## [0.11.0] - 2020-08-04
 ### Fixed
@@ -40,6 +42,7 @@
 [#2010]: https://github.com/raiden-network/light-client/issues/2010
 [#2019]: https://github.com/raiden-network/light-client/issues/2019
 [#2022]: https://github.com/raiden-network/light-client/pull/2022
+[#2049]: https://github.com/raiden-network/light-client/issues/2049
 
 ## [0.10.0] - 2020-07-13
 ### Fixed

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -4,11 +4,10 @@
   "description": "Raiden Light Client Typescript/Javascript SDK",
   "main": "dist:cjs/index.js",
   "module": "dist/index.js",
-  "esnext": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "start": "pnpm run versions && pnpm run contracts && tsc -p src/tsconfig.cjs.json -w",
-    "build": "pnpm run versions && pnpm run contracts && tsc -p src/tsconfig.json && tsc -p src/tsconfig.cjs.json && pnpm run contracts:post",
+    "start": "pnpm run versions && pnpm run contracts && tsc -w",
+    "build": "pnpm run versions && pnpm run contracts && tsc && tsc -p ./tsconfig.cjs.json && pnpm run contracts:post",
     "test": "pnpm run lint && NODE_ENV=development jest --coverage=true --testPathIgnorePatterns tests/integration",
     "test:integration": "NODE_ENV=development jest --runInBand --ci --coverage=true --testPathIgnorePatterns tests/unit tests/e2e",
     "test:unit": "NODE_ENV=development jest --runInBand --ci --coverage=true --testPathIgnorePatterns tests/integration tests/e2e",
@@ -102,7 +101,8 @@
     "ethers": "^4.0.47"
   },
   "files": [
-    "/dist*"
+    "/dist",
+    "/dist:cjs"
   ],
   "eslintConfig": {
     "parser": "@typescript-eslint/parser",
@@ -162,7 +162,8 @@
   "eslintIgnore": [
     "raiden-contracts/*",
     "scripts/*",
-    "dist*/*",
+    "dist/*",
+    "dist:cjs/*",
     "src/contracts/*"
   ],
   "prettier": {

--- a/raiden-ts/src/tsconfig.json
+++ b/raiden-ts/src/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "../dist"
-  },
-  "exclude": [
-    "./contracts/*Factory.ts"
-  ]
-}

--- a/raiden-ts/tests/tsconfig.json
+++ b/raiden-ts/tests/tsconfig.json
@@ -1,17 +1,17 @@
 {
   "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "..",
+    "paths": {
+      "raiden-ts/*": ["./src/*"],
+      "matrix-js-sdk": ["./node_modules/@types/matrix-js-sdk/index.d.ts"]
+    }
+  },
   "include": [
     "./**/*.ts"
   ],
   "files": [
-    "../src/global.d.ts",
-    "../tests/global.d.ts"
-  ],
-  "compilerOptions": {
-    "baseUrl": "..",
-    "paths": {
-      "raiden-ts/*": ["src/*"],
-      "matrix-js-sdk": ["node_modules/@types/matrix-js-sdk/index.d.ts"]
-    }
-  }
+    "./global.d.ts",
+    "../src/global.d.ts"
+  ]
 }

--- a/raiden-ts/tsconfig.cjs.json
+++ b/raiden-ts/tsconfig.cjs.json
@@ -1,8 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "../dist:cjs",
-    "target": "es5",
+    "outDir": "./dist:cjs",
     "module": "commonjs"
   }
 }

--- a/raiden-ts/tsconfig.json
+++ b/raiden-ts/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es6",
-    "module": "esNext",
+    "target": "ES2019",
+    "module": "ES6",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "esModuleInterop": true,
@@ -9,10 +9,15 @@
     "sourceMap": true,
     "declaration": true,
     "pretty": true,
-    "lib": ["es2015", "es2016", "es2017", "dom"],
+    "lib": ["ES2019", "dom"],
     "baseUrl": ".",
     "paths": {
-      "matrix-js-sdk": ["node_modules/@types/matrix-js-sdk/index.d.ts"]
-    }
-  }
+      "matrix-js-sdk": ["./node_modules/@types/matrix-js-sdk/index.d.ts"]
+    },
+    "outDir": "./dist/"
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": [
+    "./src/contracts/*Factory.ts"
+  ]
 }


### PR DESCRIPTION
Fixes #2049 (for now, until we decide to revisit the ESM subject)

**Short description**
We already use a few features from up to ES2018, but we weren't explicit about them. Node12 (our minimum required version) supports the full set of ES2019. Therefore, we bump the build requirement to this version, in order to produce more optimized and smaller code. Babel must be used anyway if someone really need to run the SDK on environments which support ES5- only.
We need to keep the CommonJS build, as it's required on Node for now.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Build the SDK
2. Build the CLI
3. Check CLI still runs on bare Node12 (without `--experimental-*` flags)
