### PR TITLE
Improve types and convert timed tuples to extended objects

### DIFF
--- a/raiden-ts/src/channels/reducer.ts
+++ b/raiden-ts/src/channels/reducer.ts
@@ -211,9 +211,9 @@ function channelLockRegisteredReducer(
   // now that secret is stored in transfer, if it's a confirmed on-chain registration,
   // also update channel's lock to reflect it
   if (!action.payload.confirmed || !(secrethash in state[action.meta.direction])) return state;
-  const transf = state[action.meta.direction][secrethash].transfer[1];
+  const locked = state[action.meta.direction][secrethash].transfer;
   const key = channelKey({
-    tokenNetwork: transf.token_network_address,
+    tokenNetwork: locked.token_network_address,
     partner: state[action.meta.direction][secrethash].partner,
   });
   if (!(key in state.channels)) return state;

--- a/raiden-ts/src/global.d.ts
+++ b/raiden-ts/src/global.d.ts
@@ -12,3 +12,5 @@ declare module 'matrix-js-sdk/lib/webrtc/call';
 
 declare module 'abort-controller/polyfill';
 declare module 'wrtc'; // types provided by @types/webrtc
+
+declare type Mutable<T> = { -readonly [P in keyof T]: T[P] };

--- a/raiden-ts/src/messages/types.ts
+++ b/raiden-ts/src/messages/types.ts
@@ -320,7 +320,7 @@ export interface MonitorRequestC
   extends t.Type<MonitorRequest, t.OutputOf<typeof _MonitorRequest>> {}
 export const MonitorRequest: MonitorRequestC = _MonitorRequest;
 
-const messages = [
+const _messages = [
   Delivered,
   Processed,
   SecretRequest,
@@ -336,9 +336,10 @@ const messages = [
   PFSFeeUpdate,
   MonitorRequest,
 ] as const;
+const messages = _messages as Mutable<typeof _messages>;
 
 // prefer an explicit union to have the union of the interfaces, instead of the union of t.TypeOf's
 export type Message = t.TypeOf<typeof messages[number]>;
-export interface MessageC extends t.Type<Message, t.OutputOf<typeof messages[number]>> {}
-export const Message: MessageC = t.union([...messages]);
+export interface MessageC extends t.UnionC<typeof messages> {}
+export const Message: MessageC = t.union(messages);
 export type EnvelopeMessage = LockedTransfer | RefundTransfer | Unlock | LockExpired;

--- a/raiden-ts/src/migration/6.ts
+++ b/raiden-ts/src/migration/6.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Transform timed tuples to { ...obj, ts: number } extended objects
+ *
+ * @param state - RaidenState version 5
+ * @returns State version 6
+ */
+export default function migrate6(state: any) {
+  for (const direction of ['sent', 'received']) {
+    for (const transfer of Object.values<any>(state[direction])) {
+      for (const [k, v] of Object.entries(transfer)) {
+        if (!Array.isArray(v) || v.length !== 2 || typeof v[1] !== 'object') continue;
+        Object.assign(transfer, { [k]: { ...v[1], ts: v[0] } });
+      }
+      const closed = transfer.channelClosed;
+      if (closed) {
+        Object.assign(transfer, {
+          channelClosed: { txHash: closed[1], txBlock: 0, ts: closed[0] },
+        });
+      }
+    }
+  }
+  return state;
+}

--- a/raiden-ts/src/migration/index.ts
+++ b/raiden-ts/src/migration/index.ts
@@ -7,9 +7,10 @@ import m2 from './2';
 import m3 from './3';
 import m4 from './4';
 import m5 from './5';
+import m6 from './6';
 
 // import above and populate this array with new migrator functions, index is version
-const migrations = [m0, m1, m2, m3, m4, m5];
+const migrations = [m0, m1, m2, m3, m4, m5, m6];
 export const CURRENT_STATE_VERSION = migrations.length - 1;
 
 /**

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -953,13 +953,13 @@ export class Raiden {
     const transf = raidenTransfer(this.state[direction][secrethash]);
     // already completed/past transfer
     if (transf.completed) {
-      if (transf.success) return this.state[direction][secrethash].secretRequest?.[1]?.amount;
+      if (transf.success) return this.state[direction][secrethash].secretRequest?.amount;
       else throw new RaidenError(ErrorCodes.XFER_ALREADY_COMPLETED, { status: transf.status });
     }
 
     // throws/rejects if a failure occurs
     await asyncActionToPromise(transfer, { secrethash, direction }, this.action$);
-    return this.state[direction][secrethash].secretRequest?.[1]?.amount;
+    return this.state[direction][secrethash].secretRequest?.amount;
   }
 
   /**

--- a/raiden-ts/src/transfers/epics/expire.ts
+++ b/raiden-ts/src/transfers/epics/expire.ts
@@ -36,9 +36,9 @@ function autoExpire$(
         !sent.unlock &&
         !sent.lockExpired &&
         !sent.channelClosed &&
-        sent.transfer[1].lock.expiration.add(confirmationBlocks).lte(blockNumber) &&
+        sent.transfer.lock.expiration.add(confirmationBlocks).lte(blockNumber) &&
         // don't expire if secret got registered before lock expired
-        !sent.secret?.[1]?.registerBlock,
+        !sent.secret?.registerBlock,
     ),
     mergeMap(([secrethash, sent]) => {
       const meta = { secrethash, direction: Direction.SENT };
@@ -53,7 +53,7 @@ function autoExpire$(
         of(
           transfer.failure(
             new RaidenError(ErrorCodes.XFER_EXPIRED, {
-              block: sent.transfer[1].lock.expiration.toString(),
+              block: sent.transfer.lock.expiration.toString(),
             }),
             meta,
           ),

--- a/raiden-ts/src/transfers/epics/processed.ts
+++ b/raiden-ts/src/transfers/epics/processed.ts
@@ -43,8 +43,8 @@ export const transferProcessedReceivedEpic = (
       let secrethash: Hash | undefined = undefined;
       for (const [key, sent] of Object.entries(state.sent)) {
         if (
-          sent.transfer[1].message_identifier.eq(message.message_identifier) &&
-          sent.transfer[1].recipient === action.meta.address
+          sent.transfer.message_identifier.eq(message.message_identifier) &&
+          sent.transfer.recipient === action.meta.address
         ) {
           secrethash = key as Hash;
           break;
@@ -104,15 +104,13 @@ export const transferUnlockProcessedReceivedEpic = (
         state.sent,
         (sent) =>
           sent.unlock &&
-          sent.unlock[1].message_identifier.eq(message.message_identifier) &&
+          sent.unlock.message_identifier.eq(message.message_identifier) &&
           sent.partner === action.meta.address,
       ) as Hash | undefined;
       if (!secrethash) return;
       const meta = { secrethash, direction: Direction.SENT };
       yield transfer.success(
-        {
-          balanceProof: getBalanceProofFromEnvelopeMessage(state.sent[secrethash].unlock![1]),
-        },
+        { balanceProof: getBalanceProofFromEnvelopeMessage(state.sent[secrethash].unlock!) },
         meta,
       );
       yield transferUnlockProcessed({ message }, meta);
@@ -141,7 +139,7 @@ export const transferExpireProcessedEpic = (
         state.sent,
         (sent) =>
           sent.lockExpired &&
-          sent.lockExpired[1].message_identifier.eq(message.message_identifier) &&
+          sent.lockExpired.message_identifier.eq(message.message_identifier) &&
           sent.partner === action.meta.address,
       ) as Hash | undefined;
       if (!secrethash) return;

--- a/raiden-ts/src/transfers/epics/refund.ts
+++ b/raiden-ts/src/transfers/epics/refund.ts
@@ -41,7 +41,7 @@ export const transferRefundedEpic = (
       const secrethash = message.lock.secrethash;
       if (!(secrethash in state.sent)) return;
       const sent = state.sent[secrethash];
-      const locked = sent.transfer[1];
+      const locked = sent.transfer;
       if (
         message.initiator !== locked.recipient ||
         !message.payment_identifier.eq(locked.payment_identifier) ||

--- a/raiden-ts/src/transfers/epics/retry.ts
+++ b/raiden-ts/src/transfers/epics/retry.ts
@@ -94,7 +94,7 @@ const unlockedRetryMessage$ = (
     switchMap(([state, { pollingInterval, httpTimeout }]) => {
       const secrethash = action.meta.secrethash;
       const unlock = action.payload.message;
-      const locked = state.sent[secrethash].transfer[1];
+      const locked = state.sent[secrethash].transfer;
       const send = messageSend.request(
         { message: unlock },
         { address: locked.recipient, msgId: unlock.message_identifier.toString() },
@@ -144,7 +144,7 @@ const expiredRetryMessages$ = (
       const send = messageSend.request(
         { message: lockExpired },
         {
-          address: state.sent[secrethash].transfer[1].recipient,
+          address: state.sent[secrethash].transfer.recipient,
           msgId: lockExpired.message_identifier.toString(),
         },
       );
@@ -180,7 +180,7 @@ const secretRequestRetryMessage$ = (
       const send = messageSend.request(
         { message: request },
         {
-          address: state.received[secrethash].transfer[1].initiator,
+          address: state.received[secrethash].transfer.initiator,
           msgId: request.message_identifier.toString(),
         },
       );
@@ -232,7 +232,7 @@ const secretRevealRetryMessage$ = (
         // we don't test for lockExpired, as we know the secret and must not accept LockExpired
         filter(
           (received) =>
-            !!(received.unlock || received.secret?.[1]?.registerBlock || received.channelClosed),
+            !!(received.unlock || received.secret?.registerBlock || received.channelClosed),
         ),
       );
       // emit request once immediatelly, then wait until respective success,

--- a/raiden-ts/src/transfers/state.ts
+++ b/raiden-ts/src/transfers/state.ts
@@ -52,7 +52,7 @@ const _TransferState = t.readonly(
        * In the case a channel is closed (possibly middle transfer), this will be the txHash of the
        * CloseChannel transaction. No further actions are possible after it's set.
        */
-      channelClosed: Timed(Hash),
+      channelClosed: Timed(t.type({ txHash: Hash, txBlock: t.number })),
       /**
        * <- incoming secret request from target
        * If this is set, it means the target requested the secret, not necessarily with a valid

--- a/raiden-ts/tests/unit/epics/channels.spec.ts
+++ b/raiden-ts/tests/unit/epics/channels.spec.ts
@@ -729,7 +729,7 @@ describe('channelSettleEpic', () => {
     await ensureChannelIsClosed([partner, raiden]); // partner closes channel
 
     // LockedTransfer message we sent, not one before latest BP
-    const locked = partner.store.getState().received[secrethash].transfer[1];
+    const locked = partner.store.getState().received[secrethash].transfer;
     // ensure our latest own BP is the unlocked one, the one after Locked
     expect(getChannel(raiden, partner).own.balanceProof.nonce).toEqual(locked.nonce.add(1));
 
@@ -798,7 +798,7 @@ describe('channelSettleEpic', () => {
     await ensureChannelIsClosed([partner, raiden]); // partner closes channel
 
     // LockedTransfer message we received, not one before latest BP
-    const locked = raiden.store.getState().received[secrethash].transfer[1];
+    const locked = raiden.store.getState().received[secrethash].transfer;
     // ensure our latest partner BP is the unlocked one, the one after Locked
     expect(getChannel(raiden, partner).partner.balanceProof.nonce).toEqual(locked.nonce.add(1));
 

--- a/raiden-ts/tests/unit/epics/receive.spec.ts
+++ b/raiden-ts/tests/unit/epics/receive.spec.ts
@@ -46,7 +46,7 @@ import {
   initQueuePendingReceivedEpic,
 } from 'raiden-ts/transfers/epics';
 import { matrixPresence } from 'raiden-ts/transport/actions';
-import { UInt, Int, Signed } from 'raiden-ts/utils/types';
+import { UInt, Int, Signed, untime } from 'raiden-ts/utils/types';
 import {
   makeMessageId,
   makeSecret,
@@ -571,7 +571,7 @@ describe('receive transfers', () => {
       await expect(
         depsMock.latest$.pipe(pluck('state'), first()).toPromise(),
       ).resolves.not.toMatchObject({
-        received: { [secrethash]: { secret: [expect.any(Number), { value: secret }] } },
+        received: { [secrethash]: { secret: { value: secret, ts: expect.any(Number) } } },
       });
 
       await expect(
@@ -587,7 +587,7 @@ describe('receive transfers', () => {
       await expect(
         depsMock.latest$.pipe(pluck('state'), first()).toPromise(),
       ).resolves.toMatchObject({
-        received: { [secrethash]: { secret: [expect.any(Number), { value: secret }] } },
+        received: { [secrethash]: { secret: { value: secret, ts: expect.any(Number) } } },
       });
     });
 
@@ -636,7 +636,7 @@ describe('receive transfers', () => {
       ).resolves.toMatchObject({
         received: {
           [secrethash]: {
-            secretReveal: [expect.any(Number), { type: MessageType.SECRET_REVEAL }],
+            secretReveal: { type: MessageType.SECRET_REVEAL, ts: expect.any(Number) },
           },
         },
       });
@@ -814,13 +814,13 @@ describe('receive transfers', () => {
 
       // receiving enabled, unknown secret
       const transf = await state$
-        .pipe(pluck('received', secrethash, 'transfer', '1'), first())
+        .pipe(pluck('received', secrethash, 'transfer'), first())
         .toPromise();
       await expect(
         initQueuePendingReceivedEpic(EMPTY, state$, depsMock).pipe(toArray()).toPromise(),
       ).resolves.toEqual([
         transferSigned(
-          { message: transf, fee: Zero as Int<32>, partner },
+          { message: untime(transf), fee: Zero as Int<32>, partner },
           { secrethash, direction },
         ),
         matrixPresence.request(undefined, { address: partner }),
@@ -838,7 +838,7 @@ describe('receive transfers', () => {
       );
       expect(output).toEqual([
         transferSigned(
-          { message: transf, fee: Zero as Int<32>, partner },
+          { message: untime(transf), fee: Zero as Int<32>, partner },
           { secrethash, direction },
         ),
       ]);
@@ -846,7 +846,7 @@ describe('receive transfers', () => {
       action$.next(raidenConfigUpdate({ caps: { [Capabilities.NO_RECEIVE]: false } }));
       expect(output).toEqual([
         transferSigned(
-          { message: transf, fee: Zero as Int<32>, partner },
+          { message: untime(transf), fee: Zero as Int<32>, partner },
           { secrethash, direction },
         ),
         matrixPresence.request(undefined, { address: partner }),
@@ -864,7 +864,7 @@ describe('receive transfers', () => {
         initQueuePendingReceivedEpic(EMPTY, state$, depsMock).pipe(toArray()).toPromise(),
       ).resolves.toEqual([
         transferSigned(
-          { message: transf, fee: Zero as Int<32>, partner },
+          { message: untime(transf), fee: Zero as Int<32>, partner },
           { secrethash, direction },
         ),
         transferSecret({ secret }, { secrethash, direction }),
@@ -882,7 +882,7 @@ describe('receive transfers', () => {
         initQueuePendingReceivedEpic(EMPTY, state$, depsMock).pipe(toArray()).toPromise(),
       ).resolves.toEqual([
         transferSigned(
-          { message: transf, fee: Zero as Int<32>, partner },
+          { message: untime(transf), fee: Zero as Int<32>, partner },
           { secrethash, direction },
         ),
         transferSecretReveal({ message: reveal }, { secrethash, direction }),

--- a/raiden-ts/tests/unit/epics/send.spec.ts
+++ b/raiden-ts/tests/unit/epics/send.spec.ts
@@ -761,7 +761,7 @@ describe('send transfers', () => {
         // expect unlock to be set
         await expect(
           depsMock.latest$
-            .pipe(pluck('state', 'sent', secrethash, 'unlock', '1'), first(isntNil))
+            .pipe(pluck('state', 'sent', secrethash, 'unlock'), first(isntNil))
             .toPromise(),
         ).resolves.toMatchObject({
           type: MessageType.UNLOCK,
@@ -1391,7 +1391,7 @@ describe('send transfers', () => {
 
         // expect reveal to be persisted on state
         const reveal = (await depsMock.latest$
-          .pipe(pluck('state', 'sent', secrethash, 'secretReveal', '1'), first(isntNil))
+          .pipe(pluck('state', 'sent', secrethash, 'secretReveal'), first(isntNil))
           .toPromise()) as Signed<SecretReveal>;
         expect(reveal).toMatchObject({
           type: MessageType.SECRET_REVEAL,
@@ -1489,7 +1489,7 @@ describe('send transfers', () => {
         // expect unlock to be set
         await expect(
           depsMock.latest$
-            .pipe(pluck('state', 'sent', secrethash, 'unlock', '1'), first(isntNil))
+            .pipe(pluck('state', 'sent', secrethash, 'unlock'), first(isntNil))
             .toPromise(),
         ).resolves.toMatchObject({
           type: MessageType.UNLOCK,
@@ -1873,7 +1873,7 @@ describe('monitorSecretRegistryEpic', () => {
     const { secretRegistryContract } = raiden.deps;
 
     const sent = await ensureTransferPending([raiden, partner]);
-    await waitBlock(sent.transfer[1].lock.expiration.add(1).toNumber());
+    await waitBlock(sent.transfer.lock.expiration.add(1).toNumber());
 
     const txBlock = raiden.deps.provider.blockNumber;
     await providersEmit(
@@ -1919,10 +1919,11 @@ describe('monitorSecretRegistryEpic', () => {
         { direction: Direction.SENT, secrethash },
       ),
     );
-    expect(raiden.store.getState().sent[secrethash].secret).toEqual([
-      expect.any(Number),
-      { value: secret, registerBlock: txBlock },
-    ]);
+    expect(raiden.store.getState().sent[secrethash].secret).toEqual({
+      value: secret,
+      registerBlock: txBlock,
+      ts: expect.any(Number),
+    });
     expect(getChannel(raiden, partner).own.locks).toContainEqual(
       expect.objectContaining({
         secrethash,

--- a/raiden-ts/tests/unit/fixtures.ts
+++ b/raiden-ts/tests/unit/fixtures.ts
@@ -18,7 +18,7 @@ import { AddressZero, Zero, HashZero } from 'ethers/constants';
 import { bigNumberify, defaultAbiCoder } from 'ethers/utils';
 import { Filter } from 'ethers/providers';
 
-import { Address, Hash, Int, UInt } from 'raiden-ts/utils/types';
+import { Address, Hash, Int, UInt, untime } from 'raiden-ts/utils/types';
 import { Processed, MessageType } from 'raiden-ts/messages/types';
 import {
   makeMessageId,
@@ -392,7 +392,7 @@ export async function ensureTransferPending(
     .toPromise();
   partner.store.dispatch(
     messageReceived(
-      { text: '', message: sent.transfer[1], ts: Date.now() },
+      { text: '', message: untime(sent.transfer), ts: Date.now() },
       { address: raiden.address },
     ),
   );
@@ -433,7 +433,7 @@ export async function ensureTransferUnlocked(
     .toPromise();
   partner.store.dispatch(
     messageReceived(
-      { text: '', message: sent.unlock![1], ts: Date.now() },
+      { text: '', message: untime(sent.unlock!), ts: Date.now() },
       { address: raiden.address },
     ),
   );

--- a/raiden-ts/tests/unit/reducers.spec.ts
+++ b/raiden-ts/tests/unit/reducers.spec.ts
@@ -942,10 +942,11 @@ describe('raidenReducer', () => {
         transferSecret({ secret }, { secrethash, direction }),
       ].reduce(raidenReducer, state);
 
-      expect(newState.sent[secrethash]?.secret).toStrictEqual([
-        expect.any(Number),
-        { value: secret, registerBlock: 0 },
-      ]);
+      expect(newState.sent[secrethash]?.secret).toStrictEqual({
+        value: secret,
+        registerBlock: 0,
+        ts: expect.any(Number),
+      });
 
       // with blockNumber saves it as well
       newState = [
@@ -954,10 +955,11 @@ describe('raidenReducer', () => {
           { secrethash, direction },
         ),
       ].reduce(raidenReducer, newState);
-      expect(newState.sent[secrethash].secret).toStrictEqual([
-        expect.any(Number),
-        { value: secret, registerBlock: 123 },
-      ]);
+      expect(newState.sent[secrethash].secret).toStrictEqual({
+        value: secret,
+        registerBlock: 123,
+        ts: expect.any(Number),
+      });
 
       // if already registered with blockNumber and try without, keep the blockNumber
       newState = [
@@ -966,10 +968,11 @@ describe('raidenReducer', () => {
           { secrethash, direction },
         ),
       ].reduce(raidenReducer, newState);
-      expect(newState.sent[secrethash].secret).toStrictEqual([
-        expect.any(Number),
-        { value: secret, registerBlock: 123 },
-      ]);
+      expect(newState.sent[secrethash].secret).toStrictEqual({
+        value: secret,
+        registerBlock: 123,
+        ts: expect.any(Number),
+      });
     });
 
     test('transfer signed', () => {
@@ -987,7 +990,7 @@ describe('raidenReducer', () => {
         newState,
       );
       expect(newState.sent[secrethash]).toEqual({
-        transfer: [expect.any(Number), message],
+        transfer: { ...message, ts: expect.any(Number) },
         fee,
         partner,
       });
@@ -1000,7 +1003,7 @@ describe('raidenReducer', () => {
           { secrethash, direction },
         ),
       ].reduce(raidenReducer, newState);
-      expect(newState.sent[secrethash]?.transfer?.[1]).toBe(message);
+      expect(newState.sent[secrethash]?.transfer).toEqual({ ...message, ts: expect.any(Number) });
     });
 
     test('transfer processed', () => {
@@ -1021,7 +1024,10 @@ describe('raidenReducer', () => {
         transferProcessed({ message: processed }, { secrethash, direction }),
       ].reduce(raidenReducer, state);
 
-      expect(newState.sent[secrethash]?.transferProcessed?.[1]).toBe(processed);
+      expect(newState.sent[secrethash]?.transferProcessed).toEqual({
+        ...processed,
+        ts: expect.any(Number),
+      });
     });
 
     test('transfer secret request', () => {
@@ -1040,7 +1046,10 @@ describe('raidenReducer', () => {
           action,
         ].reduce(raidenReducer, state);
 
-      expect(newState.sent[secrethash]?.secretRequest?.[1]).toBe(secretRequest);
+      expect(newState.sent[secrethash]?.secretRequest).toEqual({
+        ...secretRequest,
+        ts: expect.any(Number),
+      });
     });
 
     test('transfer secret reveal', () => {
@@ -1056,7 +1065,10 @@ describe('raidenReducer', () => {
           action,
         ].reduce(raidenReducer, state);
 
-      expect(newState.sent[secrethash]?.secretReveal?.[1]).toBe(secretReveal);
+      expect(newState.sent[secrethash]?.secretReveal).toEqual({
+        ...secretReveal,
+        ts: expect.any(Number),
+      });
 
       const newState2 = [
         transferSecretReveal({ message: secretReveal }, { secrethash, direction }),
@@ -1099,7 +1111,7 @@ describe('raidenReducer', () => {
         transferUnlock.success({ message: unlock, partner }, { secrethash, direction }),
       ].reduce(raidenReducer, newState);
 
-      expect(newState.sent[secrethash]?.unlock?.[1]).toBe(unlock);
+      expect(newState.sent[secrethash]?.unlock).toEqual({ ...unlock, ts: expect.any(Number) });
 
       const processed: Signed<Processed> = {
         type: MessageType.PROCESSED,
@@ -1110,7 +1122,10 @@ describe('raidenReducer', () => {
         transferUnlockProcessed({ message: processed }, { secrethash, direction }),
       ].reduce(raidenReducer, newState);
 
-      expect(newState.sent[secrethash]?.unlockProcessed?.[1]).toBe(processed);
+      expect(newState.sent[secrethash]?.unlockProcessed).toEqual({
+        ...processed,
+        ts: expect.any(Number),
+      });
     });
 
     test('transfer expired', () => {
@@ -1147,7 +1162,10 @@ describe('raidenReducer', () => {
         transferExpire.success({ message: lockExpired, partner }, { secrethash, direction }),
       ].reduce(raidenReducer, newState);
 
-      expect(newState.sent[secrethash]?.lockExpired?.[1]).toBe(lockExpired);
+      expect(newState.sent[secrethash]?.lockExpired).toEqual({
+        ...lockExpired,
+        ts: expect.any(Number),
+      });
 
       const processed: Signed<Processed> = {
         type: MessageType.PROCESSED,
@@ -1158,7 +1176,10 @@ describe('raidenReducer', () => {
         transferExpireProcessed({ message: processed }, { secrethash, direction }),
       ].reduce(raidenReducer, newState);
 
-      expect(newState.sent[secrethash]?.lockExpiredProcessed?.[1]).toBe(processed);
+      expect(newState.sent[secrethash]?.lockExpiredProcessed).toEqual({
+        ...processed,
+        ts: expect.any(Number),
+      });
     });
 
     test('transfer refunded', () => {
@@ -1192,7 +1213,7 @@ describe('raidenReducer', () => {
         transferRefunded({ message: refund, partner }, { secrethash, direction }),
       ].reduce(raidenReducer, newState);
 
-      expect(newState.sent[secrethash]?.refund?.[1]).toBe(refund);
+      expect(newState.sent[secrethash]?.refund).toEqual({ ...refund, ts: expect.any(Number) });
     });
 
     test('transfer channel closed', () => {
@@ -1200,7 +1221,7 @@ describe('raidenReducer', () => {
         transferSigned({ message: transfer, fee, partner }, { secrethash, direction }),
       ].reduce(raidenReducer, state);
 
-      expect(newState.sent[secrethash].transfer[1]).toBe(transfer);
+      expect(newState.sent[secrethash].transfer).toEqual({ ...transfer, ts: expect.any(Number) });
       expect(newState.sent[secrethash].secret).toBeUndefined();
 
       newState = [
@@ -1216,7 +1237,11 @@ describe('raidenReducer', () => {
         ),
       ].reduce(raidenReducer, newState);
 
-      expect(newState.sent[secrethash]?.channelClosed?.[1]).toBe(txHash);
+      expect(newState.sent[secrethash]?.channelClosed).toEqual({
+        txHash,
+        txBlock: closeBlock,
+        ts: expect.any(Number),
+      });
     });
 
     // withdraw request is under transfer just to use its pending transfer setup/vars

--- a/raiden-ts/tests/unit/states/6_full.json
+++ b/raiden-ts/tests/unit/states/6_full.json
@@ -1,0 +1,288 @@
+{
+  "address": "0x11111111111111111111111111aaaaaaaaaaaaaa",
+  "version": 6,
+  "chainId": 1338,
+  "registry": "0x0000000000000000000000000000000000000070",
+  "blockNumber": 123,
+  "config": {
+    "matrixServerLookup": "http://raw.yaml",
+    "settleTimeout": 50,
+    "revealTimeout": 10,
+    "httpTimeout": 10e3,
+    "discoveryRoom": "raiden_test_discovery",
+    "pfsRoom": "raiden_test_path_finding",
+    "matrixExcessRooms": 2,
+    "pfsSafetyMargin": 1.1,
+    "confirmationBlocks": 2,
+    "logger": "debug"
+  },
+  "channels": {
+    "0x0000000000000000000000000000000000020002@0x0000000000000000000000000000000000020001": {
+      "state": "open",
+      "id": 17,
+      "settleTimeout": 50,
+      "openBlock": 121,
+      "isFirstParticipant": true,
+      "tokenNetwork": "0x0000000000000000000000000000000000020001",
+      "token": "0x0000000000000000000000000000000000010001",
+      "own": {
+        "address": "0x11111111111111111111111111aaaaaaaaaaaaaa",
+        "deposit": "1000",
+        "withdraw": "0",
+        "locks": [{
+          "amount": "20",
+          "expiration": 132,
+          "secrethash": "0x0000000000000000000000000000000000000020111111111111111111111111"
+        }],
+        "balanceProof": {
+          "chainId": "1338",
+          "tokenNetworkAddress": "0x0000000000000000000000000000000000020001",
+          "channelId": "17",
+          "nonce": "1",
+          "transferredAmount": "0",
+          "lockedAmount": "20",
+          "locksroot": "0x0000000000000000000000000000000000000020111111111111111111111111",
+          "additionalHash": "0x0000000000000000000000000000000000000020111111111111111111111111",
+          "signature": "0x0000000000000000000000000000000000000020111111111111111111111111000000000000000000000000000000000000002011111111111111111111111101"
+        },
+        "pendingWithdraws": [],
+        "nextNonce": "2"
+      },
+      "partner": {
+        "address": "0x0000000000000000000000000000000000020002",
+        "deposit": "80",
+        "withdraw": "0",
+        "locks": [],
+        "balanceProof": {
+          "chainId": "1338",
+          "tokenNetworkAddress": "0x0000000000000000000000000000000000020001",
+          "channelId": "17",
+          "nonce": "1",
+          "transferredAmount": "0",
+          "lockedAmount": "20",
+          "locksroot": "0x0000000000000000000000000000000000000020111111111111111111111111",
+          "additionalHash": "0x0000000000000000000000000000000000000020111111111111111111111111",
+          "signature": "0x0000000000000000000000000000000000000020111111111111111111111111000000000000000000000000000000000000002011111111111111111111111101"
+        },
+        "pendingWithdraws": [],
+        "nextNonce": "2"
+      }
+    },
+    "0x0000000000000000000000000000000000020003@0x0000000000000000000000000000000000020001": {
+      "state": "closed",
+      "id": 17,
+      "settleTimeout": 50,
+      "openBlock": 121,
+      "isFirstParticipant": true,
+      "closeBlock": 122,
+      "closeParticipant": "0x0000000000000000000000000000000000020003",
+      "tokenNetwork": "0x0000000000000000000000000000000000020001",
+      "token": "0x0000000000000000000000000000000000010001",
+      "own": {
+        "address": "0x11111111111111111111111111aaaaaaaaaaaaaa",
+        "deposit": "1000",
+        "withdraw": "0",
+        "locks": [],
+        "balanceProof": {
+          "chainId": "1338",
+          "tokenNetworkAddress": "0x0000000000000000000000000000000000020001",
+          "channelId": "17",
+          "nonce": "1",
+          "transferredAmount": "0",
+          "lockedAmount": "20",
+          "locksroot": "0x0000000000000000000000000000000000000020111111111111111111111111",
+          "additionalHash": "0x0000000000000000000000000000000000000020111111111111111111111111",
+          "signature": "0x0000000000000000000000000000000000000020111111111111111111111111000000000000000000000000000000000000002011111111111111111111111101"
+        },
+        "pendingWithdraws": [],
+        "nextNonce": "2"
+      },
+      "partner": {
+        "address": "0x0000000000000000000000000000000000020002",
+        "deposit": "80",
+        "withdraw": "0",
+        "locks": [],
+        "balanceProof": {
+          "chainId": "1338",
+          "tokenNetworkAddress": "0x0000000000000000000000000000000000020001",
+          "channelId": "17",
+          "nonce": "1",
+          "transferredAmount": "0",
+          "lockedAmount": "20",
+          "locksroot": "0x0000000000000000000000000000000000000020111111111111111111111111",
+          "additionalHash": "0x0000000000000000000000000000000000000020111111111111111111111111",
+          "signature": "0x0000000000000000000000000000000000000020111111111111111111111111000000000000000000000000000000000000002011111111111111111111111101"
+        },
+        "pendingWithdraws": [],
+        "nextNonce": "2"
+      }
+    }
+  },
+  "oldChannels": {
+    "13#0x0000000000000000000000000000000000020003@0x0000000000000000000000000000000000020001": {
+      "state": "settled",
+      "id": 13,
+      "settleTimeout": 50,
+      "openBlock": 71,
+      "isFirstParticipant": true,
+      "closeBlock": 93,
+      "settleBlock": 143,
+      "closeParticipant": "0x0000000000000000000000000000000000020003",
+      "tokenNetwork": "0x0000000000000000000000000000000000020001",
+      "token": "0x0000000000000000000000000000000000010001",
+      "own": {
+        "address": "0x11111111111111111111111111aaaaaaaaaaaaaa",
+        "deposit": "1000",
+        "withdraw": "0",
+        "locks": [],
+        "balanceProof": {
+          "chainId": "1338",
+          "tokenNetworkAddress": "0x0000000000000000000000000000000000020001",
+          "channelId": "17",
+          "nonce": "1",
+          "transferredAmount": "0",
+          "lockedAmount": "20",
+          "locksroot": "0x0000000000000000000000000000000000000020111111111111111111111111",
+          "additionalHash": "0x0000000000000000000000000000000000000020111111111111111111111111",
+          "signature": "0x0000000000000000000000000000000000000020111111111111111111111111000000000000000000000000000000000000002011111111111111111111111101"
+        },
+        "pendingWithdraws": [],
+        "nextNonce": "2"
+      },
+      "partner": {
+        "address": "0x0000000000000000000000000000000000020002",
+        "deposit": "80",
+        "withdraw": "0",
+        "locks": [],
+        "balanceProof": {
+          "chainId": "1338",
+          "tokenNetworkAddress": "0x0000000000000000000000000000000000020001",
+          "channelId": "17",
+          "nonce": "1",
+          "transferredAmount": "0",
+          "lockedAmount": "20",
+          "locksroot": "0x0000000000000000000000000000000000000020111111111111111111111111",
+          "additionalHash": "0x0000000000000000000000000000000000000020111111111111111111111111",
+          "signature": "0x0000000000000000000000000000000000000020111111111111111111111111000000000000000000000000000000000000002011111111111111111111111101"
+        },
+        "pendingWithdraws": [],
+        "nextNonce": "2"
+      }
+    }
+  },
+  "tokens": {
+    "0x0000000000000000000000000000000000010001": "0x0000000000000000000000000000000000020001"
+  },
+  "transport": {
+    "server": "https://matrix.raiden.test",
+    "setup": {
+      "userId": "@0x11111111111111111111111111aaaaaaaaaaaaaa:matrix.raiden.test",
+      "accessToken": "#access_token",
+      "deviceId": "!deviceId",
+      "displayName": "0x0000000000000000000000000000000000000020111111111111111111111111000000000000000000000000000000000000002011111111111111111111111101"
+    },
+    "rooms": { "0x0000000000000000000000000000000000020002": ["#roomId:matrix.raiden.test"] }
+  },
+  "sent": {
+    "0x0000000000000000000000000000000000000020111111111111111111111111": {
+      "partner": "0x2A915FDA69746F515b46C520eD511401d5CCD5e2",
+      "transfer": {
+        "type": "LockedTransfer",
+        "chain_id": "1338",
+        "message_identifier": "123456",
+        "payment_identifier": "1",
+        "nonce": "1",
+        "token_network_address": "0xe82ae5475589b828D3644e1B56546F93cD27d1a4",
+        "token": "0xc778417E063141139Fce010982780140Aa0cD5Ab",
+        "channel_identifier": "1338",
+        "transferred_amount": "0",
+        "locked_amount": "10",
+        "recipient": "0x2A915FDA69746F515b46C520eD511401d5CCD5e2",
+        "locksroot": "0x607e890c54e5ba67cd483bedae3ba9da9bf2ef2fbf237b9fb39a723b2296077b",
+        "lock": {
+          "amount": "10",
+          "expiration": "1",
+          "secrethash": "0x59cad5948673622c1d64e2322488bf01619f7ff45789741b15a9f782ce9290a8"
+        },
+        "target": "0x811957b07304d335B271feeBF46754696694b09e",
+        "initiator": "0x540B51eDc5900B8012091cc7c83caf2cb243aa86",
+        "metadata": {
+          "routes": [
+            {
+              "route": [
+                "0x2A915FDA69746F515b46C520eD511401d5CCD5e2",
+                "0x811957b07304d335B271feeBF46754696694b09e"
+              ]
+            }
+          ]
+        },
+        "signature": "0xa4beb47c2067e196de4cd9d5643d1c7af37caf4ac87de346e10ac27351505d405272f3d68960322bd53d1ea95460e4dd323dbef7c862fa6596444a57732ddb2b1c",
+        "ts": 990
+      },
+      "fee": "0",
+      "secret": { "value": "0x0000000000000000000000000000000000000020111111111111111111111111", "registerBlock": 122, "ts": 990 },
+      "transferProcessed": {
+        "type": "Processed",
+        "message_identifier": "123456",
+        "signature": "0xdc1647ec6cdd805d8d4af231c5d5b2105bda2e5c7e81b9a6314f37aef9e5db8e62c253189ddb9886201427e1908876aa68d7a3ec6c45aaa3b1de4587efc70a3f1c",
+        "ts": 991
+      },
+      "secretReveal": {
+        "type": "RevealSecret",
+        "message_identifier": "123454",
+        "secret": "0x3bc51dd335dda4f6aee24b3f88d88c5ee0b0d43aea4ed25a384531ce29fb062e",
+        "signature": "0x758eace7b5443a3afb5daf06eda3d2d024ca4d2cdbd0e72b36bcc9408d5bbf0d32153f53fc180c4145fd7b6b3038554484b9d3a56382b03bfed5f3ce01c5ea1b1b",
+        "ts": 992
+      },
+      "unlock": {
+        "type": "Unlock",
+        "chain_id": "337",
+        "message_identifier": "123457",
+        "payment_identifier": "1",
+        "secret": "0x3bc51dd335dda4f6aee24b3f88d88c5ee0b0d43aea4ed25a384531ce29fb062e",
+        "nonce": "1",
+        "token_network_address": "0xe82ae5475589b828D3644e1B56546F93cD27d1a4",
+        "channel_identifier": "1338",
+        "transferred_amount": "0",
+        "locked_amount": "10",
+        "locksroot": "0x607e890c54e5ba67cd483bedae3ba9da9bf2ef2fbf237b9fb39a723b2296077b",
+        "signature": "0xd153bbef8ca5462e62ba5dceda7929fc2ee7d866e983c033afe59e7f7958b8d80c734d5fba96028e8fb689300ca3c6a47764c0c0d6fbfffca9cf70729efb8e7e1c",
+        "ts": 993
+      },
+      "unlockProcessed": {
+        "type": "Processed",
+        "message_identifier": "123457",
+        "signature": "0xdc1647ec6cdd805d8d4af231c5d5b2105bda2e5c7e81b9a6314f37aef9e5db8e62c253189ddb9886201427e1908876aa68d7a3ec6c45aaa3b1de4587efc70a3f1c",
+        "ts": 994
+      }
+    }
+  },
+  "received": {},
+  "iou": {
+    "0x0000000000000000000000000000000000020001": {
+      "0x0000000000000000000000000000000000070002": {
+        "sender": "0x11111111111111111111111111aaaaaaaaaaaaaa",
+        "receiver": "0x0000000000000000000000000000000000070002",
+        "amount": "20",
+        "expiration_block": "132",
+        "one_to_n_address": "0x0000000000000000000000000000000000090002",
+        "chain_id": "1338",
+        "signature": "0xdc1647ec6cdd805d8d4af231c5d5b2105bda2e5c7e81b9a6314f37aef9e5db8e62c253189ddb9886201427e1908876aa68d7a3ec6c45aaa3b1de4587efc70a3f1c"
+      }
+    }
+  },
+  "pendingTxs": [{
+    "type": "channel/deposit/success",
+    "payload": {
+      "id": 17,
+      "participant": "0x11111111111111111111111111aaaaaaaaaaaaaa",
+      "totalDeposit": "100",
+      "txHash": "0x3bc51dd335dda4f6aee24b3f88d88c5ee0b0d43aea4ed25a384531ce29fb062e",
+      "txBlock": 123
+    },
+    "meta": {
+      "tokenNetwork": "0x0000000000000000000000000000000000020001",
+      "partner": "0x0000000000000000000000000000000000020002"
+    }
+  }]
+}

--- a/raiden-ts/tests/unit/states/6_min.json
+++ b/raiden-ts/tests/unit/states/6_min.json
@@ -1,0 +1,16 @@
+{
+  "address": "0x1111111111111111111111111111111111111111",
+  "version": 6,
+  "chainId": 1338,
+  "registry": "0x0000000000000000000000000000000000000070",
+  "blockNumber": 123,
+  "config": {},
+  "channels": {},
+  "oldChannels": {},
+  "tokens": {},
+  "transport": {},
+  "sent": {},
+  "received": {},
+  "iou": {},
+  "pendingTxs": []
+}

--- a/raiden-ts/tests/unit/utils.spec.ts
+++ b/raiden-ts/tests/unit/utils.spec.ts
@@ -163,13 +163,13 @@ describe('types', () => {
   });
 
   test('Timed', () => {
-    const TimedAddress = Timed(Address);
+    const TimedAddress = Timed(t.type({ address: Address }));
     type TimedAddress = t.TypeOf<typeof TimedAddress>;
 
     const address = '0x000000000000000000000000000000000004000A' as Address,
-      data: TimedAddress = timed(address);
+      data: TimedAddress = timed({ address });
     expect(TimedAddress.is(data)).toBe(true);
-    expect(TimedAddress.is(['invalid number', address])).toBe(false);
+    expect(TimedAddress.is({ address, ts: 'invalid number' })).toBe(false);
   });
 
   test('ErrorCodec', () => {

--- a/raiden-ts/tests/unit/utils.spec.ts
+++ b/raiden-ts/tests/unit/utils.spec.ts
@@ -132,8 +132,6 @@ describe('types', () => {
     const address = '0x000000000000000000000000000000000004000A',
       address2 = '0x00000000000000000000000000000000000300Aa';
 
-    const hexCodec = HexString(20);
-    const hexPred = jest.spyOn(hexCodec, 'is');
     const addrPred = jest.spyOn(Address, 'is');
 
     expect(Address.is(address)).toBe(true);
@@ -149,7 +147,6 @@ describe('types', () => {
     expect(address2decoded).not.toEqual(address2.toLowerCase());
 
     expect(addrPred).toHaveBeenCalledTimes(4);
-    expect(hexPred).toHaveBeenCalledTimes(5); // 'parent' codec was also checked, +1 for decode
 
     // narrow address to Address below
     if (!Address.is(address)) throw new Error('not an address');


### PR DESCRIPTION
Part of #2044

**Short description**
This change is purely internal, and shouldn't affect the user at all.
It improves some refined tipes inheritance (in order to properly identify them later) and convert the `timed` tuples (`[<timestamp>, <object>]`) to an extended object (`{ ...<object>, ts: number }`), which effectively extends the object (i.e. the resulting object is assignable to a variable of type of the original object) and can be properly described by a `json-schema` (for RxDB), while tuples can't on the json-schema subset supported by rxdb.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Tests cover the whole extend of these changes; migration and migration tests are also provided
