### PR TITLE
dApp: UDC deposit bug fixes

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+- [#2047] Conversion and token amount display in UDC deposit dialog
+
+### Added
+
+### Changed
+
+[#2047]: https://github.com/raiden-network/light-client/issues/2047
+
 ## [0.11.0] - 2020-08-04
 
 ### Fixed

--- a/raiden-dapp/src/components/AmountInput.vue
+++ b/raiden-dapp/src/components/AmountInput.vue
@@ -2,7 +2,6 @@
   <fieldset class="amount-input">
     <div class="amount-input__label">{{ label }}</div>
     <v-text-field
-      id="amount"
       ref="input"
       :class="{ invalid: !valid }"
       :disabled="disabled"

--- a/raiden-dapp/src/components/dialogs/UdcDepositDialog.vue
+++ b/raiden-dapp/src/components/dialogs/UdcDepositDialog.vue
@@ -8,7 +8,7 @@
         {{
           $t('udc-deposit-dialog.available-utility-token', {
             utilityTokenSymbol: udcToken.symbol,
-            utilityTokenBalance: mainAccountUtilityTokenAmount,
+            utilityTokenBalance: utilityTokenBalance,
           })
         }}
       </div>
@@ -95,6 +95,8 @@ import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
 import ErrorMessage from '@/components/ErrorMessage.vue';
 import Spinner from '@/components/icons/Spinner.vue';
 import { RaidenError } from 'raiden-ts';
+import Filters from '@/filters';
+import { BigNumber } from 'ethers/utils';
 
 @Component({
   components: {
@@ -113,10 +115,10 @@ export default class UdcDepositDialog extends Vue {
   uniswapURL: string = '';
   udcToken!: Token;
   defaultUtilityTokenAmount: string = '';
-  mainAccountUtilityTokenAmount: string = '';
   step: 'mint' | 'approve' | 'deposit' | '' = '';
   loading: boolean = false;
   error: Error | RaidenError | null = null;
+  displayFormat = Filters.displayFormat;
 
   @Prop({ required: true, type: Boolean })
   visible!: boolean;
@@ -124,6 +126,13 @@ export default class UdcDepositDialog extends Vue {
   @Emit()
   cancel() {
     this.error = null;
+  }
+
+  get utilityTokenBalance(): string {
+    return this.displayFormat(
+      this.udcToken.balance as BigNumber,
+      this.udcToken.decimals
+    );
   }
 
   get valid(): boolean {
@@ -140,14 +149,8 @@ export default class UdcDepositDialog extends Vue {
       mainAccountAddress: mainAccountAddress,
     }) as string;
 
-    const utilityTokenAmount = await this.$raiden.getTokenBalance(
-      this.udcToken.address
-    );
-
-    this.mainAccountUtilityTokenAmount = utilityTokenAmount;
-
     this.mainnet
-      ? (this.defaultUtilityTokenAmount = utilityTokenAmount)
+      ? (this.defaultUtilityTokenAmount = this.utilityTokenBalance)
       : (this.defaultUtilityTokenAmount = '10');
   }
 

--- a/raiden-dapp/src/components/dialogs/UdcDepositDialog.vue
+++ b/raiden-dapp/src/components/dialogs/UdcDepositDialog.vue
@@ -118,7 +118,6 @@ export default class UdcDepositDialog extends Vue {
   step: 'mint' | 'approve' | 'deposit' | '' = '';
   loading: boolean = false;
   error: Error | RaidenError | null = null;
-  displayFormat = Filters.displayFormat;
 
   @Prop({ required: true, type: Boolean })
   visible!: boolean;
@@ -129,7 +128,7 @@ export default class UdcDepositDialog extends Vue {
   }
 
   get utilityTokenBalance(): string {
-    return this.displayFormat(
+    return Filters.displayFormat(
       this.udcToken.balance as BigNumber,
       this.udcToken.decimals
     );

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -22,6 +22,7 @@ import i18n from '@/i18n';
 import { NotificationPayload } from '@/store/notifications/types';
 import { NotificationContext } from '@/store/notifications/notification-context';
 import { NotificationImportance } from '@/store/notifications/notification-importance';
+import uniq from 'lodash/uniq';
 
 export default class RaidenService {
   private _raiden?: Raiden;
@@ -144,7 +145,6 @@ export default class RaidenService {
         this.store.commit('account', account);
 
         this._userDepositTokenAddress = await raiden.userDepositTokenAddress();
-        await this.fetchTokenData([this._userDepositTokenAddress]);
         this.store.commit(
           'userDepositTokenAddress',
           this._userDepositTokenAddress
@@ -164,7 +164,11 @@ export default class RaidenService {
             filter((value) => value.type === 'block/new'),
             exhaustMap(() =>
               this.fetchTokenData(
-                this.store.getters.tokens.map((m: TokenModel) => m.address)
+                uniq(
+                  this.store.getters.tokens
+                    .map((m: TokenModel) => m.address)
+                    .concat(this._userDepositTokenAddress)
+                )
               )
             )
           )


### PR DESCRIPTION
Fixes #2047 

**Short description**
This PR makes sure that the utility token balance (as is before having been deposited) is updated in real-time in the dialog. It also converts its values.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to the dApp, visit the UDC and proceed to purchase and make a deposit of RDN or mint and make a deposit of SVT.
