### PR TITLE
0.11.0 -> v0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "light-client",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Raiden Light Client monorepo",
   "author": "brainbot labs est.",
   "private": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
       '@types/node': 14.0.27
       '@types/node-localstorage': 1.3.0
       '@types/yargs': 15.0.5
-      '@typescript-eslint/eslint-plugin': 3.8.0_10ba673673dc243503626141d5ea2938
-      '@typescript-eslint/parser': 3.8.0_eslint@7.6.0
+      '@typescript-eslint/eslint-plugin': 3.9.1_a41fa870346fc9d6bbe0c1287f584058
+      '@typescript-eslint/parser': 3.9.1_eslint@7.6.0+typescript@3.9.7
       eslint: 7.6.0
       eslint-config-prettier: 6.11.0_eslint@7.6.0
       eslint-plugin-import: 2.22.0_eslint@7.6.0
@@ -33,7 +33,7 @@ importers:
       node-pre-gyp: 0.15.0
       prettier: 2.0.5
       symbol-observable: 1.2.0
-      ts-loader: 8.0.2
+      ts-loader: 8.0.2_typescript@3.9.7
       typescript: 3.9.7
       webpack: 4.44.1_7d74d9f6ceb0e540c1e44d9709220c58
       webpack-cli: 3.3.12_webpack@4.44.1
@@ -45,8 +45,8 @@ importers:
       '@types/node': ^14.0.27
       '@types/node-localstorage': ^1.3.0
       '@types/yargs': ^15.0.5
-      '@typescript-eslint/eslint-plugin': ^3.8.0
-      '@typescript-eslint/parser': ^3.8.0
+      '@typescript-eslint/eslint-plugin': ^3.9.0
+      '@typescript-eslint/parser': ^3.9.0
       cors: ^2.8.5
       eslint: ^7.6.0
       eslint-config-prettier: ^6.11.0
@@ -77,7 +77,7 @@ importers:
       ethereum-blockies-base64: 1.0.2
       ethers: 4.0.47
       idb: 5.0.4
-      lodash: 4.17.19
+      lodash: 4.17.20
       loglevel: 1.6.8
       raiden-ts: 'link:../raiden-ts'
       register-service-worker: 1.7.1
@@ -86,10 +86,10 @@ importers:
       typeface-roboto: 0.0.75
       vue: 2.6.11
       vue-class-component: 7.2.5_vue@2.6.11
-      vue-i18n: 8.20.0
+      vue-i18n: 8.21.0
       vue-property-decorator: 9.0.0_ca358c81848ed432ed1021d8d24ee103
-      vue-qrcode-reader: 2.3.11
-      vue-router: 3.4.2
+      vue-qrcode-reader: 2.3.12
+      vue-router: 3.4.3
       vue-virtual-scroller: 1.0.10_vue@2.6.11
       vuetify: 2.3.8_vue@2.6.11
       vuex: 3.5.1_vue@2.6.11
@@ -99,30 +99,30 @@ importers:
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.10.4_@babel+core@7.11.1
       '@babel/plugin-proposal-optional-chaining': 7.11.0_@babel+core@7.11.1
       '@cypress/code-coverage': 3.8.1
-      '@cypress/webpack-preprocessor': 5.4.2_b8f14bfdfb441b4a899bfa2d9a8ffb44
+      '@cypress/webpack-preprocessor': 5.4.4_b8f14bfdfb441b4a899bfa2d9a8ffb44
       '@kazupon/vue-i18n-loader': 0.5.0
-      '@mdi/font': 5.4.55
+      '@mdi/font': 5.5.55
       '@namics/stylelint-bem': 6.3.1_stylelint@13.6.1
-      '@testing-library/jest-dom': 5.11.2
+      '@testing-library/jest-dom': 5.11.3
       '@types/jest': 26.0.9
       '@types/lodash': 4.14.159
       '@types/tiny-async-pool': 1.0.0
       '@types/vue-i18n': 7.0.0
       '@types/webpack': 4.41.21
-      '@typescript-eslint/eslint-plugin': 3.8.0_9195d7e59c976ef8295ee5e80b40ac89
-      '@typescript-eslint/parser': 3.8.0_eslint@7.6.0+typescript@3.9.7
-      '@vue/cli': 4.4.6_@babel+core@7.11.1
-      '@vue/cli-plugin-babel': 4.4.6_@vue+cli-service@4.4.6
-      '@vue/cli-plugin-e2e-cypress': 4.4.6_6c821a40f0a2d8835e16e5ebfd7b1ebf
-      '@vue/cli-plugin-eslint': 4.4.6_6c821a40f0a2d8835e16e5ebfd7b1ebf
-      '@vue/cli-plugin-pwa': 4.4.6_@vue+cli-service@4.4.6
-      '@vue/cli-plugin-router': 4.4.6_@vue+cli-service@4.4.6
-      '@vue/cli-plugin-typescript': 4.4.6_2cd7e791e65be4de82396ed67a9ebbf7
-      '@vue/cli-plugin-unit-jest': 4.4.6_eef3f0ce5d3e1ce88a26a2b548935028
-      '@vue/cli-plugin-vuex': 4.4.6_@vue+cli-service@4.4.6
-      '@vue/cli-service': 4.4.6_255d3d88478251a4aa4f1b8708a9639f
+      '@typescript-eslint/eslint-plugin': 3.9.1_a41fa870346fc9d6bbe0c1287f584058
+      '@typescript-eslint/parser': 3.9.1_eslint@7.6.0+typescript@3.9.7
+      '@vue/cli': 4.5.4
+      '@vue/cli-plugin-babel': 4.5.4_364fdb513435e8d82ece309724904eee
+      '@vue/cli-plugin-e2e-cypress': 4.5.4_511bab0d8ebb70591126cd2a4897c648
+      '@vue/cli-plugin-eslint': 4.5.4_511bab0d8ebb70591126cd2a4897c648
+      '@vue/cli-plugin-pwa': 4.5.4_@vue+cli-service@4.5.4
+      '@vue/cli-plugin-router': 4.5.4_@vue+cli-service@4.5.4
+      '@vue/cli-plugin-typescript': 4.5.4_4f7240ec1d501f44b76c18ad81851ebb
+      '@vue/cli-plugin-unit-jest': 4.5.4_2648f2e402f249480c628d640fa6fc32
+      '@vue/cli-plugin-vuex': 4.5.4_@vue+cli-service@4.5.4
+      '@vue/cli-service': 4.5.4_a4d969c3f98f98c5c04ee82d4e7ab0d6
       '@vue/eslint-config-prettier': 6.0.0_48457c35cef25e6674274a219f17ddc1
-      '@vue/eslint-config-typescript': 5.0.2_3f36a09e6f084b19821addb41bb8b921
+      '@vue/eslint-config-typescript': 5.0.2_bd76f009a7fcfa4e2222f197079d817e
       '@vue/test-utils': 1.0.3_d81dac297579cfd5597855dabf60f13b
       babel-core: 7.0.0-bridge.0_@babel+core@7.11.1
       babel-eslint: 10.1.0_eslint@7.6.0
@@ -132,24 +132,24 @@ importers:
       eslint: 7.6.0
       eslint-import-resolver-alias: 1.1.2_eslint-plugin-import@2.22.0
       eslint-plugin-import: 2.22.0_eslint@7.6.0
-      eslint-plugin-jsdoc: 30.2.1_eslint@7.6.0
+      eslint-plugin-jsdoc: 30.2.4_eslint@7.6.0
       eslint-plugin-prettier: 3.1.4_eslint@7.6.0
       eslint-plugin-vue: 6.2.2_eslint@7.6.0
       eslint-plugin-vue-i18n: 0.3.0_eslint@7.6.0
       eslint-plugin-vuetify: 1.0.0-beta.7_eslint@7.6.0+vuetify@2.3.8
       flush-promises: 1.0.2
-      jest: 26.2.2
+      jest: 26.4.0_canvas@2.6.1
       jest-junit: 11.1.0
       material-design-icons-iconfont: 5.0.1
       nyc: 15.1.0
       sass: 1.26.10
-      sass-loader: 9.0.3_webpack@4.44.1
+      sass-loader: 9.0.3_sass@1.26.10+webpack@4.44.1
       source-map-loader: 1.0.1_webpack@4.44.1
       stylelint: 13.6.1
       stylelint-config-recommended-scss: 4.2.0_10e17cd3bd594037572f86f9e2baa954
       stylelint-scss: 3.18.0_stylelint@13.6.1
       symbol-observable: 1.2.0
-      ts-jest: 26.1.4_jest@26.2.2+typescript@3.9.7
+      ts-jest: 26.2.0_jest@26.4.0+typescript@3.9.7
       tslib: 2.0.1
       typescript: 3.9.7
       vue-cli-plugin-i18n: 1.0.1
@@ -163,28 +163,28 @@ importers:
       '@babel/plugin-proposal-nullish-coalescing-operator': ^7.10.4
       '@babel/plugin-proposal-optional-chaining': ^7.11.0
       '@cypress/code-coverage': ^3.8.1
-      '@cypress/webpack-preprocessor': ^5.4.2
+      '@cypress/webpack-preprocessor': ^5.4.4
       '@kazupon/vue-i18n-loader': ^0.5.0
-      '@mdi/font': ^5.4.55
+      '@mdi/font': ^5.5.55
       '@namics/stylelint-bem': ^6.3.1
-      '@testing-library/jest-dom': ^5.11.2
+      '@testing-library/jest-dom': ^5.11.3
       '@types/jest': ^26.0.9
       '@types/lodash': ^4.14.159
       '@types/tiny-async-pool': ^1.0.0
       '@types/vue-i18n': ^7.0.0
       '@types/webpack': ^4.41.21
-      '@typescript-eslint/eslint-plugin': ^3.8.0
-      '@typescript-eslint/parser': ^3.8.0
-      '@vue/cli': ^4.4.6
-      '@vue/cli-plugin-babel': ^4.4.6
-      '@vue/cli-plugin-e2e-cypress': ^4.4.6
-      '@vue/cli-plugin-eslint': ^4.4.6
-      '@vue/cli-plugin-pwa': ^4.4.6
-      '@vue/cli-plugin-router': ^4.4.6
-      '@vue/cli-plugin-typescript': ^4.4.6
-      '@vue/cli-plugin-unit-jest': ^4.4.6
-      '@vue/cli-plugin-vuex': ^4.4.6
-      '@vue/cli-service': ^4.4.6
+      '@typescript-eslint/eslint-plugin': ^3.9.0
+      '@typescript-eslint/parser': ^3.9.0
+      '@vue/cli': ^4.5.3
+      '@vue/cli-plugin-babel': ^4.5.3
+      '@vue/cli-plugin-e2e-cypress': ^4.5.3
+      '@vue/cli-plugin-eslint': ^4.5.3
+      '@vue/cli-plugin-pwa': ^4.5.3
+      '@vue/cli-plugin-router': ^4.5.3
+      '@vue/cli-plugin-typescript': ^4.5.3
+      '@vue/cli-plugin-unit-jest': ^4.5.3
+      '@vue/cli-plugin-vuex': ^4.5.3
+      '@vue/cli-service': ^4.5.3
       '@vue/eslint-config-prettier': ^6.0.0
       '@vue/eslint-config-typescript': ^5.0.2
       '@vue/test-utils': ^1.0.3
@@ -197,7 +197,7 @@ importers:
       eslint: ^7.6.0
       eslint-import-resolver-alias: ^1.1.2
       eslint-plugin-import: ^2.22.0
-      eslint-plugin-jsdoc: ^30.2.1
+      eslint-plugin-jsdoc: ^30.2.2
       eslint-plugin-prettier: ^3.1.4
       eslint-plugin-vue: ^6.2.2
       eslint-plugin-vue-i18n: ^0.3.0
@@ -206,9 +206,9 @@ importers:
       ethers: ^4.0.47
       flush-promises: ^1.0.2
       idb: ^5.0.4
-      jest: ^26.2.2
+      jest: ^26.4.0
       jest-junit: ^11.1.0
-      lodash: ^4.17.19
+      lodash: ^4.17.20
       loglevel: ^1.6.8
       material-design-icons-iconfont: ^5.0.1
       nyc: ^15.1.0
@@ -223,7 +223,7 @@ importers:
       stylelint-scss: ^3.18.0
       symbol-observable: ^1.2.0
       tiny-async-pool: ^1.1.0
-      ts-jest: ^26.1.4
+      ts-jest: ^26.2.0
       tslib: ^2.0.1
       typeface-roboto: ^0.0.75
       typescript: ^3.9.7
@@ -231,11 +231,11 @@ importers:
       vue-class-component: ^7.2.5
       vue-cli-plugin-i18n: ^1.0.1
       vue-cli-plugin-vuetify: ^2.0.7
-      vue-i18n: ^8.20.0
+      vue-i18n: ^8.21.0
       vue-jest: ^3.0.6
       vue-property-decorator: ^9.0.0
-      vue-qrcode-reader: ^2.3.11
-      vue-router: ^3.4.2
+      vue-qrcode-reader: ^2.3.12
+      vue-router: ^3.4.3
       vue-template-compiler: ^2.6.11
       vue-virtual-scroller: ^1.0.10
       vuetify: ^2.3.8
@@ -250,7 +250,7 @@ importers:
       fp-ts: 2.7.1
       io-ts: 2.2.9_fp-ts@2.7.1
       isomorphic-fetch: 2.2.1
-      lodash: 4.17.19
+      lodash: 4.17.20
       loglevel: 1.6.8
       matrix-js-sdk: 8.0.0
       redux: 4.0.5
@@ -269,15 +269,15 @@ importers:
       '@types/node-localstorage': 1.3.0
       '@types/redux-logger': 3.0.8
       '@types/tiny-async-pool': 1.0.0
-      '@typescript-eslint/eslint-plugin': 3.8.0_ca0faf4066da35843277552e510770b3
-      '@typescript-eslint/parser': 3.8.0_eslint@7.5.0+typescript@3.9.7
+      '@typescript-eslint/eslint-plugin': 3.9.1_c966759c017b8c3f0ae352c464ebe3fe
+      '@typescript-eslint/parser': 3.9.1_eslint@7.5.0+typescript@3.9.7
       eslint: 7.5.0
       eslint-config-prettier: 6.11.0_eslint@7.5.0
       eslint-plugin-import: 2.22.0_eslint@7.5.0
-      eslint-plugin-jsdoc: 30.2.0_eslint@7.5.0
+      eslint-plugin-jsdoc: 30.2.4_eslint@7.5.0
       eslint-plugin-prettier: 3.1.4_eslint@7.5.0+prettier@2.0.5
       ganache-cli: 6.9.1
-      jest: 26.2.2
+      jest: 26.4.0
       jest-junit: 11.1.0
       memdown: 5.1.0
       node-localstorage: 2.1.6
@@ -287,10 +287,10 @@ importers:
       rxjs-marbles: 6.0.1_rxjs@6.6.2
       symbol-observable: 1.2.0
       tiny-async-pool: 1.1.0
-      ts-jest: 26.1.4_jest@26.2.2+typescript@3.9.7
+      ts-jest: 26.2.0_jest@26.4.0+typescript@3.9.7
       typechain: 2.0.0_typescript@3.9.7
-      typedoc: 0.17.8_typescript@3.9.7
-      typedoc-plugin-markdown: 2.3.1_typedoc@0.17.8
+      typedoc: 0.18.0_typescript@3.9.7
+      typedoc-plugin-markdown: 2.3.1_typedoc@0.18.0
       typescript: 3.9.7
       vuepress: 1.5.2
     specifiers:
@@ -304,22 +304,22 @@ importers:
       '@types/node-localstorage': ^1.3.0
       '@types/redux-logger': ^3.0.8
       '@types/tiny-async-pool': ^1.0.0
-      '@typescript-eslint/eslint-plugin': ^3.8.0
-      '@typescript-eslint/parser': ^3.8.0
+      '@typescript-eslint/eslint-plugin': ^3.9.0
+      '@typescript-eslint/parser': ^3.9.0
       abort-controller: ^3.0.0
       eslint: ^7.6.0
       eslint-config-prettier: ^6.11.0
       eslint-plugin-import: ^2.22.0
-      eslint-plugin-jsdoc: ^30.2.1
+      eslint-plugin-jsdoc: ^30.2.2
       eslint-plugin-prettier: ^3.1.4
       ethers: ^4.0.47
       fp-ts: ^2.8.1
       ganache-cli: ^6.10.1
       io-ts: ^2.2.9
       isomorphic-fetch: ^2.2.1
-      jest: ^26.2.2
+      jest: ^26.4.0
       jest-junit: ^11.1.0
-      lodash: ^4.17.19
+      lodash: ^4.17.20
       loglevel: ^1.6.8
       matrix-js-sdk: ^8.0.1
       memdown: ^5.1.0
@@ -334,9 +334,9 @@ importers:
       rxjs-marbles: ^6.0.1
       symbol-observable: ^1.2.0
       tiny-async-pool: ^1.1.0
-      ts-jest: ^26.1.4
+      ts-jest: ^26.2.0
       typechain: ^2.0.0
-      typedoc: ^0.17.8
+      typedoc: ^0.18.0
       typedoc-plugin-markdown: ^2.4.0
       typescript: ^3.9.7
       vuepress: ^1.5.3
@@ -351,6 +351,25 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-t4WmWoGV9gyzypwG3y3JlcK2t8fKLtvzBA7xEoFTj9SMPvOuLsf13uh4ikK0RRaaa9RPPWLgFUdOyIRaQvCpwQ==
+  /@ant-design-vue/babel-helper-vue-transform-on/1.0.1:
+    dev: true
+    resolution:
+      integrity: sha512-dOAPf/tCM2lCG8FhvOMFBaOdMElMEGhOoocMXEWvHW2l1KIex+UibDcq4bdBEJpDMLrnbNOqci9E7P2dARP6lg==
+  /@ant-design-vue/babel-plugin-jsx/1.0.0-rc.1_@babel+core@7.11.1:
+    dependencies:
+      '@ant-design-vue/babel-helper-vue-transform-on': 1.0.1
+      '@babel/helper-module-imports': 7.10.4
+      '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.11.1
+      '@babel/traverse': 7.11.0
+      '@babel/types': 7.11.0
+      camelcase: 6.0.0
+      html-tags: 3.1.0
+      svg-tags: 1.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': '*'
+    resolution:
+      integrity: sha512-x7PfAHSs5/emIuey1Df7Bh/vJU27S9KBdufzoAA7kgwTpEpY85R7CXD9gl6sJFB7aG2pZpl4Tmm+FsHlzgp7fA==
   /@apollo/federation/0.17.0_graphql@14.7.0:
     dependencies:
       apollo-graphql: 0.4.5_graphql@14.7.0
@@ -451,6 +470,14 @@ packages:
     dev: true
     resolution:
       integrity: sha512-mPVoWNzIpYJHbWje0if7Ck36bpbtTvIxOi9+6WSK9wjGEXearAqlwBoTQvVjsAY2VIwgcs8V940geY3okzRCEw==
+  /@babel/compat-data/7.11.0:
+    dependencies:
+      browserslist: 4.13.0
+      invariant: 2.2.4
+      semver: 5.7.1
+    dev: true
+    resolution:
+      integrity: sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==
   /@babel/core/7.10.5:
     dependencies:
       '@babel/code-frame': 7.10.4
@@ -543,9 +570,9 @@ packages:
       integrity: sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==
   /@babel/generator/7.10.4:
     dependencies:
-      '@babel/types': 7.10.4
+      '@babel/types': 7.11.0
       jsesc: 2.5.2
-      lodash: 4.17.19
+      lodash: 4.17.20
       source-map: 0.5.7
     dev: true
     resolution:
@@ -575,7 +602,7 @@ packages:
   /@babel/helper-builder-binary-assignment-operator-visitor/7.10.4:
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.10.4
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==
@@ -628,7 +655,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-replace-supers': 7.10.4
-      '@babel/helper-split-export-declaration': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -642,7 +669,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-replace-supers': 7.10.4
-      '@babel/helper-split-export-declaration': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -656,7 +683,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-replace-supers': 7.10.4
-      '@babel/helper-split-export-declaration': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -698,15 +725,15 @@ packages:
   /@babel/helper-define-map/7.10.5:
     dependencies:
       '@babel/helper-function-name': 7.10.4
-      '@babel/types': 7.10.5
-      lodash: 4.17.19
+      '@babel/types': 7.11.0
+      lodash: 4.17.20
     dev: true
     resolution:
       integrity: sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==
   /@babel/helper-explode-assignable-expression/7.10.4:
     dependencies:
-      '@babel/traverse': 7.10.5
-      '@babel/types': 7.10.5
+      '@babel/traverse': 7.11.0
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-4K71RyRQNPRrR85sr5QY4X3VwG4wtVoXZB9+L3r1Gp38DhELyHCtovqydRi7c1Ovb17eRGiQ/FD5s8JdU0Uy5A==
@@ -726,7 +753,7 @@ packages:
       integrity: sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
   /@babel/helper-hoist-variables/7.10.4:
     dependencies:
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==
@@ -778,7 +805,7 @@ packages:
       integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
   /@babel/helper-regex/7.10.5:
     dependencies:
-      lodash: 4.17.19
+      lodash: 4.17.20
     dev: true
     resolution:
       integrity: sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==
@@ -787,8 +814,8 @@ packages:
       '@babel/helper-annotate-as-pure': 7.10.4
       '@babel/helper-wrap-function': 7.10.4
       '@babel/template': 7.10.4
-      '@babel/traverse': 7.10.5
-      '@babel/types': 7.10.5
+      '@babel/traverse': 7.11.0
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-86Lsr6NNw3qTNl+TBcF1oRZMaVzJtbWTyTko+CQL/tvNvcGYEFKbLXDPxtW0HKk3McNOk4KzY55itGWCAGK5tg==
@@ -814,12 +841,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-0XIdiQln4Elglgjbwo9wuJpL/K7AGCY26kmEt0+pRP0TAj4jjyNq1MjoRvikrTVqKcx4Gysxt4cXvVFXP/JO2Q==
-  /@babel/helper-split-export-declaration/7.10.4:
-    dependencies:
-      '@babel/types': 7.10.5
-    dev: true
-    resolution:
-      integrity: sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==
   /@babel/helper-split-export-declaration/7.11.0:
     dependencies:
       '@babel/types': 7.11.0
@@ -834,8 +855,8 @@ packages:
     dependencies:
       '@babel/helper-function-name': 7.10.4
       '@babel/template': 7.10.4
-      '@babel/traverse': 7.10.5
-      '@babel/types': 7.10.5
+      '@babel/traverse': 7.11.0
+      '@babel/types': 7.11.0
     dev: true
     resolution:
       integrity: sha512-6py45WvEF0MhiLrdxtRjKjufwLL1/ob2qDJgg5JgNdojBAZSAKnAjkyOCNug6n+OBl4VW76XjvgSFTdaMcW0Ug==
@@ -950,6 +971,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-Sc5TAQSZuLzgY0664mMDn24Vw2P8g/VhyLyGPaWiHahhgLqeZvcGeyBZOrJW0oSKIK2mvQ22a1ENXBIQLhrEiQ==
+  /@babel/plugin-proposal-decorators/7.10.5_@babel+core@7.11.1:
+    dependencies:
+      '@babel/core': 7.11.1
+      '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.11.1
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-decorators': 7.10.4_@babel+core@7.11.1
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-Sc5TAQSZuLzgY0664mMDn24Vw2P8g/VhyLyGPaWiHahhgLqeZvcGeyBZOrJW0oSKIK2mvQ22a1ENXBIQLhrEiQ==
   /@babel/plugin-proposal-dynamic-import/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
@@ -970,6 +1002,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-up6oID1LeidOOASNXgv/CFbgBqTuKJ0cJjz6An5tWD+NVBNlp3VNSBxv2ZdU7SYl3NxJC7agAQDApZusV6uFwQ==
+  /@babel/plugin-proposal-export-namespace-from/7.10.4_@babel+core@7.11.1:
+    dependencies:
+      '@babel/core': 7.11.1
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.11.1
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-aNdf0LY6/3WXkhh0Fdb6Zk9j1NMD8ovj3F6r0+3j837Pn1S1PdNtcwJ5EG9WkVPNHPxyJDaxMaAOVq4eki0qbg==
   /@babel/plugin-proposal-json-strings/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
@@ -1000,6 +1042,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-fCL7QF0Jo83uy1K0P2YXrfX11tj3lkpN7l4dMv9Y9VkowkhkQDwFHFd8IiwyK5MZjE8UpbgokkgtcReH88Abaw==
+  /@babel/plugin-proposal-logical-assignment-operators/7.11.0_@babel+core@7.11.1:
+    dependencies:
+      '@babel/core': 7.11.1
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.11.1
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-/f8p4z+Auz0Uaf+i8Ekf1iM7wUNLcViFUGiPxKeXvxTSl63B875YPiVdUDdem7hREcI0E0kSpEhS8tF5RphK7Q==
   /@babel/plugin-proposal-nullish-coalescing-operator/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
@@ -1051,17 +1103,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==
-  /@babel/plugin-proposal-object-rest-spread/7.10.4_@babel+core@7.11.1:
-    dependencies:
-      '@babel/core': 7.11.1
-      '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.11.1
-      '@babel/plugin-transform-parameters': 7.10.5_@babel+core@7.11.1
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==
   /@babel/plugin-proposal-object-rest-spread/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1073,6 +1114,17 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==
+  /@babel/plugin-proposal-object-rest-spread/7.11.0_@babel+core@7.11.1:
+    dependencies:
+      '@babel/core': 7.11.1
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.11.1
+      '@babel/plugin-transform-parameters': 7.10.5_@babel+core@7.11.1
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==
   /@babel/plugin-proposal-object-rest-spread/7.3.2_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1118,16 +1170,6 @@ packages:
       '@babel/core': 7.10.5
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.10.5
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-ZIhQIEeavTgouyMSdZRap4VPPHqJJ3NEs2cuHs5p0erH+iz6khB0qfgU8g7UuJkG88+fBMy23ZiU+nuHvekJeQ==
-  /@babel/plugin-proposal-optional-chaining/7.10.4_@babel+core@7.11.1:
-    dependencies:
-      '@babel/core': 7.11.1
-      '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.11.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1227,9 +1269,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
-  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.10.5:
+  /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.11.1:
     dependencies:
-      '@babel/core': 7.10.5
+      '@babel/core': 7.11.1
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -1263,6 +1305,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-2NaoC6fAk2VMdhY1eerkfHV+lVYC1u8b+jmRJISqANCJlTxYy19HGdIkkQtix2UtkcPuPu+IlDgrVseZnU03bw==
+  /@babel/plugin-syntax-decorators/7.10.4_@babel+core@7.11.1:
+    dependencies:
+      '@babel/core': 7.11.1
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-2NaoC6fAk2VMdhY1eerkfHV+lVYC1u8b+jmRJISqANCJlTxYy19HGdIkkQtix2UtkcPuPu+IlDgrVseZnU03bw==
   /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
@@ -1281,18 +1332,27 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
-  /@babel/plugin-syntax-flow/7.10.4_@babel+core@7.10.5:
+  /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.11.1:
     dependencies:
-      '@babel/core': 7.10.5
+      '@babel/core': 7.11.1
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==
+  /@babel/plugin-syntax-flow/7.10.4_@babel+core@7.11.1:
+    dependencies:
+      '@babel/core': 7.11.1
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-yxQsX1dJixF4qEEdzVbst3SZQ58Nrooz8NV9Z9GL4byTE25BvJgl5lf0RECUf0fh28rZBb/RYTWn/eeKwCMrZQ==
-  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.10.5:
+  /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.11.1:
     dependencies:
-      '@babel/core': 7.10.5
+      '@babel/core': 7.11.1
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -1335,6 +1395,15 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==
+  /@babel/plugin-syntax-jsx/7.10.4_@babel+core@7.11.1:
+    dependencies:
+      '@babel/core': 7.11.1
+      '@babel/helper-plugin-utils': 7.10.4
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==
   /@babel/plugin-syntax-jsx/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -1344,9 +1413,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==
-  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.10.5:
+  /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.11.1:
     dependencies:
-      '@babel/core': 7.10.5
+      '@babel/core': 7.11.1
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -1479,9 +1548,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==
-  /@babel/plugin-syntax-typescript/7.10.4_@babel+core@7.10.5:
+  /@babel/plugin-syntax-typescript/7.10.4_@babel+core@7.11.1:
     dependencies:
-      '@babel/core': 7.10.5
+      '@babel/core': 7.11.1
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -1611,7 +1680,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-replace-supers': 7.10.4
-      '@babel/helper-split-export-declaration': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
       globals: 11.12.0
     dev: true
     peerDependencies:
@@ -1627,7 +1696,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-replace-supers': 7.10.4
-      '@babel/helper-split-export-declaration': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
       globals: 11.12.0
     dev: true
     peerDependencies:
@@ -1643,7 +1712,7 @@ packages:
       '@babel/helper-optimise-call-expression': 7.10.4
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-replace-supers': 7.10.4
-      '@babel/helper-split-export-declaration': 7.10.4
+      '@babel/helper-split-export-declaration': 7.11.0
       globals: 11.12.0
     dev: true
     peerDependencies:
@@ -1791,11 +1860,11 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-S5HgLVgkBcRdyQAHbKj+7KyuWx8C6t5oETmUuwz1pt3WTWJhsUV0WIIXuVvfXMxl/QQyHKlSCNNtaIamG8fysw==
-  /@babel/plugin-transform-flow-strip-types/7.10.4_@babel+core@7.10.5:
+  /@babel/plugin-transform-flow-strip-types/7.10.4_@babel+core@7.11.1:
     dependencies:
-      '@babel/core': 7.10.5
+      '@babel/core': 7.11.1
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-flow': 7.10.4_@babel+core@7.10.5
+      '@babel/plugin-syntax-flow': 7.10.4_@babel+core@7.11.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1915,7 +1984,7 @@ packages:
   /@babel/plugin-transform-modules-amd/7.10.5_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-module-transforms': 7.10.5
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
     dev: true
@@ -1926,7 +1995,7 @@ packages:
   /@babel/plugin-transform-modules-amd/7.10.5_@babel+core@7.11.1:
     dependencies:
       '@babel/core': 7.11.1
-      '@babel/helper-module-transforms': 7.10.5
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
     dev: true
@@ -1937,7 +2006,7 @@ packages:
   /@babel/plugin-transform-modules-amd/7.10.5_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
-      '@babel/helper-module-transforms': 7.10.5
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
     dev: true
@@ -1948,7 +2017,7 @@ packages:
   /@babel/plugin-transform-modules-commonjs/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-module-transforms': 7.10.5
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-simple-access': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
@@ -1960,7 +2029,7 @@ packages:
   /@babel/plugin-transform-modules-commonjs/7.10.4_@babel+core@7.11.1:
     dependencies:
       '@babel/core': 7.11.1
-      '@babel/helper-module-transforms': 7.10.5
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-simple-access': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
@@ -1972,7 +2041,7 @@ packages:
   /@babel/plugin-transform-modules-commonjs/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
-      '@babel/helper-module-transforms': 7.10.5
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/helper-simple-access': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
@@ -1985,7 +2054,7 @@ packages:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/helper-hoist-variables': 7.10.4
-      '@babel/helper-module-transforms': 7.10.5
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
     dev: true
@@ -1997,7 +2066,7 @@ packages:
     dependencies:
       '@babel/core': 7.11.1
       '@babel/helper-hoist-variables': 7.10.4
-      '@babel/helper-module-transforms': 7.10.5
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
     dev: true
@@ -2009,7 +2078,7 @@ packages:
     dependencies:
       '@babel/core': 7.4.5
       '@babel/helper-hoist-variables': 7.10.4
-      '@babel/helper-module-transforms': 7.10.5
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
     dev: true
@@ -2020,7 +2089,7 @@ packages:
   /@babel/plugin-transform-modules-umd/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
-      '@babel/helper-module-transforms': 7.10.5
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -2030,7 +2099,7 @@ packages:
   /@babel/plugin-transform-modules-umd/7.10.4_@babel+core@7.11.1:
     dependencies:
       '@babel/core': 7.11.1
-      '@babel/helper-module-transforms': 7.10.5
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -2040,7 +2109,7 @@ packages:
   /@babel/plugin-transform-modules-umd/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
-      '@babel/helper-module-transforms': 7.10.5
+      '@babel/helper-module-transforms': 7.11.0
       '@babel/helper-plugin-utils': 7.10.4
     dev: true
     peerDependencies:
@@ -2295,6 +2364,18 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tV4V/FjElJ9lQtyjr5xD2IFFbgY46r7EeVu5a8CpEKT5laheHKSlFeHjpkPppW3PqzGLAuv5k2qZX5LgVZIX5w==
+  /@babel/plugin-transform-runtime/7.11.0_@babel+core@7.11.1:
+    dependencies:
+      '@babel/core': 7.11.1
+      '@babel/helper-module-imports': 7.10.4
+      '@babel/helper-plugin-utils': 7.10.4
+      resolve: 1.17.0
+      semver: 5.7.1
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-LFEsP+t3wkYBlis8w6/kmnd6Kb1dxTd+wGJ8MlxTGzQo//ehtqlVL4S9DNUa53+dtPSQobN2CXx4d81FqC58cw==
   /@babel/plugin-transform-runtime/7.2.0_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -2343,15 +2424,6 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-1e/51G/Ni+7uH5gktbWv+eCED9pP8ZpRhZB3jOaI3mmzfvJTWHkuyYTv0Z5PYtyM+Tr2Ccr9kUdQxn60fI5WuQ==
-  /@babel/plugin-transform-spread/7.10.4_@babel+core@7.11.1:
-    dependencies:
-      '@babel/core': 7.11.1
-      '@babel/helper-plugin-utils': 7.10.4
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-1e/51G/Ni+7uH5gktbWv+eCED9pP8ZpRhZB3jOaI3mmzfvJTWHkuyYTv0Z5PYtyM+Tr2Ccr9kUdQxn60fI5WuQ==
   /@babel/plugin-transform-spread/7.10.4_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -2361,6 +2433,16 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-1e/51G/Ni+7uH5gktbWv+eCED9pP8ZpRhZB3jOaI3mmzfvJTWHkuyYTv0Z5PYtyM+Tr2Ccr9kUdQxn60fI5WuQ==
+  /@babel/plugin-transform-spread/7.11.0_@babel+core@7.11.1:
+    dependencies:
+      '@babel/core': 7.11.1
+      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-skip-transparent-expression-wrappers': 7.11.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==
   /@babel/plugin-transform-sticky-regex/7.10.4_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
@@ -2448,12 +2530,12 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-QqNgYwuuW0y0H+kUE/GWSR45t/ccRhe14Fs/4ZRouNNQsyd4o3PG4OtHiIrepbM2WKUBDAXKCAK/Lk4VhzTaGA==
-  /@babel/plugin-transform-typescript/7.10.5_@babel+core@7.10.5:
+  /@babel/plugin-transform-typescript/7.10.5_@babel+core@7.11.1:
     dependencies:
-      '@babel/core': 7.10.5
-      '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.10.5
+      '@babel/core': 7.11.1
+      '@babel/helper-create-class-features-plugin': 7.10.5_@babel+core@7.11.1
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-syntax-typescript': 7.10.4_@babel+core@7.10.5
+      '@babel/plugin-syntax-typescript': 7.10.4_@babel+core@7.11.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2579,9 +2661,9 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-tcmuQ6vupfMZPrLrc38d0sF2OjLT3/bZ0dry5HchNCQbrokoQi4reXqclvkkAT5b+gWc23meVWpve5P/7+w/zw==
-  /@babel/preset-env/7.10.4_@babel+core@7.11.1:
+  /@babel/preset-env/7.11.0_@babel+core@7.11.1:
     dependencies:
-      '@babel/compat-data': 7.10.5
+      '@babel/compat-data': 7.11.0
       '@babel/core': 7.11.1
       '@babel/helper-compilation-targets': 7.10.4_@babel+core@7.11.1
       '@babel/helper-module-imports': 7.10.4
@@ -2589,18 +2671,22 @@ packages:
       '@babel/plugin-proposal-async-generator-functions': 7.10.5_@babel+core@7.11.1
       '@babel/plugin-proposal-class-properties': 7.10.4_@babel+core@7.11.1
       '@babel/plugin-proposal-dynamic-import': 7.10.4_@babel+core@7.11.1
+      '@babel/plugin-proposal-export-namespace-from': 7.10.4_@babel+core@7.11.1
       '@babel/plugin-proposal-json-strings': 7.10.4_@babel+core@7.11.1
+      '@babel/plugin-proposal-logical-assignment-operators': 7.11.0_@babel+core@7.11.1
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.10.4_@babel+core@7.11.1
       '@babel/plugin-proposal-numeric-separator': 7.10.4_@babel+core@7.11.1
-      '@babel/plugin-proposal-object-rest-spread': 7.10.4_@babel+core@7.11.1
+      '@babel/plugin-proposal-object-rest-spread': 7.11.0_@babel+core@7.11.1
       '@babel/plugin-proposal-optional-catch-binding': 7.10.4_@babel+core@7.11.1
-      '@babel/plugin-proposal-optional-chaining': 7.10.4_@babel+core@7.11.1
+      '@babel/plugin-proposal-optional-chaining': 7.11.0_@babel+core@7.11.1
       '@babel/plugin-proposal-private-methods': 7.10.4_@babel+core@7.11.1
       '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.11.1
       '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.11.1
       '@babel/plugin-syntax-class-properties': 7.10.4_@babel+core@7.11.1
       '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.11.1
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3_@babel+core@7.11.1
       '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.11.1
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.11.1
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.11.1
       '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.11.1
       '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.11.1
@@ -2633,14 +2719,14 @@ packages:
       '@babel/plugin-transform-regenerator': 7.10.4_@babel+core@7.11.1
       '@babel/plugin-transform-reserved-words': 7.10.4_@babel+core@7.11.1
       '@babel/plugin-transform-shorthand-properties': 7.10.4_@babel+core@7.11.1
-      '@babel/plugin-transform-spread': 7.10.4_@babel+core@7.11.1
+      '@babel/plugin-transform-spread': 7.11.0_@babel+core@7.11.1
       '@babel/plugin-transform-sticky-regex': 7.10.4_@babel+core@7.11.1
       '@babel/plugin-transform-template-literals': 7.10.5_@babel+core@7.11.1
       '@babel/plugin-transform-typeof-symbol': 7.10.4_@babel+core@7.11.1
       '@babel/plugin-transform-unicode-escapes': 7.10.4_@babel+core@7.11.1
       '@babel/plugin-transform-unicode-regex': 7.10.4_@babel+core@7.11.1
       '@babel/preset-modules': 0.1.3_@babel+core@7.11.1
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
       browserslist: 4.13.0
       core-js-compat: 3.6.5
       invariant: 2.2.4
@@ -2650,7 +2736,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
-      integrity: sha512-tcmuQ6vupfMZPrLrc38d0sF2OjLT3/bZ0dry5HchNCQbrokoQi4reXqclvkkAT5b+gWc23meVWpve5P/7+w/zw==
+      integrity: sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==
   /@babel/preset-env/7.4.5_@babel+core@7.4.5:
     dependencies:
       '@babel/core': 7.4.5
@@ -2707,11 +2793,11 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-f2yNVXM+FsR5V8UwcFeIHzHWgnhXg3NpRmy0ADvALpnhB0SLbCvrCRr4BLOUYbQNLS+Z0Yer46x9dJXpXewI7w==
-  /@babel/preset-flow/7.10.4_@babel+core@7.10.5:
+  /@babel/preset-flow/7.10.4_@babel+core@7.11.1:
     dependencies:
-      '@babel/core': 7.10.5
+      '@babel/core': 7.11.1
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-transform-flow-strip-types': 7.10.4_@babel+core@7.10.5
+      '@babel/plugin-transform-flow-strip-types': 7.10.4_@babel+core@7.11.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2723,7 +2809,7 @@ packages:
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.10.5
       '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.10.5
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
       esutils: 2.0.3
     dev: true
     peerDependencies:
@@ -2736,7 +2822,7 @@ packages:
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-proposal-unicode-property-regex': 7.10.4_@babel+core@7.11.1
       '@babel/plugin-transform-dotall-regex': 7.10.4_@babel+core@7.11.1
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
       esutils: 2.0.3
     dev: true
     peerDependencies:
@@ -2756,21 +2842,21 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==
-  /@babel/preset-typescript/7.10.4_@babel+core@7.10.5:
+  /@babel/preset-typescript/7.10.4_@babel+core@7.11.1:
     dependencies:
-      '@babel/core': 7.10.5
+      '@babel/core': 7.11.1
       '@babel/helper-plugin-utils': 7.10.4
-      '@babel/plugin-transform-typescript': 7.10.5_@babel+core@7.10.5
+      '@babel/plugin-transform-typescript': 7.10.5_@babel+core@7.11.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-SdYnvGPv+bLlwkF2VkJnaX/ni1sMNetcGI1+nThF1gyv6Ph8Qucc4ZZAjM5yZcE/AKRXIOTZz7eSRDWOEjPyRQ==
-  /@babel/register/7.10.5_@babel+core@7.10.5:
+  /@babel/register/7.10.5_@babel+core@7.11.1:
     dependencies:
-      '@babel/core': 7.10.5
+      '@babel/core': 7.11.1
       find-cache-dir: 2.1.0
-      lodash: 4.17.19
+      lodash: 4.17.20
       make-dir: 2.1.0
       pirates: 4.0.1
       source-map-support: 0.5.19
@@ -2791,6 +2877,12 @@ packages:
       regenerator-runtime: 0.13.7
     resolution:
       integrity: sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==
+  /@babel/runtime/7.11.2:
+    dependencies:
+      regenerator-runtime: 0.13.7
+    dev: true
+    resolution:
+      integrity: sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
   /@babel/runtime/7.3.1:
     dependencies:
       regenerator-runtime: 0.12.1
@@ -2836,7 +2928,7 @@ packages:
   /@babel/types/7.10.4:
     dependencies:
       '@babel/helper-validator-identifier': 7.10.4
-      lodash: 4.17.19
+      lodash: 4.17.20
       to-fast-properties: 2.0.0
     dev: true
     resolution:
@@ -2921,7 +3013,7 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=
-  /@cypress/webpack-preprocessor/5.4.2_b8f14bfdfb441b4a899bfa2d9a8ffb44:
+  /@cypress/webpack-preprocessor/5.4.4_b8f14bfdfb441b4a899bfa2d9a8ffb44:
     dependencies:
       '@babel/core': 7.11.1
       babel-loader: 8.1.0_7e7526731d462686de4308c8ba1cfd85
@@ -2936,7 +3028,7 @@ packages:
       babel-loader: ^8.0.2
       webpack: ^4.18.1
     resolution:
-      integrity: sha512-ffydnj6mTVm83qc1p63dE2qxRkiIQNXxiHp2xyuVelwmksX+l0VSBxawYd/9Z99rInmqa583yUDPKk8IkCtmDg==
+      integrity: sha512-aNOS4J7vilVO6CgzYUnMCraZTCF+SvQtGTlG0HKdqbpI4+dzCWGRFpwpqiSsCb83m+WAP2gfuGQVaFTCM43JcA==
   /@cypress/xvfb/1.2.4:
     dependencies:
       debug: 3.2.6
@@ -2993,12 +3085,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
-  /@intervolga/optimize-cssnano-plugin/1.0.6_webpack@4.43.0:
+  /@intervolga/optimize-cssnano-plugin/1.0.6_webpack@4.44.1:
     dependencies:
       cssnano: 4.1.10
       cssnano-preset-default: 4.0.7
       postcss: 7.0.32
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     peerDependencies:
       webpack: ^4.0.0
@@ -3032,19 +3124,19 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==
-  /@jest/console/26.2.0:
+  /@jest/console/26.3.0:
     dependencies:
-      '@jest/types': 26.2.0
+      '@jest/types': 26.3.0
       '@types/node': 14.0.27
       chalk: 4.1.0
-      jest-message-util: 26.2.0
-      jest-util: 26.2.0
+      jest-message-util: 26.3.0
+      jest-util: 26.3.0
       slash: 3.0.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-mXQfx3nSLwiHm1i7jbu+uvi+vvpVjNGzIQYLCfsat9rapC+MJkS4zBseNrgJE0vU921b3P67bQzhduphjY3Tig==
+      integrity: sha512-/5Pn6sJev0nPUcAdpJHMVIsA8sKizL2ZkcKPE5+dJrCccks7tcM7c9wbgHudBJbxXLoTbqsHkG1Dofoem4F09w==
   /@jest/core/24.9.0:
     dependencies:
       '@jest/console': 24.9.0
@@ -3080,31 +3172,31 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-Fogg3s4wlAr1VX7q+rhV9RVnUv5tD7VuWfYy1+whMiWUrvl7U3QJSJyWcDio9Lq2prqYsZaeTv2Rz24pWGkJ2A==
-  /@jest/core/26.2.2:
+  /@jest/core/26.4.0:
     dependencies:
-      '@jest/console': 26.2.0
-      '@jest/reporters': 26.2.2
-      '@jest/test-result': 26.2.0
-      '@jest/transform': 26.2.2
-      '@jest/types': 26.2.0
+      '@jest/console': 26.3.0
+      '@jest/reporters': 26.4.0
+      '@jest/test-result': 26.3.0
+      '@jest/transform': 26.3.0
+      '@jest/types': 26.3.0
       '@types/node': 14.0.27
       ansi-escapes: 4.3.1
       chalk: 4.1.0
       exit: 0.1.2
       graceful-fs: 4.2.4
-      jest-changed-files: 26.2.0
-      jest-config: 26.2.2
-      jest-haste-map: 26.2.2
-      jest-message-util: 26.2.0
+      jest-changed-files: 26.3.0
+      jest-config: 26.4.0
+      jest-haste-map: 26.3.0
+      jest-message-util: 26.3.0
       jest-regex-util: 26.0.0
-      jest-resolve: 26.2.2_jest-resolve@26.2.2
-      jest-resolve-dependencies: 26.2.2
-      jest-runner: 26.2.2
-      jest-runtime: 26.2.2
-      jest-snapshot: 26.2.2
-      jest-util: 26.2.0
-      jest-validate: 26.2.0
-      jest-watcher: 26.2.0
+      jest-resolve: 26.4.0_jest-resolve@26.4.0
+      jest-resolve-dependencies: 26.4.0
+      jest-runner: 26.4.0
+      jest-runtime: 26.4.0
+      jest-snapshot: 26.4.0
+      jest-util: 26.3.0
+      jest-validate: 26.4.0
+      jest-watcher: 26.3.0
       micromatch: 4.0.2
       p-each-series: 2.1.0
       rimraf: 3.0.2
@@ -3113,8 +3205,47 @@ packages:
     dev: true
     engines:
       node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
     resolution:
-      integrity: sha512-UwA8gNI8aeV4FHGfGAUfO/DHjrFVvlBravF1Tm9Kt6qFE+6YHR47kFhgdepOFpADEKstyO+MVdPvkV6/dyt9sA==
+      integrity: sha512-mpXm4OjWQbz7qbzGIiSqvfNZ1FxX6ywWgLtdSD2luPORt5zKPtqcdDnX7L8RdfMaj1znDBgN2+gB094ZIr7vnA==
+  /@jest/core/26.4.0_canvas@2.6.1:
+    dependencies:
+      '@jest/console': 26.3.0
+      '@jest/reporters': 26.4.0
+      '@jest/test-result': 26.3.0
+      '@jest/transform': 26.3.0
+      '@jest/types': 26.3.0
+      '@types/node': 14.0.27
+      ansi-escapes: 4.3.1
+      chalk: 4.1.0
+      exit: 0.1.2
+      graceful-fs: 4.2.4
+      jest-changed-files: 26.3.0
+      jest-config: 26.4.0_canvas@2.6.1
+      jest-haste-map: 26.3.0
+      jest-message-util: 26.3.0
+      jest-regex-util: 26.0.0
+      jest-resolve: 26.4.0_jest-resolve@26.4.0
+      jest-resolve-dependencies: 26.4.0
+      jest-runner: 26.4.0_canvas@2.6.1
+      jest-runtime: 26.4.0
+      jest-snapshot: 26.4.0
+      jest-util: 26.3.0
+      jest-validate: 26.4.0
+      jest-watcher: 26.3.0
+      micromatch: 4.0.2
+      p-each-series: 2.1.0
+      rimraf: 3.0.2
+      slash: 3.0.0
+      strip-ansi: 6.0.0
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-mpXm4OjWQbz7qbzGIiSqvfNZ1FxX6ywWgLtdSD2luPORt5zKPtqcdDnX7L8RdfMaj1znDBgN2+gB094ZIr7vnA==
   /@jest/environment/24.9.0:
     dependencies:
       '@jest/fake-timers': 24.9.0
@@ -3126,17 +3257,17 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==
-  /@jest/environment/26.2.0:
+  /@jest/environment/26.3.0:
     dependencies:
-      '@jest/fake-timers': 26.2.0
-      '@jest/types': 26.2.0
+      '@jest/fake-timers': 26.3.0
+      '@jest/types': 26.3.0
       '@types/node': 14.0.27
-      jest-mock: 26.2.0
+      jest-mock: 26.3.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-oCgp9NmEiJ5rbq9VI/v/yYLDpladAAVvFxZgNsnJxOETuzPZ0ZcKKHYjKYwCtPOP1WCrM5nmyuOhMStXFGHn+g==
+      integrity: sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==
   /@jest/fake-timers/24.9.0:
     dependencies:
       '@jest/types': 24.9.0
@@ -3147,29 +3278,29 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==
-  /@jest/fake-timers/26.2.0:
+  /@jest/fake-timers/26.3.0:
     dependencies:
-      '@jest/types': 26.2.0
+      '@jest/types': 26.3.0
       '@sinonjs/fake-timers': 6.0.1
       '@types/node': 14.0.27
-      jest-message-util: 26.2.0
-      jest-mock: 26.2.0
-      jest-util: 26.2.0
+      jest-message-util: 26.3.0
+      jest-mock: 26.3.0
+      jest-util: 26.3.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-45Gfe7YzYTKqTayBrEdAF0qYyAsNRBzfkV0IyVUm3cx7AsCWlnjilBM4T40w7IXT5VspOgMPikQlV0M6gHwy/g==
-  /@jest/globals/26.2.0:
+      integrity: sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==
+  /@jest/globals/26.4.0:
     dependencies:
-      '@jest/environment': 26.2.0
-      '@jest/types': 26.2.0
-      expect: 26.2.0
+      '@jest/environment': 26.3.0
+      '@jest/types': 26.3.0
+      expect: 26.4.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-Hoc6ScEIPaym7RNytIL2ILSUWIGKlwEv+JNFof9dGYOdvPjb2evEURSslvCMkNuNg1ECEClTE8PH7ULlMJntYA==
+      integrity: sha512-QKwoVAeL9d0xaEM9ebPvfc+bolN04F+o3zM2jswGDBiiNjCogZ3LvOaqumRdDyz6kLmbx+UhgMBAVuLunbXZ2A==
   /@jest/reporters/24.9.0:
     dependencies:
       '@jest/environment': 24.9.0
@@ -3198,13 +3329,13 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-mu4X0yjaHrffOsWmVLzitKmmmWSQ3GGuefgNscUSWNiUNcEOSEQk9k3pERKEQVBb0Cnn88+UESIsZEMH3o88Gw==
-  /@jest/reporters/26.2.2:
+  /@jest/reporters/26.4.0:
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
-      '@jest/console': 26.2.0
-      '@jest/test-result': 26.2.0
-      '@jest/transform': 26.2.2
-      '@jest/types': 26.2.0
+      '@jest/console': 26.3.0
+      '@jest/test-result': 26.3.0
+      '@jest/transform': 26.3.0
+      '@jest/types': 26.3.0
       chalk: 4.1.0
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -3215,22 +3346,22 @@ packages:
       istanbul-lib-report: 3.0.0
       istanbul-lib-source-maps: 4.0.0
       istanbul-reports: 3.0.2
-      jest-haste-map: 26.2.2
-      jest-resolve: 26.2.2_jest-resolve@26.2.2
-      jest-util: 26.2.0
-      jest-worker: 26.2.1
+      jest-haste-map: 26.3.0
+      jest-resolve: 26.4.0_jest-resolve@26.4.0
+      jest-util: 26.3.0
+      jest-worker: 26.3.0
       slash: 3.0.0
       source-map: 0.6.1
       string-length: 4.0.1
       terminal-link: 2.1.1
-      v8-to-istanbul: 4.1.4
+      v8-to-istanbul: 5.0.1
     dev: true
     engines:
       node: '>= 10.14.2'
     optionalDependencies:
       node-notifier: 7.0.2
     resolution:
-      integrity: sha512-7854GPbdFTAorWVh+RNHyPO9waRIN6TcvCezKVxI1khvFq9YjINTW7J3WU+tbR038Ynn6WjYred6vtT0YmIWVQ==
+      integrity: sha512-14OPAAuYhgRBSNxAocVluX6ksdMdK/EuP9NmtBXU9g1uKaVBrPnohn/CVm6iMot1a9iU8BCxa5715YRf8FEg/A==
   /@jest/source-map/24.9.0:
     dependencies:
       callsites: 3.1.0
@@ -3241,7 +3372,7 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==
-  /@jest/source-map/26.1.0:
+  /@jest/source-map/26.3.0:
     dependencies:
       callsites: 3.1.0
       graceful-fs: 4.2.4
@@ -3250,7 +3381,7 @@ packages:
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-XYRPYx4eEVX15cMT9mstnO7hkHP3krNtKfxUYd8L7gbtia8JvZZ6bMzSwa6IQJENbudTwKMw5R1BePRD+bkEmA==
+      integrity: sha512-hWX5IHmMDWe1kyrKl7IhFwqOuAreIwHhbe44+XH2ZRHjrKIh0LO5eLQ/vxHFeAfRwJapmxuqlGAEYLadDq6ZGQ==
   /@jest/test-result/24.9.0:
     dependencies:
       '@jest/console': 24.9.0
@@ -3261,17 +3392,17 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==
-  /@jest/test-result/26.2.0:
+  /@jest/test-result/26.3.0:
     dependencies:
-      '@jest/console': 26.2.0
-      '@jest/types': 26.2.0
+      '@jest/console': 26.3.0
+      '@jest/types': 26.3.0
       '@types/istanbul-lib-coverage': 2.0.3
       collect-v8-coverage: 1.0.1
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-kgPlmcVafpmfyQEu36HClK+CWI6wIaAWDHNxfQtGuKsgoa2uQAYdlxjMDBEa3CvI40+2U3v36gQF6oZBkoKatw==
+      integrity: sha512-a8rbLqzW/q7HWheFVMtghXV79Xk+GWwOK1FrtimpI5n1la2SY0qHri3/b0/1F0Ve0/yJmV8pEhxDfVwiUBGtgg==
   /@jest/test-sequencer/24.9.0:
     dependencies:
       '@jest/test-result': 24.9.0
@@ -3283,21 +3414,37 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-6qqsU4o0kW1dvA95qfNog8v8gkRN9ph6Lz7r96IvZpHdNipP2cBcb07J1Z45mz/VIS01OHJ3pY8T5fUY38tg4A==
-  /@jest/test-sequencer/26.2.2:
+  /@jest/test-sequencer/26.4.0:
     dependencies:
-      '@jest/test-result': 26.2.0
+      '@jest/test-result': 26.3.0
       graceful-fs: 4.2.4
-      jest-haste-map: 26.2.2
-      jest-runner: 26.2.2
-      jest-runtime: 26.2.2
+      jest-haste-map: 26.3.0
+      jest-runner: 26.4.0
+      jest-runtime: 26.4.0
     dev: true
     engines:
       node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
     resolution:
-      integrity: sha512-SliZWon5LNqV/lVXkeowSU6L8++FGOu3f43T01L1Gv6wnFDP00ER0utV9jyK9dVNdXqfMNCN66sfcyar/o7BNw==
+      integrity: sha512-9Z7lCShS7vERp+DRwIVNH/6sHMWwJK1DPnGCpGeVLGJJWJ4Y08sQI3vIKdmKHu2KmwlUBpRM+BFf7NlVUkl5XA==
+  /@jest/test-sequencer/26.4.0_canvas@2.6.1:
+    dependencies:
+      '@jest/test-result': 26.3.0
+      graceful-fs: 4.2.4
+      jest-haste-map: 26.3.0
+      jest-runner: 26.4.0_canvas@2.6.1
+      jest-runtime: 26.4.0
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-9Z7lCShS7vERp+DRwIVNH/6sHMWwJK1DPnGCpGeVLGJJWJ4Y08sQI3vIKdmKHu2KmwlUBpRM+BFf7NlVUkl5XA==
   /@jest/transform/24.9.0:
     dependencies:
-      '@babel/core': 7.10.5
+      '@babel/core': 7.11.1
       '@jest/types': 24.9.0
       babel-plugin-istanbul: 5.2.0
       chalk: 2.4.2
@@ -3318,18 +3465,18 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==
-  /@jest/transform/26.2.2:
+  /@jest/transform/26.3.0:
     dependencies:
-      '@babel/core': 7.10.5
-      '@jest/types': 26.2.0
+      '@babel/core': 7.11.1
+      '@jest/types': 26.3.0
       babel-plugin-istanbul: 6.0.0
       chalk: 4.1.0
       convert-source-map: 1.7.0
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.4
-      jest-haste-map: 26.2.2
+      jest-haste-map: 26.3.0
       jest-regex-util: 26.0.0
-      jest-util: 26.2.0
+      jest-util: 26.3.0
       micromatch: 4.0.2
       pirates: 4.0.1
       slash: 3.0.0
@@ -3339,7 +3486,7 @@ packages:
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-c1snhvi5wRVre1XyoO3Eef5SEWpuBCH/cEbntBUd9tI5sNYiBDmO0My/lc5IuuGYKp/HFIHV1eZpSx5yjdkhKw==
+      integrity: sha512-Isj6NB68QorGoFWvcOjlUhpkT56PqNIsXKR7XfvoDlCANn/IANlh8DrKAA2l2JKC3yWSMH5wS0GwuQM20w3b2A==
   /@jest/types/24.9.0:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
@@ -3361,17 +3508,6 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
-  /@jest/types/26.1.0:
-    dependencies:
-      '@types/istanbul-lib-coverage': 2.0.3
-      '@types/istanbul-reports': 1.1.2
-      '@types/yargs': 15.0.5
-      chalk: 4.1.0
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    resolution:
-      integrity: sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==
   /@jest/types/26.2.0:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
@@ -3384,6 +3520,18 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-lvm3rJvctxd7+wxKSxxbzpDbr4FXDLaC57WEKdUIZ2cjTYuxYSc0zlyD7Z4Uqr5VdKxRUrtwIkiqBuvgf8uKJA==
+  /@jest/types/26.3.0:
+    dependencies:
+      '@types/istanbul-lib-coverage': 2.0.3
+      '@types/istanbul-reports': 3.0.0
+      '@types/node': 14.0.27
+      '@types/yargs': 15.0.5
+      chalk: 4.1.0
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    resolution:
+      integrity: sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==
   /@kazupon/vue-i18n-loader/0.5.0:
     dependencies:
       js-yaml: 3.14.0
@@ -3394,10 +3542,10 @@ packages:
       node: '>= 10'
     resolution:
       integrity: sha512-Tp2mXKemf9/RBhI9CW14JjR9oKjL2KH7tV6S0eKEjIBuQBAOFNuPJu3ouacmz9hgoXbNp+nusw3MVQmxZWFR9g==
-  /@mdi/font/5.4.55:
+  /@mdi/font/5.5.55:
     dev: true
     resolution:
-      integrity: sha512-M+Wdcs4nZ4/Kid949fcI0DsnvHtpE6pwk6Hv8YJZDp+Zne7ZtYdIN0z73cvcANkbyNnY3ncScULGMIceNd0xxQ==
+      integrity: sha512-xrVCXiRMz7ubB8mu6ehDhMADmGpLBsk3GWZccs39jWmhoTxatFnOvW8STJjqMGtePPNgGYYu/6m/AJVyMjBxnw==
   /@mrmlnc/readdir-enhanced/2.2.1:
     dependencies:
       call-me-maybe: 1.0.1
@@ -3573,7 +3721,7 @@ packages:
       '@oclif/command': 1.7.0
       cli-ux: 4.9.3
       fast-levenshtein: 2.0.6
-      lodash: 4.17.19
+      lodash: 4.17.20
     dev: true
     engines:
       node: '>=8.0.0'
@@ -3591,7 +3739,7 @@ packages:
       load-json-file: 5.3.0
       npm-run-path: 3.1.0
       semver: 7.3.2
-      tslib: 2.0.0
+      tslib: 2.0.1
       yarn: 1.22.4
     dev: true
     engines:
@@ -3695,12 +3843,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
-  /@soda/friendly-errors-webpack-plugin/1.7.1_webpack@4.43.0:
+  /@soda/friendly-errors-webpack-plugin/1.7.1_webpack@4.44.1:
     dependencies:
       chalk: 1.1.3
       error-stack-parser: 2.0.6
       string-width: 2.1.1
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     peerDependencies:
       webpack: ^2.0.0 || ^3.0.0 || ^4.0.0
@@ -3741,7 +3889,7 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
-  /@testing-library/jest-dom/5.11.2:
+  /@testing-library/jest-dom/5.11.3:
     dependencies:
       '@babel/runtime': 7.10.5
       '@types/testing-library__jest-dom': 5.9.1
@@ -3751,7 +3899,7 @@ packages:
       css.escape: 1.5.1
       jest-diff: 25.5.0
       jest-matcher-utils: 25.5.0
-      lodash: 4.17.19
+      lodash: 4.17.20
       redent: 3.0.0
     dev: true
     engines:
@@ -3759,7 +3907,7 @@ packages:
       npm: '>=6'
       yarn: '>=1'
     resolution:
-      integrity: sha512-s+rWJx+lanEGKqvOl4qJR0rGjCrxsEjj9qjxFlg4NV4/FRD7fnUUAWPHqwpyafNHfLYArs58FADgdn4UKmjFmw==
+      integrity: sha512-vP8ABJt4+YIzu9UItbpJ6nM5zN3g9/tpLcp2DJiXyfX9gnwgcmLsa42+YiohNGEtSUTsseb6xB9HAwlgk8WdaQ==
   /@typechain/ethers-v4/1.0.0_ethers@4.0.47+typechain@2.0.0:
     dependencies:
       ethers: 4.0.47
@@ -3776,7 +3924,7 @@ packages:
       integrity: sha512-wYxU3kp5zItbxKmeRYCEplS2MW7DzyBnxPGj+GJVHZEUZiK/nn5Ei1sUFgURDh+X051+zsGe28iud3oHjrYWQQ==
   /@types/accepts/1.3.5:
     dependencies:
-      '@types/node': 14.0.24
+      '@types/node': 14.0.27
     dev: true
     resolution:
       integrity: sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==
@@ -3786,7 +3934,7 @@ packages:
       integrity: sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
   /@types/babel__core/7.1.9:
     dependencies:
-      '@babel/parser': 7.11.0
+      '@babel/parser': 7.11.3
       '@babel/types': 7.11.0
       '@types/babel__generator': 7.6.1
       '@types/babel__template': 7.0.2
@@ -3802,7 +3950,7 @@ packages:
       integrity: sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==
   /@types/babel__template/7.0.2:
     dependencies:
-      '@babel/parser': 7.11.0
+      '@babel/parser': 7.11.3
       '@babel/types': 7.11.0
     dev: true
     resolution:
@@ -3823,6 +3971,13 @@ packages:
   /@types/color-name/1.1.1:
     resolution:
       integrity: sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+  /@types/connect-history-api-fallback/1.3.3:
+    dependencies:
+      '@types/express-serve-static-core': 4.17.9
+      '@types/node': 14.0.27
+    dev: true
+    resolution:
+      integrity: sha512-7SxFCd+FLlxCfwVwbyPxbR4khL9aNikJhrorw8nUIOqeuooc9gifBuDQOJw5kzN7i6i3vLn9G8Wde/4QDihpYw==
   /@types/connect/3.4.33:
     dependencies:
       '@types/node': 14.0.24
@@ -3836,18 +3991,22 @@ packages:
   /@types/cookies/0.7.4:
     dependencies:
       '@types/connect': 3.4.33
-      '@types/express': 4.17.4
+      '@types/express': 4.17.7
       '@types/keygrip': 1.0.2
-      '@types/node': 14.0.24
+      '@types/node': 14.0.27
     dev: true
     resolution:
       integrity: sha512-oTGtMzZZAVuEjTwCjIh8T8FrC8n/uwy+PG0yTvQcdZ7etoel7C7/3MSd7qrukENTgQtotG7gvBlBojuVs7X5rw==
   /@types/cors/2.8.6:
     dependencies:
-      '@types/express': 4.17.4
+      '@types/express': 4.17.7
     dev: true
     resolution:
       integrity: sha512-invOmosX0DqbpA+cE2yoHGUlF/blyf7nB0OGYBBiH27crcVm5NmFaZkLP4Ta1hGaesckCi5lVLlydNJCxkTOSg==
+  /@types/ejs/2.7.0:
+    dev: true
+    resolution:
+      integrity: sha512-kM2g9Fdk/du24fKuuQhA/LBleFR4Z4JP2MVKpLxQQSzofF1uJ06D+c05zfLDAkkDO55aEeNwJih0gHrE/Ci20A==
   /@types/eslint-visitor-keys/1.0.0:
     dev: true
     resolution:
@@ -3884,14 +4043,14 @@ packages:
       integrity: sha512-dCOT5lcmV/uC2J9k0rPafATeeyz+99xTt54ReX11/LObZgfzJqZNcW27zGhYyX+9iSEGXGt5qLPwRSvBZcLvtQ==
   /@types/fs-capacitor/2.0.0:
     dependencies:
-      '@types/node': 14.0.24
+      '@types/node': 14.0.27
     dev: true
     resolution:
       integrity: sha512-FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==
   /@types/glob/7.1.3:
     dependencies:
       '@types/minimatch': 3.0.3
-      '@types/node': 14.0.24
+      '@types/node': 14.0.27
     dev: true
     resolution:
       integrity: sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
@@ -3903,7 +4062,7 @@ packages:
       integrity: sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==
   /@types/graphql-upload/8.0.3:
     dependencies:
-      '@types/express': 4.17.4
+      '@types/express': 4.17.7
       '@types/fs-capacitor': 2.0.0
       '@types/koa': 2.11.3
       graphql: 14.7.0
@@ -3918,6 +4077,27 @@ packages:
     dev: false
     resolution:
       integrity: sha512-2aoSC4UUbHDj2uCsCxcG/vRMXey/m17bC7UwitVm5hn22nI8O8Y9iDpA76Orc+DWkQ4zZrOKEshCqR/jSuXAHA==
+  /@types/http-proxy-middleware/0.19.3:
+    dependencies:
+      '@types/connect': 3.4.33
+      '@types/http-proxy': 1.17.4
+      '@types/node': 14.0.27
+    dev: true
+    resolution:
+      integrity: sha512-lnBTx6HCOUeIJMLbI/LaL5EmdKLhczJY5oeXZpX/cXE4rRqb3RmV7VcMpiEfYkmTjipv3h7IAyIINe4plEv7cA==
+  /@types/http-proxy/1.17.4:
+    dependencies:
+      '@types/node': 14.0.27
+    dev: true
+    resolution:
+      integrity: sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==
+  /@types/inquirer/6.5.0:
+    dependencies:
+      '@types/through': 0.0.30
+      rxjs: 6.6.2
+    dev: true
+    resolution:
+      integrity: sha512-rjaYQ9b9y/VFGOpqBEXRavc3jh0a+e6evAbI31tMda8VlPaSy0AZJfXsvmIe3wklc7W6C3zCSfleuMXR7NOyXw==
   /@types/inquirer/7.3.0:
     dependencies:
       '@types/through': 0.0.30
@@ -3946,6 +4126,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
+  /@types/istanbul-reports/3.0.0:
+    dependencies:
+      '@types/istanbul-lib-report': 3.0.0
+    dev: true
+    resolution:
+      integrity: sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
   /@types/jest/24.9.1:
     dependencies:
       jest-diff: 24.9.0
@@ -3966,6 +4152,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-k4qFfJ5AUKrWok5KYXp2EPm89b0P/KZpl7Vg4XuOTVVQEhLDBDBU3iBFrjjdgd8fLw96aAtmnwhXHl63bWeBQQ==
+  /@types/jscodeshift/0.7.1:
+    dependencies:
+      ast-types: 0.12.1
+      recast: 0.17.2
+    dev: true
+    resolution:
+      integrity: sha512-4jkASx74qGl2OUK8NNFEq10QP0MXriOIqeBeNb1IdevHP8k8VDqS5Uv6nIixAA6ZUjjF6/SwOvecrjXkbcaFzw==
   /@types/json-schema/7.0.5:
     dev: true
     resolution:
@@ -3992,7 +4185,7 @@ packages:
       '@types/http-assert': 1.5.1
       '@types/keygrip': 1.0.2
       '@types/koa-compose': 3.2.5
-      '@types/node': 14.0.24
+      '@types/node': 14.0.27
     dev: true
     resolution:
       integrity: sha512-ABxVkrNWa4O/Jp24EYI/hRNqEVRlhB9g09p48neQp4m3xL1TJtdWk2NyNQSMCU45ejeELMQZBYyfstyVvO2H3Q==
@@ -4022,6 +4215,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==
+  /@types/mini-css-extract-plugin/0.9.1:
+    dependencies:
+      '@types/webpack': 4.41.21
+    dev: true
+    optional: true
+    resolution:
+      integrity: sha512-+mN04Oszdz9tGjUP/c1ReVwJXxSniLd7lF++sv+8dkABxVNthg6uccei+4ssKxRHGoMmPxdn7uBdJWONSJGTGQ==
   /@types/minimatch/3.0.3:
     dev: true
     resolution:
@@ -4044,7 +4244,7 @@ packages:
       integrity: sha512-2j5IKrgJpEP6xw/uiVb2Xfga0W0sSVD9JP9t7EZLvpBENdB0OKgcnoKS8IsjNeNnZ/86robdZ61Orl0QCFGOXg==
   /@types/node-fetch/2.5.7:
     dependencies:
-      '@types/node': 14.0.24
+      '@types/node': 14.0.27
       form-data: 3.0.0
     dev: true
     resolution:
@@ -4139,7 +4339,7 @@ packages:
       integrity: sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
   /@types/testing-library__jest-dom/5.9.1:
     dependencies:
-      '@types/jest': 26.0.8
+      '@types/jest': 26.0.9
     dev: true
     resolution:
       integrity: sha512-yYn5EKHO3MPEMSOrcAb1dLWY+68CG29LiXKsWmmpVHqoP5+ZRiAVLyUHvPNrO2dABDdUGZvavMsaGpWNjM6N2g==
@@ -4170,6 +4370,16 @@ packages:
     dev: true
     resolution:
       integrity: sha512-4e3EvN4k+B6eTq1qWDFW1wpzCgz+8nNCn6LAQTkcRoGJx9rVO5iYzyEogFTi9RwBJ588+Rx0nUwRFjKUYPe/BQ==
+  /@types/webpack-dev-server/3.11.0:
+    dependencies:
+      '@types/connect-history-api-fallback': 1.3.3
+      '@types/express': 4.17.7
+      '@types/http-proxy-middleware': 0.19.3
+      '@types/serve-static': 1.13.4
+      '@types/webpack': 4.41.21
+    dev: true
+    resolution:
+      integrity: sha512-3+86AgSzl18n5P1iUP9/lz3G3GMztCp+wxdDvVuNhx1sr1jE79GpYfKHL8k+Vht3N74K2n98CuAEw4YPJCYtDA==
   /@types/webpack-env/1.15.2:
     dev: true
     resolution:
@@ -4195,7 +4405,7 @@ packages:
       integrity: sha512-2j9WVnNrr/8PLAB5csW44xzQSJwS26aOnICsP3pSGCEdsu6KYtfQ6QJsVUKHWRnm1bL7HziJsfh5fHqth87yKA==
   /@types/ws/7.2.6:
     dependencies:
-      '@types/node': 14.0.24
+      '@types/node': 14.0.27
     dev: true
     resolution:
       integrity: sha512-Q07IrQUSNpr+cXU4E4LtkSIBPie5GLZyyMC1QtQYRLWz701+XcoVygGUZgvLqElq1nU4ICldMYPnexlBsg3dqQ==
@@ -4219,32 +4429,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
-  /@typescript-eslint/eslint-plugin/3.8.0_10ba673673dc243503626141d5ea2938:
+  /@typescript-eslint/eslint-plugin/3.9.1_a41fa870346fc9d6bbe0c1287f584058:
     dependencies:
-      '@typescript-eslint/experimental-utils': 3.8.0_eslint@7.6.0
-      '@typescript-eslint/parser': 3.8.0_eslint@7.6.0
-      debug: 4.1.1
-      eslint: 7.6.0
-      functional-red-black-tree: 1.0.1
-      regexpp: 3.1.0
-      semver: 7.3.2
-      tsutils: 3.17.1
-    dev: true
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      '@typescript-eslint/parser': ^3.0.0
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    resolution:
-      integrity: sha512-lFb4VCDleFSR+eo4Ew+HvrJ37ZH1Y9ZyE+qyP7EiwBpcCVxwmUc5PAqhShCQ8N8U5vqYydm74nss+a0wrrCErw==
-  /@typescript-eslint/eslint-plugin/3.8.0_9195d7e59c976ef8295ee5e80b40ac89:
-    dependencies:
-      '@typescript-eslint/experimental-utils': 3.8.0_eslint@7.6.0+typescript@3.9.7
-      '@typescript-eslint/parser': 3.8.0_eslint@7.6.0+typescript@3.9.7
+      '@typescript-eslint/experimental-utils': 3.9.1_eslint@7.6.0+typescript@3.9.7
+      '@typescript-eslint/parser': 3.9.1_eslint@7.6.0+typescript@3.9.7
       debug: 4.1.1
       eslint: 7.6.0
       functional-red-black-tree: 1.0.1
@@ -4263,11 +4451,11 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-lFb4VCDleFSR+eo4Ew+HvrJ37ZH1Y9ZyE+qyP7EiwBpcCVxwmUc5PAqhShCQ8N8U5vqYydm74nss+a0wrrCErw==
-  /@typescript-eslint/eslint-plugin/3.8.0_ca0faf4066da35843277552e510770b3:
+      integrity: sha512-XIr+Mfv7i4paEdBf0JFdIl9/tVxyj+rlilWIfZ97Be0lZ7hPvUbS5iHt9Glc8kRI53dsr0PcAEudbf8rO2wGgg==
+  /@typescript-eslint/eslint-plugin/3.9.1_c966759c017b8c3f0ae352c464ebe3fe:
     dependencies:
-      '@typescript-eslint/experimental-utils': 3.8.0_eslint@7.5.0+typescript@3.9.7
-      '@typescript-eslint/parser': 3.8.0_eslint@7.5.0+typescript@3.9.7
+      '@typescript-eslint/experimental-utils': 3.9.1_eslint@7.5.0+typescript@3.9.7
+      '@typescript-eslint/parser': 3.9.1_eslint@7.5.0+typescript@3.9.7
       debug: 4.1.1
       eslint: 7.5.0
       functional-red-black-tree: 1.0.1
@@ -4286,12 +4474,12 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-lFb4VCDleFSR+eo4Ew+HvrJ37ZH1Y9ZyE+qyP7EiwBpcCVxwmUc5PAqhShCQ8N8U5vqYydm74nss+a0wrrCErw==
-  /@typescript-eslint/experimental-utils/3.8.0_eslint@7.5.0+typescript@3.9.7:
+      integrity: sha512-XIr+Mfv7i4paEdBf0JFdIl9/tVxyj+rlilWIfZ97Be0lZ7hPvUbS5iHt9Glc8kRI53dsr0PcAEudbf8rO2wGgg==
+  /@typescript-eslint/experimental-utils/3.9.1_eslint@7.5.0+typescript@3.9.7:
     dependencies:
       '@types/json-schema': 7.0.5
-      '@typescript-eslint/types': 3.8.0
-      '@typescript-eslint/typescript-estree': 3.8.0_typescript@3.9.7
+      '@typescript-eslint/types': 3.9.1
+      '@typescript-eslint/typescript-estree': 3.9.1_typescript@3.9.7
       eslint: 7.5.0
       eslint-scope: 5.1.0
       eslint-utils: 2.1.0
@@ -4302,28 +4490,12 @@ packages:
       eslint: '*'
       typescript: '*'
     resolution:
-      integrity: sha512-o8T1blo1lAJE0QDsW7nSyvZHbiDzQDjINJKyB44Z3sSL39qBy5L10ScI/XwDtaiunoyKGLiY9bzRk4YjsUZl8w==
-  /@typescript-eslint/experimental-utils/3.8.0_eslint@7.6.0:
+      integrity: sha512-lkiZ8iBBaYoyEKhCkkw4SAeatXyBq9Ece5bZXdLe1LWBUwTszGbmbiqmQbwWA8cSYDnjWXp9eDbXpf9Sn0hLAg==
+  /@typescript-eslint/experimental-utils/3.9.1_eslint@7.6.0+typescript@3.9.7:
     dependencies:
       '@types/json-schema': 7.0.5
-      '@typescript-eslint/types': 3.8.0
-      '@typescript-eslint/typescript-estree': 3.8.0
-      eslint: 7.6.0
-      eslint-scope: 5.1.0
-      eslint-utils: 2.1.0
-    dev: true
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      eslint: '*'
-      typescript: '*'
-    resolution:
-      integrity: sha512-o8T1blo1lAJE0QDsW7nSyvZHbiDzQDjINJKyB44Z3sSL39qBy5L10ScI/XwDtaiunoyKGLiY9bzRk4YjsUZl8w==
-  /@typescript-eslint/experimental-utils/3.8.0_eslint@7.6.0+typescript@3.9.7:
-    dependencies:
-      '@types/json-schema': 7.0.5
-      '@typescript-eslint/types': 3.8.0
-      '@typescript-eslint/typescript-estree': 3.8.0_typescript@3.9.7
+      '@typescript-eslint/types': 3.9.1
+      '@typescript-eslint/typescript-estree': 3.9.1_typescript@3.9.7
       eslint: 7.6.0
       eslint-scope: 5.1.0
       eslint-utils: 2.1.0
@@ -4335,13 +4507,13 @@ packages:
       eslint: '*'
       typescript: '*'
     resolution:
-      integrity: sha512-o8T1blo1lAJE0QDsW7nSyvZHbiDzQDjINJKyB44Z3sSL39qBy5L10ScI/XwDtaiunoyKGLiY9bzRk4YjsUZl8w==
-  /@typescript-eslint/parser/3.8.0_eslint@7.5.0+typescript@3.9.7:
+      integrity: sha512-lkiZ8iBBaYoyEKhCkkw4SAeatXyBq9Ece5bZXdLe1LWBUwTszGbmbiqmQbwWA8cSYDnjWXp9eDbXpf9Sn0hLAg==
+  /@typescript-eslint/parser/3.9.1_eslint@7.5.0+typescript@3.9.7:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 3.8.0_eslint@7.5.0+typescript@3.9.7
-      '@typescript-eslint/types': 3.8.0
-      '@typescript-eslint/typescript-estree': 3.8.0_typescript@3.9.7
+      '@typescript-eslint/experimental-utils': 3.9.1_eslint@7.5.0+typescript@3.9.7
+      '@typescript-eslint/types': 3.9.1
+      '@typescript-eslint/typescript-estree': 3.9.1_typescript@3.9.7
       eslint: 7.5.0
       eslint-visitor-keys: 1.3.0
       typescript: 3.9.7
@@ -4355,32 +4527,13 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-u5vjOBaCsnMVQOvkKCXAmmOhyyMmFFf5dbkM3TIbg3MZ2pyv5peE4gj81UAbTHwTOXEwf7eCQTUMKrDl/+qGnA==
-  /@typescript-eslint/parser/3.8.0_eslint@7.6.0:
+      integrity: sha512-y5QvPFUn4Vl4qM40lI+pNWhTcOWtpZAJ8pOEQ21fTTW4xTJkRplMjMRje7LYTXqVKKX9GJhcyweMz2+W1J5bMg==
+  /@typescript-eslint/parser/3.9.1_eslint@7.6.0+typescript@3.9.7:
     dependencies:
       '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 3.8.0_eslint@7.6.0
-      '@typescript-eslint/types': 3.8.0
-      '@typescript-eslint/typescript-estree': 3.8.0
-      eslint: 7.6.0
-      eslint-visitor-keys: 1.3.0
-    dev: true
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0 || ^7.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    resolution:
-      integrity: sha512-u5vjOBaCsnMVQOvkKCXAmmOhyyMmFFf5dbkM3TIbg3MZ2pyv5peE4gj81UAbTHwTOXEwf7eCQTUMKrDl/+qGnA==
-  /@typescript-eslint/parser/3.8.0_eslint@7.6.0+typescript@3.9.7:
-    dependencies:
-      '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 3.8.0_eslint@7.6.0+typescript@3.9.7
-      '@typescript-eslint/types': 3.8.0
-      '@typescript-eslint/typescript-estree': 3.8.0_typescript@3.9.7
+      '@typescript-eslint/experimental-utils': 3.9.1_eslint@7.6.0+typescript@3.9.7
+      '@typescript-eslint/types': 3.9.1
+      '@typescript-eslint/typescript-estree': 3.9.1_typescript@3.9.7
       eslint: 7.6.0
       eslint-visitor-keys: 1.3.0
       typescript: 3.9.7
@@ -4394,41 +4547,21 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-u5vjOBaCsnMVQOvkKCXAmmOhyyMmFFf5dbkM3TIbg3MZ2pyv5peE4gj81UAbTHwTOXEwf7eCQTUMKrDl/+qGnA==
-  /@typescript-eslint/types/3.8.0:
+      integrity: sha512-y5QvPFUn4Vl4qM40lI+pNWhTcOWtpZAJ8pOEQ21fTTW4xTJkRplMjMRje7LYTXqVKKX9GJhcyweMz2+W1J5bMg==
+  /@typescript-eslint/types/3.9.1:
     dev: true
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
-      integrity: sha512-8kROmEQkv6ss9kdQ44vCN1dTrgu4Qxrd2kXr10kz2NP5T8/7JnEfYNxCpPkArbLIhhkGLZV3aVMplH1RXQRF7Q==
-  /@typescript-eslint/typescript-estree/3.8.0:
+      integrity: sha512-15JcTlNQE1BsYy5NBhctnEhEoctjXOjOK+Q+rk8ugC+WXU9rAcS2BYhoh6X4rOaXJEpIYDl+p7ix+A5U0BqPTw==
+  /@typescript-eslint/typescript-estree/3.9.1_typescript@3.9.7:
     dependencies:
-      '@typescript-eslint/types': 3.8.0
-      '@typescript-eslint/visitor-keys': 3.8.0
+      '@typescript-eslint/types': 3.9.1
+      '@typescript-eslint/visitor-keys': 3.9.1
       debug: 4.1.1
       glob: 7.1.6
       is-glob: 4.0.1
-      lodash: 4.17.19
-      semver: 7.3.2
-      tsutils: 3.17.1
-    dev: true
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    resolution:
-      integrity: sha512-MTv9nPDhlKfclwnplRNDL44mP2SY96YmPGxmMbMy6x12I+pERcxpIUht7DXZaj4mOKKtet53wYYXU0ABaiXrLw==
-  /@typescript-eslint/typescript-estree/3.8.0_typescript@3.9.7:
-    dependencies:
-      '@typescript-eslint/types': 3.8.0
-      '@typescript-eslint/visitor-keys': 3.8.0
-      debug: 4.1.1
-      glob: 7.1.6
-      is-glob: 4.0.1
-      lodash: 4.17.19
+      lodash: 4.17.20
       semver: 7.3.2
       tsutils: 3.17.1_typescript@3.9.7
       typescript: 3.9.7
@@ -4441,15 +4574,15 @@ packages:
       typescript:
         optional: true
     resolution:
-      integrity: sha512-MTv9nPDhlKfclwnplRNDL44mP2SY96YmPGxmMbMy6x12I+pERcxpIUht7DXZaj4mOKKtet53wYYXU0ABaiXrLw==
-  /@typescript-eslint/visitor-keys/3.8.0:
+      integrity: sha512-IqM0gfGxOmIKPhiHW/iyAEXwSVqMmR2wJ9uXHNdFpqVvPaQ3dWg302vW127sBpAiqM9SfHhyS40NKLsoMpN2KA==
+  /@typescript-eslint/visitor-keys/3.9.1:
     dependencies:
       eslint-visitor-keys: 1.3.0
     dev: true
     engines:
       node: ^8.10.0 || ^10.13.0 || >=11.10.1
     resolution:
-      integrity: sha512-gfqQWyVPpT9NpLREXNR820AYwgz+Kr1GuF3nf1wxpHD6hdxI62tq03ToomFnDxY0m3pUB39IF7sil7D5TQexLA==
+      integrity: sha512-zxdtUjeoSh+prCpogswMwVUJfEFmCOjdzK9rpNjNBfm6EyPt99x3RrJoBOGZO23FCt0WPKUCOL5mb/9D5LjdwQ==
   /@vue/babel-helper-vue-jsx-merge-props/1.0.0:
     dev: true
     resolution:
@@ -4459,6 +4592,20 @@ packages:
       '@babel/core': 7.10.5
       '@babel/helper-module-imports': 7.10.4
       '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.10.5
+      '@vue/babel-helper-vue-jsx-merge-props': 1.0.0
+      html-tags: 2.0.0
+      lodash.kebabcase: 4.1.1
+      svg-tags: 1.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-YfdaoSMvD1nj7+DsrwfTvTnhDXI7bsuh+Y5qWwvQXlD24uLgnsoww3qbiZvWf/EoviZMrvqkqN4CBw0W3BWUTQ==
+  /@vue/babel-plugin-transform-vue-jsx/1.1.2_@babel+core@7.11.1:
+    dependencies:
+      '@babel/core': 7.11.1
+      '@babel/helper-module-imports': 7.10.4
+      '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.11.1
       '@vue/babel-helper-vue-jsx-merge-props': 1.0.0
       html-tags: 2.0.0
       lodash.kebabcase: 4.1.1
@@ -4491,6 +4638,35 @@ packages:
         optional: true
     resolution:
       integrity: sha512-urIa6Qk3lKacLvscrzxMNyYlTqKFcPAUo5MohOjv1ISZ9PssHw693WTOrqSC0XksdMLtp/rnLvc6l5G8Muk0lw==
+  /@vue/babel-preset-app/4.5.4_vue@2.6.11:
+    dependencies:
+      '@ant-design-vue/babel-plugin-jsx': 1.0.0-rc.1_@babel+core@7.11.1
+      '@babel/core': 7.11.1
+      '@babel/helper-compilation-targets': 7.10.4_@babel+core@7.11.1
+      '@babel/helper-module-imports': 7.10.4
+      '@babel/plugin-proposal-class-properties': 7.10.4_@babel+core@7.11.1
+      '@babel/plugin-proposal-decorators': 7.10.5_@babel+core@7.11.1
+      '@babel/plugin-syntax-dynamic-import': 7.8.3_@babel+core@7.11.1
+      '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.11.1
+      '@babel/plugin-transform-runtime': 7.11.0_@babel+core@7.11.1
+      '@babel/preset-env': 7.11.0_@babel+core@7.11.1
+      '@babel/runtime': 7.11.2
+      '@vue/babel-preset-jsx': 1.1.2_@babel+core@7.11.1
+      babel-plugin-dynamic-import-node: 2.3.3
+      core-js: 3.6.5
+      core-js-compat: 3.6.5
+      semver: 6.3.0
+      vue: 2.6.11
+    dev: true
+    peerDependencies:
+      vue: ^2 || ^3.0.0-0
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+      vue:
+        optional: true
+    resolution:
+      integrity: sha512-a+2s/lL3fE3h9/ekvpMVLhZTDjR3xt+jnpTwuQtEZ3KIuzFHxbmwAjueRZh6BKEGfB6kgZ3KqZHFX3vx/DRJ4w==
   /@vue/babel-preset-jsx/1.1.2_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
@@ -4505,6 +4681,20 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-zDpVnFpeC9YXmvGIDSsKNdL7qCG2rA3gjywLYHPCKDT10erjxF4U+6ay9X6TW5fl4GsDlJp9bVfAVQAAVzxxvQ==
+  /@vue/babel-preset-jsx/1.1.2_@babel+core@7.11.1:
+    dependencies:
+      '@babel/core': 7.11.1
+      '@vue/babel-helper-vue-jsx-merge-props': 1.0.0
+      '@vue/babel-plugin-transform-vue-jsx': 1.1.2_@babel+core@7.11.1
+      '@vue/babel-sugar-functional-vue': 1.1.2_@babel+core@7.11.1
+      '@vue/babel-sugar-inject-h': 1.1.2_@babel+core@7.11.1
+      '@vue/babel-sugar-v-model': 1.1.2_@babel+core@7.11.1
+      '@vue/babel-sugar-v-on': 1.1.2_@babel+core@7.11.1
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-zDpVnFpeC9YXmvGIDSsKNdL7qCG2rA3gjywLYHPCKDT10erjxF4U+6ay9X6TW5fl4GsDlJp9bVfAVQAAVzxxvQ==
   /@vue/babel-sugar-functional-vue/1.1.2_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
@@ -4514,10 +4704,28 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-YhmdJQSVEFF5ETJXzrMpj0nkCXEa39TvVxJTuVjzvP2rgKhdMmQzlJuMv/HpadhZaRVMCCF3AEjjJcK5q/cYzQ==
+  /@vue/babel-sugar-functional-vue/1.1.2_@babel+core@7.11.1:
+    dependencies:
+      '@babel/core': 7.11.1
+      '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.11.1
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-YhmdJQSVEFF5ETJXzrMpj0nkCXEa39TvVxJTuVjzvP2rgKhdMmQzlJuMv/HpadhZaRVMCCF3AEjjJcK5q/cYzQ==
   /@vue/babel-sugar-inject-h/1.1.2_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
       '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.10.5
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-VRSENdTvD5htpnVp7i7DNuChR5rVMcORdXjvv5HVvpdKHzDZAYiLSD+GhnhxLm3/dMuk8pSzV+k28ECkiN5m8w==
+  /@vue/babel-sugar-inject-h/1.1.2_@babel+core@7.11.1:
+    dependencies:
+      '@babel/core': 7.11.1
+      '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.11.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -4537,6 +4745,20 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-vLXPvNq8vDtt0u9LqFdpGM9W9IWDmCmCyJXuozlq4F4UYVleXJ2Fa+3JsnTZNJcG+pLjjfnEGHci2339Kj5sGg==
+  /@vue/babel-sugar-v-model/1.1.2_@babel+core@7.11.1:
+    dependencies:
+      '@babel/core': 7.11.1
+      '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.11.1
+      '@vue/babel-helper-vue-jsx-merge-props': 1.0.0
+      '@vue/babel-plugin-transform-vue-jsx': 1.1.2_@babel+core@7.11.1
+      camelcase: 5.3.1
+      html-tags: 2.0.0
+      svg-tags: 1.0.0
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-vLXPvNq8vDtt0u9LqFdpGM9W9IWDmCmCyJXuozlq4F4UYVleXJ2Fa+3JsnTZNJcG+pLjjfnEGHci2339Kj5sGg==
   /@vue/babel-sugar-v-on/1.1.2_@babel+core@7.10.5:
     dependencies:
       '@babel/core': 7.10.5
@@ -4548,29 +4770,41 @@ packages:
       '@babel/core': ^7.0.0-0
     resolution:
       integrity: sha512-T8ZCwC8Jp2uRtcZ88YwZtZXe7eQrJcfRq0uTFy6ShbwYJyz5qWskRFoVsdTi9o0WEhmQXxhQUewodOSCUPVmsQ==
-  /@vue/cli-overlay/4.4.6:
+  /@vue/babel-sugar-v-on/1.1.2_@babel+core@7.11.1:
+    dependencies:
+      '@babel/core': 7.11.1
+      '@babel/plugin-syntax-jsx': 7.10.4_@babel+core@7.11.1
+      '@vue/babel-plugin-transform-vue-jsx': 1.1.2_@babel+core@7.11.1
+      camelcase: 5.3.1
+    dev: true
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    resolution:
+      integrity: sha512-T8ZCwC8Jp2uRtcZ88YwZtZXe7eQrJcfRq0uTFy6ShbwYJyz5qWskRFoVsdTi9o0WEhmQXxhQUewodOSCUPVmsQ==
+  /@vue/cli-overlay/4.5.4:
     dev: true
     resolution:
-      integrity: sha512-fzjg2gWQt+jw5fyLsD9HZNxGNQgZjLDI2s9bLWJwRucdfmncSi9neqA0TZyszGrgcJA4Qu4V5KgV0qwVSBYCaw==
-  /@vue/cli-plugin-babel/4.4.6_@vue+cli-service@4.4.6:
+      integrity: sha512-nthli1n7rXaqaMZsH0KNdFqeYJxDOQNeaobp9SjeSdrpD1xAj/B0+RJMWQWIFsfdQn1AQP1UVMnkfdakTiLgxA==
+  /@vue/cli-plugin-babel/4.5.4_364fdb513435e8d82ece309724904eee:
     dependencies:
-      '@babel/core': 7.10.5
-      '@vue/babel-preset-app': 4.4.6
-      '@vue/cli-service': 4.4.6_255d3d88478251a4aa4f1b8708a9639f
-      '@vue/cli-shared-utils': 4.4.6
-      babel-loader: 8.1.0_13c776b87d2822e76e5e552d0872621e
-      cache-loader: 4.1.0_webpack@4.43.0
-      thread-loader: 2.1.3_webpack@4.43.0
-      webpack: 4.43.0_webpack@4.43.0
+      '@babel/core': 7.11.1
+      '@vue/babel-preset-app': 4.5.4_vue@2.6.11
+      '@vue/cli-service': 4.5.4_a4d969c3f98f98c5c04ee82d4e7ab0d6
+      '@vue/cli-shared-utils': 4.5.4
+      babel-loader: 8.1.0_7e7526731d462686de4308c8ba1cfd85
+      cache-loader: 4.1.0_webpack@4.44.1
+      thread-loader: 2.1.3_webpack@4.44.1
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
+      vue: '*'
     resolution:
-      integrity: sha512-9cX9mN+4DIbcqw3rV6UBOA0t5zikIkrBLQloUzsOBOu5Xb7/UoD7inInFj7bnyHUflr5LqbdWJ+etCQcWAIIXA==
-  /@vue/cli-plugin-e2e-cypress/4.4.6_6c821a40f0a2d8835e16e5ebfd7b1ebf:
+      integrity: sha512-pXEzj/vkl3qOs/brhgxAu37hULCOHcOLzYKF747r1oudJq0aV1TOnQzTrP8aCE/A1CnW4Dbw/l9bt20a7btDcg==
+  /@vue/cli-plugin-e2e-cypress/4.5.4_511bab0d8ebb70591126cd2a4897c648:
     dependencies:
-      '@vue/cli-service': 4.4.6_255d3d88478251a4aa4f1b8708a9639f
-      '@vue/cli-shared-utils': 4.4.6
+      '@vue/cli-service': 4.5.4_a4d969c3f98f98c5c04ee82d4e7ab0d6
+      '@vue/cli-shared-utils': 4.5.4
       cypress: 3.8.3
       eslint-plugin-cypress: 2.11.1_eslint@7.6.0
     dev: true
@@ -4578,72 +4812,78 @@ packages:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
       eslint: '*'
     resolution:
-      integrity: sha512-bB+5cfJYjAcBNOt3BDztkrdN4zPRL68R7uMDnspbGJnKOhX/mxB+alK7J0zG5PviePbIU/ilBxw5u948A4PsXw==
-  /@vue/cli-plugin-eslint/4.4.6_6c821a40f0a2d8835e16e5ebfd7b1ebf:
+      integrity: sha512-ijmxqnfaHlXOYC2i5rA65z8INUIvJNA8WsBDDRFDuXKefpwIAxAPhEWwsEieVr8hzpDNt3ehN+LmV9sL7OwoZQ==
+  /@vue/cli-plugin-eslint/4.5.4_511bab0d8ebb70591126cd2a4897c648:
     dependencies:
-      '@vue/cli-service': 4.4.6_255d3d88478251a4aa4f1b8708a9639f
-      '@vue/cli-shared-utils': 4.4.6
+      '@vue/cli-service': 4.5.4_a4d969c3f98f98c5c04ee82d4e7ab0d6
+      '@vue/cli-shared-utils': 4.5.4
       eslint: 7.6.0
-      eslint-loader: 2.2.1_eslint@7.6.0+webpack@4.43.0
+      eslint-loader: 2.2.1_eslint@7.6.0+webpack@4.44.1
       globby: 9.2.0
       inquirer: 7.3.3
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
       yorkie: 2.0.0
     dev: true
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
       eslint: '>= 1.6.0'
     resolution:
-      integrity: sha512-3a9rVpOKPQsDgAlRkhmBMHboGobivG/47BbQGE66Z8YJxrgF/AWikP3Jy67SmxtszRkyiWfw4aJFRV9r3MzffQ==
-  /@vue/cli-plugin-pwa/4.4.6_@vue+cli-service@4.4.6:
+      integrity: sha512-mWuhKtxMiAM70nPW/NnoWtf32YJoOPPt7SyNmsAjBKSRPcje+16Egl7BD8yuPKoF1MTkvs5CM/e7gp3AnSTFzQ==
+  /@vue/cli-plugin-pwa/4.5.4_@vue+cli-service@4.5.4:
     dependencies:
-      '@vue/cli-service': 4.4.6_255d3d88478251a4aa4f1b8708a9639f
-      '@vue/cli-shared-utils': 4.4.6
-      webpack: 4.43.0_webpack@4.43.0
-      workbox-webpack-plugin: 4.3.1_webpack@4.43.0
+      '@vue/cli-service': 4.5.4_a4d969c3f98f98c5c04ee82d4e7ab0d6
+      '@vue/cli-shared-utils': 4.5.4
+      webpack: 4.44.1_webpack@4.44.1
+      workbox-webpack-plugin: 4.3.1_webpack@4.44.1
     dev: true
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
     resolution:
-      integrity: sha512-TbYKZ60phCdVFiamvaGrIDTKJA0068WJ1i8FiKNEgQaXdGEFCWII3KK4QTIEwgXSNtgY+m2hYx7mZB/y5/9/RA==
-  /@vue/cli-plugin-router/4.4.6_@vue+cli-service@4.4.6:
+      integrity: sha512-bJ3L3MWg9opjFnEfagZHP9GDmwS3mT0NG7DxBYUYyu/ELyQy6p2y+Zz4anuGwIDISJRY9jnU5/hRy9+Psyz7ew==
+  /@vue/cli-plugin-router/4.5.4_@vue+cli-service@4.5.4:
     dependencies:
-      '@vue/cli-service': 4.4.6_255d3d88478251a4aa4f1b8708a9639f
-      '@vue/cli-shared-utils': 4.4.6
+      '@vue/cli-service': 4.5.4_a4d969c3f98f98c5c04ee82d4e7ab0d6
+      '@vue/cli-shared-utils': 4.5.4
     dev: true
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
     resolution:
-      integrity: sha512-TkLdn0ZYo3zgn78Rk8doPlR+4UkGjGW2R1eGEaZEkue/mw2VhUWtTk9cKLZaYrw0eY8Ro/j+OV6mD+scyrairg==
-  /@vue/cli-plugin-typescript/4.4.6_2cd7e791e65be4de82396ed67a9ebbf7:
+      integrity: sha512-9/qRICZbq1qucq9M9z6jYT5UWNvcTu9BgHtXgsaK9gJsdmpxDIfD0SvW9nzZaHb8xxixvDRotMM/0Juw2oCsKQ==
+  /@vue/cli-plugin-typescript/4.5.4_4f7240ec1d501f44b76c18ad81851ebb:
     dependencies:
       '@types/webpack-env': 1.15.2
-      '@vue/cli-service': 4.4.6_255d3d88478251a4aa4f1b8708a9639f
-      '@vue/cli-shared-utils': 4.4.6
-      cache-loader: 4.1.0_webpack@4.43.0
+      '@vue/cli-service': 4.5.4_a4d969c3f98f98c5c04ee82d4e7ab0d6
+      '@vue/cli-shared-utils': 4.5.4
+      cache-loader: 4.1.0_webpack@4.44.1
       fork-ts-checker-webpack-plugin: 3.1.1
       globby: 9.2.0
-      thread-loader: 2.1.3_webpack@4.43.0
+      thread-loader: 2.1.3_webpack@4.44.1
       ts-loader: 6.2.2_typescript@3.9.7
       tslint: 5.20.1_typescript@3.9.7
       typescript: 3.9.7
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
       yorkie: 2.0.0
     dev: true
+    optionalDependencies:
+      fork-ts-checker-webpack-plugin-v5: /fork-ts-checker-webpack-plugin/5.1.0
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
+      '@vue/compiler-sfc': ^3.0.0-beta.14
       typescript: '>=2'
+    peerDependenciesMeta:
+      '@vue/compiler-sfc':
+        optional: true
     resolution:
-      integrity: sha512-FIIx9yqm19M62+2X4QwTrnlePdghsKnFbBPCHJawx3ULx30B11fL7X0uwmcq+kEAAHwAGBI6QyU7dgwPDRUCOw==
-  /@vue/cli-plugin-unit-jest/4.4.6_eef3f0ce5d3e1ce88a26a2b548935028:
+      integrity: sha512-+EKeZZTc65S+6IjsQECCxDqp8mnvnHZAavXkO+osm/tOHnwezTD5jXGzCfmpEuoncGkO2e6xQGFht5ZHPZAKnA==
+  /@vue/cli-plugin-unit-jest/4.5.4_2648f2e402f249480c628d640fa6fc32:
     dependencies:
-      '@babel/core': 7.10.5
-      '@babel/plugin-transform-modules-commonjs': 7.10.4_@babel+core@7.10.5
+      '@babel/core': 7.11.1
+      '@babel/plugin-transform-modules-commonjs': 7.10.4_@babel+core@7.11.1
       '@types/jest': 24.9.1
-      '@vue/cli-service': 4.4.6_255d3d88478251a4aa4f1b8708a9639f
-      '@vue/cli-shared-utils': 4.4.6
-      babel-core: 7.0.0-bridge.0_@babel+core@7.10.5
-      babel-jest: 24.9.0_@babel+core@7.10.5
+      '@vue/cli-service': 4.5.4_a4d969c3f98f98c5c04ee82d4e7ab0d6
+      '@vue/cli-shared-utils': 4.5.4
+      babel-core: 7.0.0-bridge.0_@babel+core@7.11.1
+      babel-jest: 24.9.0_@babel+core@7.11.1
       babel-plugin-transform-es2015-modules-commonjs: 6.26.2
       deepmerge: 4.2.2
       jest: 24.9.0
@@ -4660,77 +4900,83 @@ packages:
       vue: '*'
       vue-template-compiler: '*'
     resolution:
-      integrity: sha512-TwvCZV03JgXLSdc1UaD+Fjt3ooeX0gvRH2bUy58uuEx3qyk7xYx7vRM4uyJ51XZs9l4SEcegwtOlBga6lc6okA==
-  /@vue/cli-plugin-vuex/4.4.6_@vue+cli-service@4.4.6:
+      integrity: sha512-ben2WsKvEEN0r96nOWsarwelNVRrC7dUZtbnXVzRKYrxfiGL9evbbdIMdNcqN7MP0lAWnn8zrH5ruEhRuhMw4A==
+  /@vue/cli-plugin-vuex/4.5.4_@vue+cli-service@4.5.4:
     dependencies:
-      '@vue/cli-service': 4.4.6_255d3d88478251a4aa4f1b8708a9639f
+      '@vue/cli-service': 4.5.4_a4d969c3f98f98c5c04ee82d4e7ab0d6
     dev: true
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
     resolution:
-      integrity: sha512-Ho0YzUivn8BLPqFoFypntR8CMTEXYYHVr0GdnZW99XL+DbGw75f+tJfnrV9UFHDTfvZt7uewKiXDMlrzQ0l3Ug==
-  /@vue/cli-service/4.4.6_255d3d88478251a4aa4f1b8708a9639f:
+      integrity: sha512-X/F4E/dIRdiogKCdO4VGjUy5f4Fbxs7mu/gSi6Ubltle0eNE+tbBgLPH4r2g7GmHKNph4k39ikvfOMpXZcTFZg==
+  /@vue/cli-service/4.5.4_a4d969c3f98f98c5c04ee82d4e7ab0d6:
     dependencies:
-      '@intervolga/optimize-cssnano-plugin': 1.0.6_webpack@4.43.0
-      '@soda/friendly-errors-webpack-plugin': 1.7.1_webpack@4.43.0
+      '@intervolga/optimize-cssnano-plugin': 1.0.6_webpack@4.44.1
+      '@soda/friendly-errors-webpack-plugin': 1.7.1_webpack@4.44.1
       '@soda/get-current-script': 1.0.2
-      '@vue/cli-overlay': 4.4.6
-      '@vue/cli-plugin-router': 4.4.6_@vue+cli-service@4.4.6
-      '@vue/cli-plugin-vuex': 4.4.6_@vue+cli-service@4.4.6
-      '@vue/cli-shared-utils': 4.4.6
+      '@types/minimist': 1.2.0
+      '@types/webpack': 4.41.21
+      '@types/webpack-dev-server': 3.11.0
+      '@vue/cli-overlay': 4.5.4
+      '@vue/cli-plugin-router': 4.5.4_@vue+cli-service@4.5.4
+      '@vue/cli-plugin-vuex': 4.5.4_@vue+cli-service@4.5.4
+      '@vue/cli-shared-utils': 4.5.4
       '@vue/component-compiler-utils': 3.2.0
-      '@vue/preload-webpack-plugin': 1.1.2_4bdb23e17c1669cd6b8d9492b9e85ea2
+      '@vue/preload-webpack-plugin': 1.1.2_5ff516492094d25eb46611af254fac10
       '@vue/web-component-wrapper': 1.2.0
-      acorn: 7.3.1
+      acorn: 7.4.0
       acorn-walk: 7.2.0
       address: 1.1.2
-      autoprefixer: 9.8.5
+      autoprefixer: 9.8.6
       browserslist: 4.13.0
-      cache-loader: 4.1.0_webpack@4.43.0
+      cache-loader: 4.1.0_webpack@4.44.1
       case-sensitive-paths-webpack-plugin: 2.3.0
       cli-highlight: 2.1.4
       clipboardy: 2.3.0
       cliui: 6.0.0
-      copy-webpack-plugin: 5.1.1_webpack@4.43.0
-      css-loader: 3.6.0_webpack@4.43.0
+      copy-webpack-plugin: 5.1.1_webpack@4.44.1
+      css-loader: 3.6.0_webpack@4.44.1
       cssnano: 4.1.10
       debug: 4.1.1
       default-gateway: 5.0.5
       dotenv: 8.2.0
       dotenv-expand: 5.1.0
-      file-loader: 4.3.0_webpack@4.43.0
+      file-loader: 4.3.0_webpack@4.44.1
       fs-extra: 7.0.1
       globby: 9.2.0
       hash-sum: 2.0.0
-      html-webpack-plugin: 3.2.0_webpack@4.43.0
+      html-webpack-plugin: 3.2.0_webpack@4.44.1
       launch-editor-middleware: 2.2.1
       lodash.defaultsdeep: 4.6.1
       lodash.mapvalues: 4.6.0
       lodash.transform: 4.6.0
-      mini-css-extract-plugin: 0.9.0_webpack@4.43.0
+      mini-css-extract-plugin: 0.9.0_webpack@4.44.1
       minimist: 1.2.5
       pnp-webpack-plugin: 1.6.4_typescript@3.9.7
       portfinder: 1.0.27
       postcss-loader: 3.0.0
-      sass-loader: 9.0.3_webpack@4.44.1
+      sass-loader: 9.0.3_sass@1.26.10+webpack@4.44.1
       ssri: 7.1.0
-      terser-webpack-plugin: 2.3.7_webpack@4.43.0
-      thread-loader: 2.1.3_webpack@4.43.0
-      url-loader: 2.3.0_file-loader@4.3.0+webpack@4.43.0
-      vue-loader: 15.9.3_19eca3d246a5abd3297fc67c463bf5f8
+      terser-webpack-plugin: 2.3.7_webpack@4.44.1
+      thread-loader: 2.1.3_webpack@4.44.1
+      url-loader: 2.3.0_file-loader@4.3.0+webpack@4.44.1
+      vue-loader: 15.9.3_5301d49b91a5273e67d0261daf815cc2
       vue-style-loader: 4.1.2
       vue-template-compiler: 2.6.11
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
       webpack-bundle-analyzer: 3.8.0
       webpack-chain: 6.5.0
-      webpack-dev-server: 3.11.0_webpack@4.43.0
+      webpack-dev-server: 3.11.0_webpack@4.44.1
       webpack-merge: 4.2.2
     dev: true
     engines:
       node: '>=8'
     hasBin: true
+    optionalDependencies:
+      vue-loader-v16: /vue-loader/16.0.0-beta.5
     peerDependencies:
       '@vue/cli-service': '*'
+      '@vue/compiler-sfc': ^3.0.0-beta.14
       less-loader: '*'
       pug-plain-loader: '*'
       raw-loader: '*'
@@ -4739,6 +4985,8 @@ packages:
       typescript: '*'
       vue-template-compiler: ^2.0.0
     peerDependenciesMeta:
+      '@vue/compiler-sfc':
+        optional: true
       less-loader:
         optional: true
       pug-plain-loader:
@@ -4752,8 +5000,8 @@ packages:
       vue-template-compiler:
         optional: true
     resolution:
-      integrity: sha512-k5OFGh2NnvRymCyq9DfBiNJvECUuun3pl5KMm3557IZyA5E5csv+RHoSW3dX8HHe0zXq18g52VswP1llvR9POw==
-  /@vue/cli-shared-utils/4.4.6:
+      integrity: sha512-30zcebYno9tMvGsvZsnSPtieBvU5H3CkRW1JgiBmPG3Fcxp3BGSAy82Dl1gOUEj1VsAUqXWKMWX6frkYldi8UA==
+  /@vue/cli-shared-utils/4.5.4:
     dependencies:
       '@hapi/joi': 15.1.1
       chalk: 2.4.2
@@ -4769,19 +5017,19 @@ packages:
       strip-ansi: 6.0.0
     dev: true
     resolution:
-      integrity: sha512-ba+FZZCjiTSu2otnLjY4qXqASe7ZIQ/QBljk5oRPgqrR0p1NUkDPUcZhqa041aOaSW1yAfSfhOD7Q84nMnWhzQ==
-  /@vue/cli-ui-addon-webpack/4.4.6:
+      integrity: sha512-7ZwAvGxl5szGuaJCc4jdPy/2Lb7oJvG847MDF+7pZ7FVl6bURwbUJjiUwL6DTxvpC4vch6B4tXfVvZFjzVP/bw==
+  /@vue/cli-ui-addon-webpack/4.5.4:
     dev: true
     resolution:
-      integrity: sha512-odDx8lo+MNFCnhOB6fsjWJnoWP/YhDhDuCUQC8YQHCtsGRHI8/mJQk1tLI8cPVrY37aAH8Z0loitg4q3klItlQ==
-  /@vue/cli-ui-addon-widgets/4.4.6:
+      integrity: sha512-J5yYNdrcBvDboYwX+I9KEpv2QdV39X+YoZl2x+mYAgc4d+Forf2mmGipBarnAOgR58d/yapFRrtQLK1dUNpk9A==
+  /@vue/cli-ui-addon-widgets/4.5.4:
     dev: true
     resolution:
-      integrity: sha512-GqtqxFR30LCxiQ+y/8b+XmAaZ983ojYT/6xOeqD0V0bZ3sNrthTxRcTXKJHbw7xdeE7bWHikHKYQ7Jn3J/Dyjw==
-  /@vue/cli-ui/4.4.6:
+      integrity: sha512-/7R3dMrv/tEP4AM22hBDPfXPF24OE/2ddR3cTF1c1fSoHT/LcUvqrlHIb8SlVgl3S7WvF9Prrunp+KzkHW9bSA==
+  /@vue/cli-ui/4.5.4:
     dependencies:
       '@akryum/winattr': 3.0.0
-      '@vue/cli-shared-utils': 4.4.6
+      '@vue/cli-shared-utils': 4.5.4
       apollo-server-express: 2.16.0_graphql@14.7.0
       clone: 2.1.2
       deepmerge: 4.2.2
@@ -4807,20 +5055,21 @@ packages:
       rss-parser: 3.9.0
       shortid: 2.2.15
       typescript: 3.9.7
-      vue-cli-plugin-apollo: 0.21.3_c23965195f13fa8d47f6f86cdc802653
+      vue-cli-plugin-apollo: 0.21.3_856e89e733915dcf427dc68ddbbf6ed8
       watch: 1.0.2
     dev: true
     engines:
       node: '>=8'
     resolution:
-      integrity: sha512-9l67vb0J9iubf14Lj6aI8Fg9DPIgB9gCLbwQWVrFtoaDTapdbo0X6cf0zK1RNeN/5CrGa5baIntqsWwC1Iqlcw==
-  /@vue/cli/4.4.6_@babel+core@7.11.1:
+      integrity: sha512-1FXRes+Xl/018OdF8pSZKxQzT+NwUpBm5/DbKkNxcxJOSgEE/sIUGmQjyQPWyYyFs6hugbIsNpEJgdYumUUjbQ==
+  /@vue/cli/4.5.4:
     dependencies:
-      '@babel/preset-env': 7.10.4_@babel+core@7.11.1
-      '@vue/cli-shared-utils': 4.4.6
-      '@vue/cli-ui': 4.4.6
-      '@vue/cli-ui-addon-webpack': 4.4.6
-      '@vue/cli-ui-addon-widgets': 4.4.6
+      '@types/ejs': 2.7.0
+      '@types/inquirer': 6.5.0
+      '@vue/cli-shared-utils': 4.5.4
+      '@vue/cli-ui': 4.5.4
+      '@vue/cli-ui-addon-webpack': 4.5.4
+      '@vue/cli-ui-addon-widgets': 4.5.4
       boxen: 4.2.0
       cmd-shim: 3.0.3
       commander: 2.20.3
@@ -4837,7 +5086,6 @@ packages:
       isbinaryfile: 4.0.6
       javascript-stringify: 1.6.0
       js-yaml: 3.14.0
-      jscodeshift: 0.10.0_@babel+preset-env@7.10.4
       leven: 3.1.0
       lodash.clonedeep: 4.5.0
       lru-cache: 5.1.1
@@ -4848,16 +5096,62 @@ packages:
       slash: 3.0.0
       validate-npm-package-name: 3.0.0
       vue: 2.6.11
-      vue-jscodeshift-adapter: 2.1.0
+      vue-codemod: 0.0.4
       yaml-front-matter: 3.4.1
     dev: true
     engines:
       node: '>=8.9'
     hasBin: true
-    peerDependencies:
-      '@babel/core': '*'
     resolution:
-      integrity: sha512-IaLrnZ80BrBLPAkBup8bn363S1NHfNf8jfCJLWoXad598cUm6byMqntWtDFeTq0c3KohXcsIbT+nqLc5S9vz0w==
+      integrity: sha512-UFhxsmiKtXxZwvuW0HB+35bEIovAjYg9oiA9uyOMkDh3ZTf90FmyPre09xKviLn0B+0WnzD35P+ZB/bgJZ/HOA==
+  /@vue/compiler-core/3.0.0-rc.5:
+    dependencies:
+      '@babel/parser': 7.11.3
+      '@babel/types': 7.11.0
+      '@vue/shared': 3.0.0-rc.5
+      estree-walker: 2.0.1
+      source-map: 0.6.1
+    dev: true
+    resolution:
+      integrity: sha512-dNz5AObEYg0Oglw3emIsBhTAOVfObrfxDaAzR0UTRDDq+Ohfr6KTSaVQAH88Ym+oa08ZlLZBFc6ARe9doAOIxg==
+  /@vue/compiler-dom/3.0.0-rc.5:
+    dependencies:
+      '@vue/compiler-core': 3.0.0-rc.5
+      '@vue/shared': 3.0.0-rc.5
+    dev: true
+    resolution:
+      integrity: sha512-z8n+R1GhFnWuKURLYxfVSEfP7nSNM91qteobxwys55fhlZZuReouMnUwgrn+ois/IL6RdFlT9H+n4+N6yLrdJA==
+  /@vue/compiler-sfc/3.0.0-rc.5_vue@3.0.0-rc.5:
+    dependencies:
+      '@babel/parser': 7.11.3
+      '@babel/types': 7.11.0
+      '@vue/compiler-core': 3.0.0-rc.5
+      '@vue/compiler-dom': 3.0.0-rc.5
+      '@vue/compiler-ssr': 3.0.0-rc.5
+      '@vue/shared': 3.0.0-rc.5
+      consolidate: 0.15.1
+      estree-walker: 2.0.1
+      hash-sum: 2.0.0
+      lru-cache: 5.1.1
+      magic-string: 0.25.7
+      merge-source-map: 1.1.0
+      postcss: 7.0.32
+      postcss-modules: 3.2.0
+      postcss-selector-parser: 6.0.2
+      source-map: 0.6.1
+      vue: 3.0.0-rc.5
+    dev: true
+    peerDependencies:
+      vue: 3.0.0-rc.5
+    resolution:
+      integrity: sha512-huoIFEfFCJxHcpoByAUQti7CIwJdHPLJXKuy2HG7J1B+IEKugtBdF50CLH35ZD8dWM0nyOMFFqTbO7i6CCjL3Q==
+  /@vue/compiler-ssr/3.0.0-rc.5:
+    dependencies:
+      '@vue/compiler-dom': 3.0.0-rc.5
+      '@vue/shared': 3.0.0-rc.5
+    dev: true
+    resolution:
+      integrity: sha512-OU5Vl2+bCDMImS9OeCVnl4lfxZ3/sopdwX2SrUWVKQvCxmmmlyWvoVkC6nNGCs/MrOmIMhKmL6etgzLTWyCkUg==
   /@vue/component-compiler-utils/3.2.0:
     dependencies:
       consolidate: 0.15.1
@@ -4885,10 +5179,10 @@ packages:
       prettier: '>= 1.13.0'
     resolution:
       integrity: sha512-wFQmv45c3ige5EA+ngijq40YpVcIkAy0Lihupnsnd1Dao5CBbPyfCzqtejFLZX1EwH/kCJdpz3t6s+5wd3+KxQ==
-  /@vue/eslint-config-typescript/5.0.2_3f36a09e6f084b19821addb41bb8b921:
+  /@vue/eslint-config-typescript/5.0.2_bd76f009a7fcfa4e2222f197079d817e:
     dependencies:
-      '@typescript-eslint/eslint-plugin': 3.8.0_9195d7e59c976ef8295ee5e80b40ac89
-      '@typescript-eslint/parser': 3.8.0_eslint@7.6.0+typescript@3.9.7
+      '@typescript-eslint/eslint-plugin': 3.9.1_a41fa870346fc9d6bbe0c1287f584058
+      '@typescript-eslint/parser': 3.9.1_eslint@7.6.0+typescript@3.9.7
       eslint: 7.6.0
       eslint-plugin-vue: 6.2.2_eslint@7.6.0
       vue-eslint-parser: 7.1.0_eslint@7.6.0
@@ -4900,10 +5194,10 @@ packages:
       eslint-plugin-vue: ^5.2.3 || ^6.0.0
     resolution:
       integrity: sha512-GEZOHKOnelgQf5npA+6VNuhJZu9xEJaics3SYUyRjaSay+2SCpEINHhEpt6fXoNy/aIFt8CkDlt9CaEb+QPIcg==
-  /@vue/preload-webpack-plugin/1.1.2_4bdb23e17c1669cd6b8d9492b9e85ea2:
+  /@vue/preload-webpack-plugin/1.1.2_5ff516492094d25eb46611af254fac10:
     dependencies:
-      html-webpack-plugin: 3.2.0_webpack@4.43.0
-      webpack: 4.43.0_webpack@4.43.0
+      html-webpack-plugin: 3.2.0_webpack@4.44.1
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     engines:
       node: '>=6.0.0'
@@ -4912,6 +5206,31 @@ packages:
       webpack: '>=4.0.0'
     resolution:
       integrity: sha512-LIZMuJk38pk9U9Ur4YzHjlIyMuxPlACdBIHH9/nGYVTsaGKOSnSuELiE8vS9wa+dJpIYspYUOqk+L1Q4pgHQHQ==
+  /@vue/reactivity/3.0.0-rc.5:
+    dependencies:
+      '@vue/shared': 3.0.0-rc.5
+    dev: true
+    resolution:
+      integrity: sha512-oe9C+1jtWUdYL/iNc0OPWbwgOk2rOW2uQ+exx3I6Jo6PKOmnAiPkMElalf9vRnO53rnUphVecMp8BlTJvcNgDw==
+  /@vue/runtime-core/3.0.0-rc.5:
+    dependencies:
+      '@vue/reactivity': 3.0.0-rc.5
+      '@vue/shared': 3.0.0-rc.5
+    dev: true
+    resolution:
+      integrity: sha512-MRIWreFigxdRuI2moFociUL5rVBfgYPrT7rWfQ0XfOyW46b+AiuCJyZvgbsRXwkAERfW1Tb/mY5forYjX2thOg==
+  /@vue/runtime-dom/3.0.0-rc.5:
+    dependencies:
+      '@vue/runtime-core': 3.0.0-rc.5
+      '@vue/shared': 3.0.0-rc.5
+      csstype: 2.6.13
+    dev: true
+    resolution:
+      integrity: sha512-0jwpO3MBqMToq7qC816Z8Y6G8aN4ZKbv7MupgRaepzxhiK0sXcjLQmOATP3g/NyX52UCBJS4wAwsxidqGnAabA==
+  /@vue/shared/3.0.0-rc.5:
+    dev: true
+    resolution:
+      integrity: sha512-ZhcgGzBpp+pUzisZgQpM4ctIGgLpYjBj7/rZfbhEPxFHF/BuTV2jmhXvAl8aF9xDAejIcw85xCy92gDSwKtPag==
   /@vue/test-utils/1.0.3_d81dac297579cfd5597855dabf60f13b:
     dependencies:
       dom-event-types: 1.0.0
@@ -5179,7 +5498,7 @@ packages:
       integrity: sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==
   /@wry/context/0.4.4:
     dependencies:
-      '@types/node': 14.0.24
+      '@types/node': 14.0.27
       tslib: 1.13.0
     dev: true
     resolution:
@@ -5251,7 +5570,7 @@ packages:
       integrity: sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==
   /acorn-globals/6.0.0:
     dependencies:
-      acorn: 7.3.1
+      acorn: 7.4.0
       acorn-walk: 7.2.0
     dev: true
     resolution:
@@ -5313,6 +5632,13 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
+  /acorn/7.4.0:
+    dev: true
+    engines:
+      node: '>=0.4.0'
+    hasBin: true
+    resolution:
+      integrity: sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
   /address/1.1.2:
     dev: true
     engines:
@@ -5320,7 +5646,6 @@ packages:
     resolution:
       integrity: sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
   /aes-js/3.0.0:
-    dev: false
     resolution:
       integrity: sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=
   /agentkeepalive/2.2.0:
@@ -5571,7 +5896,7 @@ packages:
   /apollo-codegen-core/0.37.7_typescript@3.9.7:
     dependencies:
       '@babel/generator': 7.10.4
-      '@babel/parser': 7.10.5
+      '@babel/parser': 7.11.3
       '@babel/types': 7.10.4
       apollo-env: 0.6.5
       apollo-language-server: 1.23.2_typescript@3.9.7
@@ -5733,7 +6058,7 @@ packages:
       core-js: 3.6.5
       cosmiconfig: 5.2.1
       dotenv: 8.2.0
-      glob: 7.1.5
+      glob: 7.1.6
       graphql: 14.7.0
       graphql-tag: 2.10.4_graphql@14.7.0
       lodash.debounce: 4.0.8
@@ -5958,7 +6283,7 @@ packages:
       integrity: sha512-l7g+uILw7v32GA46IRXIx5XXbZhFI96BhSqrGK9yyvfq+NMcvVZrj3kIhRImPGhAjMdV+5biA/jztabElAbDjg==
   /apollo-upload-client/11.0.0_graphql@14.7.0:
     dependencies:
-      '@babel/runtime': 7.10.5
+      '@babel/runtime': 7.11.2
       apollo-link: 1.2.14_graphql@14.7.0
       apollo-link-http-common: 0.2.16_graphql@14.7.0
       extract-files: 5.0.1
@@ -6219,6 +6544,12 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+  /ast-types/0.12.1:
+    dev: true
+    engines:
+      node: '>=4'
+    resolution:
+      integrity: sha512-H2izJAyT2xwew4TxShpmxe6f9R5hHgJQy1QloLiUC2yrJMtyraBWNJL7903rpeCY9keNUipORR/zIUC2XcYKng==
   /ast-types/0.13.3:
     dev: true
     engines:
@@ -6247,7 +6578,7 @@ packages:
       integrity: sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==
   /async/2.6.1:
     dependencies:
-      lodash: 4.17.19
+      lodash: 4.17.20
     dev: true
     resolution:
       integrity: sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==
@@ -6292,6 +6623,19 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-C2p5KkumJlsTHoNv9w31NrBRgXhf6eCMteJuHZi2xhkgC+5Vm40MEtCKPhc0qdgAOhox0YPy1SQHTAky05UoKg==
+  /autoprefixer/9.8.6:
+    dependencies:
+      browserslist: 4.13.0
+      caniuse-lite: 1.0.30001115
+      colorette: 1.2.1
+      normalize-range: 0.1.2
+      num2fraction: 1.2.2
+      postcss: 7.0.32
+      postcss-value-parser: 4.1.0
+    dev: true
+    hasBin: true
+    resolution:
+      integrity: sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==
   /await-to-js/2.1.1:
     dev: true
     engines:
@@ -6312,14 +6656,6 @@ packages:
     dev: true
     resolution:
       integrity: sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=
-  /babel-core/7.0.0-bridge.0_@babel+core@7.10.5:
-    dependencies:
-      '@babel/core': 7.10.5
-    dev: true
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    resolution:
-      integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
   /babel-core/7.0.0-bridge.0_@babel+core@7.11.1:
     dependencies:
       '@babel/core': 7.11.1
@@ -6352,14 +6688,14 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-qWWzi4TlddohA91bFwgt6zO/J0X+io7Qp184Fw0m2JYRSTZnJbFR8+07KmzudHCZgOiKRCrjhylwv9Xd8gfhVQ==
-  /babel-jest/24.9.0_@babel+core@7.10.5:
+  /babel-jest/24.9.0_@babel+core@7.11.1:
     dependencies:
-      '@babel/core': 7.10.5
+      '@babel/core': 7.11.1
       '@jest/transform': 24.9.0
       '@jest/types': 24.9.0
       '@types/babel__core': 7.1.9
       babel-plugin-istanbul: 5.2.0
-      babel-preset-jest: 24.9.0_@babel+core@7.10.5
+      babel-preset-jest: 24.9.0_@babel+core@7.11.1
       chalk: 2.4.2
       slash: 2.0.0
     dev: true
@@ -6369,14 +6705,14 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-ntuddfyiN+EhMw58PTNL1ph4C9rECiQXjI4nMMBKBaNjXvqLdkXpPRcMSr4iyBrJg/+wz9brFUD6RhOAT6r4Iw==
-  /babel-jest/26.2.2_@babel+core@7.10.5:
+  /babel-jest/26.3.0_@babel+core@7.11.1:
     dependencies:
-      '@babel/core': 7.10.5
-      '@jest/transform': 26.2.2
-      '@jest/types': 26.2.0
+      '@babel/core': 7.11.1
+      '@jest/transform': 26.3.0
+      '@jest/types': 26.3.0
       '@types/babel__core': 7.1.9
       babel-plugin-istanbul: 6.0.0
-      babel-preset-jest: 26.2.0_@babel+core@7.10.5
+      babel-preset-jest: 26.3.0_@babel+core@7.11.1
       chalk: 4.1.0
       graceful-fs: 4.2.4
       slash: 3.0.0
@@ -6386,7 +6722,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-JmLuePHgA+DSOdOL8lPxCgD2LhPPm+rdw1vnxR73PpIrnmKCS2/aBhtkAcxQWuUcW2hBrH8MJ3LKXE7aWpNZyA==
+      integrity: sha512-sxPnQGEyHAOPF8NcUsD0g7hDCnvLL2XyblRBcgrzTWBB/mAIpWow3n1bEL+VghnnZfreLhFSBsFluRoK2tRK4g==
   /babel-loader/8.1.0_13c776b87d2822e76e5e552d0872621e:
     dependencies:
       '@babel/core': 7.10.5
@@ -6508,29 +6844,29 @@ packages:
     dev: true
     resolution:
       integrity: sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=
-  /babel-preset-current-node-syntax/0.1.3_@babel+core@7.10.5:
+  /babel-preset-current-node-syntax/0.1.3_@babel+core@7.11.1:
     dependencies:
-      '@babel/core': 7.10.5
-      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.10.5
-      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.10.5
-      '@babel/plugin-syntax-class-properties': 7.10.4_@babel+core@7.10.5
-      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.10.5
-      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.10.5
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.10.5
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.10.5
-      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.10.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.10.5
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.10.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.10.5
+      '@babel/core': 7.11.1
+      '@babel/plugin-syntax-async-generators': 7.8.4_@babel+core@7.11.1
+      '@babel/plugin-syntax-bigint': 7.8.3_@babel+core@7.11.1
+      '@babel/plugin-syntax-class-properties': 7.10.4_@babel+core@7.11.1
+      '@babel/plugin-syntax-import-meta': 7.10.4_@babel+core@7.11.1
+      '@babel/plugin-syntax-json-strings': 7.8.3_@babel+core@7.11.1
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4_@babel+core@7.11.1
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3_@babel+core@7.11.1
+      '@babel/plugin-syntax-numeric-separator': 7.10.4_@babel+core@7.11.1
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.11.1
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3_@babel+core@7.11.1
+      '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.11.1
     dev: true
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==
-  /babel-preset-jest/24.9.0_@babel+core@7.10.5:
+  /babel-preset-jest/24.9.0_@babel+core@7.11.1:
     dependencies:
-      '@babel/core': 7.10.5
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.10.5
+      '@babel/core': 7.11.1
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3_@babel+core@7.11.1
       babel-plugin-jest-hoist: 24.9.0
     dev: true
     engines:
@@ -6539,18 +6875,18 @@ packages:
       '@babel/core': ^7.0.0
     resolution:
       integrity: sha512-izTUuhE4TMfTRPF92fFwD2QfdXaZW08qvWTFCI51V8rW5x00UuPgc3ajRoWofXOuxjfcOM5zzSYsQS3H8KGCAg==
-  /babel-preset-jest/26.2.0_@babel+core@7.10.5:
+  /babel-preset-jest/26.3.0_@babel+core@7.11.1:
     dependencies:
-      '@babel/core': 7.10.5
+      '@babel/core': 7.11.1
       babel-plugin-jest-hoist: 26.2.0
-      babel-preset-current-node-syntax: 0.1.3_@babel+core@7.10.5
+      babel-preset-current-node-syntax: 0.1.3_@babel+core@7.11.1
     dev: true
     engines:
       node: '>= 10.14.2'
     peerDependencies:
       '@babel/core': ^7.0.0
     resolution:
-      integrity: sha512-R1k8kdP3R9phYQugXeNnK/nvCGlBzG4m3EoIIukC80GXb6wCv2XiwPhK6K9MAkQcMszWBYvl2Wm+yigyXFQqXg==
+      integrity: sha512-5WPdf7nyYi2/eRxCbVrE1kKCWxgWY4RsPEbdJWFm7QsesFGqjdkyLeu1zRkwM1cxK6EPIlNd6d2AxLk7J+t4pw==
   /babel-runtime/6.26.0:
     dependencies:
       core-js: 2.6.11
@@ -7200,7 +7536,7 @@ packages:
       webpack: ^4.0.0
     resolution:
       integrity: sha512-HzJIvGiGqYsFUrMjAJNDbVZoG7qQA+vy9AIoKs7s9DscNfki0I589mf2w6/tW+kkFH3zyiknoWV5Jdynu6b/zw==
-  /cache-loader/4.1.0_webpack@4.43.0:
+  /cache-loader/4.1.0_webpack@4.44.1:
     dependencies:
       buffer-json: 2.0.0
       find-cache-dir: 3.3.1
@@ -7208,7 +7544,7 @@ packages:
       mkdirp: 0.5.5
       neo-async: 2.6.2
       schema-utils: 2.7.0
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     engines:
       node: '>= 8.9.0'
@@ -7343,7 +7679,7 @@ packages:
   /caniuse-api/3.0.0:
     dependencies:
       browserslist: 4.13.0
-      caniuse-lite: 1.0.30001105
+      caniuse-lite: 1.0.30001115
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
     dev: true
@@ -7353,6 +7689,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-JupOe6+dGMr7E20siZHIZQwYqrllxotAhiaej96y6x00b/48rPt42o+SzOSCPbrpsDWvRja40Hwrj0g0q6LZJg==
+  /caniuse-lite/1.0.30001115:
+    dev: true
+    resolution:
+      integrity: sha512-NZrG0439ePYna44lJX8evHX2L7Z3/z3qjVLnHgbBb/duNEnGo348u+BQS5o4HTWcrb++100dHFrU36IesIrC1Q==
   /canvas/2.6.1:
     dependencies:
       nan: 2.14.1
@@ -7509,19 +7849,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==
-  /cheerio/1.0.0-rc.3:
-    dependencies:
-      css-select: 1.2.0
-      dom-serializer: 0.1.1
-      entities: 1.1.2
-      htmlparser2: 3.10.1
-      lodash: 4.17.19
-      parse5: 3.0.3
-    dev: true
-    engines:
-      node: '>= 0.6'
-    resolution:
-      integrity: sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==
   /chokidar/2.1.8:
     dependencies:
       anymatch: 2.0.0
@@ -7729,7 +8056,7 @@ packages:
       hyperlinker: 1.0.0
       indent-string: 3.2.0
       is-wsl: 1.1.0
-      lodash: 4.17.19
+      lodash: 4.17.20
       password-prompt: 1.1.2
       semver: 5.7.1
       strip-ansi: 5.2.0
@@ -7760,7 +8087,7 @@ packages:
       indent-string: 4.0.0
       is-wsl: 2.2.0
       js-yaml: 3.14.0
-      lodash: 4.17.19
+      lodash: 4.17.20
       natural-orderby: 2.0.3
       object-treeify: 1.1.26
       password-prompt: 1.1.2
@@ -7769,7 +8096,7 @@ packages:
       strip-ansi: 5.2.0
       supports-color: 7.1.0
       supports-hyperlinks: 1.0.1
-      tslib: 2.0.0
+      tslib: 2.0.1
     dev: true
     engines:
       node: '>=8.0.0'
@@ -8009,12 +8336,12 @@ packages:
       node: '>= 0.6.x'
     resolution:
       integrity: sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=
-  /comment-parser/0.7.5:
+  /comment-parser/0.7.6:
     dev: true
     engines:
       node: '>= 6.0.0'
     resolution:
-      integrity: sha512-iH9YA35ccw94nx5244GVkpyC9eVTsL71jZz6iz5w6RIf79JLF2AsXHXq9p6Oaohyl3sx5qSMnGsWUDFIAfWL4w==
+      integrity: sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg==
   /common-tags/1.8.0:
     dev: true
     engines:
@@ -8214,6 +8541,28 @@ packages:
       schema-utils: 1.0.0
       serialize-javascript: 2.1.2
       webpack: 4.43.0_webpack@4.43.0
+      webpack-log: 2.0.0
+    dev: true
+    engines:
+      node: '>= 6.9.0'
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    resolution:
+      integrity: sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==
+  /copy-webpack-plugin/5.1.1_webpack@4.44.1:
+    dependencies:
+      cacache: 12.0.4
+      find-cache-dir: 2.1.0
+      glob-parent: 3.1.0
+      globby: 7.1.1
+      is-glob: 4.0.1
+      loader-utils: 1.4.0
+      minimatch: 3.0.4
+      normalize-path: 3.0.0
+      p-limit: 2.3.0
+      schema-utils: 1.0.0
+      serialize-javascript: 2.1.2
+      webpack: 4.44.1_webpack@4.44.1
       webpack-log: 2.0.0
     dev: true
     engines:
@@ -8427,7 +8776,7 @@ packages:
       webpack: ^4.0.0
     resolution:
       integrity: sha512-OcKJU/lt232vl1P9EEDamhoO9iKY3tIjY5GU+XDLblAykTdgs6Ux9P1hTHve8nFKy5KPpOXOsVI/hIwi3841+w==
-  /css-loader/3.6.0_webpack@4.43.0:
+  /css-loader/3.6.0_webpack@4.44.1:
     dependencies:
       camelcase: 5.3.1
       cssesc: 3.0.0
@@ -8442,7 +8791,7 @@ packages:
       postcss-value-parser: 4.1.0
       schema-utils: 2.7.0
       semver: 6.3.0
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     engines:
       node: '>= 8.9.0'
@@ -8657,6 +9006,10 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
+  /csstype/2.6.13:
+    dev: true
+    resolution:
+      integrity: sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
   /csv-parser/1.12.1:
     dependencies:
       buffer-alloc: 1.2.0
@@ -9062,12 +9415,6 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=
-  /detect-indent/6.0.0:
-    dev: true
-    engines:
-      node: '>=8'
-    resolution:
-      integrity: sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
   /detect-libc/1.0.3:
     dev: true
     engines:
@@ -9130,12 +9477,12 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
-  /diff-sequences/26.0.0:
+  /diff-sequences/26.3.0:
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==
+      integrity: sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==
   /diff/4.0.2:
     dev: true
     engines:
@@ -9430,7 +9777,6 @@ packages:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
-    dev: false
     resolution:
       integrity: sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
   /elliptic/6.5.3:
@@ -9675,7 +10021,7 @@ packages:
     dev: true
     resolution:
       integrity: sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
-  /eslint-loader/2.2.1_eslint@7.6.0+webpack@4.43.0:
+  /eslint-loader/2.2.1_eslint@7.6.0+webpack@4.44.1:
     dependencies:
       eslint: 7.6.0
       loader-fs-cache: 1.0.3
@@ -9683,7 +10029,7 @@ packages:
       object-assign: 4.1.1
       object-hash: 1.3.1
       rimraf: 2.7.1
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     peerDependencies:
       eslint: '>=1.6.0 <7.0.0'
@@ -9754,13 +10100,13 @@ packages:
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0
     resolution:
       integrity: sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==
-  /eslint-plugin-jsdoc/30.2.0_eslint@7.5.0:
+  /eslint-plugin-jsdoc/30.2.4_eslint@7.5.0:
     dependencies:
-      comment-parser: 0.7.5
+      comment-parser: 0.7.6
       debug: 4.1.1
       eslint: 7.5.0
-      jsdoctypeparser: 8.0.0
-      lodash: 4.17.19
+      jsdoctypeparser: 9.0.0
+      lodash: 4.17.20
       regextras: 0.7.1
       semver: 7.3.2
       spdx-expression-parse: 3.0.1
@@ -9770,14 +10116,14 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0
     resolution:
-      integrity: sha512-gBC5Wp7vSgMBRiGtCfjCgRQ9Wzdus6Hc8WuDNetYxuJoJ5rDHQMkJzBZ0/Qdg3fFh2eIpM7EcJD0pbrYKPxKLw==
-  /eslint-plugin-jsdoc/30.2.1_eslint@7.6.0:
+      integrity: sha512-7TLp+1EK/ufnzlBUuzgDiPz5k2UUIa01cFkZTvvbJr8PE0iWVDqENg0yLhqGUYaZfYRFhHpqCML8SQR94omfrg==
+  /eslint-plugin-jsdoc/30.2.4_eslint@7.6.0:
     dependencies:
-      comment-parser: 0.7.5
+      comment-parser: 0.7.6
       debug: 4.1.1
       eslint: 7.6.0
       jsdoctypeparser: 9.0.0
-      lodash: 4.17.19
+      lodash: 4.17.20
       regextras: 0.7.1
       semver: 7.3.2
       spdx-expression-parse: 3.0.1
@@ -9787,7 +10133,7 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0
     resolution:
-      integrity: sha512-9Nx+BKMBoCTDRIbVpMV4MYfw+lvfnfsWTWYX9vwRRZrkXBpZkKtE3dsFcG6MhF7N/vW1cwpjEnoAIAtn0+a6gw==
+      integrity: sha512-7TLp+1EK/ufnzlBUuzgDiPz5k2UUIa01cFkZTvvbJr8PE0iWVDqENg0yLhqGUYaZfYRFhHpqCML8SQR94omfrg==
   /eslint-plugin-prettier/3.1.4_eslint@7.5.0+prettier@2.0.5:
     dependencies:
       eslint: 7.5.0
@@ -10061,6 +10407,10 @@ packages:
       node: '>=4.0'
     resolution:
       integrity: sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
+  /estree-walker/2.0.1:
+    dev: true
+    resolution:
+      integrity: sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==
   /esutils/2.0.3:
     dev: true
     engines:
@@ -10089,7 +10439,6 @@ packages:
       setimmediate: 1.0.4
       uuid: 2.0.1
       xmlhttprequest: 1.8.0
-    dev: false
     resolution:
       integrity: sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==
   /event-pubsub/4.3.0:
@@ -10341,19 +10690,19 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==
-  /expect/26.2.0:
+  /expect/26.4.0:
     dependencies:
-      '@jest/types': 26.2.0
+      '@jest/types': 26.3.0
       ansi-styles: 4.2.1
-      jest-get-type: 26.0.0
-      jest-matcher-utils: 26.2.0
-      jest-message-util: 26.2.0
+      jest-get-type: 26.3.0
+      jest-matcher-utils: 26.4.0
+      jest-message-util: 26.3.0
       jest-regex-util: 26.0.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-8AMBQ9UVcoUXt0B7v+5/U5H6yiUR87L6eKCfjE3spx7Ya5lF+ebUo37MCFBML2OiLfkX1sxmQOZhIDonyVTkcw==
+      integrity: sha512-dbYDJhFcqQsamlos6nEwAMe+ahdckJBk5fmw1DYGLQGabGSlUuT+Fm2jHYw5119zG3uIhP+lCQbjJhFEdZMJtg==
   /express-history-api-fallback/2.2.1:
     dev: true
     resolution:
@@ -10633,18 +10982,6 @@ packages:
       webpack: ^4.0.0
     resolution:
       integrity: sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==
-  /file-loader/4.3.0_webpack@4.43.0:
-    dependencies:
-      loader-utils: 1.4.0
-      schema-utils: 2.7.0
-      webpack: 4.43.0_webpack@4.43.0
-    dev: true
-    engines:
-      node: '>= 8.9.0'
-    peerDependencies:
-      webpack: ^4.0.0
-    resolution:
-      integrity: sha512-aKrYPYjF1yG3oX0kWRrqrSMfgftm7oJW5M+m4owoldH5C51C0RkIwB++JbRvEW3IU6/ZG5n8UvEcdgwOt2UOWA==
   /file-loader/4.3.0_webpack@4.44.1:
     dependencies:
       loader-utils: 1.4.0
@@ -10938,6 +11275,26 @@ packages:
       yarn: '>=1.0.0'
     resolution:
       integrity: sha512-DuVkPNrM12jR41KM2e+N+styka0EgLkTnXmNcXdgOM37vtGeY+oCBK/Jx0hzSeEU6memFCtWb4htrHPMDfwwUQ==
+  /fork-ts-checker-webpack-plugin/5.1.0:
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      '@types/json-schema': 7.0.5
+      chalk: 4.1.0
+      cosmiconfig: 6.0.0
+      deepmerge: 4.2.2
+      fs-extra: 9.0.1
+      memfs: 3.2.0
+      minimatch: 3.0.4
+      schema-utils: 2.7.0
+      semver: 7.3.2
+      tapable: 1.1.3
+    dev: true
+    engines:
+      node: '>=10'
+      yarn: '>=1.0.0'
+    optional: true
+    resolution:
+      integrity: sha512-vuKyEjSLGbhQbEr5bifXXOkr9iV73L6n72mHoHIv7okvrf7O7z6RKeplM6C6ATPsukoQivij+Ba1vcptL60Z2g==
   /form-data/2.3.3:
     dependencies:
       asynckit: 0.4.0
@@ -11078,6 +11435,11 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  /fs-monkey/1.0.1:
+    dev: true
+    optional: true
+    resolution:
+      integrity: sha512-fcSa+wyTqZa46iWweI7/ZiUfegOZl0SG8+dltIwFXo7+zYU9J9kpS3NB6pZcSlJdhvIwp81Adx2XhZorncxiaA==
   /fs-write-stream-atomic/1.0.10:
     dependencies:
       graceful-fs: 4.2.4
@@ -11168,6 +11530,12 @@ packages:
     dev: true
     resolution:
       integrity: sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=
+  /generic-names/2.0.1:
+    dependencies:
+      loader-utils: 1.4.0
+    dev: true
+    resolution:
+      integrity: sha512-kPCHWa1m9wGG/OwQpeweTwM/PYiQLrUIxXbt/P4Nic3LbGjCP0YwrALHW1uNLKZ0LIMg+RF+XRlj2ekT9ZlZAQ==
   /gensync/1.0.0-beta.1:
     dev: true
     engines:
@@ -11427,6 +11795,21 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
+  /globby/10.0.2:
+    dependencies:
+      '@types/glob': 7.1.3
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.2.4
+      glob: 7.1.6
+      ignore: 5.1.8
+      merge2: 1.4.1
+      slash: 3.0.0
+    dev: true
+    engines:
+      node: '>=8'
+    resolution:
+      integrity: sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==
   /globby/11.0.0:
     dependencies:
       array-union: 2.1.0
@@ -11499,8 +11882,8 @@ packages:
       integrity: sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=
   /globule/1.3.2:
     dependencies:
-      glob: 7.1.5
-      lodash: 4.17.19
+      glob: 7.1.6
+      lodash: 4.17.20
       minimatch: 3.0.4
     dev: true
     engines:
@@ -11860,7 +12243,6 @@ packages:
     dependencies:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
-    dev: false
     resolution:
       integrity: sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==
   /hash.js/1.1.7:
@@ -12005,16 +12387,16 @@ packages:
       node: '>=8'
     resolution:
       integrity: sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
-  /html-webpack-plugin/3.2.0_webpack@4.43.0:
+  /html-webpack-plugin/3.2.0_webpack@4.44.1:
     dependencies:
       html-minifier: 3.5.21
       loader-utils: 0.2.17
-      lodash: 4.17.19
+      lodash: 4.17.20
       pretty-error: 2.1.1
       tapable: 1.1.3
       toposort: 1.0.7
       util.promisify: 1.0.0
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     engines:
       node: '>=6.9'
@@ -13045,11 +13427,11 @@ packages:
       integrity: sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==
   /istanbul-lib-instrument/3.3.0:
     dependencies:
-      '@babel/generator': 7.10.5
-      '@babel/parser': 7.10.5
+      '@babel/generator': 7.11.0
+      '@babel/parser': 7.11.3
       '@babel/template': 7.10.4
-      '@babel/traverse': 7.10.5
-      '@babel/types': 7.10.5
+      '@babel/traverse': 7.11.0
+      '@babel/types': 7.11.0
       istanbul-lib-coverage: 2.0.5
       semver: 6.3.0
     dev: true
@@ -13178,16 +13560,16 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-6aTWpe2mHF0DhL28WjdkO8LyGjs3zItPET4bMSeXU6T3ub4FPMw+mcOcbdGXQOAfmLcxofD23/5Bl9Z4AkFwqg==
-  /jest-changed-files/26.2.0:
+  /jest-changed-files/26.3.0:
     dependencies:
-      '@jest/types': 26.2.0
+      '@jest/types': 26.3.0
       execa: 4.0.3
       throat: 5.0.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-+RyJb+F1K/XBLIYiL449vo5D+CvlHv29QveJUWNPXuUicyZcq+tf1wNxmmFeRvAU1+TzhwqczSjxnCCFt7+8iA==
+      integrity: sha512-1C4R4nijgPltX6fugKxM4oQ18zimS7LqQ+zTTY8lMCMFPrxqBFb7KJH0Z2fRQJvw2Slbaipsqq7s1mgX5Iot+g==
   /jest-cli/24.9.0:
     dependencies:
       '@jest/core': 24.9.0
@@ -13209,33 +13591,58 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-+VLRKyitT3BWoMeSUIHRxV/2g8y9gw91Jh5z2UmXZzkZKpbC08CSehVxgHUwTpy+HwGcns/tqafQDJW7imYvGg==
-  /jest-cli/26.2.2:
+  /jest-cli/26.4.0:
     dependencies:
-      '@jest/core': 26.2.2
-      '@jest/test-result': 26.2.0
-      '@jest/types': 26.2.0
+      '@jest/core': 26.4.0
+      '@jest/test-result': 26.3.0
+      '@jest/types': 26.3.0
       chalk: 4.1.0
       exit: 0.1.2
       graceful-fs: 4.2.4
       import-local: 3.0.2
       is-ci: 2.0.0
-      jest-config: 26.2.2
-      jest-util: 26.2.0
-      jest-validate: 26.2.0
+      jest-config: 26.4.0
+      jest-util: 26.3.0
+      jest-validate: 26.4.0
       prompts: 2.3.2
       yargs: 15.4.1
     dev: true
     engines:
       node: '>= 10.14.2'
     hasBin: true
+    peerDependencies:
+      canvas: '*'
     resolution:
-      integrity: sha512-vVcly0n/ijZvdy6gPQiQt0YANwX2hLTPQZHtW7Vi3gcFdKTtif7YpI85F8R8JYy5DFSWz4x1OW0arnxlziu5Lw==
+      integrity: sha512-kw2Pr3V2x9/WzSDGsbz/MJBNlCoPMxMudrIavft4bqRlv5tASjU51tyO+1Os1LdW2dAnLQZYsxFUZ8oWPyssGQ==
+  /jest-cli/26.4.0_canvas@2.6.1:
+    dependencies:
+      '@jest/core': 26.4.0_canvas@2.6.1
+      '@jest/test-result': 26.3.0
+      '@jest/types': 26.3.0
+      chalk: 4.1.0
+      exit: 0.1.2
+      graceful-fs: 4.2.4
+      import-local: 3.0.2
+      is-ci: 2.0.0
+      jest-config: 26.4.0_canvas@2.6.1
+      jest-util: 26.3.0
+      jest-validate: 26.4.0
+      prompts: 2.3.2
+      yargs: 15.4.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    hasBin: true
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-kw2Pr3V2x9/WzSDGsbz/MJBNlCoPMxMudrIavft4bqRlv5tASjU51tyO+1Os1LdW2dAnLQZYsxFUZ8oWPyssGQ==
   /jest-config/24.9.0:
     dependencies:
-      '@babel/core': 7.10.5
+      '@babel/core': 7.11.1
       '@jest/test-sequencer': 24.9.0
       '@jest/types': 24.9.0
-      babel-jest: 24.9.0_@babel+core@7.10.5
+      babel-jest: 24.9.0_@babel+core@7.11.1
       chalk: 2.4.2
       glob: 7.1.6
       jest-environment-jsdom: 24.9.0
@@ -13254,31 +13661,60 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-RATtQJtVYQrp7fvWg6f5y3pEFj9I+H8sWw4aKxnDZ96mob5i5SD6ZEGWgMLXQ4LE8UurrjbdlLWdUeo+28QpfQ==
-  /jest-config/26.2.2:
+  /jest-config/26.4.0:
     dependencies:
-      '@babel/core': 7.10.5
-      '@jest/test-sequencer': 26.2.2
-      '@jest/types': 26.2.0
-      babel-jest: 26.2.2_@babel+core@7.10.5
+      '@babel/core': 7.11.1
+      '@jest/test-sequencer': 26.4.0
+      '@jest/types': 26.3.0
+      babel-jest: 26.3.0_@babel+core@7.11.1
       chalk: 4.1.0
       deepmerge: 4.2.2
       glob: 7.1.6
       graceful-fs: 4.2.4
-      jest-environment-jsdom: 26.2.0
-      jest-environment-node: 26.2.0
-      jest-get-type: 26.0.0
-      jest-jasmine2: 26.2.2
+      jest-environment-jsdom: 26.3.0
+      jest-environment-node: 26.3.0
+      jest-get-type: 26.3.0
+      jest-jasmine2: 26.4.0
       jest-regex-util: 26.0.0
-      jest-resolve: 26.2.2_jest-resolve@26.2.2
-      jest-util: 26.2.0
-      jest-validate: 26.2.0
+      jest-resolve: 26.4.0_jest-resolve@26.4.0
+      jest-util: 26.3.0
+      jest-validate: 26.4.0
       micromatch: 4.0.2
-      pretty-format: 26.2.0
+      pretty-format: 26.4.0
     dev: true
     engines:
       node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
     resolution:
-      integrity: sha512-2lhxH0y4YFOijMJ65usuf78m7+9/8+hAb1PZQtdRdgnQpAb4zP6KcVDDktpHEkspBKnc2lmFu+RQdHukUUbiTg==
+      integrity: sha512-MxsvrBug8YY+C4QcUBtmgnHyFeW7w3Ouk/w9eplCDN8VJGVyBEZFe8Lxzfp2pSqh0Dqurqv8Oik2YkbekGUlxg==
+  /jest-config/26.4.0_canvas@2.6.1:
+    dependencies:
+      '@babel/core': 7.11.1
+      '@jest/test-sequencer': 26.4.0_canvas@2.6.1
+      '@jest/types': 26.3.0
+      babel-jest: 26.3.0_@babel+core@7.11.1
+      chalk: 4.1.0
+      deepmerge: 4.2.2
+      glob: 7.1.6
+      graceful-fs: 4.2.4
+      jest-environment-jsdom: 26.3.0_canvas@2.6.1
+      jest-environment-node: 26.3.0
+      jest-get-type: 26.3.0
+      jest-jasmine2: 26.4.0
+      jest-regex-util: 26.0.0
+      jest-resolve: 26.4.0_jest-resolve@26.4.0
+      jest-util: 26.3.0
+      jest-validate: 26.4.0
+      micromatch: 4.0.2
+      pretty-format: 26.4.0
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-MxsvrBug8YY+C4QcUBtmgnHyFeW7w3Ouk/w9eplCDN8VJGVyBEZFe8Lxzfp2pSqh0Dqurqv8Oik2YkbekGUlxg==
   /jest-diff/24.9.0:
     dependencies:
       chalk: 2.4.2
@@ -13301,17 +13737,17 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==
-  /jest-diff/26.2.0:
+  /jest-diff/26.4.0:
     dependencies:
       chalk: 4.1.0
-      diff-sequences: 26.0.0
-      jest-get-type: 26.0.0
-      pretty-format: 26.2.0
+      diff-sequences: 26.3.0
+      jest-get-type: 26.3.0
+      pretty-format: 26.4.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-Wu4Aopi2nzCsHWLBlD48TgRy3Z7OsxlwvHNd1YSnHc7q1NJfrmyCPoUXrTIrydQOG5ApaYpsAsdfnMbJqV1/wQ==
+      integrity: sha512-wwC38HlOW+iTq6j5tkj/ZamHn6/nrdcEOc/fKaVILNtN2NLWGdkfRaHWwfNYr5ehaLvuoG2LfCZIcWByVj0gjg==
   /jest-docblock/24.9.0:
     dependencies:
       detect-newline: 2.1.0
@@ -13340,18 +13776,18 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-ONi0R4BvW45cw8s2Lrx8YgbeXL1oCQ/wIDwmsM3CqM/nlblNCPmnC3IPQlMbRFZu3wKdQ2U8BqM6lh3LJ5Bsog==
-  /jest-each/26.2.0:
+  /jest-each/26.4.0:
     dependencies:
-      '@jest/types': 26.2.0
+      '@jest/types': 26.3.0
       chalk: 4.1.0
-      jest-get-type: 26.0.0
-      jest-util: 26.2.0
-      pretty-format: 26.2.0
+      jest-get-type: 26.3.0
+      jest-util: 26.3.0
+      pretty-format: 26.4.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-gHPCaho1twWHB5bpcfnozlc6mrMi+VAewVPNgmwf81x2Gzr6XO4dl+eOrwPWxbkYlgjgrYjWK2xgKnixbzH3Ew==
+      integrity: sha512-+cyBh1ehs6thVT/bsZVG+WwmRn2ix4Q4noS9yLZgM10yGWPW12/TDvwuOV2VZXn1gi09/ZwJKJWql6YW1C9zNw==
   /jest-environment-jsdom-fifteen/1.0.2_canvas@2.6.1:
     dependencies:
       '@jest/environment': 24.9.0
@@ -13378,20 +13814,38 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-Zv9FV9NBRzLuALXjvRijO2351DRQeLYXtpD4xNvfoVFw21IOKNhZAEUKcbiEtjTkm2GsJ3boMVgkaR7rN8qetA==
-  /jest-environment-jsdom/26.2.0:
+  /jest-environment-jsdom/26.3.0:
     dependencies:
-      '@jest/environment': 26.2.0
-      '@jest/fake-timers': 26.2.0
-      '@jest/types': 26.2.0
+      '@jest/environment': 26.3.0
+      '@jest/fake-timers': 26.3.0
+      '@jest/types': 26.3.0
       '@types/node': 14.0.27
-      jest-mock: 26.2.0
-      jest-util: 26.2.0
+      jest-mock: 26.3.0
+      jest-util: 26.3.0
       jsdom: 16.3.0
     dev: true
     engines:
       node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
     resolution:
-      integrity: sha512-sDG24+5M4NuIGzkI3rJW8XUlrpkvIdE9Zz4jhD8OBnVxAw+Y1jUk9X+lAOD48nlfUTlnt3lbAI3k2Ox+WF3S0g==
+      integrity: sha512-zra8He2btIMJkAzvLaiZ9QwEPGEetbxqmjEBQwhH3CA+Hhhu0jSiEJxnJMbX28TGUvPLxBt/zyaTLrOPF4yMJA==
+  /jest-environment-jsdom/26.3.0_canvas@2.6.1:
+    dependencies:
+      '@jest/environment': 26.3.0
+      '@jest/fake-timers': 26.3.0
+      '@jest/types': 26.3.0
+      '@types/node': 14.0.27
+      jest-mock: 26.3.0
+      jest-util: 26.3.0
+      jsdom: 16.3.0_canvas@2.6.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-zra8He2btIMJkAzvLaiZ9QwEPGEetbxqmjEBQwhH3CA+Hhhu0jSiEJxnJMbX28TGUvPLxBt/zyaTLrOPF4yMJA==
   /jest-environment-node/24.9.0:
     dependencies:
       '@jest/environment': 24.9.0
@@ -13404,19 +13858,19 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==
-  /jest-environment-node/26.2.0:
+  /jest-environment-node/26.3.0:
     dependencies:
-      '@jest/environment': 26.2.0
-      '@jest/fake-timers': 26.2.0
-      '@jest/types': 26.2.0
+      '@jest/environment': 26.3.0
+      '@jest/fake-timers': 26.3.0
+      '@jest/types': 26.3.0
       '@types/node': 14.0.27
-      jest-mock: 26.2.0
-      jest-util: 26.2.0
+      jest-mock: 26.3.0
+      jest-util: 26.3.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-4M5ExTYkJ19efBzkiXtBi74JqKLDciEk4CEsp5tTjWGYMrlKFQFtwIVG3tW1OGE0AlXhZjuHPwubuRYY4j4uOw==
+      integrity: sha512-c9BvYoo+FGcMj5FunbBgtBnbR5qk3uky8PKyRVpSfe2/8+LrNQMiXX53z6q2kY+j15SkjQCOSL/6LHnCPLVHNw==
   /jest-get-type/24.9.0:
     dev: true
     engines:
@@ -13429,12 +13883,12 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==
-  /jest-get-type/26.0.0:
+  /jest-get-type/26.3.0:
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==
+      integrity: sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
   /jest-haste-map/24.9.0:
     dependencies:
       '@jest/types': 24.9.0
@@ -13455,18 +13909,18 @@ packages:
       fsevents: 1.2.13
     resolution:
       integrity: sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==
-  /jest-haste-map/26.2.2:
+  /jest-haste-map/26.3.0:
     dependencies:
-      '@jest/types': 26.2.0
+      '@jest/types': 26.3.0
       '@types/graceful-fs': 4.1.3
       '@types/node': 14.0.27
       anymatch: 3.1.1
       fb-watchman: 2.0.1
       graceful-fs: 4.2.4
       jest-regex-util: 26.0.0
-      jest-serializer: 26.2.0
-      jest-util: 26.2.0
-      jest-worker: 26.2.1
+      jest-serializer: 26.3.0
+      jest-util: 26.3.0
+      jest-worker: 26.3.0
       micromatch: 4.0.2
       sane: 4.1.0
       walker: 1.0.7
@@ -13476,10 +13930,10 @@ packages:
     optionalDependencies:
       fsevents: 2.1.3
     resolution:
-      integrity: sha512-3sJlMSt+NHnzCB+0KhJ1Ut4zKJBiJOlbrqEYNdRQGlXTv8kqzZWjUKQRY3pkjmlf+7rYjAV++MQ4D6g4DhAyOg==
+      integrity: sha512-DHWBpTJgJhLLGwE5Z1ZaqLTYqeODQIZpby0zMBsCU9iRFHYyhklYqP4EiG73j5dkbaAdSZhgB938mL51Q5LeZA==
   /jest-jasmine2/24.9.0:
     dependencies:
-      '@babel/traverse': 7.10.5
+      '@babel/traverse': 7.11.0
       '@jest/environment': 24.9.0
       '@jest/test-result': 24.9.0
       '@jest/types': 24.9.0
@@ -13500,31 +13954,33 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-Cq7vkAgaYKp+PsX+2/JbTarrk0DmNhsEtqBXNwUHkdlbrTBLtMJINADf2mf5FkowNsq8evbPc07/qFO0AdKTzw==
-  /jest-jasmine2/26.2.2:
+  /jest-jasmine2/26.4.0:
     dependencies:
       '@babel/traverse': 7.11.0
-      '@jest/environment': 26.2.0
-      '@jest/source-map': 26.1.0
-      '@jest/test-result': 26.2.0
-      '@jest/types': 26.2.0
+      '@jest/environment': 26.3.0
+      '@jest/source-map': 26.3.0
+      '@jest/test-result': 26.3.0
+      '@jest/types': 26.3.0
       '@types/node': 14.0.27
       chalk: 4.1.0
       co: 4.6.0
-      expect: 26.2.0
+      expect: 26.4.0
       is-generator-fn: 2.1.0
-      jest-each: 26.2.0
-      jest-matcher-utils: 26.2.0
-      jest-message-util: 26.2.0
-      jest-runtime: 26.2.2
-      jest-snapshot: 26.2.2
-      jest-util: 26.2.0
-      pretty-format: 26.2.0
+      jest-each: 26.4.0
+      jest-matcher-utils: 26.4.0
+      jest-message-util: 26.3.0
+      jest-runtime: 26.4.0
+      jest-snapshot: 26.4.0
+      jest-util: 26.3.0
+      pretty-format: 26.4.0
       throat: 5.0.0
     dev: true
     engines:
       node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
     resolution:
-      integrity: sha512-Q8AAHpbiZMVMy4Hz9j1j1bg2yUmPa1W9StBvcHqRaKa9PHaDUMwds8LwaDyzP/2fkybcTQE4+pTMDOG9826tEw==
+      integrity: sha512-cGBxwzDDKB09EPJ4pE69BMDv+2lO442IB1xQd+vL3cua2OKdeXQK6iDlQKoRX/iP0RgU5T8sn9yahLcx/+ox8Q==
   /jest-junit/11.1.0:
     dependencies:
       mkdirp: 1.0.4
@@ -13545,15 +14001,15 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-tYkFIDsiKTGwb2FG1w8hX9V0aUb2ot8zY/2nFg087dUageonw1zrLMP4W6zsRO59dPkTSKie+D4rhMuP9nRmrA==
-  /jest-leak-detector/26.2.0:
+  /jest-leak-detector/26.4.0:
     dependencies:
-      jest-get-type: 26.0.0
-      pretty-format: 26.2.0
+      jest-get-type: 26.3.0
+      pretty-format: 26.4.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-aQdzTX1YiufkXA1teXZu5xXOJgy7wZQw6OJ0iH5CtQlOETe6gTSocaYKUNui1SzQ91xmqEUZ/WRavg9FD82rtQ==
+      integrity: sha512-7EXKKEKnAWUPyiVtGZzJflbPOtYUdlNoevNVOkAcPpdR8xWiYKPGNGA6sz25S+8YhZq3rmkQJYAh3/P0VnoRwA==
   /jest-matcher-utils/24.9.0:
     dependencies:
       chalk: 2.4.2
@@ -13576,17 +14032,17 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-VWI269+9JS5cpndnpCwm7dy7JtGQT30UHfrnM3mXl22gHGt/b7NkjBqXfbhZ8V4B7ANUsjK18PlSBmG0YH7gjw==
-  /jest-matcher-utils/26.2.0:
+  /jest-matcher-utils/26.4.0:
     dependencies:
       chalk: 4.1.0
-      jest-diff: 26.2.0
-      jest-get-type: 26.0.0
-      pretty-format: 26.2.0
+      jest-diff: 26.4.0
+      jest-get-type: 26.3.0
+      pretty-format: 26.4.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-2cf/LW2VFb3ayPHrH36ZDjp9+CAeAe/pWBAwsV8t3dKcrINzXPVxq8qMWOxwt5BaeBCx4ZupVGH7VIgB8v66vQ==
+      integrity: sha512-u+xdCdq+F262DH+PutJKXLGr2H5P3DImdJCir51PGSfi3TtbLQ5tbzKaN8BkXbiTIU6ayuAYBWTlU1nyckVdzA==
   /jest-message-util/24.9.0:
     dependencies:
       '@babel/code-frame': 7.10.4
@@ -13602,10 +14058,10 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==
-  /jest-message-util/26.2.0:
+  /jest-message-util/26.3.0:
     dependencies:
       '@babel/code-frame': 7.10.4
-      '@jest/types': 26.2.0
+      '@jest/types': 26.3.0
       '@types/stack-utils': 1.0.1
       chalk: 4.1.0
       graceful-fs: 4.2.4
@@ -13616,7 +14072,7 @@ packages:
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-g362RhZaJuqeqG108n1sthz5vNpzTNy926eNDszo4ncRbmmcMRIUAZibnd6s5v2XSBCChAxQtCoN25gnzp7JbQ==
+      integrity: sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==
   /jest-mock/24.9.0:
     dependencies:
       '@jest/types': 24.9.0
@@ -13625,15 +14081,15 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==
-  /jest-mock/26.2.0:
+  /jest-mock/26.3.0:
     dependencies:
-      '@jest/types': 26.2.0
+      '@jest/types': 26.3.0
       '@types/node': 14.0.27
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-XeC7yWtWmWByoyVOHSsE7NYsbXJLtJNgmhD7z4MKumKm6ET0si81bsSLbQ64L5saK3TgsHo2B/UqG5KNZ1Sp/Q==
+      integrity: sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==
   /jest-pnp-resolver/1.2.2_jest-resolve@24.9.0:
     dependencies:
       jest-resolve: 24.9.0_jest-resolve@24.9.0
@@ -13647,9 +14103,9 @@ packages:
         optional: true
     resolution:
       integrity: sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
-  /jest-pnp-resolver/1.2.2_jest-resolve@26.2.2:
+  /jest-pnp-resolver/1.2.2_jest-resolve@26.4.0:
     dependencies:
-      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-resolve: 26.4.0_jest-resolve@26.4.0
     dev: true
     engines:
       node: '>=6'
@@ -13682,16 +14138,16 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-Fm7b6AlWnYhT0BXy4hXpactHIqER7erNgIsIozDXWl5dVm+k8XdGVe1oTg1JyaFnOxarMEbax3wyRJqGP2Pq+g==
-  /jest-resolve-dependencies/26.2.2:
+  /jest-resolve-dependencies/26.4.0:
     dependencies:
-      '@jest/types': 26.2.0
+      '@jest/types': 26.3.0
       jest-regex-util: 26.0.0
-      jest-snapshot: 26.2.2
+      jest-snapshot: 26.4.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-S5vufDmVbQXnpP7435gr710xeBGUFcKNpNswke7RmFvDQtmqPjPVU/rCeMlEU0p6vfpnjhwMYeaVjKZAy5QYJA==
+      integrity: sha512-hznK/hlrlhu8hwdbieRdHFKmcV83GW8t30libt/v6j1L3IEzb8iN21SaWzV8KRAAK4ijiU0kuge0wnHn+0rytQ==
   /jest-resolve/24.9.0_jest-resolve@24.9.0:
     dependencies:
       '@jest/types': 24.9.0
@@ -13706,13 +14162,13 @@ packages:
       jest-resolve: '*'
     resolution:
       integrity: sha512-TaLeLVL1l08YFZAt3zaPtjiVvyy4oSA6CRe+0AFPPVX3Q/VI0giIWWoAvoS5L96vj9Dqxj4fB5p2qrHCmTU/MQ==
-  /jest-resolve/26.2.2_jest-resolve@26.2.2:
+  /jest-resolve/26.4.0_jest-resolve@26.4.0:
     dependencies:
-      '@jest/types': 26.2.0
+      '@jest/types': 26.3.0
       chalk: 4.1.0
       graceful-fs: 4.2.4
-      jest-pnp-resolver: 1.2.2_jest-resolve@26.2.2
-      jest-util: 26.2.0
+      jest-pnp-resolver: 1.2.2_jest-resolve@26.4.0
+      jest-util: 26.3.0
       read-pkg-up: 7.0.1
       resolve: 1.17.0
       slash: 3.0.0
@@ -13722,7 +14178,7 @@ packages:
     peerDependencies:
       jest-resolve: '*'
     resolution:
-      integrity: sha512-ye9Tj/ILn/0OgFPE/3dGpQPUqt4dHwIocxt5qSBkyzxQD8PbL0bVxBogX2FHxsd3zJA7V2H/cHXnBnNyyT9YoQ==
+      integrity: sha512-bn/JoZTEXRSlEx3+SfgZcJAVuTMOksYq9xe9O6s4Ekg84aKBObEaVXKOEilULRqviSLAYJldnoWV9c07kwtiCg==
   /jest-runner/24.9.0:
     dependencies:
       '@jest/console': 24.9.0
@@ -13749,33 +14205,64 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-KksJQyI3/0mhcfspnxxEOBueGrd5E4vV7ADQLT9ESaCzz02WnbdbKWIf5Mkaucoaj7obQckYPVX6JJhgUcoWWg==
-  /jest-runner/26.2.2:
+  /jest-runner/26.4.0:
     dependencies:
-      '@jest/console': 26.2.0
-      '@jest/environment': 26.2.0
-      '@jest/test-result': 26.2.0
-      '@jest/types': 26.2.0
+      '@jest/console': 26.3.0
+      '@jest/environment': 26.3.0
+      '@jest/test-result': 26.3.0
+      '@jest/types': 26.3.0
       '@types/node': 14.0.27
       chalk: 4.1.0
       emittery: 0.7.1
       exit: 0.1.2
       graceful-fs: 4.2.4
-      jest-config: 26.2.2
+      jest-config: 26.4.0
       jest-docblock: 26.0.0
-      jest-haste-map: 26.2.2
-      jest-leak-detector: 26.2.0
-      jest-message-util: 26.2.0
-      jest-resolve: 26.2.2_jest-resolve@26.2.2
-      jest-runtime: 26.2.2
-      jest-util: 26.2.0
-      jest-worker: 26.2.1
+      jest-haste-map: 26.3.0
+      jest-leak-detector: 26.4.0
+      jest-message-util: 26.3.0
+      jest-resolve: 26.4.0_jest-resolve@26.4.0
+      jest-runtime: 26.4.0
+      jest-util: 26.3.0
+      jest-worker: 26.3.0
       source-map-support: 0.5.19
       throat: 5.0.0
     dev: true
     engines:
       node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
     resolution:
-      integrity: sha512-/qb6ptgX+KQ+aNMohJf1We695kaAfuu3u3ouh66TWfhTpLd9WbqcF6163d/tMoEY8GqPztXPLuyG0rHRVDLxCA==
+      integrity: sha512-XF+tnUGolnPriu6Gg+HHWftspMjD5NkTV2mQppQnpZe39GcUangJ0al7aBGtA3GbVAcRd048DQiJPmsQRdugjw==
+  /jest-runner/26.4.0_canvas@2.6.1:
+    dependencies:
+      '@jest/console': 26.3.0
+      '@jest/environment': 26.3.0
+      '@jest/test-result': 26.3.0
+      '@jest/types': 26.3.0
+      '@types/node': 14.0.27
+      chalk: 4.1.0
+      emittery: 0.7.1
+      exit: 0.1.2
+      graceful-fs: 4.2.4
+      jest-config: 26.4.0_canvas@2.6.1
+      jest-docblock: 26.0.0
+      jest-haste-map: 26.3.0
+      jest-leak-detector: 26.4.0
+      jest-message-util: 26.3.0
+      jest-resolve: 26.4.0_jest-resolve@26.4.0
+      jest-runtime: 26.4.0
+      jest-util: 26.3.0
+      jest-worker: 26.3.0
+      source-map-support: 0.5.19
+      throat: 5.0.0
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-XF+tnUGolnPriu6Gg+HHWftspMjD5NkTV2mQppQnpZe39GcUangJ0al7aBGtA3GbVAcRd048DQiJPmsQRdugjw==
   /jest-runtime/24.9.0:
     dependencies:
       '@jest/console': 24.9.0
@@ -13807,31 +14294,31 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-8oNqgnmF3v2J6PVRM2Jfuj8oX3syKmaynlDMMKQ4iyzbQzIG6th5ub/lM2bCMTmoTKM3ykcUYI2Pw9xwNtjMnw==
-  /jest-runtime/26.2.2:
+  /jest-runtime/26.4.0:
     dependencies:
-      '@jest/console': 26.2.0
-      '@jest/environment': 26.2.0
-      '@jest/fake-timers': 26.2.0
-      '@jest/globals': 26.2.0
-      '@jest/source-map': 26.1.0
-      '@jest/test-result': 26.2.0
-      '@jest/transform': 26.2.2
-      '@jest/types': 26.2.0
+      '@jest/console': 26.3.0
+      '@jest/environment': 26.3.0
+      '@jest/fake-timers': 26.3.0
+      '@jest/globals': 26.4.0
+      '@jest/source-map': 26.3.0
+      '@jest/test-result': 26.3.0
+      '@jest/transform': 26.3.0
+      '@jest/types': 26.3.0
       '@types/yargs': 15.0.5
       chalk: 4.1.0
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.1.6
       graceful-fs: 4.2.4
-      jest-config: 26.2.2
-      jest-haste-map: 26.2.2
-      jest-message-util: 26.2.0
-      jest-mock: 26.2.0
+      jest-config: 26.4.0
+      jest-haste-map: 26.3.0
+      jest-message-util: 26.3.0
+      jest-mock: 26.3.0
       jest-regex-util: 26.0.0
-      jest-resolve: 26.2.2_jest-resolve@26.2.2
-      jest-snapshot: 26.2.2
-      jest-util: 26.2.0
-      jest-validate: 26.2.0
+      jest-resolve: 26.4.0_jest-resolve@26.4.0
+      jest-snapshot: 26.4.0
+      jest-util: 26.3.0
+      jest-validate: 26.4.0
       slash: 3.0.0
       strip-bom: 4.0.0
       yargs: 15.4.1
@@ -13839,8 +14326,10 @@ packages:
     engines:
       node: '>= 10.14.2'
     hasBin: true
+    peerDependencies:
+      canvas: '*'
     resolution:
-      integrity: sha512-a8VXM3DxCDnCIdl9+QucWFfQ28KdqmyVFqeKLigHdErtsx56O2ZIdQkhFSuP1XtVrG9nTNHbKxjh5XL1UaFDVQ==
+      integrity: sha512-1fjZgGpkyQBUTo59Vi19I4IcsBwzY6uwVFNjUmR06iIi3XRErkY28yimi4IUDRrofQErqcDEw2n3DF9WmQ6vEg==
   /jest-serializer-vue/2.0.2:
     dependencies:
       pretty: 2.0.0
@@ -13853,7 +14342,7 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==
-  /jest-serializer/26.2.0:
+  /jest-serializer/26.3.0:
     dependencies:
       '@types/node': 14.0.27
       graceful-fs: 4.2.4
@@ -13861,10 +14350,10 @@ packages:
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-V7snZI9IVmyJEu0Qy0inmuXgnMWDtrsbV2p9CRAcmlmPVwpC2ZM8wXyYpiugDQnwLHx0V4+Pnog9Exb3UO8M6Q==
+      integrity: sha512-IDRBQBLPlKa4flg77fqg0n/pH87tcRKwe8zxOVTWISxGpPHYkRZ1dXKyh04JOja7gppc60+soKVZ791mruVdow==
   /jest-snapshot/24.9.0:
     dependencies:
-      '@babel/types': 7.10.5
+      '@babel/types': 7.11.0
       '@jest/types': 24.9.0
       chalk: 2.4.2
       expect: 24.9.0
@@ -13882,28 +14371,28 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-uI/rszGSs73xCM0l+up7O7a40o90cnrk429LOiK3aeTvfC0HHmldbd81/B7Ix81KSFe1lwkbl7GnBGG4UfuDew==
-  /jest-snapshot/26.2.2:
+  /jest-snapshot/26.4.0:
     dependencies:
-      '@babel/types': 7.10.5
-      '@jest/types': 26.2.0
+      '@babel/types': 7.11.0
+      '@jest/types': 26.3.0
       '@types/prettier': 2.0.2
       chalk: 4.1.0
-      expect: 26.2.0
+      expect: 26.4.0
       graceful-fs: 4.2.4
-      jest-diff: 26.2.0
-      jest-get-type: 26.0.0
-      jest-haste-map: 26.2.2
-      jest-matcher-utils: 26.2.0
-      jest-message-util: 26.2.0
-      jest-resolve: 26.2.2_jest-resolve@26.2.2
+      jest-diff: 26.4.0
+      jest-get-type: 26.3.0
+      jest-haste-map: 26.3.0
+      jest-matcher-utils: 26.4.0
+      jest-message-util: 26.3.0
+      jest-resolve: 26.4.0_jest-resolve@26.4.0
       natural-compare: 1.4.0
-      pretty-format: 26.2.0
+      pretty-format: 26.4.0
       semver: 7.3.2
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-NdjD8aJS7ePu268Wy/n/aR1TUisG0BOY+QOW4f6h46UHEKOgYmmkvJhh2BqdVZQ0BHSxTMt04WpCf9njzx8KtA==
+      integrity: sha512-vFGmNGWHMBomrlOpheTMoqihymovuH3GqfmaEIWoPpsxUXyxT3IlbxI5I4m2vg0uv3HUJYg5JoGrkgMzVsAwCg==
   /jest-transform-stub/2.0.0:
     dev: true
     resolution:
@@ -13927,18 +14416,6 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==
-  /jest-util/26.1.0:
-    dependencies:
-      '@jest/types': 26.1.0
-      chalk: 4.1.0
-      graceful-fs: 4.2.4
-      is-ci: 2.0.0
-      micromatch: 4.0.2
-    dev: true
-    engines:
-      node: '>= 10.14.2'
-    resolution:
-      integrity: sha512-rNMOwFQevljfNGvbzNQAxdmXQ+NawW/J72dmddsK0E8vgxXCMtwQ/EH0BiWEIxh0hhMcTsxwAxINt7Lh46Uzbg==
   /jest-util/26.2.0:
     dependencies:
       '@jest/types': 26.2.0
@@ -13952,6 +14429,19 @@ packages:
       node: '>= 10.14.2'
     resolution:
       integrity: sha512-YmDwJxLZ1kFxpxPfhSJ0rIkiZOM0PQbRcfH0TzJOhqCisCAsI1WcmoQqO83My9xeVA2k4n+rzg2UuexVKzPpig==
+  /jest-util/26.3.0:
+    dependencies:
+      '@jest/types': 26.3.0
+      '@types/node': 14.0.27
+      chalk: 4.1.0
+      graceful-fs: 4.2.4
+      is-ci: 2.0.0
+      micromatch: 4.0.2
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    resolution:
+      integrity: sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==
   /jest-validate/24.9.0:
     dependencies:
       '@jest/types': 24.9.0
@@ -13965,19 +14455,19 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==
-  /jest-validate/26.2.0:
+  /jest-validate/26.4.0:
     dependencies:
-      '@jest/types': 26.2.0
+      '@jest/types': 26.3.0
       camelcase: 6.0.0
       chalk: 4.1.0
-      jest-get-type: 26.0.0
+      jest-get-type: 26.3.0
       leven: 3.1.0
-      pretty-format: 26.2.0
+      pretty-format: 26.4.0
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-8XKn3hM6VIVmLNuyzYLCPsRCT83o8jMZYhbieh4dAyKLc4Ypr36rVKC+c8WMpWkfHHpGnEkvWUjjIAyobEIY/Q==
+      integrity: sha512-t56Z/FRMrLP6mpmje7/YgHy0wOzcuc6i3LBXz6kjmsUWYN62OuMdC86Vg9/dX59SvyitSqqegOrx+h7BkNXeaQ==
   /jest-watch-typeahead/0.4.2:
     dependencies:
       ansi-escapes: 4.3.1
@@ -14004,20 +14494,20 @@ packages:
       node: '>= 6'
     resolution:
       integrity: sha512-+/fLOfKPXXYJDYlks62/4R4GoT+GU1tYZed99JSCOsmzkkF7727RqKrjNAxtfO4YpGv11wybgRvCjR73lK2GZw==
-  /jest-watcher/26.2.0:
+  /jest-watcher/26.3.0:
     dependencies:
-      '@jest/test-result': 26.2.0
-      '@jest/types': 26.2.0
+      '@jest/test-result': 26.3.0
+      '@jest/types': 26.3.0
       '@types/node': 14.0.27
       ansi-escapes: 4.3.1
       chalk: 4.1.0
-      jest-util: 26.2.0
+      jest-util: 26.3.0
       string-length: 4.0.1
     dev: true
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-674Boco4Joe0CzgKPL6K4Z9LgyLx+ZvW2GilbpYb8rFEUkmDGgsZdv1Hv5rxsRpb1HLgKUOL/JfbttRCuFdZXQ==
+      integrity: sha512-XnLdKmyCGJ3VoF6G/p5ohbJ04q/vv5aH9ENI+i6BL0uu9WWB6Z7Z2lhQQk0d2AVZcRGp1yW+/TsoToMhBFPRdQ==
   /jest-worker/24.9.0:
     dependencies:
       merge-stream: 2.0.0
@@ -14036,16 +14526,16 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==
-  /jest-worker/26.2.1:
+  /jest-worker/26.3.0:
     dependencies:
       '@types/node': 14.0.27
       merge-stream: 2.0.0
       supports-color: 7.1.0
     dev: true
     engines:
-      node: '>= 10.14.2'
+      node: '>= 10.13.0'
     resolution:
-      integrity: sha512-+XcGMMJDTeEGncRb5M5Zq9P7K4sQ1sirhjdOxsN1462h6lFo9w59bl2LVQmdGEEeU3m+maZCkS2Tcc9SfCHO4A==
+      integrity: sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==
   /jest/24.9.0:
     dependencies:
       import-local: 2.0.0
@@ -14056,17 +14546,32 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==
-  /jest/26.2.2:
+  /jest/26.4.0:
     dependencies:
-      '@jest/core': 26.2.2
+      '@jest/core': 26.4.0
       import-local: 3.0.2
-      jest-cli: 26.2.2
+      jest-cli: 26.4.0
     dev: true
     engines:
       node: '>= 10.14.2'
     hasBin: true
+    peerDependencies:
+      canvas: '*'
     resolution:
-      integrity: sha512-EkJNyHiAG1+A8pqSz7cXttoVa34hOEzN/MrnJhYnfp5VHxflVcf2pu3oJSrhiy6LfIutLdWo+n6q63tjcoIeig==
+      integrity: sha512-lNCOS+ckRHE1wFyVtQClBmbsOVuH2GWUTJMDL3vunp9DXcah+V8vfvVVApngClcdoc3rgZpqOfCNKLjxjj2l4g==
+  /jest/26.4.0_canvas@2.6.1:
+    dependencies:
+      '@jest/core': 26.4.0_canvas@2.6.1
+      import-local: 3.0.2
+      jest-cli: 26.4.0_canvas@2.6.1
+    dev: true
+    engines:
+      node: '>= 10.14.2'
+    hasBin: true
+    peerDependencies:
+      canvas: '*'
+    resolution:
+      integrity: sha512-lNCOS+ckRHE1wFyVtQClBmbsOVuH2GWUTJMDL3vunp9DXcah+V8vfvVVApngClcdoc3rgZpqOfCNKLjxjj2l4g==
   /js-beautify/1.11.0:
     dependencies:
       config-chain: 1.1.12
@@ -14099,7 +14604,6 @@ packages:
     resolution:
       integrity: sha1-NiITz4YPRo8BJfxslqvBdCUx+Ug=
   /js-sha3/0.5.7:
-    dev: false
     resolution:
       integrity: sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
   /js-sha3/0.8.0:
@@ -14124,19 +14628,19 @@ packages:
   /jsbn/0.1.1:
     resolution:
       integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
-  /jscodeshift/0.10.0_@babel+preset-env@7.10.4:
+  /jscodeshift/0.10.0_@babel+preset-env@7.11.0:
     dependencies:
-      '@babel/core': 7.10.5
-      '@babel/parser': 7.10.5
-      '@babel/plugin-proposal-class-properties': 7.10.4_@babel+core@7.10.5
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.10.4_@babel+core@7.10.5
-      '@babel/plugin-proposal-optional-chaining': 7.10.4_@babel+core@7.10.5
-      '@babel/plugin-transform-modules-commonjs': 7.10.4_@babel+core@7.10.5
-      '@babel/preset-env': 7.10.4_@babel+core@7.11.1
-      '@babel/preset-flow': 7.10.4_@babel+core@7.10.5
-      '@babel/preset-typescript': 7.10.4_@babel+core@7.10.5
-      '@babel/register': 7.10.5_@babel+core@7.10.5
-      babel-core: 7.0.0-bridge.0_@babel+core@7.10.5
+      '@babel/core': 7.11.1
+      '@babel/parser': 7.11.3
+      '@babel/plugin-proposal-class-properties': 7.10.4_@babel+core@7.11.1
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.10.4_@babel+core@7.11.1
+      '@babel/plugin-proposal-optional-chaining': 7.11.0_@babel+core@7.11.1
+      '@babel/plugin-transform-modules-commonjs': 7.10.4_@babel+core@7.11.1
+      '@babel/preset-env': 7.11.0_@babel+core@7.11.1
+      '@babel/preset-flow': 7.10.4_@babel+core@7.11.1
+      '@babel/preset-typescript': 7.10.4_@babel+core@7.11.1
+      '@babel/register': 7.10.5_@babel+core@7.11.1
+      babel-core: 7.0.0-bridge.0_@babel+core@7.11.1
       colors: 1.4.0
       flow-parser: 0.129.0
       graceful-fs: 4.2.4
@@ -14152,13 +14656,6 @@ packages:
       '@babel/preset-env': ^7.1.6
     resolution:
       integrity: sha512-xpH2FVSEepXoNr6+cPlPHzPzBY1W9bPulufhCHOShzk8+CTCzAOQKytuOXT0b/9PvmO4biRi0g/ZIylVew815w==
-  /jsdoctypeparser/8.0.0:
-    dev: true
-    engines:
-      node: '>=10'
-    hasBin: true
-    resolution:
-      integrity: sha512-eLCs6s4JqN8TjFJfgdiLHRvogLhOAJz+5RIA2FtoMe6ZDyuvghvppnlIToqAEnVbxRqLMrfnNXpW8FpmR6IMBw==
   /jsdoctypeparser/9.0.0:
     dev: true
     engines:
@@ -14200,7 +14697,7 @@ packages:
   /jsdom/15.2.1_canvas@2.6.1:
     dependencies:
       abab: 2.0.3
-      acorn: 7.3.1
+      acorn: 7.4.0
       acorn-globals: 4.3.4
       array-equal: 1.0.0
       canvas: 2.6.1
@@ -14239,8 +14736,47 @@ packages:
   /jsdom/16.3.0:
     dependencies:
       abab: 2.0.3
-      acorn: 7.3.1
+      acorn: 7.4.0
       acorn-globals: 6.0.0
+      cssom: 0.4.4
+      cssstyle: 2.3.0
+      data-urls: 2.0.0
+      decimal.js: 10.2.0
+      domexception: 2.0.1
+      escodegen: 1.14.3
+      html-encoding-sniffer: 2.0.1
+      is-potential-custom-element-name: 1.0.0
+      nwsapi: 2.2.0
+      parse5: 5.1.1
+      request: 2.88.2
+      request-promise-native: 1.0.9_request@2.88.2
+      saxes: 5.0.1
+      symbol-tree: 3.2.4
+      tough-cookie: 3.0.1
+      w3c-hr-time: 1.0.2
+      w3c-xmlserializer: 2.0.0
+      webidl-conversions: 6.1.0
+      whatwg-encoding: 1.0.5
+      whatwg-mimetype: 2.3.0
+      whatwg-url: 8.1.0
+      ws: 7.3.1
+      xml-name-validator: 3.0.0
+    dev: true
+    engines:
+      node: '>=10'
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    resolution:
+      integrity: sha512-zggeX5UuEknpdZzv15+MS1dPYG0J/TftiiNunOeNxSl3qr8Z6cIlQpN0IdJa44z9aFxZRIVqRncvEhQ7X5DtZg==
+  /jsdom/16.3.0_canvas@2.6.1:
+    dependencies:
+      abab: 2.0.3
+      acorn: 7.4.0
+      acorn-globals: 6.0.0
+      canvas: 2.6.1
       cssom: 0.4.4
       cssstyle: 2.3.0
       data-urls: 2.0.0
@@ -14662,7 +15198,7 @@ packages:
       listr-update-renderer: 0.5.0_listr@0.14.3
       listr-verbose-renderer: 0.5.0
       p-map: 2.1.0
-      rxjs: 6.6.0
+      rxjs: 6.6.2
     dev: true
     engines:
       node: '>=6'
@@ -14779,6 +15315,10 @@ packages:
     dev: true
     resolution:
       integrity: sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
+  /lodash.camelcase/4.3.0:
+    dev: true
+    resolution:
+      integrity: sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
   /lodash.clonedeep/4.5.0:
     dev: true
     resolution:
@@ -14866,6 +15406,9 @@ packages:
   /lodash/4.17.19:
     resolution:
       integrity: sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+  /lodash/4.17.20:
+    resolution:
+      integrity: sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
   /log-symbols/1.0.2:
     dependencies:
       chalk: 1.1.3
@@ -14932,7 +15475,7 @@ packages:
     dependencies:
       graceful-fs: 4.2.4
       is-promise: 2.2.2
-      lodash: 4.17.19
+      lodash: 4.17.20
       pify: 3.0.0
       steno: 0.4.4
     dev: true
@@ -14997,6 +15540,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==
+  /magic-string/0.25.7:
+    dependencies:
+      sourcemap-codec: 1.4.8
+    dev: true
+    resolution:
+      integrity: sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
   /make-dir/1.3.0:
     dependencies:
       pify: 3.0.0
@@ -15112,13 +15661,13 @@ packages:
     dev: true
     resolution:
       integrity: sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==
-  /marked/1.0.0:
+  /marked/1.1.1:
     dev: true
     engines:
       node: '>= 8.16.2'
     hasBin: true
     resolution:
-      integrity: sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==
+      integrity: sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==
   /material-design-icons-iconfont/5.0.1:
     dev: true
     resolution:
@@ -15185,6 +15734,15 @@ packages:
       node: '>=6'
     resolution:
       integrity: sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==
+  /memfs/3.2.0:
+    dependencies:
+      fs-monkey: 1.0.1
+    dev: true
+    engines:
+      node: '>= 4.0.0'
+    optional: true
+    resolution:
+      integrity: sha512-f/xxz2TpdKv6uDn6GtHee8ivFyxwxmPuXatBb1FBwxYNuVpbM3k/Y1Z+vC0mH/dIXXrukYfe3qe5J32Dfjg93A==
   /memory-fs/0.4.1:
     dependencies:
       errno: 0.1.7
@@ -15364,12 +15922,12 @@ packages:
       webpack: ^4.4.0
     resolution:
       integrity: sha512-79q5P7YGI6rdnVyIAV4NXpBQJFWdkzJxCim3Kog4078fM0piAaFlwocqbejdWtLW1cEzCexPrh6EdyFsPgVdAw==
-  /mini-css-extract-plugin/0.9.0_webpack@4.43.0:
+  /mini-css-extract-plugin/0.9.0_webpack@4.44.1:
     dependencies:
       loader-utils: 1.4.0
       normalize-url: 1.9.1
       schema-utils: 1.0.0
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
       webpack-sources: 1.4.3
     dev: true
     engines:
@@ -16699,12 +17257,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-CF+TKjXqoqyDwHqBhFQ+3l5t83xYi6fVT1tQNg+Ye0JRLnTxWvIroCjEp1A0k4lneHNBGnICUf0cfYVYGEazqw==
-  /parse5/3.0.3:
-    dependencies:
-      '@types/node': 14.0.24
-    dev: true
-    resolution:
-      integrity: sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
   /parse5/4.0.0:
     dev: true
     resolution:
@@ -17196,6 +17748,20 @@ packages:
     dev: true
     resolution:
       integrity: sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==
+  /postcss-modules/3.2.0:
+    dependencies:
+      generic-names: 2.0.1
+      icss-replace-symbols: 1.1.0
+      lodash.camelcase: 4.3.0
+      postcss: 7.0.32
+      postcss-modules-extract-imports: 2.0.0
+      postcss-modules-local-by-default: 3.0.2
+      postcss-modules-scope: 2.2.0
+      postcss-modules-values: 3.0.0
+      string-hash: 1.1.3
+    dev: true
+    resolution:
+      integrity: sha512-ceodlVbBypGD3R7EI1xM7gz28J0syaXq0VKd7rJVXVlOSkxUIRBRJQjBgpoKnKVFNAcCjtLVgZqBA3mUNntWPA==
   /postcss-normalize-charset/4.0.1:
     dependencies:
       postcss: 7.0.32
@@ -17504,9 +18070,9 @@ packages:
       node: '>= 8.3'
     resolution:
       integrity: sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
-  /pretty-format/26.2.0:
+  /pretty-format/26.4.0:
     dependencies:
-      '@jest/types': 26.2.0
+      '@jest/types': 26.3.0
       ansi-regex: 5.0.0
       ansi-styles: 4.2.1
       react-is: 16.13.1
@@ -17514,7 +18080,7 @@ packages:
     engines:
       node: '>= 10.14.2'
     resolution:
-      integrity: sha512-qi/8IuBu2clY9G7qCXgCdD1Bf9w+sXakdHTRToknzMtVy0g7c4MBWaZy7MfB7ndKZovRO6XRwJiAYqq+MC7SDA==
+      integrity: sha512-mEEwwpCseqrUtuMbrJG4b824877pM5xald3AkilJ47Po2YLr97/siejYQHqj2oDQBeJNbu+Q0qUuekJ8F0NAPg==
   /pretty-time/1.1.0:
     dev: true
     engines:
@@ -17905,6 +18471,17 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
+  /recast/0.17.2:
+    dependencies:
+      ast-types: 0.12.1
+      esprima: 4.0.1
+      private: 0.1.8
+      source-map: 0.6.1
+    dev: true
+    engines:
+      node: '>= 4'
+    resolution:
+      integrity: sha512-YHFvn4rBXl8eIjALjUiOV/AP3xFpyGNGNHDw9mAncAWuIdgnBKjbZQ9+P3VlsKcNaNapRVFlTEX1dvDRlYwyxg==
   /recast/0.18.10:
     dependencies:
       ast-types: 0.13.3
@@ -18003,7 +18580,7 @@ packages:
       integrity: sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
   /regenerator-transform/0.14.5:
     dependencies:
-      '@babel/runtime': 7.10.5
+      '@babel/runtime': 7.11.2
     dev: true
     resolution:
       integrity: sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==
@@ -18206,7 +18783,7 @@ packages:
       integrity: sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=
   /request-promise-core/1.1.4_request@2.88.2:
     dependencies:
-      lodash: 4.17.19
+      lodash: 4.17.20
       request: 2.88.2
     dev: true
     engines:
@@ -18516,7 +19093,6 @@ packages:
   /rxjs/6.6.2:
     dependencies:
       tslib: 1.13.0
-    dev: false
     engines:
       npm: '>=2.0.0'
     resolution:
@@ -18553,11 +19129,12 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==
-  /sass-loader/9.0.3_webpack@4.44.1:
+  /sass-loader/9.0.3_sass@1.26.10+webpack@4.44.1:
     dependencies:
       klona: 1.1.2
       loader-utils: 2.0.0
       neo-async: 2.6.2
+      sass: 1.26.10
       schema-utils: 2.7.0
       semver: 7.3.2
       webpack: 4.44.1_webpack@4.44.1
@@ -18632,7 +19209,6 @@ packages:
     resolution:
       integrity: sha1-cV1bnMV3YPsivczDvvtb/gaxoxc=
   /scrypt-js/2.0.4:
-    dev: false
     resolution:
       integrity: sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==
   /sec/1.0.0:
@@ -18791,7 +19367,6 @@ packages:
     resolution:
       integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
   /setimmediate/1.0.4:
-    dev: false
     resolution:
       integrity: sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=
   /setimmediate/1.0.5:
@@ -18863,7 +19438,7 @@ packages:
       integrity: sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
   /shelljs/0.7.7:
     dependencies:
-      glob: 7.1.5
+      glob: 7.1.6
       interpret: 1.4.0
       rechoir: 0.6.2
     dev: true
@@ -19117,6 +19692,10 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+  /sourcemap-codec/1.4.8:
+    dev: true
+    resolution:
+      integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
   /spawn-wrap/2.0.0:
     dependencies:
       foreground-child: 2.0.0
@@ -19355,6 +19934,10 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+  /string-hash/1.1.3:
+    dev: true
+    resolution:
+      integrity: sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=
   /string-length/2.0.0:
     dependencies:
       astral-regex: 1.0.0
@@ -19969,7 +20552,7 @@ packages:
       webpack: ^4.0.0
     resolution:
       integrity: sha512-U4mACBHIegmfoEe5fdongHESNJWqsGU+W0S/9+BmYGVQDw1+c2Ow05TpMhxjPK1sRb7cuYq1BPl1e5YHJMTCqA==
-  /terser-webpack-plugin/2.3.7_webpack@4.43.0:
+  /terser-webpack-plugin/2.3.7_webpack@4.44.1:
     dependencies:
       cacache: 13.0.1
       find-cache-dir: 3.3.1
@@ -19979,7 +20562,7 @@ packages:
       serialize-javascript: 3.1.0
       source-map: 0.6.1
       terser: 4.8.0
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
       webpack-sources: 1.4.3
     dev: true
     engines:
@@ -20047,12 +20630,12 @@ packages:
     dev: true
     resolution:
       integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
-  /thread-loader/2.1.3_webpack@4.43.0:
+  /thread-loader/2.1.3_webpack@4.44.1:
     dependencies:
       loader-runner: 2.4.0
       loader-utils: 1.4.0
       neo-async: 2.6.2
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     engines:
       node: '>= 6.9.0 <7.0.0 || >= 8.9.0'
@@ -20365,13 +20948,14 @@ packages:
       jest: '>=24 <25'
     resolution:
       integrity: sha512-Hb94C/+QRIgjVZlJyiWwouYUF+siNJHJHknyspaOcZ+OQAIdFG/UrdQVXw/0B8Z3No34xkUXZJpOTy9alOWdVQ==
-  /ts-jest/26.1.4_jest@26.2.2+typescript@3.9.7:
+  /ts-jest/26.2.0_jest@26.4.0+typescript@3.9.7:
     dependencies:
+      '@types/jest': 26.0.9
       bs-logger: 0.2.6
       buffer-from: 1.1.1
       fast-json-stable-stringify: 2.1.0
-      jest: 26.2.2
-      jest-util: 26.1.0
+      jest: 26.4.0
+      jest-util: 26.2.0
       json5: 2.1.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -20387,7 +20971,7 @@ packages:
       jest: '>=26 <27'
       typescript: '>=3.8 <4.0'
     resolution:
-      integrity: sha512-Nd7diUX6NZWfWq6FYyvcIPR/c7GbEF75fH1R6coOp3fbNzbRJBZZAn0ueVS0r8r9ral1VcrpneAFAwB3TsVS1Q==
+      integrity: sha512-9+y2qwzXdAImgLSYLXAb/Rhq9+K4rbt0417b8ai987V60g2uoNWBBmMkYgutI7D8Zhu+IbCSHbBtrHxB9d7xyA==
   /ts-loader/6.2.2_typescript@3.9.7:
     dependencies:
       chalk: 2.4.2
@@ -20403,13 +20987,14 @@ packages:
       typescript: '*'
     resolution:
       integrity: sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==
-  /ts-loader/8.0.2:
+  /ts-loader/8.0.2_typescript@3.9.7:
     dependencies:
       chalk: 2.4.2
       enhanced-resolve: 4.3.0
       loader-utils: 1.4.0
       micromatch: 4.0.2
       semver: 6.3.0
+      typescript: 3.9.7
     dev: true
     engines:
       node: '>=10.0.0'
@@ -20467,10 +21052,6 @@ packages:
   /tslib/1.13.0:
     resolution:
       integrity: sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
-  /tslib/2.0.0:
-    dev: true
-    resolution:
-      integrity: sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
   /tslib/2.0.1:
     dev: true
     resolution:
@@ -20508,16 +21089,6 @@ packages:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
     resolution:
       integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==
-  /tsutils/3.17.1:
-    dependencies:
-      tslib: 1.13.0
-    dev: true
-    engines:
-      node: '>= 6'
-    peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
-    resolution:
-      integrity: sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
   /tsutils/3.17.1_typescript@3.9.7:
     dependencies:
       tslib: 1.13.0
@@ -20641,11 +21212,11 @@ packages:
       node: '>= 8'
     resolution:
       integrity: sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==
-  /typedoc-plugin-markdown/2.3.1_typedoc@0.17.8:
+  /typedoc-plugin-markdown/2.3.1_typedoc@0.18.0:
     dependencies:
       fs-extra: 9.0.1
       handlebars: 4.7.6
-      typedoc: 0.17.8_typescript@3.9.7
+      typedoc: 0.18.0_typescript@3.9.7
     dev: true
     engines:
       node: '>= 8.0.0'
@@ -20653,14 +21224,14 @@ packages:
       typedoc: '>=0.17.0'
     resolution:
       integrity: sha512-7rlmg1tLjddYy11uznHCAlyoOpxdWnFXqGEZ7j2mJ4KJg2avwWgEpw6SFZVofgPCGn36zklpFS51lHxYSRTLVQ==
-  /typedoc/0.17.8_typescript@3.9.7:
+  /typedoc/0.18.0_typescript@3.9.7:
     dependencies:
-      fs-extra: 8.1.0
+      fs-extra: 9.0.1
       handlebars: 4.7.6
       highlight.js: 10.1.1
-      lodash: 4.17.19
+      lodash: 4.17.20
       lunr: 2.3.8
-      marked: 1.0.0
+      marked: 1.1.1
       minimatch: 3.0.4
       progress: 2.0.3
       shelljs: 0.8.4
@@ -20668,12 +21239,12 @@ packages:
       typescript: 3.9.7
     dev: true
     engines:
-      node: '>= 8.0.0'
+      node: '>= 10.0.0'
     hasBin: true
     peerDependencies:
       typescript: '>=3.8.3'
     resolution:
-      integrity: sha512-/OyrHCJ8jtzu+QZ+771YaxQ9s4g5Z3XsQE3Ma7q+BL392xxBn4UMvvCdVnqKC2T/dz03/VXSLVKOP3lHmDdc/w==
+      integrity: sha512-UgDQwapCGQCCdYhEQzQ+kGutmcedklilgUGf62Vw6RdI29u6FcfAXFQfRTiJEbf16aK3YnkB20ctQK1JusCRbA==
   /typeface-roboto/0.0.75:
     dev: false
     resolution:
@@ -20997,13 +21568,13 @@ packages:
       webpack: ^3.0.0 || ^4.0.0
     resolution:
       integrity: sha512-dXHkKmw8FhPqu8asTc1puBfe3TehOCo2+RmOOev5suNCIYBcT626kxiWg1NBVkwc4rO8BGa7gP70W7VXuqHrjg==
-  /url-loader/2.3.0_file-loader@4.3.0+webpack@4.43.0:
+  /url-loader/2.3.0_file-loader@4.3.0+webpack@4.44.1:
     dependencies:
-      file-loader: 4.3.0_webpack@4.43.0
+      file-loader: 4.3.0_webpack@4.44.1
       loader-utils: 1.4.0
       mime: 2.4.6
       schema-utils: 2.7.0
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     engines:
       node: '>= 8.9.0'
@@ -21105,7 +21676,6 @@ packages:
     resolution:
       integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
   /uuid/2.0.1:
-    dev: false
     resolution:
       integrity: sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=
   /uuid/3.4.0:
@@ -21121,16 +21691,16 @@ packages:
     dev: true
     resolution:
       integrity: sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
-  /v8-to-istanbul/4.1.4:
+  /v8-to-istanbul/5.0.1:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.3
       convert-source-map: 1.7.0
       source-map: 0.7.3
     dev: true
     engines:
-      node: 8.x.x || >=10.10.0
+      node: '>=10.10.0'
     resolution:
-      integrity: sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==
+      integrity: sha512-mbDNjuDajqYe3TXFk5qxcQy8L1msXNE37WTlLoqqpBfRsimbNcrlhQlDPntmECEcUvdC+AQ8CyMMf6EUx1r74Q==
   /validate-npm-package-license/3.0.4:
     dependencies:
       spdx-correct: 3.1.1
@@ -21224,9 +21794,9 @@ packages:
       vue: ^2.0.0
     resolution:
       integrity: sha512-0CSftHY0bDTD+4FbYkuFf6+iKDjZ4h2in2YYJDRMk5daZIjrgT9LjFHvP7Rzqy9/s1pij3zDtTSLRUjsPWMwqg==
-  /vue-cli-plugin-apollo/0.21.3_c23965195f13fa8d47f6f86cdc802653:
+  /vue-cli-plugin-apollo/0.21.3_856e89e733915dcf427dc68ddbbf6ed8:
     dependencies:
-      '@vue/cli-shared-utils': 4.4.6
+      '@vue/cli-shared-utils': 4.5.4
       apollo: 2.30.1_typescript@3.9.7
       apollo-cache-inmemory: 1.6.6_graphql@14.7.0
       apollo-client: 2.6.10_graphql@14.7.0
@@ -21280,7 +21850,7 @@ packages:
   /vue-cli-plugin-vuetify/2.0.7_46332c69527428b618b3b05bceeb0ca8:
     dependencies:
       null-loader: 3.0.0_webpack@4.44.1
-      sass-loader: 9.0.3_webpack@4.44.1
+      sass-loader: 9.0.3_sass@1.26.10+webpack@4.44.1
       semver: 7.3.2
       shelljs: 0.8.4
       vuetify-loader: 1.6.0_43620c27f77956ac5513827160fed361
@@ -21296,6 +21866,24 @@ packages:
         optional: true
     resolution:
       integrity: sha512-4riK5bzyvkZ4CxpQk/Vl6z8n8tmJUhuxh+k8xc/MZRdCt9RxAm3G4SxcEweroqKGXg+CRRfhqysaEQVtd4D40Q==
+  /vue-codemod/0.0.4:
+    dependencies:
+      '@babel/core': 7.11.1
+      '@babel/preset-env': 7.11.0_@babel+core@7.11.1
+      '@types/jscodeshift': 0.7.1
+      '@vue/compiler-sfc': 3.0.0-rc.5_vue@3.0.0-rc.5
+      debug: 4.1.1
+      globby: 10.0.2
+      inquirer: 7.3.3
+      jscodeshift: 0.10.0_@babel+preset-env@7.11.0
+      vue: 3.0.0-rc.5
+      yargs: 15.4.1
+    dev: true
+    engines:
+      node: '>= 8.9'
+    hasBin: true
+    resolution:
+      integrity: sha512-mAI9g4CcY3GJOOt/fTOC8Cz9lYtBEuSiDizQHgvcX0HpoKw1bNZBPaNUqFoNxnk6+nGZVgt0/CXYnq80rRK9vg==
   /vue-eslint-parser/6.0.5_eslint@7.6.0:
     dependencies:
       debug: 4.1.1
@@ -21348,10 +21936,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-0X5nBTCZAVjlwcrPaYJwNs3iipBBTv0AUHwQUOa8yP3XbQGWKbRHqBb3OhCYtum/IHDD21d/df5Xd2VgyxbxfA==
-  /vue-i18n/8.20.0:
+  /vue-i18n/8.21.0:
     dev: false
     resolution:
-      integrity: sha512-ZiAOoeR4d/JtKpbjipx3I80ey7cYG1ki5gQ7HwzWm4YFio9brA15BEYHjalEoBaEfzF5OBEZP+Y2MvAaWnyXXg==
+      integrity: sha512-pKBq6Kg5hNacFHMFgPbpYsFlDIMRu4Ew/tpvTWns14CZoCxt7B3tmSNdrLruGMMivnJu1rhhRqsQqT6YwHkuQQ==
   /vue-jest/3.0.6_64ba5b21466dd6d31604ca8f3ce0789b:
     dependencies:
       babel-core: 7.0.0-bridge.0_@babel+core@7.11.1
@@ -21375,27 +21963,17 @@ packages:
       vue-template-compiler: ^2.x
     resolution:
       integrity: sha512-VyuM8wR0vAlYCbPRY+PhIqRU5yUyBnUmwYTo4IFScs2+tiuis5VBItU0PGC8Wcx6qJwKB5jq5p7WFhabzMFMgQ==
-  /vue-jscodeshift-adapter/2.1.0:
-    dependencies:
-      cheerio: 1.0.0-rc.3
-      detect-indent: 6.0.0
-      indent-string: 4.0.0
-      vue-sfc-descriptor-to-string: 1.0.0
-      vue-template-compiler: 2.6.11
-    dev: true
-    resolution:
-      integrity: sha512-xDn8kpZ0/yG9Z1Z+osrfnd1k1y5AJIdUtqHWNJY2eRz37Gs1tftiZ8BUK89Pab0ddnwhZqh5eNFfOT0SFlZnWQ==
-  /vue-loader/15.9.3_19eca3d246a5abd3297fc67c463bf5f8:
+  /vue-loader/15.9.3_5301d49b91a5273e67d0261daf815cc2:
     dependencies:
       '@vue/component-compiler-utils': 3.2.0
-      cache-loader: 4.1.0_webpack@4.43.0
-      css-loader: 3.6.0_webpack@4.43.0
+      cache-loader: 4.1.0_webpack@4.44.1
+      css-loader: 3.6.0_webpack@4.44.1
       hash-sum: 1.0.2
       loader-utils: 1.4.0
       vue-hot-reload-api: 2.3.4
       vue-style-loader: 4.1.2
       vue-template-compiler: 2.6.11
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
     dev: true
     peerDependencies:
       cache-loader: '*'
@@ -21433,6 +22011,18 @@ packages:
         optional: true
     resolution:
       integrity: sha512-Y67VnGGgVLH5Voostx8JBZgPQTlDQeOVBLOEsjc2cXbCYBKexSKEpOA56x0YZofoDOTszrLnIShyOX1p9uCEHA==
+  /vue-loader/16.0.0-beta.5:
+    dependencies:
+      '@types/mini-css-extract-plugin': 0.9.1
+      chalk: 3.0.0
+      hash-sum: 2.0.0
+      loader-utils: 1.4.0
+      merge-source-map: 1.1.0
+      source-map: 0.6.1
+    dev: true
+    optional: true
+    resolution:
+      integrity: sha512-ciWfzNefqWlmzKznCWY9hl+fPP4KlQ0A9MtHbJ/8DpyY+dAM8gDrjufIdxwTgC4szE4EZC3A6ip/BbrqM84GqA==
   /vue-observe-visibility/0.4.6:
     dev: false
     resolution:
@@ -21447,14 +22037,14 @@ packages:
       vue-class-component: '*'
     resolution:
       integrity: sha512-oegTNPItuHOkW0AP1MnbdNwkmyhfsUIIXvIRHpgC18tVoEo21/i6kItyeekjMs8JgZJeuHzsaTc/DZaJFH4IWQ==
-  /vue-qrcode-reader/2.3.11:
+  /vue-qrcode-reader/2.3.12:
     dependencies:
       callforth: 0.3.1
       core-js: 3.6.5
       vue: 2.6.11
     dev: false
     resolution:
-      integrity: sha512-5A/zeGpIG8ky1GHIv+L6QTlvyugilRmskQEOppa4+lQ4MVKLVeL55EYnnBw+YQ0N45LBVcUwBLr//AHjdfkmZA==
+      integrity: sha512-LQsdMYvd/UuyzydSqEfI+08aiqvIg2UZXwFCj13SFQ3KcXzcOSyLNZmbDLVrBhaALh4P7EQJsaLOjuiM/6QgqQ==
   /vue-resize/0.4.5_vue@2.6.11:
     dependencies:
       vue: 2.6.11
@@ -21467,10 +22057,10 @@ packages:
     dev: true
     resolution:
       integrity: sha512-SdKRBeoXUjaZ9R/8AyxsdTqkOfMcI5tWxPZOUX5Ie1BTL5rPSZ0O++pbiZCeYeythiZIdLEfkDiQPKIaWk5hDg==
-  /vue-router/3.4.2:
+  /vue-router/3.4.3:
     dev: false
     resolution:
-      integrity: sha512-n3Ok70hW0EpcJF4lcWIwSHAQbFTnIOLl/fhO8+oTs4jHNtBNsovcVvPZeTOyKEd8C3xF1Crft2ASuOiVT5K1mw==
+      integrity: sha512-BADg1mjGWX18Dpmy6bOGzGNnk7B/ZA0RxuA6qedY/YJwirMfKXIDzcccmHbQI0A6k5PzMdMloc0ElHfyOoX35A==
   /vue-server-renderer/2.6.11:
     dependencies:
       chalk: 1.1.3
@@ -21484,12 +22074,6 @@ packages:
     dev: true
     resolution:
       integrity: sha512-V3faFJHr2KYfdSIalL+JjinZSHYUhlrvJ9pzCIjjwSh77+pkrsXpK4PucdPcng57+N77pd1LrKqwbqjQdktU1A==
-  /vue-sfc-descriptor-to-string/1.0.0:
-    dependencies:
-      indent-string: 3.2.0
-    dev: true
-    resolution:
-      integrity: sha512-VYNMsrIPZQZau5Gk8IVtgonN1quOznP9/pLIF5m2c4R30KCDDe3NwthrsM7lSUY2K4lezcb8j3Wu8cQhBuZEMQ==
   /vue-style-loader/4.1.2:
     dependencies:
       hash-sum: 1.0.2
@@ -21522,6 +22106,14 @@ packages:
   /vue/2.6.11:
     resolution:
       integrity: sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==
+  /vue/3.0.0-rc.5:
+    dependencies:
+      '@vue/compiler-dom': 3.0.0-rc.5
+      '@vue/runtime-dom': 3.0.0-rc.5
+      '@vue/shared': 3.0.0-rc.5
+    dev: true
+    resolution:
+      integrity: sha512-8t8Y4sHMBGD5iLZ7JfBGmKBJlzesPoL+/nW9EV8s+4LwnKC4rGlRp+Lj2rcign4iQaj0GFaL7DrQ8IoOfVX6+w==
   /vuepress-html-webpack-plugin/3.2.0_webpack@4.43.0:
     dependencies:
       html-minifier: 3.5.21
@@ -21583,7 +22175,6 @@ packages:
   /vuetify/2.3.8_vue@2.6.11:
     dependencies:
       vue: 2.6.11
-    dev: false
     peerDependencies:
       vue: ^2.6.4
     resolution:
@@ -21715,7 +22306,7 @@ packages:
       integrity: sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
   /webpack-bundle-analyzer/3.8.0:
     dependencies:
-      acorn: 7.3.1
+      acorn: 7.4.0
       acorn-walk: 7.2.0
       bfj: 6.1.2
       chalk: 2.4.2
@@ -21724,7 +22315,7 @@ packages:
       express: 4.17.1
       filesize: 3.6.1
       gzip-size: 5.1.1
-      lodash: 4.17.19
+      lodash: 4.17.20
       mkdirp: 0.5.5
       opener: 1.5.1
       ws: 6.2.1
@@ -21787,6 +22378,21 @@ packages:
       webpack: ^4.0.0
     resolution:
       integrity: sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==
+  /webpack-dev-middleware/3.7.2_webpack@4.44.1:
+    dependencies:
+      memory-fs: 0.4.1
+      mime: 2.4.6
+      mkdirp: 0.5.5
+      range-parser: 1.2.1
+      webpack: 4.44.1_webpack@4.44.1
+      webpack-log: 2.0.0
+    dev: true
+    engines:
+      node: '>= 6'
+    peerDependencies:
+      webpack: ^4.0.0
+    resolution:
+      integrity: sha512-1xC42LxbYoqLNAhV6YzTYacicgMZQTqRd27Sim9wn5hJrX3I5nxYy1SxSd4+gjUFsz1dQFj+yEe6zEVmSkeJjw==
   /webpack-dev-server/3.11.0_webpack@4.43.0:
     dependencies:
       ansi-html: 0.0.7
@@ -21820,6 +22426,54 @@ packages:
       url: 0.11.0
       webpack: 4.43.0_webpack@4.43.0
       webpack-dev-middleware: 3.7.2_webpack@4.43.0
+      webpack-log: 2.0.0
+      ws: 6.2.1
+      yargs: 13.3.2
+    dev: true
+    engines:
+      node: '>= 6.11.5'
+    hasBin: true
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    resolution:
+      integrity: sha512-PUxZ+oSTxogFQgkTtFndEtJIPNmml7ExwufBZ9L2/Xyyd5PnOL5UreWe5ZT7IU25DSdykL9p1MLQzmLh2ljSeg==
+  /webpack-dev-server/3.11.0_webpack@4.44.1:
+    dependencies:
+      ansi-html: 0.0.7
+      bonjour: 3.5.0
+      chokidar: 2.1.8
+      compression: 1.7.4
+      connect-history-api-fallback: 1.6.0
+      debug: 4.1.1
+      del: 4.1.1
+      express: 4.17.1
+      html-entities: 1.3.1
+      http-proxy-middleware: 0.19.1
+      import-local: 2.0.0
+      internal-ip: 4.3.0
+      ip: 1.1.5
+      is-absolute-url: 3.0.3
+      killable: 1.0.1
+      loglevel: 1.6.8
+      opn: 5.5.0
+      p-retry: 3.0.1
+      portfinder: 1.0.27
+      schema-utils: 1.0.0
+      selfsigned: 1.10.7
+      semver: 6.3.0
+      serve-index: 1.9.1
+      sockjs: 0.3.20
+      sockjs-client: 1.4.0
+      spdy: 4.0.2
+      strip-ansi: 3.0.1
+      supports-color: 6.1.0
+      url: 0.11.0
+      webpack: 4.44.1_webpack@4.44.1
+      webpack-dev-middleware: 3.7.2_webpack@4.44.1
       webpack-log: 2.0.0
       ws: 6.2.1
       yargs: 13.3.2
@@ -22123,7 +22777,7 @@ packages:
       integrity: sha512-MTSfgzIljpKLTBPROo4IpKjESD86pPFlZwlvVG32Kb70hW+aob4Jxpblud8EhNb1/L5m43DUM4q7C+W6eQMMbA==
   /workbox-build/4.3.1:
     dependencies:
-      '@babel/runtime': 7.10.5
+      '@babel/runtime': 7.11.2
       '@hapi/joi': 15.1.1
       common-tags: 1.8.0
       fs-extra: 4.0.3
@@ -22216,11 +22870,11 @@ packages:
     dev: true
     resolution:
       integrity: sha512-0jXdusCL2uC5gM3yYFT6QMBzKfBr2XTk0g5TPAV4y8IZDyVNDyj1a8uSXy3/XrvkVTmQvLN4O5k3JawGReXr9w==
-  /workbox-webpack-plugin/4.3.1_webpack@4.43.0:
+  /workbox-webpack-plugin/4.3.1_webpack@4.44.1:
     dependencies:
-      '@babel/runtime': 7.10.5
+      '@babel/runtime': 7.11.2
       json-stable-stringify: 1.0.1
-      webpack: 4.43.0_webpack@4.43.0
+      webpack: 4.44.1_webpack@4.44.1
       workbox-build: 4.3.1
     dev: true
     engines:
@@ -22416,7 +23070,6 @@ packages:
     resolution:
       integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
   /xmlhttprequest/1.8.0:
-    dev: false
     engines:
       node: '>=0.4.0'
     resolution:

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -1,42 +1,48 @@
 #!/usr/bin/env bash
 
 if [[ "$#" -ne 1 ]]; then
-    VERSION_PARAMS=`pnpm version --help | grep -oPm1 'npm version (.*)' | sed 's/npm version/''/g'`
-    echo "USAGE: $0 $VERSION_PARAMS"
-    exit 1
+  VERSION_PARAMS=$(pnpm version --help | grep -oPm1 'npm version (.*)' | sed 's/npm version/''/g')
+  echo "USAGE: $0 $VERSION_PARAMS"
+  exit 1
 fi
 
 cd raiden-ts
 
-PACKAGE_VERSION=$(cat package.json \
-  | grep version \
-  | head -1 \
-  | awk -F: '{ print $2 }' \
-  | sed 's/[",]//g' \
-  | tr -d '[[:space:]]')
+PACKAGE_VERSION=$(cat package.json |
+  grep version |
+  head -1 |
+  awk -F: '{ print $2 }' |
+  sed 's/[",]//g' |
+  tr -d '[[:space:]]')
 
 # Using `--no-git-tag-version` in January 2020 serves no purpose due to `npm version`
 # expecting the command to run from the same directory that also hosts the `.git` folder
 # You can find more information on https://github.com/npm/npm/issues/9111.
 # We disable the whole functionality because there no option exists to disable only automatic tagging.
-VERSION=$(pnpm version $1 --no-git-tag-version )
+VERSION=$(pnpm version $1 --no-git-tag-version)
 echo "sdk version update updated to $VERSION"
-MESSAGE="$PACKAGE_VERSION -> $VERSION";
+MESSAGE="$PACKAGE_VERSION -> $VERSION"
 
 cd ../raiden-dapp/
 
 DAPP_VERSION=$(pnpm version $1 --no-git-tag-version)
 echo "dApp version update updated to $DAPP_VERSION"
 
+cd ../raiden-cli/
+
+CLI_VERSION=$(pnpm version $1 --no-git-tag-version)
+echo "cli version update updated to $CLI_VERSION"
+
 cd ../
 ROOT_VERSION=$(pnpm version $1 --no-git-tag-version)
-echo "dApp version update updated to $ROOT_VERSION"
+echo "light client version update updated to $ROOT_VERSION"
 
 pnpm install
 
 git add package.json
 git add raiden-ts/package.json
 git add raiden-dapp/package.json
+git add raiden-cli/package.json
 git add pnpm-lock.yaml
 
 echo "Preparing to commit version update $MESSAGE"

--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [Unreleased]
+
+## [0.11.1] - 2020-08-18
+### Changed
+- [#2054] Update to Raiden contracts `v0.37.1`
+
+[#2054]: https://github.com/raiden-network/light-client/pulls/2054

--- a/raiden-cli/package.json
+++ b/raiden-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-cli",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Raiden Light Client standalone command-line app",
   "main": "build/index.js",
   "scripts": {

--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,14 +2,15 @@
 
 ## [Unreleased]
 
+## [0.11.1] - 2020-08-18
 ### Fixed
 - [#2047] Conversion and token amount display in UDC deposit dialog
 
-### Added
-
 ### Changed
+- [#1951] Update to be compatible with Raiden Python client `v1.1.1`
 
 [#2047]: https://github.com/raiden-network/light-client/issues/2047
+[#1951]: https://github.com/raiden-network/light-client/issues/1951
 
 ## [0.11.0] - 2020-08-04
 

--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-dapp",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "description": "A dApp that showcases the Raiden Light Client sdk functionality",
   "author": "brainbot labs est.",

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
 ## [Unreleased]
+
+## [0.11.1] - 2020-08-18
 ### Changed
 - [#2049] Target ES2019 (NodeJS 12+) on SDK builds
+- [#2054] Update to Raiden contracts `v0.37.1`
+
+[#2049]: https://github.com/raiden-network/light-client/issues/2049
+[#2054]: https://github.com/raiden-network/light-client/pulls/2054
+
 
 ## [0.11.0] - 2020-08-04
 ### Fixed

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-ts",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Raiden Light Client Typescript/Javascript SDK",
   "main": "dist:cjs/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
Part of #1951

This is about a tiny path release which is mainly just for the update of the contracts to `v.37.1` to be compatible with the Python client `v1.1.1`.