### PR TITLE
dApp: Transfer screen redirect when no channels exist

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -6,9 +6,13 @@
 ### Fixed
 - [#2047] Conversion and token amount display in UDC deposit dialog
 
+### Added
+- [#2039] Dialog with redirect button if all channels are settled
+
 ### Changed
 - [#1951] Update to be compatible with Raiden Python client `v1.1.1`
 
+[#2039]: https://github.com/raiden-network/light-client/issues/2039
 [#2047]: https://github.com/raiden-network/light-client/issues/2047
 [#1951]: https://github.com/raiden-network/light-client/issues/1951
 

--- a/raiden-dapp/src/components/dialogs/NoChannelsDialog.vue
+++ b/raiden-dapp/src/components/dialogs/NoChannelsDialog.vue
@@ -1,0 +1,45 @@
+<template>
+  <raiden-dialog class="no-channels-dialog" :visible="visible" hide-close>
+    <v-card-title>{{ $t('transfer.no-channels-dialog.title') }}</v-card-title>
+    <v-card-action>
+      <v-img
+        class="no-channels-dialog__warning"
+        :src="require('@/assets/warning.svg')"
+        height="132px"
+        width="150px"
+      />
+      <action-button
+        :text="$t('transfer.no-channels-dialog.button')"
+        enabled
+        @click="navigateToTokenSelect()"
+      />
+    </v-card-action>
+  </raiden-dialog>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Mixins } from 'vue-property-decorator';
+import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
+import ActionButton from '@/components/ActionButton.vue';
+import NavigationMixin from '../../mixins/navigation-mixin';
+
+@Component({
+  components: { RaidenDialog, ActionButton },
+})
+export default class NoChannelsDialog extends Mixins(NavigationMixin) {
+  @Prop({ required: true })
+  visible!: boolean;
+}
+</script>
+
+<style scoped lang="scss">
+.no-channels-dialog {
+  &__warning {
+    /* Blue to red */
+    filter: hue-rotate(165deg);
+    margin: 0 auto;
+    margin-top: 20px;
+    margin-bottom: 45px;
+  }
+}
+</style>

--- a/raiden-dapp/src/components/dialogs/NoChannelsDialog.vue
+++ b/raiden-dapp/src/components/dialogs/NoChannelsDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <raiden-dialog class="no-channels-dialog" :visible="visible" hide-close>
     <v-card-title>{{ $t('transfer.no-channels-dialog.title') }}</v-card-title>
-    <v-card-action>
+    <div>
       <v-img
         class="no-channels-dialog__warning"
         :src="require('@/assets/warning.svg')"
@@ -13,7 +13,7 @@
         enabled
         @click="navigateToTokenSelect()"
       />
-    </v-card-action>
+    </div>
   </raiden-dialog>
 </template>
 

--- a/raiden-dapp/src/components/navigation/Transfer.vue
+++ b/raiden-dapp/src/components/navigation/Transfer.vue
@@ -11,6 +11,7 @@
       :capacity="capacity"
     />
     <transaction-list class="transfer__list" :token="token" />
+    <no-channels-dialog :visible="!openChannels" />
   </v-container>
 </template>
 
@@ -20,6 +21,7 @@ import { mapGetters } from 'vuex';
 import TransferHeaders from '@/components/transfer/TransferHeaders.vue';
 import TransferInputs from '@/components/transfer/TransferInputs.vue';
 import TransactionList from '@/components/transaction-history/TransactionList.vue';
+import NoChannelsDialog from '@/components/dialogs/NoChannelsDialog.vue';
 import { RaidenChannel } from 'raiden-ts';
 import { BigNumber } from 'ethers/utils';
 import { Zero } from 'ethers/constants';
@@ -30,9 +32,10 @@ import { Token } from '@/model/types';
     TransferHeaders,
     TransferInputs,
     TransactionList,
+    NoChannelsDialog,
   },
   computed: {
-    ...mapGetters(['channelWithBiggestCapacity']),
+    ...mapGetters(['channelWithBiggestCapacity', 'openChannels']),
   },
 })
 export default class Transfer extends Vue {

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -369,6 +369,10 @@
     "transfer-inputs": {
       "title": "Transfer"
     },
+    "no-channels-dialog": {
+      "title": "No connected tokens and open channels",
+      "button": "Connect new token"
+    },
     "steps": {
       "request-route": {
         "title": "Request Route",

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -201,6 +201,9 @@ const store: StoreOptions<RootState> = {
       }
       return channels;
     },
+    openChannels: (state: RootState) => {
+      return Object.keys(state.channels).length > 0;
+    },
     token: (state: RootState) => (tokenAddress: string) => {
       if (tokenAddress in state.tokens) {
         return state.tokens[tokenAddress];

--- a/raiden-dapp/tests/unit/components/dialogs/no-channels-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/dialogs/no-channels-dialog.spec.ts
@@ -1,0 +1,41 @@
+jest.mock('vue-router');
+import Mocked = jest.Mocked;
+import { mount, Wrapper } from '@vue/test-utils';
+import Vue from 'vue';
+import VueRouter from 'vue-router';
+import { RouteNames } from '@/router/route-names';
+import Vuetify from 'vuetify';
+import NoChannelsDialog from '@/components/dialogs/NoChannelsDialog.vue';
+import ActionButton from '@/components/ActionButton.vue';
+
+Vue.use(Vuetify);
+
+describe('NoChannelsDialog.vue', () => {
+  const vuetify = new Vuetify();
+  const router = new VueRouter() as Mocked<VueRouter>;
+
+  const wrapper: Wrapper<NoChannelsDialog> = mount(NoChannelsDialog, {
+    vuetify,
+    propsData: {
+      visible: true,
+    },
+    stubs: ['raiden-dialog'],
+    mocks: {
+      $router: router,
+      $t: (msg: string) => msg,
+    },
+  });
+
+  test('clicking dialog button redirects to token select screen', async () => {
+    const connectNewTokenButton = wrapper
+      .findComponent(ActionButton)
+      .find('button');
+    connectNewTokenButton.trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect(router.push).toHaveBeenCalledTimes(1);
+    expect(router.push).toHaveBeenCalledWith(
+      expect.objectContaining({ name: RouteNames.SELECT_TOKEN })
+    );
+  });
+});


### PR DESCRIPTION
Fixes #2039

**Short description**
Whenever all channels for all connected tokens are closed and settled a dialog appears warning the user about not having any connected open channels or connected tokens. The dialog has a button that redirects the user to the token select screen.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to a token and open a channel.
2. Close and settle the channel.
