### PR TITLE
dApp: UDC deposit validation logic bug fix

### DIFF
--- a/raiden-dapp/src/components/dialogs/UdcDepositDialog.vue
+++ b/raiden-dapp/src/components/dialogs/UdcDepositDialog.vue
@@ -149,7 +149,7 @@ export default class UdcDepositDialog extends Vue {
 
     if (this.mainnet) {
       return (
-        utilityTokenAmount.lte(this.udcToken.balance) &&
+        utilityTokenAmount.lte(this.udcToken.balance as BigNumber) &&
         utilityTokenAmount.gt(Zero)
       );
     } else {

--- a/raiden-dapp/src/components/dialogs/UdcDepositDialog.vue
+++ b/raiden-dapp/src/components/dialogs/UdcDepositDialog.vue
@@ -144,19 +144,17 @@ export default class UdcDepositDialog extends Vue {
         this.udcToken.decimals
       );
     } catch (err) {
-      utilityTokenAmount = Zero;
+      return false;
     }
 
-    if (!this.mainnet) return utilityTokenAmount.gt(Zero);
-
-    const utilityTokenBalance = parseUnits(
-      this.utilityTokenBalance,
-      this.udcToken.decimals
-    );
-
-    return (
-      utilityTokenAmount.lte(utilityTokenBalance) && utilityTokenAmount.gt(Zero)
-    );
+    if (this.mainnet) {
+      return (
+        utilityTokenAmount.lte(this.udcToken.balance) &&
+        utilityTokenAmount.gt(Zero)
+      );
+    } else {
+      return utilityTokenAmount.gt(Zero);
+    }
   }
 
   async mounted() {

--- a/raiden-dapp/src/components/dialogs/UdcDepositDialog.vue
+++ b/raiden-dapp/src/components/dialogs/UdcDepositDialog.vue
@@ -135,7 +135,17 @@ export default class UdcDepositDialog extends Vue {
   }
 
   get valid(): boolean {
-    return /^[1-9]\d*$/.test(this.defaultUtilityTokenAmount);
+    const utilityTokenAmount = Number(this.defaultUtilityTokenAmount);
+    const utilityTokenBalance = Number(this.utilityTokenBalance);
+    const amountRegEx = /^\d+\.?\d*$/;
+
+    if (!this.mainnet) return amountRegEx.test(this.defaultUtilityTokenAmount);
+
+    return (
+      utilityTokenAmount <= utilityTokenBalance &&
+      utilityTokenAmount > 0 &&
+      amountRegEx.test(this.defaultUtilityTokenAmount)
+    );
   }
 
   async mounted() {

--- a/raiden-dapp/src/components/dialogs/UdcDepositDialog.vue
+++ b/raiden-dapp/src/components/dialogs/UdcDepositDialog.vue
@@ -96,7 +96,8 @@ import ErrorMessage from '@/components/ErrorMessage.vue';
 import Spinner from '@/components/icons/Spinner.vue';
 import { RaidenError } from 'raiden-ts';
 import Filters from '@/filters';
-import { BigNumber } from 'ethers/utils';
+import { BigNumber, parseUnits } from 'ethers/utils';
+import { Zero } from 'ethers/constants';
 
 @Component({
   components: {
@@ -135,16 +136,26 @@ export default class UdcDepositDialog extends Vue {
   }
 
   get valid(): boolean {
-    const utilityTokenAmount = Number(this.defaultUtilityTokenAmount);
-    const utilityTokenBalance = Number(this.utilityTokenBalance);
-    const amountRegEx = /^\d+\.?\d*$/;
+    let utilityTokenAmount: BigNumber;
 
-    if (!this.mainnet) return amountRegEx.test(this.defaultUtilityTokenAmount);
+    try {
+      utilityTokenAmount = parseUnits(
+        this.defaultUtilityTokenAmount,
+        this.udcToken.decimals
+      );
+    } catch (err) {
+      utilityTokenAmount = Zero;
+    }
+
+    if (!this.mainnet) return utilityTokenAmount.gt(Zero);
+
+    const utilityTokenBalance = parseUnits(
+      this.utilityTokenBalance,
+      this.udcToken.decimals
+    );
 
     return (
-      utilityTokenAmount <= utilityTokenBalance &&
-      utilityTokenAmount > 0 &&
-      amountRegEx.test(this.defaultUtilityTokenAmount)
+      utilityTokenAmount.lte(utilityTokenBalance) && utilityTokenAmount.gt(Zero)
     );
   }
 

--- a/raiden-dapp/tests/unit/components/dialogs/udc-deposit-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/dialogs/udc-deposit-dialog.spec.ts
@@ -106,7 +106,10 @@ describe('UdcDepositDialog.vue', () => {
         '0x3a989D97388a39A0B5796306C615d10B7416bE77'
       );
       store.commit('updateTokens', {
-        '0x3a989D97388a39A0B5796306C615d10B7416bE77': token,
+        '0x3a989D97388a39A0B5796306C615d10B7416bE77': {
+          ...token,
+          balance: bigNumberify('10000000000000000000'),
+        },
       });
       store.commit('network', { name: 'mainnet', chainId: 1 });
 
@@ -122,6 +125,27 @@ describe('UdcDepositDialog.vue', () => {
       expect(wrapper.vm.$data.uniswapURL).toBe(
         'udc-deposit-dialog.uniswap-url'
       );
+    });
+
+    test('amount validates to true if inputted amount is lower or equal to available amount', async () => {
+      const inputField = wrapper.find('input');
+      inputField.setValue('5.55');
+      await wrapper.vm.$nextTick();
+
+      expect((wrapper.vm as any).valid).toBe(true);
+
+      inputField.setValue('10');
+      await wrapper.vm.$nextTick();
+
+      expect((wrapper.vm as any).valid).toBe(true);
+    });
+
+    test('amount validates to false if inputted amount is higher than available amount', async () => {
+      const inputField = wrapper.find('input');
+      inputField.setValue('50');
+      await wrapper.vm.$nextTick();
+
+      expect((wrapper.vm as any).valid).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Fixes #2099 

**Short description**
This fixes a bug in the amount input validation regex. The regex used to only check for integers which made the validation fail on values like `5.0` but not `5`.

The PR also adapts the validation logic for mainnet. When mainnet is used it checks whether the utility token balance that the user types is less or equal to the total available amount, whether the inputted amount is more than zero and whether it matches above mentioned regex.


**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Works as expected on testnet, mainnet needs to be tested @agatsoh 