### PR TITLE
dApp: Disables input fields on no open channels

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- [#2098] Input fields disabled on transfer screen when no channels are open
+
+### Added
+
+### Changes
+
+[#2098]: https://github.com/raiden-network/light-client/issues/2098
 
 ## [0.11.1] - 2020-08-18
 ### Fixed

--- a/raiden-dapp/src/components/AddressInput.vue
+++ b/raiden-dapp/src/components/AddressInput.vue
@@ -4,6 +4,7 @@
       id="address-input"
       ref="address"
       v-model="address"
+      :disabled="disabled"
       :error-messages="errorMessages"
       :rules="isAddressValid"
       :hide-details="hideErrorLabel"

--- a/raiden-dapp/src/components/transfer/TransferInputs.vue
+++ b/raiden-dapp/src/components/transfer/TransferInputs.vue
@@ -25,6 +25,7 @@
         <address-input
           v-model="target"
           class="transfer-inputs__form__address"
+          :disabled="noChannels"
           :exclude="[token.address, defaultAccount]"
           hide-error-label
           :block="blockedHubs"
@@ -37,6 +38,7 @@
           class="transfer-inputs__form__amount"
           limit
           hide-error-label
+          :disabled="noChannels"
           :token="token"
           :max="capacity"
           :placeholder="$t('transfer.amount-placeholder')"
@@ -64,6 +66,7 @@ import AddressUtils from '@/utils/address-utils';
 import { RaidenChannel, ChannelState } from 'raiden-ts';
 import { BigNumber } from 'ethers/utils';
 import { Token } from '@/model/types';
+import { Zero } from 'ethers/constants';
 
 @Component({
   components: {
@@ -116,6 +119,10 @@ export default class TransferInputs extends Mixins(NavigationMixin) {
     if (this.token.decimals === 0 && this.amount.indexOf('.') > -1) {
       this.amount = this.amount.split('.')[0];
     }
+  }
+
+  get noChannels(): boolean {
+    return this.capacity === Zero;
   }
 
   get blockedHubs(): string[] {


### PR DESCRIPTION
Fixes #2098 

**Short description**
Disables input fields on no open channels.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Have an open channel for a token and the input fields should be enabled.
2. Close the open channel and the input fields should be disabled.
