### PR TITLE
dApp: Disclaimer design refinement

### DIFF
--- a/raiden-dapp/src/views/DisclaimerRoute.vue
+++ b/raiden-dapp/src/views/DisclaimerRoute.vue
@@ -1,7 +1,7 @@
 <template>
-  <v-container fluid class="disclaimer">
-    <v-row no-gutters>
-      <v-col cols="10" offset="1">
+  <v-container fluid>
+    <v-row no-gutters class="disclaimer">
+      <div>
         <div class="disclaimer__paragraphs font-weight-light">
           <p
             v-for="(paragraph, index) in $t('disclaimer.paragraphs')"
@@ -24,7 +24,7 @@
           dense
           hide-details
         />
-      </v-col>
+      </div>
     </v-row>
     <action-button
       :text="$t('disclaimer.accept-button')"
@@ -66,15 +66,28 @@ export default class Disclaimer extends Vue {
 </script>
 
 <style lang="scss" scoped>
+@import '../scss/colors';
 @import '../scss/scroll';
 
 .disclaimer {
+  border-top: solid 1px $primary-color;
+  padding: 30px 30px 0 30px;
+
   &__paragraphs {
-    text-align: justify;
-    max-height: 70%;
+    font-size: 15px;
     overflow-y: auto;
+    text-align: justify;
     @extend .themed-scrollbar;
-    margin-bottom: 50px;
+  }
+
+  &__accept-checkbox,
+  &__persist-checkbox {
+    ::v-deep {
+      .v-label {
+        font-size: 14px;
+        padding-bottom: 2px;
+      }
+    }
   }
 }
 </style>


### PR DESCRIPTION
Fixes #2027 

**Short description**
Updated the disclaimer design, after and before images below @christianbrb The non-centered header is part of another issue.
<img width="627" alt="disclaimer" src="https://user-images.githubusercontent.com/43838780/91041592-9ca2c680-e610-11ea-9ae6-01b65579b8aa.png">

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**