### PR TITLE
Path new tests

### DIFF
--- a/raiden-ts/tests/unit/fixtures.ts
+++ b/raiden-ts/tests/unit/fixtures.ts
@@ -162,6 +162,9 @@ export const matrixServer = 'matrix.raiden.test';
 export const secret = makeSecret();
 export const secrethash = getSecrethash(secret);
 export const amount = bigNumberify(10) as UInt<32>;
+export const pfsAddress = makeAddress();
+export const pfsTokenAddress = makeAddress();
+export const fee = bigNumberify(3) as Int<32>;
 
 /**
  * Get channel state with partner for tokenNetwork

--- a/raiden-ts/tests/unit/fixtures.ts
+++ b/raiden-ts/tests/unit/fixtures.ts
@@ -162,8 +162,6 @@ export const matrixServer = 'matrix.raiden.test';
 export const secret = makeSecret();
 export const secrethash = getSecrethash(secret);
 export const amount = bigNumberify(10) as UInt<32>;
-export const pfsAddress = makeAddress();
-export const pfsTokenAddress = makeAddress();
 export const fee = bigNumberify(3) as Int<32>;
 
 /**
@@ -222,6 +220,8 @@ export async function ensureTokenIsMonitored(raiden: MockedRaiden): Promise<void
  * @param clients - Clients tuple
  * @param clients.0 - Own raiden
  * @param clients.1 - Partner raiden to open channel with
+ * @param opts - Options
+ * @param opts.channelId - Channel id of new channel
  */
 export async function ensureChannelIsOpen(
   [raiden, partner]: [MockedRaiden, MockedRaiden],

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -46,6 +46,7 @@ import { MonitoringServiceFactory } from 'raiden-ts/contracts/MonitoringServiceF
 import { MonitoringService } from 'raiden-ts/contracts/MonitoringService';
 
 import { RaidenEpicDeps, ContractsInfo, Latest } from 'raiden-ts/types';
+import { IOU } from 'raiden-ts/services/types';
 import { makeInitialState, RaidenState } from 'raiden-ts/state';
 import { assert } from 'raiden-ts/utils';
 import { Address, Signature, UInt, Hash } from 'raiden-ts/utils/types';
@@ -177,6 +178,40 @@ export function makeTransaction(
   };
 }
 
+/**
+ * @param raiden - Instance of MockedRaiden
+ * @param pfsAddress - Ethereum Address of the pfs
+ * @returns Mocked PFSResponse message
+ */
+export function makePfsInfoResponse(raiden: MockedRaiden, pfsAddress: Address) {
+  return {
+    message: 'pfs message',
+    network_info: {
+      chain_id: raiden.deps.network.chainId,
+      token_network_registry_address: raiden.deps.contractsInfo.TokenNetworkRegistry.address,
+    },
+    operator: 'pfs operator',
+    payment_address: pfsAddress,
+    price_info: 2,
+    version: '0.4.1',
+  };
+}
+
+/**
+ * @param raiden - Instance of MockedRaiden
+ * @param pfsAddress - Ethereum Address of the pfs
+ * @returns Mocked IOU type Object
+ */
+export function makeIou(raiden: MockedRaiden, pfsAddress: Address) {
+  return {
+    sender: raiden.address,
+    receiver: pfsAddress,
+    one_to_n_address: '0x0A0000000000000000000000000000000000000a' as Address,
+    chain_id: bigNumberify(raiden.deps.network.chainId) as UInt<32>,
+    expiration_block: bigNumberify(3232341) as UInt<32>,
+    amount: bigNumberify(100) as UInt<32>,
+  } as IOU;
+}
 /**
  * Returns a mocked MatrixClient
  *


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #1616

**Short description**
Please check these 3 tests 
1. `fail on failing matrix presence request` from the `PFS: pathFindServiceEpic1`  tests which is **failing**, I am looking into it but if you can give me an idea it would be great
2. `skip: channel is not open` from the `PFS: pfsFeeUpdateEpic1` which is passing but i am not sure whether I am testing the right thing
3. `skip: NO_MEDIATE` from the `PFS: pfsFeeUpdateEpic1` which is passing but I am not sure whether i am testing the correct thing.

I will create fixup commits for the review comments and changes that may come and i am sure there would be many.
Thanks a lot.


**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
