### PR TITLE
dApp: centers app header route and network

### DIFF
--- a/raiden-dapp/src/components/AppHeader.vue
+++ b/raiden-dapp/src/components/AppHeader.vue
@@ -1,68 +1,58 @@
 <template>
   <div class="app-header">
-    <v-row class="app-header__top" justify="center" align="center" no-gutters>
-      <v-col cols="12">
-        <div class="app-header__top__content">
-          <div class="app-header__top__content__back">
-            <v-btn
-              v-if="canGoBack"
-              height="40px"
-              width="40px"
-              text
-              icon
-              @click="onBackClicked()"
-            >
-              <v-img
-                :src="require('@/assets/back_arrow.svg')"
-                max-width="34px"
-              />
-            </v-btn>
-          </div>
-          <v-col>
-            <div class="app-header__top__content__title">
-              {{ $route.meta.title }}
-            </div>
-            <div
-              v-if="!showTitleOnly"
-              class="app-header__top__content__network"
-            >
-              {{ network }}
-            </div>
-          </v-col>
-          <span v-if="!showTitleOnly" class="app-header__notifications-wrapper">
-            <v-btn
-              icon
-              height="30px"
-              width="25px"
-              @click.native="notificationPanel()"
-            >
-              <v-badge
-                v-if="newNotifications"
-                color="notification"
-                overlap
-                bordered
-                dot
-              >
-                <v-img
-                  height="30px"
-                  width="25px"
-                  :src="require('@/assets/notifications.svg')"
-                />
-              </v-badge>
-              <v-img
-                v-else
-                height="30px"
-                width="25px"
-                :src="require('@/assets/notifications.svg')"
-              />
-            </v-btn>
-          </span>
-          <span v-if="!isDisclaimerRoute" class="app-header__account-wrapper">
-            <header-identicon @click.native="navigateToAccoount()" />
-          </span>
-        </div>
-      </v-col>
-    </v-row>
+    <div class="app-header__back">
+      <v-btn
+        v-if="canGoBack"
+        height="40px"
+        width="40px"
+        icon
+        @click="onBackClicked()"
+      >
+        <v-img :src="require('@/assets/back_arrow.svg')" />
+      </v-btn>
+    </div>
+    <div class="app-header__title">
+      <span class="app-header__title__route">
+        {{ $route.meta.title }}
+      </span>
+      <span v-if="!showTitleOnly" class="app-header__title__network">
+        {{ network }}
+      </span>
+    </div>
+    <div class="app-header__icons">
+      <v-btn
+        v-if="!showTitleOnly"
+        icon
+        height="30px"
+        width="25px"
+        @click.native="notificationPanel()"
+      >
+        <v-badge
+          v-if="newNotifications"
+          color="notification"
+          overlap
+          bordered
+          dot
+        >
+          <v-img
+            height="30px"
+            width="25px"
+            :src="require('@/assets/notifications.svg')"
+          />
+        </v-badge>
+        <v-img
+          v-else
+          height="30px"
+          width="25px"
+          :src="require('@/assets/notifications.svg')"
+        />
+      </v-btn>
+      <header-identicon
+        v-if="!isDisclaimerRoute"
+        class="app-header__icons__identicon"
+        @click.native="navigateToAccoount()"
+      />
+    </div>
   </div>
 </template>
 
@@ -133,54 +123,44 @@ export default class AppHeader extends Mixins(NavigationMixin) {
 @import '../scss/fonts';
 
 .app-header {
-  &__top {
-    background-color: $card-background;
-    border-radius: 10px 10px 0 0;
-    height: 80px;
-    @include respond-to(handhelds) {
-      width: 100%;
-      border-radius: 0;
+  align-items: center;
+  display: flex;
+  height: 80px;
+
+  &__back {
+    flex: 1;
+    margin-left: 20px;
+  }
+
+  &__title {
+    display: flex;
+    flex-direction: column;
+    flex: 3;
+    align-items: center;
+
+    &__route {
+      color: $color-white;
+      font-size: 24px;
     }
 
-    &__content {
-      align-items: center;
-      display: flex;
-      justify-content: center;
-      margin: 0 20px 0 40px;
-
-      &__back {
-        align-items: center;
-        display: flex;
-        flex-direction: column;
-        height: 36px;
-        justify-content: center;
-        width: 36px;
-      }
-
-      &__title {
-        color: $color-white;
-        font-family: $main-font;
-        font-size: 24px;
-        line-height: 28px;
-        text-align: center;
-      }
-
-      &__network {
-        color: $secondary-text-color;
-        font-size: 12px;
-        font-weight: 500;
-        text-align: center;
-      }
+    &__network {
+      color: $secondary-text-color;
+      font-size: 12px;
+      font-weight: 500;
     }
   }
 
-  &__notifications-wrapper {
+  &__icons {
+    align-items: center;
+    display: flex;
+    flex: 1;
+    justify-content: flex-end;
     margin-right: 20px;
-    cursor: pointer;
-  }
 
-  &__account-wrapper {
-    cursor: pointer;
+    &__identicon {
+      cursor: pointer;
+      margin-left: 15px;
+    }
   }
 }
 </style>

--- a/raiden-dapp/tests/unit/components/app-header.spec.ts
+++ b/raiden-dapp/tests/unit/components/app-header.spec.ts
@@ -71,19 +71,17 @@ describe('AppHeader.vue', () => {
   test('show title only if on disclaimer route', () => {
     connectAccount();
     wrapper = createWrapper(RouteNames.DISCLAIMER);
-    const title = wrapper.find('.app-header__top__content__title');
+    const title = wrapper.find('.app-header__title__route');
     const networkLabel = wrapper.find('.app-header__top__content__network');
     const notificationsBadge = wrapper.find(
       '.app-header__notifications-wrapper'
     );
-    const identicon = wrapper.find('.app-header__account-wrapper');
-    const addressBar = wrapper.find('.app-header__bottom__address');
+    const identicon = wrapper.find('.app-header__icons__identicon');
 
     expect((wrapper.vm as any).canGoBack).toBe(false);
     expect(title.exists()).toBe(true);
     expect(networkLabel.exists()).toBe(false);
     expect(notificationsBadge.exists()).toBe(false);
     expect(identicon.exists()).toBe(false);
-    expect(addressBar.exists()).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #1984

**Short description**
This PR takes care of centering the title of the network in the dApp header across all routes including the disclaimer screen.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Navigate the various routes
