### PR TITLE
dApp: Removed delay time on tooltips

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
+- [#2026] Removed delay time on tooltips
 - [#2098] Input fields disabled on transfer screen when no channels are open
 - [#1838] Fixes Disclaimer mobile layout
 
@@ -10,6 +11,7 @@
 ### Changes
 - [#1929] Design adjustments to settlement notifications and notification panel 
 
+[#2026]: https://github.com/raiden-network/light-client/issues/2026
 [#1929]: https://github.com/raiden-network/light-client/issues/1929
 [#2098]: https://github.com/raiden-network/light-client/issues/2098
 [#1838]: https://github.com/raiden-network/light-client/issues/1838

--- a/raiden-dapp/src/components/AddressDisplay.vue
+++ b/raiden-dapp/src/components/AddressDisplay.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="address__container">
-    <v-tooltip bottom close-delay="1400">
+    <v-tooltip bottom>
       <template #activator="{ on }">
         <p class="address__label" v-on="on" @click="copy">
           {{ addressOutput }}


### PR DESCRIPTION
Fixes #2026 

**Short description**
Removing the delay time from the tooltips prevents them form cluttering the dApp.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Go to the transfer screen and fill the transfer history list by making a couple of transfers.
2. Move the mouse over all addresses in the transfer list.
