### PR TITLE
Fix some Metamask warnings and state upload

### DIFF
--- a/raiden-dapp/src/components/navigation/TransferSteps.vue
+++ b/raiden-dapp/src/components/navigation/TransferSteps.vue
@@ -508,6 +508,7 @@ export default class TransferSteps extends Mixins(
       this.transferDone = true;
       this.dismissProgress();
     } catch (e) {
+      console.error('Transfer error', e);
       this.error = e;
     }
   }

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -257,6 +257,7 @@ export default class RaidenService {
         }
       }
     } catch (e) {
+      console.error('Init error', e);
       let deniedReason: DeniedReason;
       if (e.message && e.message.indexOf('No deploy info provided') > -1) {
         deniedReason = DeniedReason.UNSUPPORTED_NETWORK;
@@ -576,8 +577,9 @@ export default class RaidenService {
 
   /* istanbul ignore next */
   async getState() {
-    this._raiden?.stop();
-    return await this._raiden?.state$.toPromise();
+    this._raiden!.stop();
+    await this._raiden!.state$.toPromise();
+    return this._raiden!.dumpDatabase();
   }
 
   /* istanbul ignore next */

--- a/raiden-dapp/src/services/web3-provider.ts
+++ b/raiden-dapp/src/services/web3-provider.ts
@@ -1,6 +1,5 @@
 export class Web3Provider {
   static async provider(rpcEndpoint?: string) {
-    const ethereum = window.ethereum;
     let provider = null;
 
     if (rpcEndpoint) {
@@ -9,17 +8,17 @@ export class Web3Provider {
       } else {
         provider = rpcEndpoint;
       }
-    } else if (typeof ethereum !== 'undefined') {
-      await ethereum.enable();
-      provider = ethereum;
+    } else if (typeof window.ethereum !== 'undefined') {
+      window.ethereum.autoRefreshOnNetworkChange = false;
+      await window.ethereum.request({ method: 'eth_requestAccounts' });
+      provider = window.ethereum;
     } else if (window.web3) {
       provider = window.web3.currentProvider;
     }
 
     /* istanbul ignore next */
     if (provider && provider.isMetaMask) {
-      provider.autoRefreshOnNetworkChange = false;
-      provider.on('networkChanged', () =>
+      provider.on('chainChanged', () =>
         window.location.replace(window.location.origin)
       );
     }

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -242,15 +242,9 @@ const store: StoreOptions<RootState> = {
           return pendingTransfers;
         }, {}),
     transfer: (state: RootState) => (paymentId: BigNumber) => {
-      const key = Object.keys(state.transfers).find(
-        (key) => state.transfers[key].paymentId === paymentId
+      return Object.values(state.transfers).find((transfer) =>
+        transfer.paymentId.eq(paymentId)
       );
-
-      if (key) {
-        return state.transfers[key];
-      }
-
-      return undefined;
     },
     isConnected: (state: RootState): boolean => {
       return (

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -131,10 +131,15 @@ const store: StoreOptions<RootState> = {
       state.network = network;
     },
     reset(state: RootState) {
-      // Preserve settings when resetting state
-      const { settings, disclaimerAccepted } = state;
+      // Preserve settings and backup when resetting state
+      const { settings, disclaimerAccepted, stateBackup } = state;
 
-      Object.assign(state, { ...defaultState(), settings, disclaimerAccepted });
+      Object.assign(state, {
+        ...defaultState(),
+        settings,
+        disclaimerAccepted,
+        stateBackup,
+      });
     },
     updateTransfers(state: RootState, transfer: RaidenTransfer) {
       state.transfers = { ...state.transfers, [transfer.key]: transfer };

--- a/raiden-dapp/src/views/Home.vue
+++ b/raiden-dapp/src/views/Home.vue
@@ -124,12 +124,14 @@ export default class Home extends Vue {
 
     this.connectDialog = false;
     this.connecting = true;
+    const stateBackup = this.stateBackup;
+
     this.$store.commit('reset');
     // Have to reset this explicitly, for some reason
     this.$store.commit('accessDenied', DeniedReason.UNDEFINED);
 
     await this.$raiden.connect(
-      this.stateBackup,
+      stateBackup,
       useRaidenAccount ? true : undefined
     );
     this.connecting = false;


### PR DESCRIPTION
Fixes #2089 

**Short description**
Metamask currently is deprecating `ethereum.enable` function and moving to a specific JSON RPC method to enable/list accounts. This PR adapts the dApp to use this new pattern.
It also fixes the store resetting the uploaded state when trying to connect, not allowing it to be passed to the SDK for upload.

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
