### PR TITLE
Bugfix/dapp transfer route can not handle optional route parameter

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#2098] Input fields disabled on transfer screen when no channels are open
 - [#1838] Fixes Disclaimer mobile layout
 - [#2096] Fixes buggy wallet connection procedure
+- [#2144] Fixes navigation to transfer screen when token was selected
 
 ### Added
 - [#1941] Notification for opening channels
@@ -19,6 +20,7 @@
 [#2098]: https://github.com/raiden-network/light-client/issues/2098
 [#1838]: https://github.com/raiden-network/light-client/issues/1838
 [#2096]: https://github.com/raiden-network/light-client/issues/1838
+[#2144]: https://github.com/raiden-network/light-client/issues/2144
 
 ## [0.11.1] - 2020-08-18
 ### Fixed

--- a/raiden-dapp/src/views/TransferRoute.vue
+++ b/raiden-dapp/src/views/TransferRoute.vue
@@ -53,21 +53,24 @@ export default class TransferRoute extends Vue {
     return this.tokens.length === 0;
   }
 
-  get token(): Token {
-    const { token: address } = this.$route.params;
-    return this.$store.getters.token(address) || ({ address } as Token);
+  get token(): Token | undefined {
+    if (this.noTokens) {
+      return undefined;
+    } else {
+      const address = this.$route.params.tokens ?? this.tokens[0].address;
+      return this.$store.getters.token(address) || ({ address } as Token);
+    }
   }
 
   get capacity(): BigNumber {
-    const channelWithBiggestCapacity = this.channelWithBiggestCapacity(
-      this.token.address
-    );
-
-    if (channelWithBiggestCapacity) {
-      return channelWithBiggestCapacity.capacity;
+    if (this.token) {
+      const channelWithBiggestCapacity = this.channelWithBiggestCapacity(
+        this.token.address
+      );
+      return channelWithBiggestCapacity?.capacity ?? Zero;
+    } else {
+      return Zero;
     }
-
-    return Zero;
   }
 }
 </script>

--- a/raiden-dapp/tests/unit/utils/data-generator.ts
+++ b/raiden-dapp/tests/unit/utils/data-generator.ts
@@ -1,11 +1,17 @@
 import times from 'lodash/times';
 import { BigNumber } from 'ethers/utils';
 import { Zero } from 'ethers/constants';
-import { RaidenTransfer, Address } from 'raiden-ts';
+import {
+  RaidenTransfer,
+  Address,
+  RaidenChannel,
+  ChannelState,
+} from 'raiden-ts';
 import { Token } from '@/model/types';
 
 const HEXADECIMAL_CHARACTERS = '0123456789abcdefABCDEF';
 const ALPHABET_CHARACTERS = 'abcdefghijklmnopqrstuvwxyz';
+const NUMBER_CHARACTERS = '0123456789';
 
 function getRandomString(
   charSet: string,
@@ -27,6 +33,10 @@ function getRandomEthereumAddress(): string {
 
 function getRandomTransactionKey(): string {
   return getRandomString(ALPHABET_CHARACTERS, 10);
+}
+
+function getRandomNumericId(): number {
+  return +getRandomString(NUMBER_CHARACTERS, 5);
 }
 
 export function generateToken(partialToken: Partial<Token> = {}): Token {
@@ -65,4 +75,25 @@ export function generateTransfer(
     success: undefined,
     ...partialTransfer,
   } as RaidenTransfer;
+}
+
+export function generateChannel(
+  partialChannel: Partial<RaidenChannel>,
+  token?: Token
+): RaidenChannel {
+  return {
+    id: getRandomNumericId(),
+    openBlock: 1000,
+    partner: '0x1D36124C90f53d491b6832F1c073F43E2550E35b' as Address,
+    partnerDeposit: new BigNumber(10 ** 8),
+    settleTimeout: 500,
+    state: ChannelState.open,
+    token: token ? (token.address as Address) : getRandomEthereumAddress(),
+    tokenNetwork: getRandomEthereumAddress(),
+    ownDeposit: new BigNumber(10 ** 8),
+    balance: Zero,
+    capacity: new BigNumber(10 ** 8),
+    ownWithdrawable: new BigNumber(10 ** 8),
+    ...partialChannel,
+  } as RaidenChannel;
 }

--- a/raiden-dapp/tests/unit/views/transfer-route.spec.ts
+++ b/raiden-dapp/tests/unit/views/transfer-route.spec.ts
@@ -1,49 +1,96 @@
 jest.mock('vue-router');
-import Mocked = jest.Mocked;
-import { mount, Wrapper } from '@vue/test-utils';
+import { shallowMount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
-import store from '@/store';
-import VueRouter from 'vue-router';
+import Vuex from 'vuex';
 import Vuetify from 'vuetify';
+import { Zero } from 'ethers/constants';
 import TransferRoute from '@/views/TransferRoute.vue';
-import { TestData } from '../data/mock-data';
-import { One } from 'ethers/constants';
-import { Token } from '@/model/types';
+import NoTokens from '@/components/NoTokens.vue';
+import TransferHeaders from '@/components/transfer/TransferHeaders.vue';
+import TransferInputs from '@/components/transfer/TransferInputs.vue';
+import TransactionList from '@/components/transaction-history/TransactionList.vue';
+import NoChannelsDialog from '@/components/dialogs/NoChannelsDialog.vue';
+import { generateChannel, generateToken } from '../utils/data-generator';
 
 Vue.use(Vuetify);
+Vue.use(Vuex);
 
 describe('TransferRoute.vue', () => {
   const vuetify = new Vuetify();
-  const router = new VueRouter() as Mocked<VueRouter>;
-  const token: Token = TestData.token;
-  const openChannel = TestData.openChannel;
+  const token = generateToken();
+  const channel = generateChannel({}, token);
 
-  openChannel.capacity = One;
+  function createWrapper(
+    tokenParameter = token.address,
+    tokens = [token],
+    channels = [channel]
+  ): Wrapper<TransferRoute> {
+    const getters = {
+      tokens: () => tokens,
+      token: () => (tokenAddress: string) =>
+        tokens.filter(({ address }) => address === tokenAddress)?.[0] ?? null,
+      // This simplified version that expects one open channel per token none
+      channelWithBiggestCapacity: () => (tokenAddress: string) =>
+        channels.filter(({ token }) => token === tokenAddress)?.[0] ?? null,
+      openChannels: () => channels,
+    };
 
-  store.commit('updateTokens', { '0xtoken': token });
-  store.commit('updateChannels', {
-    '0xtoken': { '0xaddr': openChannel },
+    const store = new Vuex.Store({ getters });
+    return shallowMount(TransferRoute, {
+      vuetify,
+      store,
+      mocks: {
+        $route: { params: { token: tokenParameter }, query: {} },
+        $t: (msg: string) => msg,
+      },
+    });
+  }
+
+  // TODO: This and the following test case their description are a hint that
+  // the components template is not too nice.
+  test('displays no tokens component if there are no tokens and hide rest', () => {
+    const wrapper = createWrapper('', []);
+    expect(wrapper.findComponent(NoTokens).exists()).toBe(true);
+    expect(wrapper.findComponent(TransferHeaders).exists()).toBe(false);
+    expect(wrapper.findComponent(TransferInputs).exists()).toBe(false);
+    expect(wrapper.findComponent(TransactionList).exists()).toBe(false);
   });
 
-  router.push = jest.fn().mockImplementation(() => Promise.resolve());
-
-  const wrapper: Wrapper<TransferRoute> = mount(TransferRoute, {
-    vuetify,
-    store,
-    mocks: {
-      $router: router,
-      $route: TestData.mockRoute({
-        token: '0xtoken',
-      }),
-      $t: (msg: string) => msg,
-    },
+  test('do not displays no tokens component if there are no tokens, but rest', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.findComponent(NoTokens).exists()).toBe(false);
+    expect(wrapper.findComponent(TransferHeaders).exists()).toBe(true);
+    expect(wrapper.findComponent(TransferInputs).exists()).toBe(true);
+    expect(wrapper.findComponent(TransactionList).exists()).toBe(true);
   });
 
-  test('component can get token', () => {
+  test('show dialog if there are no open channels', () => {
+    const wrapper = createWrapper(token.address, [token], []);
+    expect(wrapper.findComponent(NoChannelsDialog).exists()).toBe(true);
+  });
+
+  test('component can get token from route parameter', () => {
+    const wrapper = createWrapper();
     expect((wrapper.vm as any).token).toEqual(token);
   });
 
-  test('component can get channel capacity', () => {
-    expect((wrapper.vm as any).capacity).toEqual(One);
+  test('uses first token as default if no routing parameter provided', () => {
+    const wrapper = createWrapper('');
+    expect((wrapper.vm as any).token).toEqual(token);
+  });
+
+  test('token is undefined if user has none connected', () => {
+    const wrapper = createWrapper(token.address, []);
+    expect((wrapper.vm as any).token).toBeUndefined();
+  });
+
+  test('component can get channel capacity from route parameter', () => {
+    const wrapper = createWrapper();
+    expect((wrapper.vm as any).capacity).toEqual(channel.capacity);
+  });
+
+  test('capacity is zero if there is the token is undefined', () => {
+    const wrapper = createWrapper('', [], []);
+    expect((wrapper.vm as any).capacity).toEqual(Zero);
   });
 });


### PR DESCRIPTION
Fixes #2144

**Short description**
Nothing to add.
Based on #2143 Will become rebased as soon as the parent PR gets merged. Just review the last commit please.

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Enter the `/transfer` route without the optional token address parameter 
2. Check that you see a "first" token that you are connected with
3. Check that there are no error messages in the console
