### PR TITLE
dapp: fix serve-pr tooling via Nginx config

### DIFF
--- a/serve_pr/nginx.conf
+++ b/serve_pr/nginx.conf
@@ -70,5 +70,12 @@ http {
         location ~* ^/pull/(\d+)/(.*)$ {
             alias /app/$1/dist/$2;
         }
+
+        # The favicon gets accessed per default on the root URL. Due to the
+        # setup with the different locations of the built dApps, this won't
+        # work.
+        location = /favicon.ico {
+          log_not_found off;
+        }
     }
 }


### PR DESCRIPTION
Fixes #2024 

**Short description**
Tested locally and on Talel his Mac.

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Run `docker-compose up` within the `serve_pr` directory
2. Enter an URL like a `http://localhost:8080/?branch=pull/2143` in your web-broweser
3. Make sure you get a properly working dApp presented
