### PR TITLE
Adapt WebRTC to new protocol

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -7,8 +7,12 @@
 ### Added
 - [#2044] Introduce PouchDB (IndexedDB/leveldown) as new persistent state storage backend
 
+### Changed
+- [#2158] Adapt WebRTC to new protocol compatible with python client
+
 [#2044]: https://github.com/raiden-network/light-client/issues/2044
 [#2094]: https://github.com/raiden-network/light-client/issues/2094
+[#2158]: https://github.com/raiden-network/light-client/issues/2158
 
 ## [0.11.1] - 2020-08-18
 ### Changed

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -281,8 +281,8 @@ export function mockRTC() {
 
   const rtcConnection = (Object.assign(new EventEmitter(), {
     createDataChannel: jest.fn(() => rtcDataChannel),
-    createOffer: jest.fn(async () => ({})),
-    createAnswer: jest.fn(async () => ({})),
+    createOffer: jest.fn(async () => ({ type: 'offer', sdp: 'offerSdp' })),
+    createAnswer: jest.fn(async () => ({ type: 'answer', sdp: 'answerSdp' })),
     setLocalDescription: jest.fn(async () => {
       /* local */
     }),


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2158 

**Short description**
On https://github.com/raiden-network/raiden/issues/6560#issuecomment-697465815 , it was decided to go with our own implementation of the VoIP/WebRTC signaling protocol over normal matrix messages to workaround some limitations in Matrix's default protocol, specially it filtering out the signaling events on rooms with more than 2 participants, which can happen on reinvite of roaming users.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Check WebRTC channels can be established and used by two light-clients on HEAD of this PR
