### PR TITLE
dApp: Unit tests for notifications store

### DIFF
--- a/raiden-dapp/src/store/notifications/getters.ts
+++ b/raiden-dapp/src/store/notifications/getters.ts
@@ -6,7 +6,13 @@ import {
 } from '@/store/notifications/types';
 import { NotificationImportance } from '@/store/notifications/notification-importance';
 
-export const getters: GetterTree<NotificationsState, RootState> = {
+type Getters = {
+  notifications(state: NotificationsState): NotificationPayload[];
+  nextNotificationId({ notifications }: NotificationsState): number;
+  notificationQueue(state: NotificationsState): NotificationPayload[];
+};
+
+export const getters: GetterTree<NotificationsState, RootState> & Getters = {
   notifications: (state: NotificationsState): NotificationPayload[] => {
     return Object.values(state.notifications).sort((a, b) => b.id - a.id);
   },

--- a/raiden-dapp/tests/unit/store/notifications/getters.spec.ts
+++ b/raiden-dapp/tests/unit/store/notifications/getters.spec.ts
@@ -1,0 +1,29 @@
+import { getters } from '@/store/notifications/getters';
+import { TestData } from '../../data/mock-data';
+import { NotificationsState } from '@/store/notifications/types';
+
+describe('notifications store getters', () => {
+  const notification = TestData.notifications;
+  const notificationState: NotificationsState = {
+    notifications: {
+      1: { ...notification, id: 29 },
+      2: { ...notification, id: 10 },
+      3: { ...notification, id: 22 },
+    },
+    newNotifications: false,
+  };
+
+  test('can get all notifications sorted by newest first', () => {
+    const allNotifications = getters.notifications(notificationState);
+
+    expect(allNotifications[0]).toMatchObject({ id: 29 });
+    expect(allNotifications[1]).toMatchObject({ id: 22 });
+    expect(allNotifications[2]).toMatchObject({ id: 10 });
+  });
+
+  test('next notification id increments current highest id', () => {
+    const newNotificationId = getters.nextNotificationId(notificationState);
+
+    expect(newNotificationId).toBe(30);
+  });
+});

--- a/raiden-dapp/tests/unit/store/notifications/getters.spec.ts
+++ b/raiden-dapp/tests/unit/store/notifications/getters.spec.ts
@@ -15,15 +15,22 @@ describe('notifications store getters', () => {
 
   test('can get all notifications sorted by newest first', () => {
     const allNotifications = getters.notifications(notificationState);
+    const notificationIds = allNotifications.map(
+      (notification) => notification.id
+    );
 
-    expect(allNotifications[0]).toMatchObject({ id: 29 });
-    expect(allNotifications[1]).toMatchObject({ id: 22 });
-    expect(allNotifications[2]).toMatchObject({ id: 10 });
+    expect(notificationIds).toEqual(expect.arrayContaining([29, 22, 10]));
   });
 
   test('next notification id increments current highest id', () => {
-    const newNotificationId = getters.nextNotificationId(notificationState);
+    const currentHighestId = Math.max(
+      ...Object.values(notificationState.notifications).map(
+        (notification) => notification.id
+      )
+    );
+    expect(currentHighestId).toBe(29);
 
+    const newNotificationId = getters.nextNotificationId(notificationState);
     expect(newNotificationId).toBe(30);
   });
 });

--- a/raiden-dapp/tests/unit/store/notifications/mutations.spec.ts
+++ b/raiden-dapp/tests/unit/store/notifications/mutations.spec.ts
@@ -1,0 +1,64 @@
+import { mutations } from '@/store/notifications/mutations';
+import { TestData } from '../../data/mock-data';
+import {
+  NotificationPayload,
+  NotificationsState,
+} from '@/store/notifications/types';
+
+describe('notifications store mutations', () => {
+  const notification = TestData.notifications;
+
+  const createNotificationState = (
+    newNotifications = false
+  ): NotificationsState => {
+    return {
+      notifications: { 1: notification },
+      newNotifications,
+    };
+  };
+
+  test('can delete notification', () => {
+    const state = createNotificationState();
+    const id = TestData.notifications.id;
+
+    mutations.notificationDelete(state, id);
+    expect(state.notifications).toMatchObject({});
+  });
+
+  test('can set notifications to viewed', () => {
+    const state = createNotificationState(true);
+
+    mutations.notificationsViewed(state);
+    expect(state.newNotifications).toBe(false);
+  });
+
+  test('can add new notifications', () => {
+    const state = createNotificationState();
+    const newNotification: NotificationPayload = {
+      ...notification,
+      txHash: '0xNewTxHash',
+    };
+
+    mutations.notificationAddOrReplace(state, newNotification);
+    expect(Object.keys(state.notifications).length).toBe(2);
+    expect(state.notifications).toMatchObject({ 1: { id: 1 }, 2: { id: 2 } });
+  });
+
+  test('can update notifications', () => {
+    const state = createNotificationState();
+    const updatedNotification: NotificationPayload = {
+      ...notification,
+      txConfirmationBlock: 1234,
+    };
+
+    mutations.notificationAddOrReplace(state, notification);
+    expect(state.notifications).toMatchObject({
+      1: { txConfirmationBlock: 123 },
+    });
+
+    mutations.notificationAddOrReplace(state, updatedNotification);
+    expect(state.notifications).toMatchObject({
+      1: { txConfirmationBlock: 1234 },
+    });
+  });
+});

--- a/raiden-dapp/tests/unit/store/notifications/mutations.spec.ts
+++ b/raiden-dapp/tests/unit/store/notifications/mutations.spec.ts
@@ -19,7 +19,7 @@ describe('notifications store mutations', () => {
 
   test('can delete notification', () => {
     const state = createNotificationState();
-    const id = TestData.notifications.id;
+    const id = notification.id;
 
     mutations.notificationDelete(state, id);
     expect(state.notifications).toMatchObject({});
@@ -27,6 +27,7 @@ describe('notifications store mutations', () => {
 
   test('can set notifications to viewed', () => {
     const state = createNotificationState(true);
+    expect(state.newNotifications).toBe(true);
 
     mutations.notificationsViewed(state);
     expect(state.newNotifications).toBe(false);


### PR DESCRIPTION
Fixes #2149 

**Short description**
Adds missing tests for the notifications store.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Run the tests or simply trust the CI. :)
