### PR TITLE
Adds toDevice capability to matrix transport

### DIFF
--- a/raiden-cli/src/config.json
+++ b/raiden-cli/src/config.json
@@ -6,7 +6,8 @@
     "noDelivery": true,
     "noReceive": false,
     "noMediate": false,
-    "webRTC": true
+    "webRTC": true,
+    "toDevice": true
   },
   "autoSettle": true
 }

--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -205,8 +205,8 @@ function shutdownRaiden(this: Cli): void {
   if (this.raiden.started) {
     this.log.info('Stopping raiden...');
     this.raiden.stop();
-    // force-exit at most 5s after stopping raiden
-    unrefTimeout(setTimeout(() => process.exit(0), 5000));
+    // force-exit at most 10s after stopping raiden
+    unrefTimeout(setTimeout(() => process.exit(0), 10000));
   } else {
     process.exit(1);
   }

--- a/raiden-cli/src/routes/channels.ts
+++ b/raiden-cli/src/routes/channels.ts
@@ -106,7 +106,7 @@ async function openChannel(this: Cli, request: Request, response: Response, next
     // a better solution.
     await this.raiden.openChannel(token, partner, {
       settleTimeout: request.body.settle_timeout,
-      deposit: request.body.total_deposit.toString(),
+      deposit: request.body.total_deposit?.toString?.(),
     });
     const channel = await this.raiden.channels$
       .pipe(pluck(token, partner), first(isntNil))

--- a/raiden-cli/src/routes/payments.ts
+++ b/raiden-cli/src/routes/payments.ts
@@ -81,7 +81,7 @@ async function doTransfer(this: Cli, request: Request, response: Response, next:
       request.params.tokenAddress,
       request.params.targetAddress,
       request.body.amount.toString(),
-      { paymentId: request.body.identifier.toString(), lockTimeout: request.body.lock_timeout },
+      { paymentId: request.body.identifier?.toString?.(), lockTimeout: request.body.lock_timeout },
     );
     const transfer = await this.raiden.waitTransfer(transferKey);
     response.send(transformSdkTransferToApiPayment(transfer));

--- a/raiden-cli/src/utils/logging.ts
+++ b/raiden-cli/src/utils/logging.ts
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import fs from 'fs';
+import util from 'util';
 import logging, { LoggingMethod } from 'loglevel';
+
+util.inspect.defaultOptions.depth = 3; // +1 from default of 2
 
 export function setupLoglevel(output?: string): void {
   const originalFactory = logging.methodFactory;

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## [Unreleased]
 ### Fixed
 - [#2094] Fix TransferState's timestamps missing
+- [#2174] Fix a few transport issues triggered on high-load scenarios
 
 ### Added
 - [#2044] Introduce PouchDB (IndexedDB/leveldown) as new persistent state storage backend
+- [#2204] Implement toDevice capability and messaging
 
 ### Changed
 - [#2158] Adapt WebRTC to new protocol compatible with python client
@@ -13,6 +15,8 @@
 [#2044]: https://github.com/raiden-network/light-client/issues/2044
 [#2094]: https://github.com/raiden-network/light-client/issues/2094
 [#2158]: https://github.com/raiden-network/light-client/issues/2158
+[#2174]: https://github.com/raiden-network/light-client/pull/2174
+[#2204]: https://github.com/raiden-network/light-client/issues/2204
 
 ## [0.11.1] - 2020-08-18
 ### Changed
@@ -20,7 +24,7 @@
 - [#2054] Update to Raiden contracts `v0.37.1`
 
 [#2049]: https://github.com/raiden-network/light-client/issues/2049
-[#2054]: https://github.com/raiden-network/light-client/pulls/2054
+[#2054]: https://github.com/raiden-network/light-client/pull/2054
 
 
 ## [0.11.0] - 2020-08-04

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -135,6 +135,7 @@ export function makeDefaultConfig(
       [Capabilities.NO_DELIVERY]: true,
       [Capabilities.NO_MEDIATE]: true,
       [Capabilities.WEBRTC]: true,
+      [Capabilities.TO_DEVICE]: true,
     },
     fallbackIceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
     rateToSvt: {},

--- a/raiden-ts/src/constants.ts
+++ b/raiden-ts/src/constants.ts
@@ -18,4 +18,5 @@ export enum Capabilities {
   NO_MEDIATE = 'noMediate', // can't mediate transfers; mediating requires receiving
   NO_DELIVERY = 'noDelivery', // don't need Delivery messages
   WEBRTC = 'webRTC', // use WebRTC channels for p2p messaging
+  TO_DEVICE = 'toDevice', // use ToDevice messages instead of rooms
 }

--- a/raiden-ts/src/messages/actions.ts
+++ b/raiden-ts/src/messages/actions.ts
@@ -12,7 +12,7 @@ export const messageSend = createAsyncAction(
   'message/send/success',
   'message/send/failure',
   t.type({ message: t.union([t.string, Signed(Message)]) }),
-  t.union([t.undefined, t.type({ via: t.string })]),
+  t.union([t.undefined, t.partial({ via: t.string })]),
 );
 export namespace messageSend {
   export interface request extends ActionType<typeof messageSend.request> {}

--- a/raiden-ts/src/polyfills.ts
+++ b/raiden-ts/src/polyfills.ts
@@ -9,6 +9,13 @@ import { logger as matrixLogger } from 'matrix-js-sdk/lib/logger';
 Object.assign(logging, { methodFactory }); // revert
 matrixLogger.setLevel(logging.levels.DEBUG); // apply
 
+declare module 'matrix-js-sdk' {
+  // augment MatrixEvent interface/class
+  export interface MatrixEvent {
+    getContent(): any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  }
+}
+
 // request.abort() is called when shutting down matrix; this patch clears some timeouts left behind
 import { getRequest, request } from 'matrix-js-sdk';
 const origRequest = getRequest();

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -417,9 +417,10 @@ export class Raiden {
       prevBlockNumber: this.state.blockNumber,
       address: this.address,
       TokenNetworkRegistry: this.deps.contractsInfo.TokenNetworkRegistry.address,
-      network: this.deps.network,
+      network: { name: this.deps.network.name, chainId: this.deps.network.chainId },
       'raiden-ts': Raiden.version,
       'raiden-contracts': Raiden.contractVersion,
+      config: this.config,
     });
 
     // Set `epicMiddleware` to `null`, this indicates the instance is not running.

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -281,7 +281,7 @@ export class Raiden {
       raidenReducer,
       // workaround for redux's PreloadedState issues with branded values
       state as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      applyMiddleware(loggerMiddleware, this.epicMiddleware, persisterMiddleware),
+      applyMiddleware(loggerMiddleware, persisterMiddleware, this.epicMiddleware),
     );
 
     // populate deps.latest$, to ensure config, logger && pollingInterval are setup before start

--- a/raiden-ts/src/transport/epics/init.ts
+++ b/raiden-ts/src/transport/epics/init.ts
@@ -34,7 +34,7 @@ import { fromFetch } from 'rxjs/fetch';
 import sortBy from 'lodash/sortBy';
 import isEmpty from 'lodash/isEmpty';
 
-import { createClient, MatrixClient, MatrixEvent } from 'matrix-js-sdk';
+import { createClient, MatrixClient, MatrixEvent, Filter } from 'matrix-js-sdk';
 import { logger as matrixLogger } from 'matrix-js-sdk/lib/logger';
 
 import { assert } from '../../utils';
@@ -97,7 +97,7 @@ function joinGlobalRooms(config: RaidenConfig, matrix: MatrixClient): Observable
  * @param roomIds - The ids of the rooms to filter out during sync.
  * @returns Observable of the {@link Filter} that was created.
  */
-async function createFilter(matrix: MatrixClient, roomIds: string[]) {
+async function createMatrixFilter(matrix: MatrixClient, roomIds: string[]): Promise<Filter> {
   const roomFilter = {
     not_rooms: roomIds,
     ephemeral: {
@@ -132,7 +132,7 @@ function startMatrixSync(
     delayWhen(([, { pollingInterval }]) => timer(Math.ceil(pollingInterval / 5))),
     mergeMap(([, config]) =>
       joinGlobalRooms(config, matrix).pipe(
-        mergeMap((roomIds) => createFilter(matrix, roomIds)),
+        mergeMap((roomIds) => createMatrixFilter(matrix, roomIds)),
         mergeMap((filter) => matrix.startClient({ filter })),
         retryWaitWhile(
           exponentialBackoff(config.pollingInterval, config.httpTimeout),

--- a/raiden-ts/src/transport/epics/messages.ts
+++ b/raiden-ts/src/transport/epics/messages.ts
@@ -1,4 +1,4 @@
-import { Observable, of, EMPTY, fromEvent, timer, defer, from } from 'rxjs';
+import { Observable, of, EMPTY, fromEvent, timer, defer, from, merge } from 'rxjs';
 import {
   catchError,
   concatMap,
@@ -13,9 +13,8 @@ import {
   takeUntil,
   tap,
 } from 'rxjs/operators';
-import find from 'lodash/find';
 
-import { MatrixClient, MatrixEvent, Room } from 'matrix-js-sdk';
+import { MatrixEvent, Room } from 'matrix-js-sdk';
 
 import { Capabilities } from '../../constants';
 import { Signed } from '../../utils/types';
@@ -170,10 +169,13 @@ export const matrixMessageReceivedEpic = (
   matrix$.pipe(
     // when matrix finishes initialization, register to matrix timeline events
     switchMap((matrix) =>
-      fromEvent<{ event: MatrixEvent; room: Room; matrix: MatrixClient }>(
-        matrix,
-        'Room.timeline',
-        (event, room) => ({ matrix, event, room }),
+      merge(
+        fromEvent<[MatrixEvent, Room]>(matrix, 'Room.timeline').pipe(
+          map(([event, room]) => ({ matrix, event, room })),
+        ),
+        fromEvent<MatrixEvent>(matrix, 'toDeviceEvent').pipe(
+          map((event) => ({ matrix, event, room: undefined })),
+        ),
       ),
     ),
     withLatestFrom(config$),
@@ -183,27 +185,32 @@ export const matrixMessageReceivedEpic = (
         event.getType() === 'm.room.message' &&
         event.event?.content?.msgtype === 'm.text' &&
         event.getSender() !== matrix.getUserId() &&
-        !globalRoomNames(config).some((g) =>
-          // generate an alias for global room of given name, and check if room matches
-          roomMatch(`#${g}:${getServerName(matrix.getHomeserverUrl())}`, room),
-        ),
+        ((room &&
+          !globalRoomNames(config).some((g) =>
+            // generate an alias for global room of given name, and check if room matches
+            roomMatch(`#${g}:${getServerName(matrix.getHomeserverUrl())}`, room),
+          )) ||
+          (!room && !!config.caps?.[Capabilities.TO_DEVICE])), // toDevice message
     ),
     mergeMap(([{ event, room }, { httpTimeout }]) =>
       latest$.pipe(
         filter(({ presences, state }) => {
-          const presence = find(presences, ['payload.userId', event.getSender()]);
+          const presence = Object.values(presences).find(
+            (presence) => presence.payload.userId === event.getSender(),
+          );
           if (!presence) return false;
           const rooms = state.transport.rooms?.[presence.meta.address] ?? [];
-          if (!rooms.includes(room.roomId)) return false;
-          return true;
+          return !room || rooms.includes(room.roomId);
         }),
         take(1),
         // take up to an arbitrary timeout to presence status for the sender
         // AND the room in which this message was sent to be in sender's address room queue
         takeUntil(timer(httpTimeout)),
         mergeMap(function* ({ presences }) {
-          const presence = find(presences, ['payload.userId', event.getSender()])!;
-          for (const line of (event.event.content.body || '').split('\n')) {
+          const presence = Object.values(presences).find(
+            (presence) => presence.payload.userId === event.getSender(),
+          )!;
+          for (const line of (event.getContent().body ?? '').split('\n')) {
             const message = parseMessage(line, presence.meta.address, { log });
             yield messageReceived(
               {
@@ -211,7 +218,7 @@ export const matrixMessageReceivedEpic = (
                 message,
                 ts: event.event.origin_server_ts ?? Date.now(),
                 userId: presence.payload.userId,
-                roomId: room.roomId,
+                ...(room ? { roomId: room.roomId } : {}),
               },
               presence.meta,
             );

--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -401,7 +401,13 @@ function listenDataChannel(
               );
             }),
           ),
-        ).pipe(finalize(() => (dataChannel.close(), connection.close()))),
+        ).pipe(
+          finalize(() => {
+            dataChannel.close();
+            // FIXME: https://github.com/node-webrtc/node-webrtc/issues/636
+            // connection.close();
+          }),
+        ),
       ),
     );
 }

--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -135,8 +135,10 @@ function matrixWebrtcEvents$<T extends RtcEventType>(
   type: T,
   sender: string,
 ) {
-  return fromEvent<[MatrixEvent]>(matrix, 'Room.timeline').pipe(
-    pluck(0),
+  return merge(
+    fromEvent<[MatrixEvent]>(matrix, 'Room.timeline').pipe(pluck(0)),
+    fromEvent<MatrixEvent>(matrix, 'toDeviceEvent'),
+  ).pipe(
     filter(
       (event): event is ExtMatrixEvent =>
         event.getType() === 'm.room.message' &&

--- a/raiden-ts/src/transport/utils.ts
+++ b/raiden-ts/src/transport/utils.ts
@@ -33,6 +33,18 @@ export const getPresences$: (action$: Observable<RaidenAction>) => Observable<Pr
 );
 
 /**
+ * @param presences - Presences mapping
+ * @param userId - Peer userId
+ * @returns Presence of peer with userId
+ */
+export function getPresenceByUserId(
+  presences: Presences,
+  userId: string,
+): matrixPresence.success | undefined {
+  return Object.values(presences).find((presence) => presence.payload.userId === userId);
+}
+
+/**
  * Stringify a caps mapping
  *
  * @param caps - Capabilities object/mapping


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2195
Fixes #2204 

**Short description**
Adds a protocol improvement which allows clients to advertise a new `toDevice` capability, and when both peers communicating through Matrix have it enabled, allows them to exchange messages without requiring room creation, invite logic and messages storing on server side.
This implementation is backwards compatible, and clients fallback to old room-based message exchange if either isn't compatible or have set this new capability.
WebRTC events can also be exchanged through this type of messages since #2158 .
Includes fixes for other transport issues found while debugging issues above, which happened only on stressing scenarios like BF6.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Run BF1, BF6 & BF7 scenarios
2. Check they pass accordingly
