### PR TITLE
Bugfix/dapp too many connected tokens lead to ui overflow

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#2096] Fixes buggy wallet connection procedure
 - [#2144] Fixes navigation to transfer screen when token was selected
 - [#2159] Fixes routing issues for account and transfer steps
+- [#2238] Fixes broken token overlay for too many connected tokens
 
 ### Added
 - [#1941] Notification for opening channels
@@ -23,6 +24,7 @@
 [#2096]: https://github.com/raiden-network/light-client/issues/1838
 [#2144]: https://github.com/raiden-network/light-client/issues/2144
 [#2159]: https://github.com/raiden-network/light-client/issues/2144
+[#2138]: https://github.com/raiden-network/light-client/issues/2138
 
 ## [0.11.1] - 2020-08-18
 ### Fixed

--- a/raiden-dapp/src/components/overlays/TokenOverlay.vue
+++ b/raiden-dapp/src/components/overlays/TokenOverlay.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-overlay :value="show" absolute opacity="1.0" class="token-network-overlay">
-    <v-container v-if="show" class="token-network__container">
+  <v-overlay absolute opacity="1.0" class="token-network-overlay">
+    <v-container class="token-network__container">
       <v-row no-gutters justify="end">
         <v-btn icon class="token-network-overlay__close-button" @click="cancel">
           <v-icon>mdi-close</v-icon>
@@ -30,110 +30,43 @@
         </v-col>
       </v-row>
 
-      <v-row>
-        <v-col cols="2" class="hidden-sm-and-down" align-self="center"></v-col>
-        <v-col
-          cols="10"
-          align-self="center"
-          class="token-network-overlay__header"
-        >
-          {{ $t('tokens.connected.header') }}
-        </v-col>
-      </v-row>
-
-      <v-row class="token-list">
-        <v-col cols="12">
-          <v-list
-            v-for="(token, i) in tokens"
-            :key="i"
-            class="token-list__item-list"
-          >
-            <v-list-item
-              :key="token.address"
-              @click="handleTokenClick(token.address)"
-            >
-              <v-col cols="2">
-                <v-list-item-avatar>
-                  <img
-                    :src="$blockie(token.address)"
-                    :src-lazy="require('@/assets/generic.svg')"
-                    :alt="$t('select-token.tokens.token.blockie-alt')"
-                  />
-                </v-list-item-avatar>
-              </v-col>
-              <v-col>
-                <v-list-item-content>
-                  <v-list-item-title class="token-list__token-title">
-                    {{
-                      $t('select-token.tokens.token.token-information', {
-                        symbol: token.symbol,
-                        name: token.name,
-                      })
-                    }}
-                  </v-list-item-title>
-                  <v-list-item-subtitle class="token-list__token-address">
-                    <address-display :address="token.address" />
-                  </v-list-item-subtitle>
-                </v-list-item-content>
-              </v-col>
-              <v-col>
-                <v-row justify="end">
-                  <v-list-item-action-text>
-                    <amount-display
-                      class="token-list__token-balance"
-                      exact-amount
-                      :amount="getTokenDetails(token).balance"
-                      :token="getTokenDetails(token)"
-                    />
-                  </v-list-item-action-text>
-                </v-row>
-              </v-col>
-            </v-list-item>
-          </v-list>
-        </v-col>
-      </v-row>
+      <token-list
+        :header="$t('tokens.connected.header')"
+        :tokens="tokens"
+        @select="handleTokenClick"
+        class="mt-8"
+      />
     </v-container>
   </v-overlay>
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Prop, Emit } from 'vue-property-decorator';
+import { Component, Mixins, Emit } from 'vue-property-decorator';
 import { mapGetters } from 'vuex';
 
 import BlockieMixin from '@/mixins/blockie-mixin';
 import NavigationMixin from '@/mixins/navigation-mixin';
 import { TokenModel, Token } from '@/model/types';
-import AddressDisplay from '@/components/AddressDisplay.vue';
-import AmountDisplay from '@/components/AmountDisplay.vue';
+import TokenList from '@/components/tokens/TokenList.vue';
 
 @Component({
-  components: { AddressDisplay, AmountDisplay },
-  computed: {
-    ...mapGetters(['tokens', 'allTokens']),
-  },
+  components: { TokenList },
+  computed: { ...mapGetters(['tokens']) },
 })
 export default class TokenOverlay extends Mixins(
   BlockieMixin,
   NavigationMixin
 ) {
-  @Prop({ required: true, type: Boolean })
-  show!: boolean;
-
-  allTokens!: Token[];
   tokens!: TokenModel[];
 
-  handleTokenClick(tokenAddress: string) {
+  handleTokenClick(selectToken: Token): void {
     const { token } = this.$route.params;
 
-    if (token !== tokenAddress) {
-      this.navigateToSelectTransferTarget(tokenAddress);
+    if (token !== selectToken.address) {
+      this.navigateToSelectTransferTarget(selectToken.address);
     }
 
     this.cancel();
-  }
-
-  getTokenDetails(token: TokenModel) {
-    return this.$store.getters.token(token.address);
   }
 
   @Emit()

--- a/raiden-dapp/src/components/overlays/TokenOverlay.vue
+++ b/raiden-dapp/src/components/overlays/TokenOverlay.vue
@@ -1,42 +1,36 @@
 <template>
-  <v-overlay absolute opacity="1.0" class="token-network-overlay">
-    <v-container class="token-network__container">
-      <v-row no-gutters justify="end">
-        <v-btn icon class="token-network-overlay__close-button" @click="cancel">
-          <v-icon>mdi-close</v-icon>
-        </v-btn>
-      </v-row>
+  <v-overlay absolute opacity="1.0" class="token-overlay">
+    <div class="d-flex justify-end">
+      <v-btn class="ma-4 token-overlay__close-button" icon @click="cancel">
+        <v-icon>mdi-close</v-icon>
+      </v-btn>
+    </div>
 
-      <v-row id="connect-new">
-        <v-col cols="12">
-          <v-list class="connect-new__item-list">
-            <v-list-item @click="navigateToTokenSelect()">
-              <v-col cols="2">
-                <v-list-item-avatar>
-                  <v-btn class="mx-2" fab dark small color="primary">
-                    <v-icon dark large>mdi-plus</v-icon>
-                  </v-btn>
-                </v-list-item-avatar>
-              </v-col>
-              <v-col
-                cols="10"
-                align-self="center"
-                class="connect-new__connect-new-token"
-              >
-                {{ $t('tokens.connect-new') }}
-              </v-col>
-            </v-list-item>
-          </v-list>
+    <v-list class="transparent">
+      <v-list-item
+        class="token-overlay__connect-new"
+        @click="navigateToTokenSelect()"
+      >
+        <v-col cols="2">
+          <v-list-item-avatar>
+            <v-btn class="mx-2" fab dark small color="primary">
+              <v-icon dark large>mdi-plus</v-icon>
+            </v-btn>
+          </v-list-item-avatar>
         </v-col>
-      </v-row>
+        <v-col cols="10" align-self="center" class="font-weight-bold">
+          {{ $t('tokens.connect-new') }}
+        </v-col>
+      </v-list-item>
+    </v-list>
 
+    <div class="token-overlay__connected-tokens mt-8">
       <token-list
         :header="$t('tokens.connected.header')"
         :tokens="tokens"
         @select="handleTokenClick"
-        class="mt-8"
       />
-    </v-container>
+    </div>
   </v-overlay>
 </template>
 
@@ -75,15 +69,7 @@ export default class TokenOverlay extends Mixins(
 </script>
 
 <style lang="scss" scoped>
-@import '@/scss/colors';
-@import '@/scss/scroll';
-@import '@/scss/fonts';
-@import '@/scss/mixins';
-
-.token-network-overlay {
-  border-bottom-left-radius: 10px;
-  border-bottom-right-radius: 10px;
-
+.token-overlay {
   ::v-deep {
     .v-overlay {
       &__scrim {
@@ -95,104 +81,16 @@ export default class TokenOverlay extends Mixins(
       }
 
       &__content {
-        position: absolute;
-        top: 0;
-        right: 0;
+        display: flex;
+        flex-direction: column;
         width: 100%;
         height: 100%;
       }
     }
-
-    .v-list-item {
-      padding: 0 0 0 48px;
-
-      @include respond-to(handhelds) {
-        padding: 0;
-      }
-    }
   }
 
-  .token-network {
-    &__container {
-      padding: 0 !important;
-      height: 100%;
-    }
-  }
-
-  &__close-button {
-    margin: 15px;
-  }
-
-  .token-list {
-    height: calc(100% - 230px);
-
-    &__item-list {
-      overflow-y: auto;
-      @extend .themed-scrollbar;
-
-      background-color: transparent !important;
-      padding-bottom: 0;
-      padding-top: 0;
-
-      ::v-deep {
-        .col-10 {
-          padding-left: 11px;
-        }
-      }
-    }
-
-    &__token-title {
-      font-weight: bold;
-      line-height: 20px;
-      font-size: 16px;
-    }
-
-    &__token-balance {
-      color: $color-white;
-      font-family: $main-font;
-      font-size: 16px;
-      font-weight: bold;
-      line-height: 20px;
-      height: 100%;
-      padding-right: 20px;
-    }
-
-    &__token-address {
-      color: #696969 !important;
-      line-height: 20px;
-      font-size: 16px;
-    }
-  }
-
-  .connect-new {
-    &__item-list {
-      height: 100%;
-      background-color: transparent !important;
-      padding-bottom: 0;
-      padding-top: 0;
-
-      ::v-deep {
-        .col-10 {
-          padding-left: 11px;
-        }
-      }
-    }
-
-    &__connect-new-token {
-      font-weight: bold;
-      line-height: 20px;
-      font-size: 16px;
-    }
-  }
-
-  &__header {
-    font-weight: bold;
-    line-height: 20px;
-    font-size: 16px;
-
-    color: $primary-color;
-    text-transform: uppercase;
-    padding-left: 58px;
+  &__connected-tokens {
+    overflow-y: hidden;
   }
 }
 </style>

--- a/raiden-dapp/src/components/tokens/TokenList.vue
+++ b/raiden-dapp/src/components/tokens/TokenList.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="token-list d-flex flex-column">
+    <list-header v-if="header" :header="header" class="flex-grow-0" />
+
+    <div class="token-list__wrapper flex-grow-1">
+      <v-virtual-scroll
+        #default="{ item }"
+        :items="tokens"
+        item-height="105"
+        bench="400"
+      >
+        <token-list-item :token="item" @select="forwardTokenSelection" />
+      </v-virtual-scroll>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop, Emit } from 'vue-property-decorator';
+import { Token } from '@/model/types';
+import ListHeader from '@/components/ListHeader.vue';
+import TokenListItem from './TokenListItem.vue';
+
+@Component({ components: { ListHeader, TokenListItem } })
+export default class TokenList extends Vue {
+  @Prop({ type: String })
+  header!: string;
+
+  @Prop({ required: true })
+  tokens!: Token[];
+
+  @Emit('select')
+  forwardTokenSelection(token: Token): Token {
+    return token;
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '@/scss/scroll';
+
+.token-list {
+  height: 100%;
+
+  &__wrapper {
+    overflow-y: auto;
+    @extend .themed-scrollbar;
+  }
+}
+</style>

--- a/raiden-dapp/src/components/tokens/TokenListItem.vue
+++ b/raiden-dapp/src/components/tokens/TokenListItem.vue
@@ -1,0 +1,86 @@
+<template>
+  <v-list-item
+    :key="detailedToken.address"
+    class="token-list-item"
+    @click="emitSelectToken"
+  >
+    <v-list-item-avatar>
+      <img
+        :src="avatarSource"
+        :src-lazy="require('@/assets/generic.svg')"
+        :alt="$t('token-list.item.blockie-alt')"
+      />
+    </v-list-item-avatar>
+
+    <v-list-item-content class="mr-4">
+      <v-list-item-title class="font-weight-bold">
+        {{
+          $t('token-list.item.information-template', {
+            symbol: detailedToken.symbol,
+            name: detailedToken.name,
+          })
+        }}
+      </v-list-item-title>
+      <v-list-item-subtitle>
+        <address-display
+          :address="detailedToken.address"
+          class="token-list-item__address"
+        />
+      </v-list-item-subtitle>
+    </v-list-item-content>
+
+    <v-list-item-action-text class="mt-n5 mr-5">
+      <amount-display
+        v-if="detailedToken.balance"
+        :amount="detailedToken.balance"
+        :token="detailedToken"
+        exact-amount
+        class="token-list-item__balance white--text font-weight-bold"
+      />
+    </v-list-item-action-text>
+  </v-list-item>
+</template>
+
+<script lang="ts">
+import { Component, Mixins, Prop, Emit } from 'vue-property-decorator';
+import BlockieMixin from '@/mixins/blockie-mixin';
+import AddressDisplay from '@/components/AddressDisplay.vue';
+import AmountDisplay from '@/components/AmountDisplay.vue';
+import { TokenModel, Token } from '@/model/types';
+
+@Component({ components: { AddressDisplay, AmountDisplay } })
+export default class TokenListItem extends Mixins(BlockieMixin) {
+  @Prop({ required: true })
+  token!: Token | TokenModel;
+
+  get detailedToken(): Token | TokenModel {
+    return this.$store.getters.token(this.token.address) ?? this.token;
+  }
+
+  get avatarSource(): string {
+    return this.$blockie(this.token.address);
+  }
+
+  @Emit('select')
+  emitSelectToken(): Token {
+    return this.token;
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '@/scss/fonts';
+
+.token-list-item {
+  height: 105px;
+  box-shadow: inset 0 -3px 0 0 rgba(0, 0, 0, 0.5);
+
+  &__address {
+    color: #696969 !important;
+  }
+
+  &__balance {
+    font-size: 16px;
+  }
+}
+</style>

--- a/raiden-dapp/src/components/transfer/TransferHeaders.vue
+++ b/raiden-dapp/src/components/transfer/TransferHeaders.vue
@@ -1,7 +1,7 @@
 <template>
   <v-row no-gutters class="transfer-menus">
     <div class="transfer-menus__token-select">
-      <span @click="showTokens = true">
+      <span @click="showTokenOverlay = true">
         {{ $t('transfer.transfer-menus.change-token-title') }}
         <v-icon>mdi-chevron-down</v-icon>
       </span>
@@ -38,7 +38,7 @@
     <span v-else>
       <amount-display exact-amount :amount="capacity" :token="token" />
     </span>
-    <token-overlay :show="showTokens" @cancel="showTokens = false" />
+    <token-overlay v-if="showTokenOverlay" @cancel="showTokenOverlay = false" />
     <channel-deposit-dialog
       :loading="loading"
       :done="done"
@@ -77,7 +77,7 @@ import { Zero } from 'ethers/constants';
   },
 })
 export default class TransferHeaders extends Mixins(NavigationMixin) {
-  showTokens: boolean = false;
+  showTokenOverlay: boolean = false;
   showDepositDialog: boolean = false;
   loading: boolean = false;
   done: boolean = false;

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -464,13 +464,7 @@
     "failed-transfer": "FAILED"
   },
   "select-token": {
-    "header": "Available",
-    "tokens": {
-      "token": {
-        "blockie-alt": "Token address blockie",
-        "token-information": "{symbol} | {name}"
-      }
-    }
+    "header": "Available Tokens"
   },
   "select-hub": {
     "select-button": "Select Hub",
@@ -672,6 +666,12 @@
     "raiden-account": {
       "title": "Use Raiden Account",
       "description": "By default the dApp uses a generated Raiden account to sign messages. Disable the Raiden account to use your Web3 provider account. All messages will then have to be signed manually."
+    }
+  },
+  "token-list": {
+    "item": {
+      "blockie-alt": "Token address blockie",
+      "information-template": "{symbol} | {name}"
     }
   }
 }

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -317,15 +317,7 @@
   },
   "tokens": {
     "connected": {
-      "header": "Connected Tokens",
-      "token": {
-        "blockie-alt": "Partner address blockie",
-        "token-info": "{symbol} | {name}",
-        "buttons": {
-          "disconnect": "Disconnect Token",
-          "view-channels": "View Channels"
-        }
-      }
+      "header": "Connected Tokens"
     },
     "connect-new": "Connect new token",
     "disconnect-dialog": {

--- a/raiden-dapp/src/views/SelectTokenRoute.vue
+++ b/raiden-dapp/src/views/SelectTokenRoute.vue
@@ -1,60 +1,10 @@
 <template>
-  <div class="select-token">
-    <list-header
+  <div class="select-token flex-grow-1 pt-8">
+    <token-list
       :header="$t('select-token.header')"
-      class="select-token__header"
-    ></list-header>
-
-    <v-row no-gutters justify="center" class="select-token__tokens__wrapper">
-      <v-col cols="12">
-        <recycle-scroller
-          #default="{ item }"
-          :items="allTokens"
-          :buffer="400"
-          :item-size="105"
-          key-field="address"
-          class="select-token__tokens"
-        >
-          <v-list-item
-            :key="item.address"
-            class="select-token__tokens__token"
-            @click="navigateToSelectHub(item.address)"
-          >
-            <v-list-item-avatar class="select-token__tokens__token__blockie">
-              <img
-                :src="$blockie(item.address)"
-                :src-lazy="require('../assets/generic.svg')"
-                :alt="$t('select-token.tokens.token.blockie-alt')"
-              />
-            </v-list-item-avatar>
-            <v-list-item-content>
-              <v-list-item-title class="select-token__tokens__token__info">
-                {{
-                  $t('select-token.tokens.token.token-information', {
-                    symbol: item.symbol,
-                    name: item.name,
-                  })
-                }}
-              </v-list-item-title>
-              <v-list-item-subtitle
-                class="select-token__tokens__token__address"
-              >
-                <address-display :address="item.address" />
-              </v-list-item-subtitle>
-            </v-list-item-content>
-            <v-list-item-action-text>
-              <amount-display
-                v-if="typeof item.decimals === 'number'"
-                class="select-token__tokens__token__balance"
-                exact-amount
-                :amount="item.balance"
-                :token="item"
-              />
-            </v-list-item-action-text>
-          </v-list-item>
-        </recycle-scroller>
-      </v-col>
-    </v-row>
+      :tokens="allTokens"
+      @select="selectToken"
+    />
   </div>
 </template>
 
@@ -64,12 +14,10 @@ import { mapGetters } from 'vuex';
 import { Token } from '@/model/types';
 import NavigationMixin from '@/mixins/navigation-mixin';
 import BlockieMixin from '@/mixins/blockie-mixin';
-import ListHeader from '@/components/ListHeader.vue';
-import AmountDisplay from '@/components/AmountDisplay.vue';
-import AddressDisplay from '@/components/AddressDisplay.vue';
+import TokenList from '@/components/tokens/TokenList.vue';
 
 @Component({
-  components: { ListHeader, AddressDisplay, AmountDisplay },
+  components: { TokenList },
   computed: mapGetters(['allTokens']),
 })
 export default class SelectTokenRoute extends Mixins(
@@ -81,76 +29,15 @@ export default class SelectTokenRoute extends Mixins(
   async mounted() {
     await this.$raiden.fetchTokenList();
   }
+
+  selectToken(token: Token): void {
+    this.navigateToSelectHub(token.address);
+  }
 }
 </script>
 
 <style lang="scss" scoped>
-@import '@/scss/scroll';
-@import '@/scss/colors';
-@import '@/scss/fonts';
-
 .select-token {
   height: 100%;
-  width: 100%;
-
-  &__header {
-    margin-top: 115px;
-  }
-
-  &__tokens {
-    height: 100%;
-    background-color: transparent !important;
-    padding-bottom: 0;
-    padding-top: 0;
-    overflow-y: scroll;
-
-    ::v-deep {
-      .v-list-item {
-        height: 105px;
-
-        &__action-text {
-          height: 44px;
-        }
-      }
-    }
-
-    &__wrapper {
-      height: calc(100% - 150px);
-      overflow-y: auto;
-      @extend .themed-scrollbar;
-
-      .col {
-        height: 100%;
-        max-height: 1000px;
-      }
-    }
-
-    &__token {
-      background-color: rgba(0, 0, 0, 0.25);
-      box-shadow: inset 0 -2px 0 0 rgba(0, 0, 0, 0.5);
-
-      &__balance {
-        color: #ffffff;
-        font-family: $main-font;
-        font-size: 16px;
-        font-weight: bold;
-        line-height: 20px;
-        height: 100%;
-        padding-right: 20px;
-      }
-
-      &__info {
-        font-weight: bold;
-        line-height: 20px;
-        font-size: 16px;
-      }
-
-      &__address {
-        color: #696969 !important;
-        line-height: 20px;
-        font-size: 16px;
-      }
-    }
-  }
 }
 </style>

--- a/raiden-dapp/src/views/TransferRoute.vue
+++ b/raiden-dapp/src/views/TransferRoute.vue
@@ -57,7 +57,8 @@ export default class TransferRoute extends Vue {
     if (this.noTokens) {
       return undefined;
     } else {
-      const address = this.$route.params.token ?? this.tokens[0].address;
+      const { token } = this.$route.params;
+      const address = token ? token : this.tokens[0].address;
       return this.$store.getters.token(address) || ({ address } as Token);
     }
   }

--- a/raiden-dapp/src/views/TransferRoute.vue
+++ b/raiden-dapp/src/views/TransferRoute.vue
@@ -57,7 +57,7 @@ export default class TransferRoute extends Vue {
     if (this.noTokens) {
       return undefined;
     } else {
-      const address = this.$route.params.tokens ?? this.tokens[0].address;
+      const address = this.$route.params.token ?? this.tokens[0].address;
       return this.$store.getters.token(address) || ({ address } as Token);
     }
   }

--- a/raiden-dapp/tests/unit/components/tokens/token-list-item.spec.ts
+++ b/raiden-dapp/tests/unit/components/tokens/token-list-item.spec.ts
@@ -1,0 +1,39 @@
+import Vue from 'vue';
+import Vuetify from 'vuetify';
+import Vuex, { Store } from 'vuex';
+import { mount } from '@vue/test-utils';
+import { generateToken } from '../../utils/data-generator';
+import { $identicon } from '../../utils/mocks';
+import TokenListItem from '@/components/tokens/TokenListItem.vue';
+
+Vue.use(Vuetify);
+Vue.use(Vuex);
+
+const token = generateToken();
+const vuetify = new Vuetify();
+const propsData = { token };
+const store = new Store({
+  getters: { token: () => (_tokenAddress: string) => null },
+});
+
+const mocks = {
+  $identicon: $identicon(),
+  $t: (msg: string) => msg,
+};
+
+const wrapper = mount(TokenListItem, {
+  vuetify,
+  store,
+  propsData,
+  mocks,
+});
+
+describe('TokenListItem.vue', () => {
+  test('emit select event when clicking on item', () => {
+    wrapper.element.click();
+
+    const selectEvents = wrapper.emitted().select ?? [];
+    expect(selectEvents.length).toBe(1);
+    expect(selectEvents[0][0]).toEqual(token);
+  });
+});

--- a/raiden-dapp/tests/unit/components/tokens/token-list.spec.ts
+++ b/raiden-dapp/tests/unit/components/tokens/token-list.spec.ts
@@ -1,0 +1,78 @@
+import Vue from 'vue';
+import Vuetify from 'vuetify';
+import Vuex, { Store } from 'vuex';
+import { mount, Wrapper } from '@vue/test-utils';
+import { generateToken } from '../../utils/data-generator';
+import { $identicon } from '../../utils/mocks';
+import { Token } from '@/model/types';
+import TokenList from '@/components/tokens/TokenList.vue';
+import TokenListItem from '@/components/tokens/TokenListItem.vue';
+import ListHeader from '@/components/ListHeader.vue';
+
+Vue.use(Vuetify);
+Vue.use(Vuex);
+
+const tokenOne = generateToken();
+const tokenTwo = generateToken();
+
+function createWrapper(
+  properties: {
+    header?: string;
+    tokens?: Token[];
+  } = {}
+): Wrapper<TokenList> {
+  const vuetify = new Vuetify();
+  const propsData = { tokens: [], ...properties };
+  const store = new Store({
+    getters: { token: () => (_tokenAddress: string) => null },
+  });
+
+  const mocks = {
+    $identicon: $identicon(),
+    $t: (msg: string) => msg,
+  };
+
+  return mount(TokenList, {
+    vuetify,
+    propsData,
+    store,
+    mocks,
+  });
+}
+
+describe('TokenList.vue', () => {
+  test('do not display list header if not defined', () => {
+    const wrapper = createWrapper();
+    const listHeader = wrapper.findComponent(ListHeader);
+    expect(listHeader.exists()).toBe(false);
+  });
+
+  test('display list header if defined', () => {
+    const wrapper = createWrapper({ header: 'test' });
+    const listHeader = wrapper.findComponent(ListHeader);
+    expect(listHeader.exists()).toBe(true);
+  });
+
+  test('do not display tokens if list is empty', () => {
+    const wrapper = createWrapper();
+    const tokenListItems = wrapper.findAllComponents(TokenListItem);
+    expect(tokenListItems.length).toBe(0);
+  });
+
+  test('display tokens if list is not empty', () => {
+    const wrapper = createWrapper({ tokens: [tokenOne, tokenTwo] });
+    const tokenListItems = wrapper.findAllComponents(TokenListItem);
+    expect(tokenListItems.length).toBe(2);
+  });
+
+  test('receive event emitted when clicking on token list item', () => {
+    const wrapper = createWrapper({ tokens: [tokenOne] });
+    const tokenListItem = wrapper.findComponent(TokenListItem);
+
+    tokenListItem.element.click();
+
+    const selectEvents = wrapper.emitted().select ?? [];
+    expect(selectEvents.length).toBe(1);
+    expect(selectEvents[0][0]).toEqual(tokenOne);
+  });
+});


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2138

**Short description**
This was solved by exporting the token list part of the select token view into its own component and re-use it also for the broken token overlay. Therefore this PR includes new components, adopted components, new tests, adopted tests, and some optimizations of former styling and templating.

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Run the client with an account that has many open channels in different token networks
2. Click on switch token
3. Make sure there is a scrollable list of connected tokens and no overflow in the UI
