### PR TITLE
dapp: add new feature - optional identifier query param in route

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -12,10 +12,12 @@
 
 ### Added
 - [#1941] Notification for opening channels
+- [#1255] Optional identifier query parameter for transfers
 
 ### Changes
 - [#1929] Design adjustments to settlement notifications and notification panel 
 
+[#1255]: https://github.com/raiden-network/light-client/issues/1255
 [#1941]: https://github.com/raiden-network/light-client/issues/1941
 [#2026]: https://github.com/raiden-network/light-client/issues/2026
 [#1929]: https://github.com/raiden-network/light-client/issues/1929

--- a/raiden-dapp/src/utils/query-params.ts
+++ b/raiden-dapp/src/utils/query-params.ts
@@ -1,4 +1,13 @@
 import AddressUtils from '@/utils/address-utils';
+import { BigNumber, bigNumberify } from 'ethers/utils';
+
+export function getPaymentId(queryParam: any): BigNumber | undefined {
+  try {
+    return bigNumberify(queryParam);
+  } catch (_error) {
+    return undefined;
+  }
+}
 
 export function getAmount(queryParam: any): string {
   let amount = '';

--- a/raiden-dapp/src/views/TransferStepsRoute.vue
+++ b/raiden-dapp/src/views/TransferStepsRoute.vue
@@ -209,7 +209,7 @@ import Checkmark from '@/components/icons/Checkmark.vue';
 import AmountDisplay from '@/components/AmountDisplay.vue';
 import ErrorDialog from '@/components/dialogs/ErrorDialog.vue';
 import { Zero } from 'ethers/constants';
-import { getAddress, getAmount } from '@/utils/query-params';
+import { getAddress, getAmount, getPaymentId } from '@/utils/query-params';
 import AddressUtils from '@/utils/address-utils';
 import Filter from '@/filters';
 import TransferProgressDialog from '@/components/dialogs/TransferProgressDialog.vue';
@@ -314,11 +314,12 @@ export default class TransferSteps extends Mixins(
   }
 
   async created() {
-    const { amount } = this.$route.query;
+    const { amount, identifier } = this.$route.query;
     const { target } = this.$route.params;
 
     this.amount = getAmount(amount);
     this.target = getAddress(target);
+    this.paymentId = getPaymentId(identifier) || this.paymentId;
 
     const { token: address } = this.$route.params;
 

--- a/raiden-dapp/tests/unit/query-params.spec.ts
+++ b/raiden-dapp/tests/unit/query-params.spec.ts
@@ -1,4 +1,5 @@
-import { getAddress, getAmount } from '@/utils/query-params';
+import { getAddress, getAmount, getPaymentId } from '@/utils/query-params';
+import { bigNumberify } from 'ethers/utils';
 
 describe('query params', () => {
   describe('amount', () => {
@@ -32,6 +33,25 @@ describe('query params', () => {
 
     test('undefined returns empty string', () => {
       expect(getAddress(undefined)).toBe('');
+    });
+  });
+
+  describe('paymentId', () => {
+    test('invalid param returns undefined', () => {
+      expect(getPaymentId('onehundred')).toBe(undefined);
+    });
+
+    test('valid string returns BigNumber', () => {
+      expect(getPaymentId('18446744073709551615')).toStrictEqual(
+        bigNumberify('18446744073709551615')
+      );
+    });
+    test('valid hex encoded string returns BigNumber', () => {
+      const num = bigNumberify('18446744073709551615');
+      expect(getPaymentId('0xffffffffffffffff')).toStrictEqual(num);
+    });
+    test('undefined returns undefined', () => {
+      expect(getPaymentId(undefined)).toStrictEqual(undefined);
     });
   });
 });

--- a/raiden-dapp/tests/unit/views/transfer-steps-route.spec.ts
+++ b/raiden-dapp/tests/unit/views/transfer-steps-route.spec.ts
@@ -80,6 +80,7 @@ describe('TransferStepsRoute.vue', () => {
           },
           query: {
             amount: '100000',
+            identifier: '123456789123456789123',
           },
         },
         $t: (msg: string, args: object) =>


### PR DESCRIPTION

Fixes #1255

**Short description**

Adds an optional `identifier` query parameter to the `TransferStepsRoute` url,
that overwrites the automatically generated `paymentId` when a value is provided.


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [x] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Initate a transfer via the transfer route with an additional `identifier` query param, e.g. `#/transfer/0xC563388e2e2fdD422166eD5E76971D11eD37A466/0x11faFfcc7Aa31d731a8Cf6e998216731ed78D7AF?identifier=640467093185029602&amount=0.001` - this has to be a `uint64`
2. Verify on the receiver's end that the transfer has the desired identifier, e.g. `640467093185029602`
