### PR TITLE
sdk: allow to replace db equal to current state

### DIFF
--- a/raiden-ts/src/db/utils.ts
+++ b/raiden-ts/src/db/utils.ts
@@ -382,7 +382,7 @@ export async function replaceDatabase(
     if (!db) continue;
     const dbMeta = await databaseMeta(db);
     assert(
-      meta.version >= version && meta.blockNumber > dbMeta.blockNumber,
+      meta.version >= version && meta.blockNumber >= dbMeta.blockNumber,
       ErrorCodes.RDN_STATE_MIGRATION,
     );
     // shouldn't happen, since [name] is generated from these parameters


### PR DESCRIPTION
It is confusing if the user attempts to backup his state and uploads it right after. This gets denied so far.