### PR TITLE
dApp: Adds missing rounded corners for transaction history box

### DIFF
--- a/raiden-dapp/src/components/transaction-history/Transaction.vue
+++ b/raiden-dapp/src/components/transaction-history/Transaction.vue
@@ -107,10 +107,14 @@ export default class Transaction extends Vue {
 
 <style scoped lang="scss">
 @import '../../main';
+@import '@/scss/mixins';
 @import '@/scss/colors';
 
 .transaction {
   height: 74px;
+  @include respond-to(handhelds) {
+    height: 90px;
+  }
 
   &__item {
     &__icon {

--- a/raiden-dapp/src/views/TransferRoute.vue
+++ b/raiden-dapp/src/views/TransferRoute.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container class="transfer">
+  <v-container class="transfer" fluid>
     <no-tokens v-if="noTokens" />
     <template v-else>
       <transfer-headers
@@ -80,12 +80,17 @@ export default class TransferRoute extends Vue {
 @import '@/scss/mixins';
 
 .transfer {
+  display: flex;
+  flex-direction: column;
+  @include respond-to(handhelds) {
+    overflow-y: auto;
+  }
+
   &__menus,
   &__inputs,
   &__list {
     margin: 0 auto;
     width: 550px;
-
     @include respond-to(handhelds) {
       width: 100%;
     }


### PR DESCRIPTION
Fixes #2185 

**Short description**
Somehow the rounded corners at the bottom of the transaction history box got lost. This PR brings them back as well as adjusts the whole Transfer view to display better on all mobile sizes. Now a user can scroll and see all the content on any screen which was previously not the case.

<img width="350" alt="Screenshot 2020-10-05 at 13 56 02" src="https://user-images.githubusercontent.com/43838780/95076882-d89e7080-0712-11eb-9d16-45295900136f.png">


**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. View the transfer screen on desktop and mobile.
