### PR TITLE
Feature/dapp cypress jest plugin

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,7 @@ importers:
       canvas: 2.6.1
       copy-webpack-plugin: 6.1.1_webpack@4.44.2
       cypress: 3.8.3
+      cypress-jest-adapter: 0.1.1_jest@26.4.2
       eslint: 7.10.0
       eslint-import-resolver-alias: 1.1.2_eslint-plugin-import@2.22.1
       eslint-plugin-import: 2.22.1_eslint@7.10.0
@@ -194,6 +195,7 @@ importers:
       copy-webpack-plugin: ^6.1.1
       core-js: ^3.6.5
       cypress: 3.8.3
+      cypress-jest-adapter: ^0.1.1
       eslint: ^7.10.0
       eslint-import-resolver-alias: ^1.1.2
       eslint-plugin-import: ^2.22.1
@@ -8246,6 +8248,17 @@ packages:
     dev: true
     resolution:
       integrity: sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
+  /cypress-jest-adapter/0.1.1_jest@26.4.2:
+    dependencies:
+      expect: 24.9.0
+      jest-get-type: 24.9.0
+      jest-jquery-matchers: 2.1.0_jest@26.4.2+jquery@3.5.1
+      jquery: 3.5.1
+    dev: true
+    peerDependencies:
+      jest: '*'
+    resolution:
+      integrity: sha512-5dSB03utqDTBG5pi1LaAvYQD5uSMtSwurSzodpM+3XS/RdrjR/644oPnFUxPRvX4FVBaIY8avRs/f/GmIAiu8w==
   /cypress/3.8.3:
     dependencies:
       '@cypress/listr-verbose-renderer': 0.4.1
@@ -13159,6 +13172,16 @@ packages:
       canvas: '*'
     resolution:
       integrity: sha512-z7H4EpCldHN1J8fNgsja58QftxBSL+JcwZmaXIvV9WKIM+x49F4GLHu/+BQh2kzRKHAgaN/E82od+8rTOBPyPA==
+  /jest-jquery-matchers/2.1.0_jest@26.4.2+jquery@3.5.1:
+    dependencies:
+      jest: 26.4.2_canvas@2.6.1
+      jquery: 3.5.1
+    dev: true
+    peerDependencies:
+      jest: '>=21.0.0'
+      jquery: '>=2.0.0'
+    resolution:
+      integrity: sha512-gbCptZOPFv4m7CJenRJcp7OTmQ432yakCDGup6gExrIwbNq8hBfxU+llXO2IXOpFuLmI0c8A+JdGMUNXe6LV9A==
   /jest-junit/11.1.0:
     dependencies:
       mkdirp: 1.0.4
@@ -13770,6 +13793,10 @@ packages:
       canvas: '*'
     resolution:
       integrity: sha512-LLCjPrUh98Ik8CzW8LLVnSCfLaiY+wbK53U7VxnFSX7Q+kWC4noVeDvGWIFw0Amfq1lq2VfGm7YHWSLBV62MJw==
+  /jquery/3.5.1:
+    dev: true
+    resolution:
+      integrity: sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
   /js-beautify/1.13.0:
     dependencies:
       config-chain: 1.1.12

--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -76,6 +76,7 @@
     "canvas": "^2.6.1",
     "copy-webpack-plugin": "^6.1.1",
     "cypress": "3.8.3",
+    "cypress-jest-adapter": "^0.1.1",
     "eslint": "^7.10.0",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-import": "^2.22.1",

--- a/raiden-dapp/tests/e2e/specs/accept-disclaimer.spec.ts
+++ b/raiden-dapp/tests/e2e/specs/accept-disclaimer.spec.ts
@@ -2,11 +2,11 @@ import { navigateToDisclaimerRoute } from '../utils';
 
 it('accepts disclaimer and redirects to home route', () => {
   navigateToDisclaimerRoute();
+  cy.contains('Disclaimer').should((div) => expect(div).toBeVisible());
 
-  cy.contains('Disclaimer').should('be.visible');
   cy.get('.disclaimer__accept-checkbox').click();
   cy.get('.disclaimer__persist-checkbox').click();
   cy.get('.disclaimer__accept-button').click();
 
-  cy.url().should('include', '/#/home');
+  cy.url().should((url) => expect(url).toContain('/#/home'));
 });

--- a/raiden-dapp/tests/e2e/support/index.ts
+++ b/raiden-dapp/tests/e2e/support/index.ts
@@ -16,6 +16,7 @@
 // Import commands.js using ES2015 syntax:
 import '@cypress/code-coverage/support';
 import './commands';
+import 'cypress-jest-adapter';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')


### PR DESCRIPTION
Related to #1584 

**Short description**
We use _Jest_ for all tests so far. Cypress is based on Mocha with Chai as assertion library. This can lead to confusion when switching between the test. It also feels like a bad practice to mix those frameworks. Unfortunately is the issue on Cypress to support Jest native still open. I'm following.  The plugin added here brings at least the Jest kind of `expect` assertions back to Cypress. Unfortunately does Cypress has the concept of asynchronous `Chainer`s. They are probably a great design approach, but make the usage of element retrieved from the DOM cumbersome, using this plugin. 
@taleldayekh Please evaluate if you are fine with this syntax with the arrow functions. For all other assertions where we have an actual object we can use `expect()` straight forward. Not sure how often this will be the case. If you dislike it and say it leads to an awkward mix, just close this PR. I'm split in my opinion because of the reasons in the above paragraph.

Eventually can [this plugins command](https://github.com/Lakitna/cypress-commands/blob/develop/docs/to.md) make things easier to use...


**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
