### PR TITLE
sdk: add 'execution reverted' to retriable channel errors

### DIFF
--- a/raiden-ts/src/channels/utils.ts
+++ b/raiden-ts/src/channels/utils.ts
@@ -192,6 +192,7 @@ export const txFailErrors: readonly string[] = [
   'always failing transaction',
   'execution failed due to an exception',
   'transaction failed',
+  'execution reverted',
 ];
 
 /**


### PR DESCRIPTION
Fixes #2196 

**Short description**
Retry a geth error triggered on high-load BF7.

Logs of the error we should retry:
```
2020-10-08T15:50:09.548Z [info] %c action     color: #03A9F4; font-weight: bold {
  type: 'channel/open/failed',
  payload: Error: execution reverted
      at getResult (/mnt/sec/Dev/brainbot/light-client/node_modules/.pnpm/ethers@4.0.48/node_modules/ethers/providers/json-rpc-provider.js:40:21)
      at exports.XMLHttpRequest.request.onreadystatechange (/mnt/sec/Dev/brainbot/light-client/node_modules/.pnpm/ethers@4.0.48/node_modules/ethers/utils/web.js:111:30)
      at exports.XMLHttpRequest.dispatchEvent (/mnt/sec/Dev/brainbot/light-client/node_modules/.pnpm/ethers@4.0.48/node_modules/ethers/node_modules/xmlhttprequest/lib/XMLHttpRequest.js:591:25)
      at setState (/mnt/sec/Dev/brainbot/light-client/node_modules/.pnpm/ethers@4.0.48/node_modules/ethers/node_modules/xmlhttprequest/lib/XMLHttpRequest.js:610:14)
      at IncomingMessage.<anonymous> (/mnt/sec/Dev/brainbot/light-client/node_modules/.pnpm/ethers@4.0.48/node_modules/ethers/node_modules/xmlhttprequest/lib/XMLHttpRequest.js:447:13)
      at IncomingMessage.emit (events.js:327:22)
      at endReadableNT (_stream_readable.js:1220:12)
      at processTicksAndRejections (internal/process/task_queues.js:84:21) {
    code: -32000,
    data: undefined,
    url: 'http://geth.goerli.ethnodes.brainbot.com:8545',
    body: '{"method":"eth_estimateGas","params":[{"gasPrice":"0x3b9aca00","from":"0x46A6a7950F096fcCc13f48189048e68997B1501F","to":"0x3EA2a1fED7FdEf300DA19E97092Ce8FdF8bf66A3","data":"0x0a798f2400000000000000000>
    responseText: '{"jsonrpc":"2.0","id":352,"error":{"code":-32000,"message":"execution reverted"}}\n'
  },
  meta: {
    tokenNetwork: '0x3EA2a1fED7FdEf300DA19E97092Ce8FdF8bf66A3',
    partner: '0xf475984f7eedDb8ca70288FAe087535f2623AAb6'
  },
  error: true
}
```

BF7 passing after this PR:

![Screenshot_20201008_144445](https://user-images.githubusercontent.com/587021/95494776-d1769d00-0974-11eb-9057-af066d20e017.png)


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. BF7 passes
