### PR TITLE
dapp: fixes red underline under amount input fields

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#2098] Input fields disabled on transfer screen when no channels are open
 - [#1838] Fixes Disclaimer mobile layout
 - [#2096] Fixes buggy wallet connection procedure
+- [#2108] Fixes red underline under amount input fields on production builds
 - [#2144] Fixes navigation to transfer screen when token was selected
 - [#2159] Fixes routing issues for account and transfer steps
 - [#2238] Fixes broken token overlay for too many connected tokens
@@ -24,6 +25,7 @@
 [#2098]: https://github.com/raiden-network/light-client/issues/2098
 [#1838]: https://github.com/raiden-network/light-client/issues/1838
 [#2096]: https://github.com/raiden-network/light-client/issues/1838
+[#2108]: https://github.com/raiden-network/light-client/issues/2108
 [#2144]: https://github.com/raiden-network/light-client/issues/2144
 [#2159]: https://github.com/raiden-network/light-client/issues/2144
 [#2138]: https://github.com/raiden-network/light-client/issues/2138

--- a/raiden-dapp/src/components/AmountInput.vue
+++ b/raiden-dapp/src/components/AmountInput.vue
@@ -189,7 +189,7 @@ $header-vertical-margin-mobile: 2rem;
         border: 1.5px solid transparent;
         &::before,
         &::after {
-          border-width: 0 0 0 0;
+          display: none;
         }
       }
       &--is-focused {


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2108

**Short description**
This only showed on production builds (not sure why, probably some Vue or Vuetify optimization).
I've managed to reproduce it locally with `pnpm run serve -- --mode production`, and used it to verify the fix works.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Build/serve the dApp on `--mode production`
2. Check the red/blue/gray underline shows up on master, but not on this PR
