### PR TITLE
sdk: improve default capability composition

### DIFF
--- a/raiden-ts/src/epics.ts
+++ b/raiden-ts/src/epics.ts
@@ -44,19 +44,16 @@ function getConfig$(
   return combineLatest([partialConfig$, udcBalance$]).pipe(
     map(
       ([userConfig, udcBalance]): RaidenConfig => {
-        const config: RaidenConfig = { ...defaultConfig, ...userConfig };
-        // if user config caps is null, disable it; else, calculate dynamic default values
-        const caps =
-          userConfig.caps === null
-            ? userConfig.caps
-            : {
-                [Capabilities.RECEIVE]:
-                  config.monitoringReward?.gt(0) && config.monitoringReward.lte(udcBalance)
-                    ? 1
-                    : 0,
-                ...config.caps, // default and user config overwrite runtime caps above
-              };
-        return { ...config, caps };
+        const config: Mutable<RaidenConfig> = { ...defaultConfig, ...userConfig };
+        // if user config caps is not disabled, calculate dynamic default values
+        if (config.caps !== null)
+          config.caps = {
+            [Capabilities.RECEIVE]:
+              config.monitoringReward?.gt(0) && config.monitoringReward.lte(udcBalance) ? 1 : 0,
+            ...defaultConfig.caps,
+            ...userConfig.caps,
+          };
+        return config;
       },
     ),
     distinctUntilChanged(isEqual),

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -523,26 +523,25 @@ describe('transport epic', () => {
       .toPromise();
     action$.next(
       raidenConfigUpdate({
-        caps: { [Capabilities.DELIVERY]: 0, [Capabilities.WEBRTC]: 1 },
+        caps: { [Capabilities.DELIVERY]: 1 },
       }),
     );
     await expect(promise).resolves.toBeUndefined();
     expect(matrix.setAvatarUrl).toHaveBeenCalledTimes(1);
     expect(matrix.setAvatarUrl).toHaveBeenCalledWith(
-      'mxc://raiden.network/cap?Receive=1&Delivery=0&webRTC=1',
+      expect.stringMatching(`mxc://raiden.network/cap?.*${Capabilities.DELIVERY}=1`),
     );
 
     promise = matrixUpdateCapsEpic(action$, state$, depsMock).toPromise();
-    action$.next(
-      raidenConfigUpdate({
-        caps: { [Capabilities.RECEIVE]: 0, customCap: 'abc' },
-      }),
-    );
+    action$.next(raidenConfigUpdate({ caps: { customCap: 'abc' } }));
     setTimeout(() => action$.complete(), 10);
+
     await expect(promise).resolves.toBeUndefined();
     expect(matrix.setAvatarUrl).toHaveBeenCalledTimes(2);
     expect(matrix.setAvatarUrl).toHaveBeenCalledWith(
-      'mxc://raiden.network/cap?Receive=0&customCap=abc',
+      expect.stringMatching(
+        `mxc://raiden.network/cap?.*${Capabilities.DELIVERY}=0&.*customCap=abc`,
+      ),
     );
   });
 

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -578,6 +578,7 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
         httpTimeout: 300,
         confirmationBlocks: 2,
         pollingInterval: 10,
+        caps: { [Capabilities.DELIVERY]: 0, [Capabilities.WEBRTC]: 0, [Capabilities.MEDIATE]: 1 },
       },
     ),
     config = { ...defaultConfig, ...state.config };


### PR DESCRIPTION
Fixes #

**Short description**
Just a small improvement to capabilities: composes the default and user defined ones, so the user defined caps object is merged with the default, instead of replacing it. This allows us to only set caps which are different from default. Only applies to advanced, direct call of the config API, since these aren't exposed in the dApp.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
