### PR TITLE
sdk: apply optional chaining operator only on optional properties

### DIFF
--- a/raiden-ts/src/channels/utils.ts
+++ b/raiden-ts/src/channels/utils.ts
@@ -220,7 +220,7 @@ export function retryTx<T>(
         err$.pipe(
           mergeMap((err, i) => {
             log.debug(`__retryTx ${i + 1}/${count} every ${interval}, error: `, err);
-            if (i < count && errors.some((error) => err.message?.includes?.(error)))
+            if (i < count && errors.some((error) => err.message?.includes(error)))
               return timer(interval);
             return throwError(err);
           }),

--- a/raiden-ts/src/db/utils.ts
+++ b/raiden-ts/src/db/utils.ts
@@ -173,7 +173,7 @@ export async function getRaidenState(db: RaidenDatabase): Promise<any | undefine
       direction: { $exists: true },
     },
   });
-  if (transfersResults.warning) log?.warn?.(transfersResults.warning, 'getRaidenState');
+  if (transfersResults.warning) log?.warn(transfersResults.warning, 'getRaidenState');
   for (const doc of transfersResults.docs) {
     state.transfers[doc._id] = doc;
   }
@@ -313,11 +313,11 @@ export async function migrateDatabase(
         )
         .toPromise();
     } catch (err) {
-      log?.error?.('Error migrating db', { from: version, to: newVersion }, err);
+      log?.error('Error migrating db', { from: version, to: newVersion }, err);
       newStorage.destroy();
       throw err;
     }
-    log?.info?.('Migrated db', { name, from: version, to: newVersion });
+    log?.info('Migrated db', { name, from: version, to: newVersion });
     if (cleanOld) await db.destroy();
     else await db.close();
     version = newVersion;
@@ -420,7 +420,7 @@ export async function replaceDatabase(
     if ('_rev' in doc) delete doc['_rev'];
     [next] = await Promise.all([iter.next(), db.put(doc)]);
   }
-  log?.warn?.('Replaced/loaded database', { name, meta });
+  log?.warn('Replaced/loaded database', { name, meta });
   await db.close();
 
   // at this point, `{name}_{meta.version}` database should contain all (and only) data from
@@ -494,11 +494,11 @@ export async function dumpDatabaseToArray(db: RaidenDatabase, opts?: { batch?: n
       if (shouldCloseAfter) await db.close(); // on success
       return result;
     } catch (e) {
-      if (e.message?.includes?.('database is closed')) {
+      if (e?.message?.includes('database is closed')) {
         shouldCloseAfter = true;
         db = await reopenDatabase(db);
       }
-      log?.warn?.('Restarting dump because', e);
+      log?.warn('Restarting dump because', e);
     }
   }
   throw new Error('Could not dump database');

--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -502,7 +502,7 @@ export async function getState(
   let { state: dump } = storage;
   const { storage: localStorage, state: _, ...pouchOpts } = storage;
   if (!dump) {
-    dump = await localStorage?.getItem?.(dbName);
+    dump = await localStorage?.getItem(dbName);
     if (dump) fromLocalStorage = true;
   }
 

--- a/raiden-ts/src/persister.ts
+++ b/raiden-ts/src/persister.ts
@@ -44,7 +44,7 @@ export function createPersisterMiddleware(
       const prevRevs = await db.allDocs({ keys });
       const getRev = (_id: string) => {
         const prev = prevRevs.rows.find((r) => r.id === _id);
-        if (prev?.value?.deleted) return { _rev: prev.value.rev, deleted: false };
+        if (prev?.value.deleted) return { _rev: prev.value.rev, deleted: false };
         else if (prev && !('error' in prev)) return { _rev: prev.value.rev };
       };
       const res = await db.bulkDocs(
@@ -101,7 +101,7 @@ export function createPersisterMiddleware(
     if (!db.busy$.value) {
       db.busy$.next(true);
       saveDatabase()
-        .catch((err) => log?.warn?.('Persister saveDatabase error', err))
+        .catch((err) => log?.warn('Persister saveDatabase error', err))
         .finally(() => db.busy$.next(false));
     }
     return result;

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -670,7 +670,7 @@ export class Raiden {
       ({ txHash }) => txHash, // pluck txHash
     );
     let depositPromise;
-    if (deposit) {
+    if (deposit?.gt(0)) {
       depositPromise = asyncActionToPromise(channelDeposit, meta, this.action$, true).then(
         ({ txHash }) => txHash, // pluck txHash
       );
@@ -999,7 +999,7 @@ export class Raiden {
       target: finalState.transfer.target,
       fee: finalState.fee.toString(),
       lockAmount: finalState.transfer.lock.amount.toString(),
-      targetReceived: finalState.secretRequest?.amount?.toString?.(),
+      targetReceived: finalState.secretRequest?.amount.toString(),
       transferTime: finalState.unlockProcessed!.ts - finalState.transfer.ts,
     });
     return raidenTransfer(finalState);

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -581,7 +581,7 @@ function makeMonitoringRequest$({
         ([{ udcBalance }, { monitoringRoom, monitoringReward, rateToSvt }]) =>
           // ignore actions while/if config.monitoringRoom isn't set
           !!monitoringRoom &&
-          !!monitoringReward?.gt?.(Zero) &&
+          !!monitoringReward?.gt(Zero) &&
           // wait for udcBalance >= monitoringReward, fires immediately if already
           udcBalance.gte(monitoringReward) &&
           // use partner's total off & on-chain unlocked, total we'd lose if don't update BP

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -724,7 +724,7 @@ function sendWithdrawRequest(
       )
         return EMPTY; // already requested, skip without failing
       assert(
-        presences[action.meta.partner]?.payload?.available,
+        presences[action.meta.partner]?.payload.available,
         ErrorCodes.CNL_WITHDRAW_PARTNER_OFFLINE,
       );
       assert(

--- a/raiden-ts/src/transport/epics/helpers.ts
+++ b/raiden-ts/src/transport/epics/helpers.ts
@@ -72,7 +72,7 @@ function waitMember$(
   return combineLatest([
     latest$.pipe(
       pluckDistinct('presences', address),
-      filter((presence) => !!presence?.payload?.available),
+      filter((presence) => !!presence?.payload.available),
     ),
     latest$.pipe(
       map(({ state }) => state.transport.rooms?.[address]?.[0]),
@@ -85,7 +85,7 @@ function waitMember$(
   ]).pipe(
     filter(
       ([presence, roomId]) =>
-        matrix.getRoom(roomId)?.getMember?.(presence.payload.userId)?.membership === 'join',
+        matrix.getRoom(roomId)?.getMember(presence.payload.userId)?.membership === 'join',
     ),
     pluck(1),
     take(1),
@@ -116,7 +116,7 @@ export function waitMemberAndSend$<C extends { msgtype: string; body: string }>(
 ): Observable<string> {
   const RETRY_COUNT = 3; // is this relevant enough to become a constant/setting?
   return latest$.pipe(
-    filter(({ presences }) => !!presences[address]?.payload?.available),
+    filter(({ presences }) => !!presences[address]?.payload.available),
     take(1),
     withLatestFrom(config$),
     mergeMap(([{ presences, rtc }, { caps }]) => {

--- a/raiden-ts/src/transport/epics/rooms.ts
+++ b/raiden-ts/src/transport/epics/rooms.ts
@@ -79,7 +79,7 @@ function inviteLoop$(
       fromEvent<[MatrixEvent, RoomMember]>(matrix, 'RoomMember.membership').pipe(
         pluck(1),
         filter((member) => member.roomId === roomId && member.userId === userId),
-        startWith(matrix.getRoom(roomId)?.getMember?.(userId)),
+        startWith(matrix.getRoom(roomId)?.getMember(userId)),
         map((member) => member?.membership !== 'join'),
         distinctUntilChanged(),
       ),

--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -518,7 +518,7 @@ function handlePresenceChange$(
             withLatestFrom(latest$, config$),
             mergeMap(
               ([, { presences }, { httpTimeout }]) =>
-                !presences[action.meta.address]?.payload?.available
+                !presences[action.meta.address]?.payload.available
                   ? EMPTY
                   : isCaller
                   ? timer(httpTimeout / 10) // caller waits some time to retry


### PR DESCRIPTION
Fixes # 

**Short description**
Refactor a few instances of the optional chaining operator to make it more strictly typed:
- If you have `foo?.bar?.baz`, where `foo` can be `undefined`, but if defined, `bar` is always a defined property of it, containing an always defined `baz` property, you don't need the second opt-chain op: the whole `foo?.bar.baz` will type-safely evaluate to `undefined` if `foo` is not defined, and to `foo.bar.baz` if it is defined.
  - Previously, there were several instances where we applied `?.` to all further properties on a chain, if a previous one could be undefined; this PR fixes this by applying the optional chain operator only to path members which can be undefined, then more strictly checking the ones expected to be defined
  - This also applies to functions/methods which are always defined if their object is (i.e. fixing unneeded `method?.(...)` usages)
- With the above also applied to the optional `deposit` param for the `Raiden.openChannel` method, this fixes an issue on BF2, where a `deposit=0` was passed to `openChannel`, which made it wait forever for a `channelDeposit.success` call which never happened because it was filtered out due to deposit=0 being noop.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Tests pass
2. BF2 pass
