### PR TITLE
sdk: clean some matrix rtc monkeypatch and use same callID as PC

### DIFF
--- a/raiden-ts/src/global.d.ts
+++ b/raiden-ts/src/global.d.ts
@@ -8,7 +8,6 @@ declare module 'matrix-js-sdk/lib/logger' {
   import { Logger } from 'loglevel';
   export const logger: Logger;
 }
-declare module 'matrix-js-sdk/lib/webrtc/call';
 
 declare module 'abort-controller/polyfill';
 declare module 'wrtc'; // types provided by @types/webrtc

--- a/raiden-ts/src/polyfills.ts
+++ b/raiden-ts/src/polyfills.ts
@@ -2,7 +2,7 @@ import 'symbol-observable';
 import 'isomorphic-fetch';
 import 'abort-controller/polyfill';
 
-// matrix-js-sdk monkey-patch root methodFactory
+// revert matrix-js-sdk monkey-patch root methodFactory
 import logging from 'loglevel';
 const methodFactory = logging.methodFactory;
 import { logger as matrixLogger } from 'matrix-js-sdk/lib/logger';
@@ -36,8 +36,3 @@ request((opts: Record<string, unknown>, cb: ReqCb) => {
 if (!('RTCPeerConnection' in globalThis)) {
   Object.assign(globalThis, require('wrtc')); // eslint-disable-line @typescript-eslint/no-var-requires
 }
-
-// patch createNewMatrixCall to prevent matrix-js-sdk from hooking WebRTC events in browser;
-// ugly, but there's no option to prevent MatrixClient to handle m.call.* events
-import * as call from 'matrix-js-sdk/lib/webrtc/call';
-Object.assign(call, { createNewMatrixCall: () => null });

--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -438,10 +438,9 @@ function handlePresenceChange$(
 
       const deps = { log, latest$, config$ };
       const callId = [address, action.meta.address]
-        .map((a) => a.toLowerCase())
-        .sort((a, b) => a.localeCompare(b))
+        .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
         .join('|');
-      const isCaller = callId.startsWith(address.toLowerCase());
+      const isCaller = callId.startsWith(address);
       const timeoutGen = exponentialBackoff(config.pollingInterval, 2 * config.httpTimeout);
 
       return defer(() => {


### PR DESCRIPTION
**Short description**
Some very small leftover cleanups and adjusts after #2158 
Before it, we used some monkeypatching to disable MatrixClient of handling `m.call.*` events. Now that we use `m.room.message`s, we don't need that patch anymore. Also, raiden-py uses checksummed addresses on the `callId`, so we make it compatible here as well. Should be backwards compatible, since we don't enforce this.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
