### PR TITLE
dApp: require mainnet to be explicitly enabled

### DIFF
--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -125,7 +125,7 @@ export default class RaidenService {
           typeof provider !== 'string' &&
           'networkVersion' in provider &&
           provider.networkVersion === '1' &&
-          process.env.VUE_APP_ALLOW_MAINNET === 'false'
+          process.env.VUE_APP_ALLOW_MAINNET !== 'true'
         ) {
           throw new RaidenError(ErrorCodes.RDN_UNRECOGNIZED_NETWORK);
         }


### PR DESCRIPTION
Fixes #2221 

No need for CHANGELOG entry since behavior has not changed.

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Build dApp with `--mode development` and `--mode ghpages` and make sure both work as intended. 
