### PR TITLE
dApp: Adds UDC token to withdrawal screen

### DIFF
--- a/raiden-dapp/src/components/account/Withdrawal.vue
+++ b/raiden-dapp/src/components/account/Withdrawal.vue
@@ -126,6 +126,7 @@ import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
 import Spinner from '@/components/icons/Spinner.vue';
 import { Zero } from 'ethers/constants';
 import uniqBy from 'lodash/uniqBy';
+import { BigNumber } from 'ethers/utils';
 
 @Component({
   components: {
@@ -152,7 +153,7 @@ export default class Withdrawal extends Mixins(BlockieMixin) {
   async mounted() {
     this.balances = await this.$raiden.getRaidenAccountBalances();
 
-    if (this.udcToken.balance.gt(Zero)) {
+    if ((this.udcToken.balance as BigNumber).gt(Zero)) {
       this.balances = uniqBy(
         [...this.balances].concat(this.udcToken),
         (token) => token.address

--- a/raiden-dapp/src/components/account/Withdrawal.vue
+++ b/raiden-dapp/src/components/account/Withdrawal.vue
@@ -125,7 +125,7 @@ import ActionButton from '@/components/ActionButton.vue';
 import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
 import Spinner from '@/components/icons/Spinner.vue';
 import { Zero } from 'ethers/constants';
-import uniq from 'lodash/uniq';
+import uniqBy from 'lodash/uniqBy';
 
 @Component({
   components: {
@@ -153,7 +153,10 @@ export default class Withdrawal extends Mixins(BlockieMixin) {
     this.balances = await this.$raiden.getRaidenAccountBalances();
 
     if (this.udcToken.balance.gt(Zero)) {
-      this.balances = uniq([...this.balances].concat(this.udcToken));
+      this.balances = uniqBy(
+        [...this.balances].concat(this.udcToken),
+        (token) => token.address
+      );
     }
 
     this.loading = false;

--- a/raiden-dapp/src/components/account/Withdrawal.vue
+++ b/raiden-dapp/src/components/account/Withdrawal.vue
@@ -115,7 +115,7 @@
 
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator';
-import { mapState } from 'vuex';
+import { mapState, mapGetters } from 'vuex';
 import { Tokens } from '@/types';
 import { Token } from '@/model/types';
 import AddressDisplay from '@/components/AddressDisplay.vue';
@@ -124,6 +124,8 @@ import AmountDisplay from '@/components/AmountDisplay.vue';
 import ActionButton from '@/components/ActionButton.vue';
 import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
 import Spinner from '@/components/icons/Spinner.vue';
+import { Zero } from 'ethers/constants';
+import uniq from 'lodash/uniq';
 
 @Component({
   components: {
@@ -135,11 +137,13 @@ import Spinner from '@/components/icons/Spinner.vue';
   },
   computed: {
     ...mapState(['tokens', 'raidenAccountBalance']),
+    ...mapGetters(['udcToken']),
   },
 })
 export default class Withdrawal extends Mixins(BlockieMixin) {
   tokens!: Tokens;
   raidenAccountBalance!: string;
+  udcToken!: Token;
   balances: Token[] = [];
   loading: boolean = true;
   withdrawing: boolean = false;
@@ -147,6 +151,11 @@ export default class Withdrawal extends Mixins(BlockieMixin) {
 
   async mounted() {
     this.balances = await this.$raiden.getRaidenAccountBalances();
+
+    if (this.udcToken.balance.gt(Zero)) {
+      this.balances = uniq([...this.balances].concat(this.udcToken));
+    }
+
     this.loading = false;
   }
 


### PR DESCRIPTION
Fixes #2237 

**Short description**
The utility token should now always be displayed on the Withdrawal screen if there is a balance.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Deposit SVT and RDN.
2. Visit the Withdrawal screen, the tokens should be visible for withdrawal.
