### PR TITLE
dapp: fix correct match of build modes and paths

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,8 +174,7 @@ jobs:
       mode:
         description: Mode to configure the environment of the dApp build
         type: enum
-        enum: ["development", "e2e", "ghpages", "raiden-package"]
-        default: "development"
+        enum: ["production", "staging", "development", "e2e", "raiden-package"]
     executor: base-executor
     working_directory: *working_dir
     steps:
@@ -225,10 +224,9 @@ jobs:
 
   deploy_gh_pages:
     parameters:
-      deploy_base:
-        description: The (sub-)directory where to put the build (empty for root)
+      public_path:
+        description: The public path where to reach deployment (must be correct according to the build mode)
         type: string
-        default: ""
     executor: base-executor
     working_directory: *dapp_working_dir
     steps:
@@ -236,7 +234,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "ed:c9:40:2a:96:6c:90:fd:46:18:2d:bf:8d:a8:a9:b3"
-      - run: ./deploy.sh << parameters.deploy_base >>
+      - run: ./deploy.sh << parameters.public_path >>
 
   publish_artifact:
     executor: base-executor
@@ -294,6 +292,7 @@ workflows:
           requires:
             - build_sdk
       - build_dapp:
+          mode: development
           requires:
             - build_sdk
       - build_cli:
@@ -323,15 +322,15 @@ workflows:
           requires:
             - install
       - build_dapp:
-          mode: "ghpages"
+          mode: staging
           requires:
             - build_sdk
       - deploy_gh_pages:
-          deploy_base: "staging"
+          public_path: /staging
           requires:
             - build_dapp
 
-  publish_release:
+  publish_production:
     jobs:
       - checkout:
           filters:
@@ -346,13 +345,14 @@ workflows:
           requires:
             - install
       - build_dapp:
-          mode: "ghpages"
+          mode: production
           requires:
             - build_sdk
       - generate_documentation:
           requires:
             - build_dapp
       - deploy_gh_pages:
+          public_path: /
           requires:
             - generate_documentation
       - publish_artifact:

--- a/raiden-dapp/.env.production
+++ b/raiden-dapp/.env.production
@@ -1,5 +1,4 @@
-VUE_APP_PUBLIC_PATH=./
 VUE_APP_PFS=https://pfs.demo001.env.raiden.network
 VUE_APP_MATRIX_SERVER=https://transport.demo001.env.raiden.network
 VUE_APP_HUB=hub.raiden.eth
-VUE_APP_ALLOW_MAINNET=true
+VUE_APP_ALLOW_MAINNET=false

--- a/raiden-dapp/.env.staging
+++ b/raiden-dapp/.env.staging
@@ -1,4 +1,4 @@
-NODE_ENV=production
+VUE_APP_PUBLIC_PATH=/staging/
 VUE_APP_PFS=https://pfs.demo001.env.raiden.network
 VUE_APP_MATRIX_SERVER=https://transport.demo001.env.raiden.network
 VUE_APP_HUB=hub.raiden.eth

--- a/raiden-dapp/deploy.sh
+++ b/raiden-dapp/deploy.sh
@@ -7,8 +7,8 @@
 # abort the script if there is a non-zero error
 set -e
 
-DEPLOY_BASE="$1"
-echo "Deploy base: $DEPLOY_BASE"
+PUBLIC_PATH="${1#/*}" # Remove eventually leading slash of first argument
+echo "Public path: $PUBLIC_PATH"
 
 echo "Preparing to deploy to GitHub Pages for commit ${CIRCLE_SHA1}"
 
@@ -40,16 +40,16 @@ git remote add --fetch origin "$remote"
 if git rev-parse --verify origin/gh-pages >/dev/null 2>&1; then
   git checkout gh-pages
   # delete any old site as we are going to replace it
-  git rm -rf ./${DEPLOY_BASE} --ignore-unmatch
+  git rm -rf ./${PUBLIC_PATH} --ignore-unmatch
 else
   git checkout --orphan gh-pages
 fi
 
-if [[ ! -d ./${DEPLOY_BASE} ]];then
-    mkdir -p ./${DEPLOY_BASE}
+if [[ ! -d ./${PUBLIC_PATH} ]];then
+    mkdir -p ./${PUBLIC_PATH}
 fi
 
-mv ../dist/* ./${DEPLOY_BASE}
+mv ../dist/* ./${PUBLIC_PATH}
 
 if [[ ! -f CNAME ]];then
     echo 'Setting CNAME'

--- a/raiden-dapp/vue.config.js
+++ b/raiden-dapp/vue.config.js
@@ -5,12 +5,9 @@ module.exports = {
   productionSourceMap: false,
   // https://forum.vuejs.org/t/solution-to-building-error-in-circleci-or-any-other-machine-with-cpu-limitations/40862
   parallel: !process.env.CIRCLECI,
-  publicPath:
-    process.env.NODE_ENV !== 'production'
-      ? './'
-      : process.env.DEPLOYMENT === 'staging'
-      ? '/staging/'
-      : '/',
+  publicPath: process.env.VUE_APP_PUBLIC_PATH
+    ? process.env.VUE_APP_PUBLIC_PATH
+    : '/',
   chainWebpack: (config) => {
     if (process.env.NODE_ENV !== 'production' && !process.env.CI) {
       config.module

--- a/serve_pr/ci_dapp.sh
+++ b/serve_pr/ci_dapp.sh
@@ -23,7 +23,7 @@ for PIPELINE in $PIPELINES; do
   WORKFLOWS=(`$CURL "$BASE/pipeline/${PIPELINE}/workflow" | grep -oP '(?<="id" : ")[^"]+'`)
   for WORKFLOW in $WORKFLOWS; do
     log "Workflow: ${WORKFLOW}"
-    JOB=`$CURL "$BASE/workflow/${WORKFLOW}/job" | grep -B5 -A0 '"status" : "success"' | grep -B3 -A0 '"name" : "build_dapp"' | grep -oP '(?<="job_number" : )\d+' | head -1`
+    JOB=`$CURL "$BASE/workflow/${WORKFLOW}/job" | grep -B5 -A0 '"status" : "success"' | grep -B3 -A0 -E '"name" : "build_dapp-[1-9]"' | grep -oP '(?<="job_number" : )\d+' | head -1`
     URL=`$CURL "$BASE/project/${CIRCLE_SLUG}/${JOB}/artifacts" | grep -oP '(?<="url" : ")[^"]+' | head -1`
     PULL=`curl -ss "https://circleci.com/api/v1.1/project/${CIRCLE_SLUG}/${JOB}?circle-token=${CIRCLE_TOKEN}" | grep -B0 -A2 '"pull_requests"' | grep -oP '(?<=/pull/)\d+' | head -1`
     [[ -n "$PULL" ]] || continue


### PR DESCRIPTION
Fixes #2269  

**Short description**
The commit message is huuuuge (sorry for that) and should basically explain everything. Checkout the below steps how to do a basic check of this fix gglocally.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Create somewhere a new directory which will later be used as root to serve static assets from
2. Build the dApp in production mode `pnpm run build --filter raiden-dapp -- --mode production` (lets be explicit with the mode)
3. Copy the build to the created directory `cp -r raiden-dapp/dist/* /to/the/static/assets/dir`
4. Build the dApp in staging mode `pnpm run build --filter raiden-dapp -- --mode staging`
5. Copy the build into the `/staging` sub-folder of the assets directory.
6. Serve the static assets locally (e.g. `npx serve /to/the/static/assets/dir`)
7. Visit the dApp in the browser on `/` and `/staging`, make sure that both work but both do not allow mainnet connecitions
