### PR TITLE
dApp: displays RDN on the Withdrawal screen

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
+- [#2237] Displays RDN token on Withdrawal screen
 - [#2026] Removed delay time on tooltips
 - [#2098] Input fields disabled on transfer screen when no channels are open
 - [#1838] Fixes Disclaimer mobile layout
@@ -18,6 +19,7 @@
 ### Changes
 - [#1929] Design adjustments to settlement notifications and notification panel 
 
+[#2237]: https://github.com/raiden-network/light-client/issues/2237
 [#1255]: https://github.com/raiden-network/light-client/issues/1255
 [#1941]: https://github.com/raiden-network/light-client/issues/1941
 [#2026]: https://github.com/raiden-network/light-client/issues/2026

--- a/raiden-dapp/src/components/account/Withdrawal.vue
+++ b/raiden-dapp/src/components/account/Withdrawal.vue
@@ -120,7 +120,7 @@
 
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator';
-import { mapGetters } from 'vuex';
+import { mapState, mapGetters } from 'vuex';
 import { Token } from '@/model/types';
 import AddressDisplay from '@/components/AddressDisplay.vue';
 import BlockieMixin from '@/mixins/blockie-mixin';
@@ -141,11 +141,13 @@ import { BigNumber } from 'ethers/utils';
     Spinner,
   },
   computed: {
+    ...mapState(['raidenAccountBalance']),
     ...mapGetters(['udcToken', 'allTokens']),
   },
 })
 export default class Withdrawal extends Mixins(BlockieMixin) {
-  allTokens: Token[];
+  allTokens!: Token[];
+  raidenAccountBlanace!: string;
   udcToken!: Token;
   balances: Token[] = [];
   loading: boolean = true;
@@ -168,7 +170,7 @@ export default class Withdrawal extends Mixins(BlockieMixin) {
     );
 
     this.balances = updatedTokenBalances.filter((token) =>
-      new BigNumber(token.balance).gt(Zero)
+      (token.balance as BigNumber).gt(Zero)
     );
     this.loading = false;
   }

--- a/raiden-dapp/src/components/account/Withdrawal.vue
+++ b/raiden-dapp/src/components/account/Withdrawal.vue
@@ -129,9 +129,6 @@ import AmountDisplay from '@/components/AmountDisplay.vue';
 import ActionButton from '@/components/ActionButton.vue';
 import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
 import Spinner from '@/components/icons/Spinner.vue';
-import { Zero } from 'ethers/constants';
-import uniqBy from 'lodash/uniqBy';
-import { BigNumber } from 'ethers/utils';
 
 @Component({
   components: {
@@ -157,14 +154,6 @@ export default class Withdrawal extends Mixins(BlockieMixin) {
 
   async mounted() {
     this.balances = await this.$raiden.getRaidenAccountBalances();
-
-    if ((this.udcToken.balance as BigNumber).gt(Zero)) {
-      this.balances = uniqBy(
-        [...this.balances].concat(this.udcToken),
-        (token) => token.address
-      );
-    }
-
     this.loading = false;
   }
 

--- a/raiden-dapp/src/components/account/Withdrawal.vue
+++ b/raiden-dapp/src/components/account/Withdrawal.vue
@@ -147,7 +147,7 @@ import { BigNumber } from 'ethers/utils';
 })
 export default class Withdrawal extends Mixins(BlockieMixin) {
   allTokens!: Token[];
-  raidenAccountBlanace!: string;
+  raidenAccountBalance!: string;
   udcToken!: Token;
   balances: Token[] = [];
   loading: boolean = true;

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -711,12 +711,12 @@ export default class RaidenService {
   async getTokenBalance(
     tokenAddress: string,
     raidenAccount?: string
-  ): Promise<string> {
+  ): Promise<BigNumber> {
     const tokenBalance = await this.raiden.getTokenBalance(
       tokenAddress,
       raidenAccount
     );
-    return tokenBalance.toString();
+    return tokenBalance;
   }
 }
 

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -1,5 +1,4 @@
 import {
-  Address,
   Capabilities,
   ChangeEvent,
   ErrorCodes,
@@ -670,11 +669,7 @@ export default class RaidenService {
     if (!raiden.mainAddress) {
       return [];
     }
-    const allTokenAddresses = uniq(
-      (await raiden.getTokenList()).concat(
-        this._userDepositTokenAddress as Address
-      )
-    );
+    const allTokenAddresses = await raiden.getTokenList();
     const balances: Tokens = {};
     const fetchTokenBalance = async (address: string): Promise<void> =>
       raiden.getTokenBalance(address, raiden.address).then((balance) => {

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -1,4 +1,5 @@
 import {
+  Address,
   Capabilities,
   ChangeEvent,
   ErrorCodes,
@@ -669,7 +670,11 @@ export default class RaidenService {
     if (!raiden.mainAddress) {
       return [];
     }
-    const allTokens = await raiden.getTokenList();
+    const allTokenAddresses = uniq(
+      (await raiden.getTokenList()).concat(
+        this._userDepositTokenAddress as Address
+      )
+    );
     const balances: Tokens = {};
     const fetchTokenBalance = async (address: string): Promise<void> =>
       raiden.getTokenBalance(address, raiden.address).then((balance) => {
@@ -681,7 +686,7 @@ export default class RaidenService {
         }
       });
 
-    await asyncPool(6, allTokens, fetchTokenBalance);
+    await asyncPool(6, allTokenAddresses, fetchTokenBalance);
     const tokens: Tokens = {};
     Object.keys(balances).forEach((address) => {
       const cached = this.store.state.tokens[address];

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -708,8 +708,14 @@ export default class RaidenService {
     await this.raiden.monitorToken(address);
   }
 
-  async getTokenBalance(tokenAddress: string): Promise<string> {
-    const tokenBalance = await this.raiden.getTokenBalance(tokenAddress);
+  async getTokenBalance(
+    tokenAddress: string,
+    raidenAccount?: string
+  ): Promise<string> {
+    const tokenBalance = await this.raiden.getTokenBalance(
+      tokenAddress,
+      raidenAccount
+    );
     return tokenBalance.toString();
   }
 }

--- a/raiden-dapp/tests/unit/components/account/withdrawal.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/withdrawal.spec.ts
@@ -1,146 +1,101 @@
-import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
-
-jest.mock('@/services/raiden-service');
 jest.mock('@/i18n', () => jest.fn());
-
+import flushPromises from 'flush-promises';
 import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuex from 'vuex';
 import Vuetify from 'vuetify';
-import store from '@/store';
 import { $identicon } from '../../utils/mocks';
+import { BigNumber } from 'ethers/utils';
 import Withdrawal from '@/components/account/Withdrawal.vue';
-import RaidenService from '@/services/raiden-service';
-import Mocked = jest.Mocked;
-import { parseUnits } from 'ethers/utils';
-import { Zero } from 'ethers/constants';
+import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
 
-Vue.use(Vuetify);
 Vue.use(Vuex);
+Vue.use(Vuetify);
+
+let vuetify: typeof Vuetify;
+let $raiden: any;
+
+const tokenBalance = new BigNumber('1000000');
+const tokenNoBalance = new BigNumber('0');
+const raidenBalance = '1000000';
+const raidenNoBalance = '0';
+
+function createWrapper(
+  tokenBalance: BigNumber,
+  raidenAccountBalance: string
+): Wrapper<Withdrawal> {
+  $raiden = {
+    getTokenBalance: jest.fn().mockResolvedValue(tokenBalance),
+    transferOnChainTokens: jest.fn(),
+  };
+
+  const state = {
+    raidenAccountBalance,
+  };
+
+  const getters = {
+    udcToken: () => {
+      return {
+        address: '0xuserdeposittoken',
+        balance: new BigNumber('0'),
+      };
+    },
+    allTokens: () => [],
+  };
+
+  const store = new Vuex.Store({ state, getters });
+
+  return mount(Withdrawal, {
+    vuetify,
+    store,
+    stubs: ['v-dialog', 'i18n'],
+    mocks: {
+      $identicon: $identicon(),
+      $t: (msg: string) => msg,
+      $raiden,
+    },
+  });
+}
+
+beforeEach(() => {});
 
 describe('Withdrawal.vue', () => {
-  let wrapper: Wrapper<Withdrawal>;
-  let vuetify: typeof Vuetify;
-  let $raiden: Mocked<RaidenService>;
+  test('can withdraw tokens', async () => {
+    const wrapper = createWrapper(tokenBalance, raidenBalance);
+    await flushPromises();
 
-  function createWrapper(raidenAccountBalance: string = '') {
-    const state = {
-      tokens: {},
-      raidenAccountBalance,
-    };
+    wrapper.find('.withdrawal__tokens__button').trigger('click');
+    await wrapper.vm.$nextTick();
 
-    const getters = {
-      balance: () => '',
-      udcToken: () => {
-        return {
-          balance: Zero,
-        };
-      },
-    };
+    const confirmButton = wrapper
+      .findComponent(RaidenDialog)
+      .findAll('button')
+      .at(1);
+    confirmButton.trigger('click');
+    await wrapper.vm.$nextTick();
 
-    const mockStore = new Vuex.Store({ state, getters });
-    return mount(Withdrawal, {
-      vuetify,
-      store: mockStore,
-      stubs: ['v-dialog', 'i18n'],
-      mocks: {
-        $identicon: $identicon(),
-        $t: (msg: string) => msg,
-        $raiden,
-      },
-    });
-  }
-
-  beforeEach(() => {
-    vuetify = new Vuetify();
-    $raiden = new RaidenService(store) as Mocked<RaidenService>;
+    expect($raiden.transferOnChainTokens).toHaveBeenCalledTimes(1);
   });
 
-  describe('no tokens', () => {
-    beforeEach(() => {
-      $raiden.getRaidenAccountBalances.mockResolvedValue([]);
-      wrapper = createWrapper();
-    });
+  test('displays empty screen if there are no tokens to withdraw', async () => {
+    const wrapper = createWrapper(tokenNoBalance, raidenBalance);
+    await flushPromises();
 
-    test('show an empty screen', () => {
-      expect(wrapper.find('.withdrawal__empty').exists()).toBe(true);
-    });
+    expect(wrapper.find('.withdrawal__empty').exists()).toBe(true);
   });
 
-  describe('with tokens and no balance', () => {
-    beforeEach(() => {
-      $raiden.getRaidenAccountBalances.mockResolvedValue([
-        {
-          address: '0xtoken',
-          decimals: 5,
-          balance: parseUnits('1.2', 5),
-          name: 'TestToken',
-          symbol: 'TTT',
-        },
-      ]);
-      wrapper = createWrapper();
-    });
+  test('disaples withdrawal confirm button if Raiden account has no balance', async () => {
+    const wrapper = createWrapper(tokenBalance, raidenNoBalance);
+    await flushPromises();
 
-    test('open a dialog when clicking withdraw for a token', async () => {
-      wrapper.find('.withdrawal__tokens').find('button').trigger('click');
+    wrapper.find('.withdrawal__tokens__button').trigger('click');
+    await wrapper.vm.$nextTick();
 
-      await wrapper.vm.$nextTick();
+    const confirmButton = wrapper
+      .findComponent(RaidenDialog)
+      .findAll('button')
+      .at(1);
 
-      expect(wrapper.findComponent(RaidenDialog).exists()).toBe(true);
-    });
-
-    test('disables withdrawal if the Raiden account has no funds', async () => {
-      wrapper.find('.withdrawal__tokens').find('button').trigger('click');
-
-      await wrapper.vm.$nextTick();
-
-      expect(
-        wrapper.find('.withdrawal-dialog__action').find('button').attributes()[
-          'disabled'
-        ]
-      ).toBe('disabled');
-    });
-
-    test('withdraw is no-op without a selection', async () => {
-      await (wrapper.vm as any).withdrawTokens();
-      expect($raiden.transferOnChainTokens).toHaveBeenCalledTimes(0);
-    });
-  });
-
-  describe('with tokens and balance', () => {
-    beforeEach(() => {
-      $raiden.getRaidenAccountBalances.mockResolvedValue([
-        {
-          address: '0xtoken',
-          decimals: 5,
-          balance: parseUnits('1.2', 5),
-          name: 'TestToken',
-          symbol: 'TTT',
-        },
-      ]);
-      wrapper = createWrapper('2');
-    });
-
-    test('withdraws tokens when the user clicks on the action button', async () => {
-      wrapper.find('.withdrawal__tokens').find('button').trigger('click');
-
-      await wrapper.vm.$nextTick();
-
-      expect(
-        wrapper.find('.withdrawal-dialog__action').find('button').attributes()[
-          'disabled'
-        ]
-      ).toBeUndefined();
-
-      wrapper
-        .find('.withdrawal-dialog__action')
-        .find('button')
-        .trigger('click');
-
-      await wrapper.vm.$nextTick();
-      expect($raiden.transferOnChainTokens).toHaveBeenCalledTimes(1);
-      await wrapper.vm.$nextTick();
-      expect(wrapper.find('.withdrawal__empty').exists()).toBe(true);
-    });
+    expect(confirmButton.attributes()['disabled']).toBe('disabled');
   });
 });

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -549,6 +549,10 @@ describe('RaidenService', () => {
               ...createToken('0x2'),
               balance: One,
             },
+            {
+              address: '0xuserdeposittoken',
+              balance: new BigNumber('1'),
+            },
           ];
 
           beforeEach(() => {
@@ -568,7 +572,7 @@ describe('RaidenService', () => {
             await expect(
               raidenService.getRaidenAccountBalances()
             ).resolves.toMatchObject(tokens);
-            expect(raiden.getTokenInfo).toHaveBeenCalledTimes(2);
+            expect(raiden.getTokenInfo).toHaveBeenCalledTimes(3);
           });
 
           test('load from cache if found', async () => {
@@ -583,7 +587,7 @@ describe('RaidenService', () => {
             await expect(
               raidenService.getRaidenAccountBalances()
             ).resolves.toMatchObject(tokens);
-            expect(raiden.getTokenInfo).toHaveBeenCalledTimes(1);
+            expect(raiden.getTokenInfo).toHaveBeenCalledTimes(2);
           });
         });
       });

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -220,10 +220,8 @@ describe('RaidenService', () => {
       const tokenBalance = await raidenService.getTokenBalance('0xtoken');
 
       expect(raiden.getTokenBalance).toHaveBeenCalledTimes(1);
-      expect(raiden.getTokenBalance).toHaveBeenCalledWith('0xtoken');
-      expect(tokenBalance).toEqual(
-        expect.stringContaining('1000000000000000000')
-      );
+      expect(raiden.getTokenBalance).toHaveBeenCalledWith('0xtoken', undefined);
+      expect(tokenBalance).toEqual(balance);
     });
 
     test('resolves when channel open and deposit are successful', async () => {
@@ -549,10 +547,6 @@ describe('RaidenService', () => {
               ...createToken('0x2'),
               balance: One,
             },
-            {
-              address: '0xuserdeposittoken',
-              balance: new BigNumber('1'),
-            },
           ];
 
           beforeEach(() => {
@@ -572,7 +566,7 @@ describe('RaidenService', () => {
             await expect(
               raidenService.getRaidenAccountBalances()
             ).resolves.toMatchObject(tokens);
-            expect(raiden.getTokenInfo).toHaveBeenCalledTimes(3);
+            expect(raiden.getTokenInfo).toHaveBeenCalledTimes(2);
           });
 
           test('load from cache if found', async () => {
@@ -587,7 +581,7 @@ describe('RaidenService', () => {
             await expect(
               raidenService.getRaidenAccountBalances()
             ).resolves.toMatchObject(tokens);
-            expect(raiden.getTokenInfo).toHaveBeenCalledTimes(2);
+            expect(raiden.getTokenInfo).toHaveBeenCalledTimes(1);
           });
         });
       });


### PR DESCRIPTION
Fixes #2237 

**Short description**
This PR fixes issue with RDN not getting displayed on the Withdrawal screen.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Withdraw RDN from the UDC dialog, wait for 100 blocks.
2. The withdrawn RDN amount should now be available for withdrawal from the Withdrawal screen.
