### PR TITLE
Feature/dapp switch eth balance according to account

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+
 ### Fixed
+
 - [#2026] Removed delay time on tooltips
 - [#2098] Input fields disabled on transfer screen when no channels are open
 - [#1838] Fixes Disclaimer mobile layout
@@ -10,13 +12,16 @@
 - [#2144] Fixes navigation to transfer screen when token was selected
 - [#2159] Fixes routing issues for account and transfer steps
 - [#2238] Fixes broken token overlay for too many connected tokens
+- [#2224] Show ETH balance of correct account when withdrawing from UDC
 
 ### Added
+
 - [#1941] Notification for opening channels
 - [#1255] Optional identifier query parameter for transfers
 
 ### Changes
-- [#1929] Design adjustments to settlement notifications and notification panel 
+
+- [#1929] Design adjustments to settlement notifications and notification panel
 
 [#1255]: https://github.com/raiden-network/light-client/issues/1255
 [#1941]: https://github.com/raiden-network/light-client/issues/1941
@@ -29,15 +34,20 @@
 [#2144]: https://github.com/raiden-network/light-client/issues/2144
 [#2159]: https://github.com/raiden-network/light-client/issues/2144
 [#2138]: https://github.com/raiden-network/light-client/issues/2138
+[#2224]: https://github.com/raiden-network/light-client/issues/2223
 
 ## [0.11.1] - 2020-08-18
+
 ### Fixed
+
 - [#2047] Conversion and token amount display in UDC deposit dialog
 
 ### Added
+
 - [#2039] Dialog with redirect button if all channels are settled
 
 ### Changed
+
 - [#1951] Update to be compatible with Raiden Python client `v1.1.1`
 
 [#2039]: https://github.com/raiden-network/light-client/issues/2039
@@ -47,6 +57,7 @@
 ## [0.11.0] - 2020-08-04
 
 ### Fixed
+
 - [#2031] "No open channels" displayed instead of 0 balance on transfer screen
 
 ### Added

--- a/raiden-dapp/src/components/account/AccountContent.vue
+++ b/raiden-dapp/src/components/account/AccountContent.vue
@@ -23,13 +23,29 @@
       </v-row>
       <v-row class="account-content__account-details__eth" no-gutters>
         <v-col cols="2">
-          <span class="account-content__account-details__eth__currency">
-            {{ $t('account-content.currency') }}
+          <span class="account-content__account-details__eth__account">
+            {{ $t('account-content.account.main') }}
           </span>
         </v-col>
         <v-col cols="10">
           <span class="account-content__account-details__eth__balance">
-            {{ balance | decimals }}
+            {{ accountBalance | decimals }}
+          </span>
+        </v-col>
+      </v-row>
+      <v-row
+        v-if="usingRaidenAccount"
+        class="account-content__account-details__eth"
+        no-gutters
+      >
+        <v-col cols="2">
+          <span class="account-content__account-details__eth__account">
+            {{ $t('account-content.account.raiden') }}
+          </span>
+        </v-col>
+        <v-col cols="10">
+          <span class="account-content__account-details__eth__balance">
+            {{ raidenAccountBalance | decimals }}
           </span>
         </v-col>
       </v-row>
@@ -74,15 +90,21 @@ import AddressDisplay from '@/components/AddressDisplay.vue';
     AddressDisplay,
   },
   computed: {
-    ...mapState(['loading', 'defaultAccount']),
-    ...mapGetters(['balance', 'isConnected']),
+    ...mapState([
+      'loading',
+      'defaultAccount',
+      'accountBalance',
+      'raidenAccountBalance',
+    ]),
+    ...mapGetters(['isConnected', 'usingRaidenAccount']),
   },
 })
 export default class AccountContent extends Mixins(NavigationMixin) {
   menuItems: {}[] = [];
   loading!: boolean;
   defaultAccount!: string;
-  balance!: string;
+  accountBalance!: string;
+  raidenAccountBalance!: string;
   isConnected!: boolean;
 
   async mounted() {
@@ -237,15 +259,13 @@ export default class AccountContent extends Mixins(NavigationMixin) {
     }
 
     &__eth {
-      margin-bottom: 66px;
-
       &__balance {
         @include respond-to(handhelds) {
           margin-left: 30px;
         }
       }
 
-      &__currency,
+      &__account,
       &__balance {
         color: rgba($color-white, 0.7);
         font-size: 14px;
@@ -255,7 +275,7 @@ export default class AccountContent extends Mixins(NavigationMixin) {
 
   &__menu {
     background-color: transparent;
-    margin-top: 30px;
+    margin-top: 50px;
 
     &__list-items {
       border: solid 2px $secondary-text-color;

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -84,7 +84,10 @@
   "account-content": {
     "account-details": "Account Details",
     "address": "Address:",
-    "currency": "ETH:",
+    "account": {
+      "main": "Main ETH:",
+      "raiden": "Raiden ETH:"
+    },
     "menu-items": {
       "settings": {
         "title": "Settings",

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -252,13 +252,11 @@ const store: StoreOptions<RootState> = {
         !!(state.defaultAccount && state.defaultAccount !== '')
       );
     },
-    balance: (state: RootState): string => {
-      return state.raidenAccountBalance
-        ? state.raidenAccountBalance
-        : state.accountBalance;
-    },
     udcToken: (state: RootState): Token => {
       return state.tokens[state.userDepositTokenAddress];
+    },
+    usingRaidenAccount: (state: RootState): boolean => {
+      return !!state.settings.useRaidenAccount;
     },
   },
   plugins: [settingsLocalStorage.plugin, disclaimerAcceptedLocalStorage.plugin],

--- a/raiden-dapp/src/views/account/UDC.vue
+++ b/raiden-dapp/src/views/account/UDC.vue
@@ -49,7 +49,7 @@
     />
     <udc-withdrawal-dialog
       :visible="withdrawFromUdc"
-      :account-balance="accountBalance"
+      :account-balance="relevantEthBalanceForWithdrawal"
       :token="udcToken"
       :capacity="udcCapacity"
       @cancel="withdrawFromUdc = false"
@@ -80,21 +80,30 @@ import Spinner from '@/components/icons/Spinner.vue';
     Spinner,
   },
   computed: {
-    ...mapState(['accountBalance']),
-    ...mapGetters(['mainnet', 'udcToken']),
+    ...mapState(['accountBalance', 'raidenAccountBalance']),
+    ...mapGetters(['mainnet', 'udcToken', 'usingRaidenAccount']),
   },
 })
 export default class UDC extends Vue {
   amount: string = '10';
   udcCapacity = Zero;
   hasEnoughServiceTokens = false;
+  accountBalance!: string;
+  raidenAccountBalance!: string;
   mainnet!: boolean;
   udcToken!: Token;
+  usingRaidenAccount!: boolean;
   showUdcDeposit = false;
   withdrawFromUdc: boolean = false;
 
   get serviceToken(): string {
     return this.udcToken.symbol ?? (this.mainnet ? 'RDN' : 'SVT');
+  }
+
+  get relevantEthBalanceForWithdrawal(): string {
+    return this.usingRaidenAccount
+      ? this.raidenAccountBalance
+      : this.accountBalance;
   }
 
   async mounted() {

--- a/raiden-dapp/tests/unit/components/account/account-content.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/account-content.spec.ts
@@ -58,16 +58,48 @@ describe('AccountContent.vue', () => {
     expect(addressMobile.text()).toBe('0x31...6043');
   });
 
-  test('displays eth', async () => {
+  test('displays balance for main account only if not using raiden account', async () => {
     store.commit('balance', '12.0');
+    store.commit('updateSettings', { useRaidenAccount: false });
     await wrapper.vm.$nextTick();
-    const ethTitle = wrapper.find(
-      '.account-content__account-details__eth__currency'
-    );
-    const eth = wrapper.find('.account-content__account-details__eth__balance');
 
-    expect(ethTitle.text()).toBe('account-content.currency');
-    expect(eth.text()).toBe('12.000');
+    const accountDetails = wrapper.findAll(
+      '.account-content__account-details__eth'
+    );
+    expect(accountDetails.length).toBe(1);
+
+    const mainAccountDetails = accountDetails.at(0);
+    const title = mainAccountDetails.find(
+      '.account-content__account-details__eth__account'
+    );
+    const balance = mainAccountDetails.find(
+      '.account-content__account-details__eth__balance'
+    );
+
+    expect(title.text()).toBe('account-content.account.main');
+    expect(balance.text()).toBe('12.000');
+  });
+
+  test('displays balance for main and raiden account if using raiden account', async () => {
+    store.commit('raidenAccountBalance', '13.0');
+    store.commit('updateSettings', { useRaidenAccount: true });
+    await wrapper.vm.$nextTick();
+
+    const accountDetails = wrapper.findAll(
+      '.account-content__account-details__eth'
+    );
+    expect(accountDetails.length).toBe(2);
+
+    const raidenAccountDetails = accountDetails.at(1);
+    const title = raidenAccountDetails.find(
+      '.account-content__account-details__eth__account'
+    );
+    const balance = raidenAccountDetails.find(
+      '.account-content__account-details__eth__balance'
+    );
+
+    expect(title.text()).toBe('account-content.account.raiden');
+    expect(balance.text()).toBe('13.000');
   });
 
   test('displays one menu item', () => {

--- a/raiden-dapp/tests/unit/store.spec.ts
+++ b/raiden-dapp/tests/unit/store.spec.ts
@@ -60,20 +60,6 @@ describe('store', () => {
     expect(store.state.raidenAccountBalance).toBe('0.1');
   });
 
-  test('balance getter retuns balance if no raidenAccountBalance exists', () => {
-    expect(store.state.raidenAccountBalance).toBe('');
-    expect(store.state.accountBalance).toBe('0.0');
-    store.commit('balance', '12.0');
-    expect(store.getters.balance).toBe('12.0');
-  });
-
-  test('balance getter returns raidenAccountBalance if it exists', () => {
-    expect(store.state.raidenAccountBalance).toBe('');
-    expect(store.state.accountBalance).toBe('0.0');
-    store.commit('raidenAccountBalance', '13.0');
-    expect(store.getters.balance).toBe('13.0');
-  });
-
   test('account mutation changes the defaultAccount state', () => {
     expect(store.state.defaultAccount).toBe('');
     store.commit('account', 'test');
@@ -344,6 +330,13 @@ describe('store', () => {
       store.commit('acceptDisclaimer', persistDecistion);
       expect(store.state.disclaimerAccepted).toBe(true);
       expect(store.state.persistDisclaimerAcceptance).toBe(persistDecistion);
+    });
+  });
+
+  test('usingRaidenAccount getter reflect settings state property', () => {
+    [true, false].forEach((useRaidenAccount) => {
+      store.commit('updateSettings', { useRaidenAccount });
+      expect(store.getters.usingRaidenAccount).toEqual(useRaidenAccount);
     });
   });
 });


### PR DESCRIPTION
Fixes #2237

**Short description**
In addition to the origin issue, I agreed with @taleldayekh that showing both ETH balances on the main account screen is another helpful addition for the user. This is ofc only the case if a Raiden account is in use.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to dApp with Raiden account enabled
2. Navigate to the account screen
3. Make sure that there are now two ETH balances shown
4. Navigate to the UDC screen and click withdraw
5. Make sure that the shown ETH balance relates to the Raiden account (probably zero if you haven't transferred something)
6. Repeat this without using a Raiden account and make sure the expected changes in the UI are there
