### PR TITLE
Fix mismatch between UDC totalDeposit and effectiveBalance

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## [Unreleased]
 ### Fixed
+- [#2078] Check for overflows before sending transfers
 - [#2094] Fix TransferState's timestamps missing
 - [#2174] Fix a few transport issues triggered on high-load scenarios
-- [#2078] Check for overflows before sending transfers
+- [#2275] Fix mismatch between UDC totalDeposit and effectiveBalance
 
 ### Added
 - [#2044] Introduce PouchDB (IndexedDB/leveldown) as new persistent state storage backend
@@ -21,6 +22,7 @@
 [#2174]: https://github.com/raiden-network/light-client/pull/2174
 [#2204]: https://github.com/raiden-network/light-client/issues/2204
 [#2205]: https://github.com/raiden-network/light-client/issues/2205
+[#2275]: https://github.com/raiden-network/light-client/issues/2225
 
 ## [0.11.1] - 2020-08-18
 ### Changed

--- a/raiden-ts/src/epics.ts
+++ b/raiden-ts/src/epics.ts
@@ -79,7 +79,7 @@ export function getLatest$(
 ): Observable<Latest> {
   const udcBalance$ = action$.pipe(
     filter(udcDeposit.success.is),
-    pluck('meta', 'totalDeposit'),
+    pluck('payload', 'balance'),
     // starts with max, to prevent receiving starting as disabled before actual balance is fetched
     startWith(MaxUint256 as UInt<32>),
   );

--- a/raiden-ts/src/services/actions.ts
+++ b/raiden-ts/src/services/actions.ts
@@ -49,8 +49,13 @@ export const udcDeposit = createAsyncAction(
   'udc/deposit/failure',
   t.intersection([t.type({ deposit: UInt(32) }), t.partial({ subkey: t.boolean })]),
   t.union([
-    t.undefined,
-    t.type({ txHash: Hash, txBlock: t.number, confirmed: t.union([t.undefined, t.boolean]) }),
+    t.type({ balance: UInt(32) }),
+    t.type({
+      balance: UInt(32),
+      txHash: Hash,
+      txBlock: t.number,
+      confirmed: t.union([t.undefined, t.boolean]),
+    }),
   ]),
 );
 export namespace udcDeposit {

--- a/raiden-ts/tests/integration/raiden.spec.ts
+++ b/raiden-ts/tests/integration/raiden.spec.ts
@@ -1299,14 +1299,17 @@ describe('Raiden', () => {
     });
 
     test('deposit success', async () => {
-      expect.assertions(1);
-      await raiden.mint(await raiden.userDepositTokenAddress(), 10);
+      expect.assertions(3);
+      await raiden.mint(await raiden.userDepositTokenAddress(), 20);
       await expect(raiden.depositToUDC(10)).resolves.toMatch(/^0x[0-9a-fA-F]{64}$/);
+      await expect(raiden.depositToUDC(5)).resolves.toMatch(/^0x[0-9a-fA-F]{64}$/);
+      await expect(raiden.getUDCCapacity()).resolves.toEqual(bigNumberify(15));
     });
 
-    test('withdraw success', async () => {
-      expect.assertions(5);
+    test('withdraw success!', async () => {
+      expect.assertions(7);
       const deposit = bigNumberify(100) as UInt<32>;
+      const newDeposit = bigNumberify(30) as UInt<32>;
       const withdraw = bigNumberify(80) as UInt<32>;
       await raiden.mint(await raiden.userDepositTokenAddress(), deposit);
       await expect(raiden.depositToUDC(deposit)).resolves.toMatch(/^0x[0-9a-fA-F]{64}$/);
@@ -1325,6 +1328,12 @@ describe('Raiden', () => {
           amount: withdraw,
         }),
       ]);
+
+      await expect(raiden.depositToUDC(newDeposit)).resolves.toMatch(/^0x[0-9a-fA-F]{64}$/);
+      await provider.mine(confirmationBlocks * 2);
+      await expect(raiden.getUDCCapacity()).resolves.toEqual(
+        deposit.sub(withdraw).add(newDeposit),
+      );
     });
 
     test('withdraw success with restart', async () => {


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2275

**Short description**
`udcDeposit` actions contained `totalDeposit` as sole `meta` property, but it actually was the `effectiveBalance` value, which raised issues when calculating the new totalDeposit when making a deposit after a withdraw was performed.
This PR fixes it by using actual `totalDeposit` as meta value (for linking `udcDeposit` requests & success/failure responses), and added `balance` to payload, to be used as UDC balance, instead of the deposit.
Integration tests were extended to assert behavior when depositing after withdraw, which works as regression test for this action.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
