### PR TITLE
Fix nonce mismatch caused by rooms waiting overhead upon sending messages

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#2078] Check for overflows before sending transfers
 - [#2094] Fix TransferState's timestamps missing
 - [#2174] Fix a few transport issues triggered on high-load scenarios
+- [#2229] Fix nonce mismatch caused by room waiting overhead
 - [#2275] Fix mismatch between UDC totalDeposit and effectiveBalance
 
 ### Added
@@ -22,6 +23,7 @@
 [#2174]: https://github.com/raiden-network/light-client/pull/2174
 [#2204]: https://github.com/raiden-network/light-client/issues/2204
 [#2205]: https://github.com/raiden-network/light-client/issues/2205
+[#2229]: https://github.com/raiden-network/light-client/issues/2229
 [#2275]: https://github.com/raiden-network/light-client/issues/2225
 
 ## [0.11.1] - 2020-08-18

--- a/raiden-ts/src/persister.ts
+++ b/raiden-ts/src/persister.ts
@@ -64,8 +64,6 @@ export function createPersisterMiddleware(
     const prevState = store.getState();
     const result = next(action);
     const state = store.getState();
-    // TODO: clear completed transfers
-
     if (state === prevState) return result;
 
     for (const k in state) {

--- a/raiden-ts/src/transport/epics/messages.ts
+++ b/raiden-ts/src/transport/epics/messages.ts
@@ -1,4 +1,15 @@
-import { Observable, of, EMPTY, fromEvent, timer, defer, from, merge } from 'rxjs';
+import {
+  Observable,
+  of,
+  EMPTY,
+  fromEvent,
+  timer,
+  defer,
+  from,
+  merge,
+  asapScheduler,
+  scheduled,
+} from 'rxjs';
 import {
   catchError,
   concatMap,
@@ -72,7 +83,7 @@ export function matrixMessageSendEpic(
         'm.room.message',
         content,
         { log, latest$, config$ },
-        true, // alowRtc
+        true, // allowRtc
       ).pipe(
         map((via) => messageSend.success({ via }, action.meta)),
         catchError((err) => {
@@ -209,7 +220,7 @@ export function matrixMessageReceivedEpic(
         mergeMap(({ presences }) => {
           const presence = getPresenceByUserId(presences, event.getSender())!;
           const lines: string[] = (event.getContent().body ?? '').split('\n');
-          return from(lines).pipe(
+          return scheduled(lines, asapScheduler).pipe(
             map((line) => {
               const message = parseMessage(line, presence.meta.address, { log });
               return messageReceived(

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -466,6 +466,10 @@ describe('transport epic', () => {
         avatar_url: `mxc://raiden.network/cap?Delivery=0`,
       });
 
+      matrix._http.authedRequest.mockResolvedValueOnce({
+        presence: 'offline',
+        last_active_ago: 123,
+      });
       matrix.emit('event', {
         getType: () => 'm.presence',
         getSender: () => partnerUserId,
@@ -979,28 +983,14 @@ describe('transport epic', () => {
       expect(matrix.sendEvent).not.toHaveBeenCalled();
 
       // a wild Room appears
-      matrix.getRoom.mockReturnValue({
+      matrix.emit('Room', {
         roomId,
         name: roomId,
-        getMember: jest.fn(
-          (userId) =>
-            ({
-              roomId,
-              userId,
-              name: userId,
-              membership: 'join',
-              user: null,
-            } as any),
-        ),
-        getJoinedMembers: jest.fn(() => []),
+        getMember: jest.fn(),
+        getJoinedMembers: jest.fn(),
         getCanonicalAlias: jest.fn(() => roomId),
         getAliases: jest.fn(() => []),
-        currentState: {
-          roomId,
-          setStateEvents: jest.fn(),
-          members: {},
-        } as any,
-      } as any);
+      });
 
       // user joins later
       matrix.emit(


### PR DESCRIPTION
Fixes #2229

**Short description**
This was a little bit hard to debug, but it seems some overhead upon explicitly queueing messages and waiting for peer to join the room with us caused some overhead which prevented the persistence callbacks from firing at proper time.
This PR was tested using BF6, and as the presence bug was kicking in, it also includes a workaround for it, by explicitly requesting peer's presence upon presence events, instead of relying on event's payload, which can be wrong.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Test bug doesn't occur
2. High-load scenarios pass
