### PR TITLE
dApp: Fixes issues where disclaimer content appears behind button on mobile

### DIFF
--- a/raiden-dapp/src/views/DisclaimerRoute.vue
+++ b/raiden-dapp/src/views/DisclaimerRoute.vue
@@ -1,7 +1,7 @@
 <template>
-  <v-container fluid>
-    <div class="disclaimer">
-      <div class="disclaimer__paragraphs font-weight-light">
+  <div class="disclaimer">
+    <div class="disclaimer__content">
+      <div class="disclaimer__content__paragraphs font-weight-light">
         <p
           v-for="(paragraph, index) in $t('disclaimer.paragraphs')"
           :key="index"
@@ -11,14 +11,14 @@
       </div>
       <v-checkbox
         v-model="checkedAccept"
-        class="disclaimer__accept-checkbox"
+        class="disclaimer__content__accept-checkbox"
         :label="$t('disclaimer.accept-checkbox')"
         dense
         hide-details
       />
       <v-checkbox
         v-model="checkedPersist"
-        class="disclaimer__persist-checkbox"
+        class="disclaimer__content__persist-checkbox"
         :label="$t('disclaimer.persist-checkbox')"
         dense
         hide-details
@@ -31,7 +31,7 @@
       sticky
       @click="accept"
     />
-  </v-container>
+  </div>
 </template>
 
 <script lang="ts">
@@ -70,29 +70,36 @@ export default class Disclaimer extends Vue {
 @import '@/scss/mixins';
 
 .disclaimer {
-  border-top: solid 1px $primary-color;
-  display: flex;
-  flex-direction: column;
-  height: calc(100% - 45px);
-  padding: 30px 30px 0 30px;
+  height: 100%;
   width: 100%;
-  @include respond-to(handhelds) {
-    padding-top: 10px;
-  }
 
-  &__paragraphs {
-    font-size: 15px;
-    overflow-y: auto;
-    text-align: justify;
-    @extend .themed-scrollbar;
-  }
+  &__content {
+    border-top: solid 1px $primary-color;
+    display: flex;
+    flex-direction: column;
+    height: calc(100% - 45px);
+    padding: 30px 45px 0 45px;
+    @include respond-to(handhelds) {
+      padding: 10px 15px 0 15px;
+    }
 
-  &__accept-checkbox,
-  &__persist-checkbox {
-    ::v-deep {
-      .v-label {
-        font-size: 14px;
-        padding-bottom: 2px;
+    &__paragraphs {
+      flex: 1;
+      font-size: 15px;
+      overflow-y: auto;
+      text-align: justify;
+      @extend .themed-scrollbar;
+    }
+
+    &__accept-checkbox,
+    &__persist-checkbox {
+      flex: none;
+      margin-top: 4px;
+      margin-bottom: 8px;
+      ::v-deep {
+        .v-label {
+          font-size: 13px;
+        }
       }
     }
   }

--- a/raiden-dapp/tests/unit/views/disclaimer-route.spec.ts
+++ b/raiden-dapp/tests/unit/views/disclaimer-route.spec.ts
@@ -37,13 +37,16 @@ describe('DisclaimerRoute.vue', () => {
   });
 
   async function clickAcceptCheckbox() {
-    wrapper.find('.disclaimer__accept-checkbox').find('input').trigger('click');
+    wrapper
+      .find('.disclaimer__content__accept-checkbox')
+      .find('input')
+      .trigger('click');
     await wrapper.vm.$nextTick();
   }
 
   async function clickPersistCheckbox() {
     wrapper
-      .find('.disclaimer__persist-checkbox')
+      .find('.disclaimer__content__persist-checkbox')
       .find('input')
       .trigger('click');
     await wrapper.vm.$nextTick();


### PR DESCRIPTION
Fixes #2276 

**Short description**
Apparently, on mobile, the content was still displayed behind the `Accept` button on the disclaimer screen. This was not the case when viewing the dApp in the dev tools but it was the case when opening the dApp on an actual mobile. I managed to reproduce the problems by viewing the dApp in the Safari dev tools. These fixes make the disclaimer screen look good in the Safari dev tools so hopefully, that will also be the case when viewing it on an actual mobile device.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. View disclaimer on actual mobile, not sure how you would go about doing this without merging this PR to master...
