### PR TITLE
Retry contract calls when network problems occur

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- [#2240] Handle network problems when connecting to the Eth node gracefully
+
+[#2240]: https://github.com/raiden-network/light-client/issues/2240
 
 ## [0.12.0] - 2020-10-22
 ### Fixed

--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -43,13 +43,14 @@ import { RaidenEpicDeps } from '../types';
 import { RaidenAction, raidenShutdown, ConfirmableAction } from '../actions';
 import { RaidenState } from '../state';
 import { ShutdownReason } from '../constants';
+import { networkErrorRetryPredicate, RaidenError, ErrorCodes, assert } from '../utils/error';
 import { chooseOnchainAccount, getContractWithSigner } from '../helpers';
 import { Address, Hash, UInt, Signature, isntNil, HexString, last } from '../utils/types';
 import { isActionOf } from '../utils/actions';
 import { pluckDistinct, distinctRecordValues, retryAsync$, takeIf } from '../utils/rx';
 import { fromEthersEvent, getNetwork, logToContractEvent } from '../utils/ethers';
 import { encode } from '../utils/data';
-import { RaidenError, ErrorCodes, assert } from '../utils/error';
+
 import { createBalanceHash, MessageTypeId } from '../messages/utils';
 import { TokenNetwork } from '../contracts/TokenNetwork';
 import { HumanStandardToken } from '../contracts/HumanStandardToken';
@@ -76,7 +77,6 @@ import {
   txNonceErrors,
   txFailErrors,
   approveIfNeeded$,
-  networkErrorRetryPredicate,
 } from './utils';
 
 /**

--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -663,7 +663,7 @@ export function channelOpenEpic(
           provider.pollingInterval,
           networkErrorRetryPredicate,
         ).pipe(
-          assertTx('openChannel', ErrorCodes.CNL_OPENCHANNEL_FAILED, { log }),
+          assertTx('openChannel', ErrorCodes.CNL_OPENCHANNEL_FAILED, { log, provider }),
           // also retry txFailErrors: if it's caused by partner having opened, takeUntil will see
           retryTx(provider.pollingInterval, undefined, txNonceErrors.concat(txFailErrors), {
             log,
@@ -713,8 +713,8 @@ function makeDeposit$(
         tokenContract,
         tokenNetworkContract.address as Address,
         ErrorCodes.CNL_APPROVE_TRANSACTION_FAILED,
+        { provider },
         { log, minimumAllowance },
-        provider.pollingInterval,
       ),
     ),
     mergeMapTo(channelId$),
@@ -744,7 +744,7 @@ function makeDeposit$(
         networkErrorRetryPredicate,
       ),
     ),
-    assertTx('setTotalDeposit', ErrorCodes.CNL_SETTOTALDEPOSIT_FAILED, { log }),
+    assertTx('setTotalDeposit', ErrorCodes.CNL_SETTOTALDEPOSIT_FAILED, { log, provider }),
     // retry also txFail errors, since estimateGas can lag behind just-opened channel or
     // just-approved allowance
     retryTx(
@@ -962,7 +962,7 @@ export function channelCloseEpic(
             provider.pollingInterval,
             networkErrorRetryPredicate,
           ).pipe(
-            assertTx('closeChannel', ErrorCodes.CNL_CLOSECHANNEL_FAILED, { log }),
+            assertTx('closeChannel', ErrorCodes.CNL_CLOSECHANNEL_FAILED, { log, provider }),
             retryTx(provider.pollingInterval, undefined, undefined, { log }),
           ),
         ),
@@ -1072,6 +1072,7 @@ export function channelUpdateEpic(
           ).pipe(
             assertTx('updateNonClosingBalanceProof', ErrorCodes.CNL_UPDATE_NONCLOSING_BP_FAILED, {
               log,
+              provider,
             }),
             retryTx(provider.pollingInterval, undefined, undefined, { log }),
           ),
@@ -1282,7 +1283,7 @@ export function channelSettleEpic(
                 provider.pollingInterval,
                 networkErrorRetryPredicate,
               ).pipe(
-                assertTx('settleChannel', ErrorCodes.CNL_SETTLECHANNEL_FAILED, { log }),
+                assertTx('settleChannel', ErrorCodes.CNL_SETTLECHANNEL_FAILED, { log, provider }),
                 retryTx(provider.pollingInterval, undefined, undefined, { log }),
               ),
             ),
@@ -1386,7 +1387,7 @@ export function channelUnlockEpic(
         provider.pollingInterval,
         networkErrorRetryPredicate,
       ).pipe(
-        assertTx('unlock', ErrorCodes.CNL_ONCHAIN_UNLOCK_FAILED, { log }),
+        assertTx('unlock', ErrorCodes.CNL_ONCHAIN_UNLOCK_FAILED, { log, provider }),
         retryTx(provider.pollingInterval, undefined, undefined, { log }),
         ignoreElements(),
         catchError((error) => {

--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -714,6 +714,7 @@ function makeDeposit$(
         tokenNetworkContract.address as Address,
         ErrorCodes.CNL_APPROVE_TRANSACTION_FAILED,
         { log, minimumAllowance },
+        provider.pollingInterval,
       ),
     ),
     mergeMapTo(channelId$),

--- a/raiden-ts/src/channels/utils.ts
+++ b/raiden-ts/src/channels/utils.ts
@@ -26,7 +26,7 @@ import { HumanStandardToken } from '../contracts/HumanStandardToken';
 import { RaidenState } from '../state';
 import { RaidenEpicDeps } from '../types';
 import { UInt, Address, Hash, Int, bnMax } from '../utils/types';
-import { RaidenError, assert, ErrorCodes } from '../utils/error';
+import { RaidenError, assert, ErrorCodes, networkErrorRetryPredicate } from '../utils/error';
 import { distinctRecordValues, retryAsync$ } from '../utils/rx';
 import { MessageType } from '../messages/types';
 import { Channel, ChannelBalances } from './state';
@@ -327,14 +327,3 @@ export function approveIfNeeded$(
   );
 }
 /* eslint-enable jsdoc/valid-types */
-
-/**
- * Predicate to that fiters erros for retrieable network problems. To be used with `retryAsync$`.
- *
- * @param error - Error in question
- * @returns `False`, if there was a retrieable network error.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function networkErrorRetryPredicate(error: any, {}): boolean {
-  return !(typeof error?.message === 'string' && error.message.includes(`invalid response`));
-}

--- a/raiden-ts/src/channels/utils.ts
+++ b/raiden-ts/src/channels/utils.ts
@@ -313,3 +313,14 @@ export function approveIfNeeded$(
   );
 }
 /* eslint-enable jsdoc/valid-types */
+
+/**
+ * Predicate to that fiters erros for retrieable network problems. To be used with `retryAsync$`.
+ *
+ * @param error - Error in question
+ * @returns `False`, if there was a retrieable network error.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function networkErrorRetryPredicate(error: any, {}): boolean {
+  return !(typeof error?.message === 'string' && error.message.includes(`invalid response`));
+}

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -48,13 +48,12 @@ import {
   assertTx,
   retryTx,
   approveIfNeeded$,
-  networkErrorRetryPredicate,
 } from '../channels/utils';
 import { Address, decode, Int, Signature, Signed, UInt, isntNil, Hash } from '../utils/types';
 import { isActionOf, isResponseOf } from '../utils/actions';
 import { encode, jsonParse, jsonStringify } from '../utils/data';
 import { fromEthersEvent, logToContractEvent } from '../utils/ethers';
-import { RaidenError, ErrorCodes, assert } from '../utils/error';
+import { RaidenError, ErrorCodes, assert, networkErrorRetryPredicate } from '../utils/error';
 import { pluckDistinct, retryAsync$ } from '../utils/rx';
 import { matrixPresence } from '../transport/actions';
 import { getCap } from '../transport/utils';

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -497,6 +497,7 @@ function makeUdcDeposit$(
         userDepositContract.address as Address,
         ErrorCodes.RDN_APPROVE_TRANSACTION_FAILED,
         { log, minimumAllowance },
+        pollingInterval,
       );
     }),
     // send setTotalDeposit transaction

--- a/raiden-ts/src/services/utils.ts
+++ b/raiden-ts/src/services/utils.ts
@@ -9,14 +9,15 @@ import { Signer } from 'ethers/abstract-signer';
 import { retryAsync$ } from '../utils/rx';
 import { RaidenState } from '../state';
 import { RaidenEpicDeps } from '../types';
+import { networkErrorRetryPredicate, RaidenError, ErrorCodes, assert } from '../utils/error';
 import { Address, UInt, decode, Signed, Signature } from '../utils/types';
 import { jsonParse, encode } from '../utils/data';
 import { Presences } from '../transport/types';
 import { getCap } from '../transport/utils';
 import { ChannelState } from '../channels/state';
-import { channelAmounts, channelKey, networkErrorRetryPredicate } from '../channels/utils';
+import { channelAmounts, channelKey } from '../channels/utils';
 import { ServiceRegistry } from '../contracts/ServiceRegistry';
-import { RaidenError, ErrorCodes, assert } from '../utils/error';
+
 import { MessageTypeId } from '../messages/utils';
 import { Capabilities } from '../constants';
 import { isValidUrl } from '../helpers';

--- a/raiden-ts/src/transfers/epics/secret.ts
+++ b/raiden-ts/src/transfers/epics/secret.ts
@@ -465,7 +465,7 @@ export function transferSecretRegisterEpic(
       const contract = getContractWithSigner(secretRegistryContract, onchainSigner);
 
       return defer(() => contract.functions.registerSecret(action.payload.secret)).pipe(
-        assertTx('registerSecret', ErrorCodes.XFER_REGISTERSECRET_TX_FAILED, { log }),
+        assertTx('registerSecret', ErrorCodes.XFER_REGISTERSECRET_TX_FAILED, { log, provider }),
         retryTx(provider.pollingInterval, undefined, undefined, { log }),
         // transferSecretRegister.success handled by monitorSecretRegistryEpic
         ignoreElements(),

--- a/raiden-ts/src/transfers/epics/withdraw.ts
+++ b/raiden-ts/src/transfers/epics/withdraw.ts
@@ -195,7 +195,10 @@ export function withdrawSendTxEpic(
               action.payload.message.signature,
             ),
           ).pipe(
-            assertTx('setTotalWithdraw', ErrorCodes.CNL_WITHDRAW_TRANSACTION_FAILED, { log }),
+            assertTx('setTotalWithdraw', ErrorCodes.CNL_WITHDRAW_TRANSACTION_FAILED, {
+              log,
+              provider,
+            }),
             retryTx(provider.pollingInterval, undefined, undefined, { log }),
           );
         }),

--- a/raiden-ts/src/utils/error.ts
+++ b/raiden-ts/src/utils/error.ts
@@ -12,6 +12,8 @@ export type ErrorCodes = keyof typeof ErrorCodes;
 export const ErrorDetails = t.record(t.string, t.union([t.string, t.number, t.boolean, t.null]));
 export interface ErrorDetails extends t.TypeOf<typeof ErrorDetails> {}
 
+export const networkErrors: readonly string[] = ['invalid response'];
+
 export class RaidenError extends Error {
   public name = 'RaidenError';
 
@@ -104,5 +106,7 @@ export const ErrorCodec = new t.Type<
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function networkErrorRetryPredicate(error: any, {}): boolean {
-  return !(typeof error?.message === 'string' && error.message.includes(`invalid response`));
+  return !(
+    typeof error?.message === 'string' && networkErrors.some((msg) => error.message.includes(msg))
+  );
 }

--- a/raiden-ts/src/utils/error.ts
+++ b/raiden-ts/src/utils/error.ts
@@ -95,3 +95,14 @@ export const ErrorCodec = new t.Type<
     ...('details' in error ? { details: error.details } : {}),
   }),
 );
+
+/**
+ * Predicate to that fiters errors for retrieable network problems. To be used with `retryAsync$`.
+ *
+ * @param error - Error in question
+ * @returns `False`, if there was a retrieable network error.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function networkErrorRetryPredicate(error: any, {}): boolean {
+  return !(typeof error?.message === 'string' && error.message.includes(`invalid response`));
+}

--- a/raiden-ts/tests/unit/error.spec.ts
+++ b/raiden-ts/tests/unit/error.spec.ts
@@ -1,0 +1,24 @@
+import { txFailErrors, txNonceErrors } from 'raiden-ts/channels/utils';
+import { networkErrorRetryPredicate, networkErrors } from 'raiden-ts/utils/error';
+
+describe('networkErrorRetryPredicate', () => {
+  test('handles non-error objects correctly', () => {
+    const errorString = 'Test';
+    const errorNumber = 123;
+    const errorObject = { name: 'goerli', chainId: 5 };
+
+    expect(networkErrorRetryPredicate(errorString, {})).toBe(true);
+    expect(networkErrorRetryPredicate(errorNumber, {})).toBe(true);
+    expect(networkErrorRetryPredicate(errorObject, {})).toBe(true);
+  });
+
+  test('returns `False` for network errors only', () => {
+    const networkError = Error(networkErrors[0]);
+    const nonceError = Error(txNonceErrors[0]);
+    const failError = Error(txFailErrors[0]);
+
+    expect(networkErrorRetryPredicate(networkError, {})).toBe(false);
+    expect(networkErrorRetryPredicate(nonceError, {})).toBe(true);
+    expect(networkErrorRetryPredicate(failError, {})).toBe(true);
+  });
+});


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2240 

**Short description**

Retry contract calls **in epics** when network problems occur. We leave the raiden class for now, some of its functions should be converted to epics as described in #1908.

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
