### PR TITLE
Feature/ci improvements and fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,13 +79,16 @@ jobs:
           command: npm install license-checker@25.0.1
       - run:
           name: Check SDK Licenses
-          command: cd ~/src/raiden-ts && license-checker --production --onlyAllow 'MIT;BSD;Apache;MPL;LGPL;ZPL;ISC;WTFPL;Unlicense' --excludePackages 'uuid@2.0.1' --excludePrivatePackages # uuid@2.0.1 has an issue with the license information but it is licensed under MIT
+          working_directory: raiden-ts
+          command: license-checker --production --onlyAllow 'MIT;BSD;Apache;MPL;LGPL;ZPL;ISC;WTFPL;Unlicense' --excludePackages 'uuid@2.0.1' --excludePrivatePackages # uuid@2.0.1 has an issue with the license information but it is licensed under MIT
       - run:
           name: Check dApp Licenses
-          command: cd ~/src/raiden-dapp && license-checker --production --onlyAllow 'MIT;BSD;Apache;MPL;LGPL;ZPL;ISC;WTFPL;Unlicense' --excludePackages 'uuid@2.0.1' --excludePrivatePackages # uuid@2.0.1 has an issue with the license information but it is licensed under MIT
+          working_directory: raiden-dapp
+          command: license-checker --production --onlyAllow 'MIT;BSD;Apache;MPL;LGPL;ZPL;ISC;WTFPL;Unlicense' --excludePackages 'uuid@2.0.1' --excludePrivatePackages # uuid@2.0.1 has an issue with the license information but it is licensed under MIT
       - run:
           name: Check CLI Licenses
-          command: cd ~/src/raiden-cli && license-checker --production --onlyAllow 'MIT;BSD;Apache;MPL;LGPL;ZPL;ISC;WTFPL;Unlicense' --excludePackages 'uuid@2.0.1' --excludePrivatePackages # uuid@2.0.1 has an issue with the license information but it is licensed under MIT
+          working_directory: raiden-cli
+          command: license-checker --production --onlyAllow 'MIT;BSD;Apache;MPL;LGPL;ZPL;ISC;WTFPL;Unlicense' --excludePackages 'uuid@2.0.1' --excludePrivatePackages # uuid@2.0.1 has an issue with the license information but it is licensed under MIT
 
   lint:
     executor: base-executor
@@ -190,7 +193,8 @@ jobs:
           command: yarn workspace raiden-dapp build --mode << parameters.mode >>
       - run:
           name: Compress dapp
-          command: cd raiden-dapp && tar -czvf dapp.tar.gz dist
+          working_directory: raiden-dapp
+          command: tar -czvf dapp.tar.gz dist
       - store_artifacts:
           path: raiden-dapp/dapp.tar.gz
           destination: dapp.tar.gz
@@ -209,8 +213,8 @@ jobs:
           command: yarn workspace raiden-cli run build && yarn workspace raiden-cli run build:bundle
       - run:
           name: Compress CLI bundle
+          working_directory: raiden-cli
           command: >
-            cd raiden-cli ;
             cp -av ./raiden bundle/ ;
             tar -czvf raiden-cli.tar.gz bundle --transform='s/^bundle/raiden-cli/'
       - store_artifacts:
@@ -222,7 +226,9 @@ jobs:
     working_directory: << pipeline.parameters.working_directory >>
     steps:
       - attach_workspace: *attach_options
-      - run: cd docs && ./generate_documentation.sh
+      - run:
+          working_directory: docs
+          command: ./generate_documentation.sh
       - persist_to_workspace:
           root: << pipeline.parameters.working_directory >>
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ executors:
   base-executor:
     <<: *executor_shared_options
     docker:
-      - image: circleci/node:<< pipeline.parameters.base_executor_image_tag >>
+      - image: cimg/node:<< pipeline.parameters.base_executor_image_tag >>
 
   e2e-environment-executor:
     <<: *executor_shared_options

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,6 @@ parameters:
     type: string
     default: ~/src
 
-  yarn_cache_key:
-    type: string
-    default: raiden-{{ .Branch }}-{{ checksum "yarn-lock.yaml" }}
-
   test_report_directory:
     type: string
     default: reports/junit
@@ -97,10 +93,14 @@ jobs:
       - run: git submodule sync
       - run: git submodule update --init
       - restore_cache:
-          key: << pipeline.parameters.yarn_cache_key >>
+          name: Restore Yarn Package Cache
+          keys:
+            - raiden-v1-yarn-{{ checksum "yarn.lock" }}
+            - raiden-v1-yarn-
       - run: yarn install
       - save_cache:
-          key: << pipeline.parameters.yarn_cache_key >>
+          name: Save Yarn Package Cache
+          key: raiden-v1-yarn-{{ checksum "yarn.lock" }}
           paths:
             - ./node_modules
             - ~/.cache # Cypress stores its stuff here.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,21 @@ executors:
     docker:
       - image: raidennetwork/lightclient-e2e-environment:<< pipeline.parameters.e2e_environment_executor_image_tag >>
 
+commands:
+  check-license:
+    parameters:
+      directory:
+        type: string
+    steps:
+      - run:
+          name: Check License for << parameters.directory >>
+          working_directory: << pipeline.parameters.working_directory>>/<< parameters.directory >>
+          command: >
+            license-checker --production
+            --onlyAllow 'MIT;BSD;Apache;MPL;LGPL;ZPL;ISC;WTFPL;Unlicense'
+            --excludePackages 'uuid@2.0.1'
+            --excludePrivatePackages # uuid@2.0.1 has an issue with the license information but it is licensed under MIT
+
 jobs:
   install:
     <<: *executor_parameter
@@ -71,24 +86,19 @@ jobs:
     working_directory: ~/
     steps:
       - attach_workspace: *attach_options
+      # TODO: Export installation into Dockerfile?
       - run:
           name: Update $PATH
           command: echo 'export PATH=$PATH:$HOME/node_modules/.bin' >> $BASH_ENV
       - run:
           name: Install license checker
           command: npm install license-checker@25.0.1
-      - run:
-          name: Check SDK Licenses
-          working_directory: raiden-ts
-          command: license-checker --production --onlyAllow 'MIT;BSD;Apache;MPL;LGPL;ZPL;ISC;WTFPL;Unlicense' --excludePackages 'uuid@2.0.1' --excludePrivatePackages # uuid@2.0.1 has an issue with the license information but it is licensed under MIT
-      - run:
-          name: Check dApp Licenses
-          working_directory: raiden-dapp
-          command: license-checker --production --onlyAllow 'MIT;BSD;Apache;MPL;LGPL;ZPL;ISC;WTFPL;Unlicense' --excludePackages 'uuid@2.0.1' --excludePrivatePackages # uuid@2.0.1 has an issue with the license information but it is licensed under MIT
-      - run:
-          name: Check CLI Licenses
-          working_directory: raiden-cli
-          command: license-checker --production --onlyAllow 'MIT;BSD;Apache;MPL;LGPL;ZPL;ISC;WTFPL;Unlicense' --excludePackages 'uuid@2.0.1' --excludePrivatePackages # uuid@2.0.1 has an issue with the license information but it is licensed under MIT
+      - check-license:
+          directory: raiden-ts
+      - check-license:
+          directory: raiden-dapp
+      - check-license:
+          directory: raiden-cli
 
   lint:
     executor: base-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,13 @@
 version: 2.1
 
 parameters:
-  base_executor_image_tag:
+  base_executor_image:
     type: string
-    default: lts-browsers
+    default: cimg/node:lts-browsers
 
-  e2e_environment_executor_image_tag:
+  e2e_environment_executor_image:
     type: string
-    default: latest
+    default: raidennetwork/lightclient-e2e-environment:latest
 
   working_directory:
     type: string
@@ -40,12 +40,12 @@ executors:
   base-executor:
     <<: *executor_shared_options
     docker:
-      - image: cimg/node:<< pipeline.parameters.base_executor_image_tag >>
+      - image: << pipeline.parameters.base_executor_image >>
 
   e2e-environment-executor:
     <<: *executor_shared_options
     docker:
-      - image: raidennetwork/lightclient-e2e-environment:<< pipeline.parameters.e2e_environment_executor_image_tag >>
+      - image: << pipeline.parameters.e2e_environment_executor_image >>
 
 commands:
   check-license:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,26 @@
 version: 2.1
 
-var_2: &cache_key raiden-{{ .Branch }}-{{ checksum "pnpm-lock.yaml" }}
-var_1: &docker_image raidennetwork/lightclient-node-pnpm:latest
-var_3: &working_dir ~/src
-var_4: &dapp_working_dir ~/src/raiden-dapp
+parameters:
+  base_executor_image_tag:
+    type: string
+    default: lts-browsers
 
-anchor_1: &package_lock_key
-  key: *cache_key
+  e2e_environment_executor_image_tag:
+    type: string
+    default: latest
 
-anchor_2: &attach_options
-  at: *working_dir
+  working_directory:
+    type: string
+    default: ~/src
 
-anchor_3: &executor_parameter
+  yarn_cache_key:
+    type: string
+    default: raiden-{{ .Branch }}-{{ checksum "yarn-lock.yaml" }}
+
+anchor_1: &attach_options
+  at: << pipeline.parameters.working_directory >>
+
+anchor_2: &executor_parameter
   parameters:
     executor:
       type: executor
@@ -26,37 +35,34 @@ anchor_3: &run_on_release_tag_only
 
 executors:
   base-executor:
-    working_directory: *working_dir
+    working_directory: << pipeline.parameters.working_directory >>
     docker:
-      - image: circleci/node:lts-browsers
+      - image: circleci/node:<< pipeline.parameters.base_executor_image_tag >>
 
   e2e-environment-executor:
-    working_directory: *working_dir
+    working_directory: << pipeline.parameters.working_directory >>
     docker:
-      - image: raidennetwork/lightclient-e2e-environment:latest
+      - image: raidennetwork/lightclient-e2e-environment:<< pipeline.parameters.e2e_environment_executor_image_tag >>
 
 jobs:
   install:
     <<: *executor_parameter
     executor: << parameters.executor >>
-    working_directory: *working_dir
+    working_directory: << pipeline.parameters.working_directory >>
     steps:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
       - restore_cache:
-          name: Restore Yarn Package Cache
-          keys:
-            - raiden-v1-yarn-{{ checksum "yarn.lock" }}
-            - raiden-v1-yarn-
-      - run: pnpm install --prefer-frozen-lockfile
-          name: Save Yarn Package Cache
-          key: raiden-v1-yarn-{{ checksum "yarn.lock" }}
+          key: << pipeline.parameters.yarn_cache_key >>
+      - run: yarn install
+      - save_cache:
+          key: << pipeline.parameters.yarn_cache_key >>
           paths:
             - ./node_modules
             - ~/.cache # Cypress stores its stuff here.
       - persist_to_workspace:
-          root: *working_dir
+          root: << pipeline.parameters.working_directory >>
           paths:
             - ./*
 
@@ -83,14 +89,14 @@ jobs:
 
   lint:
     executor: base-executor
-    working_directory: *working_dir
+    working_directory: << pipeline.parameters.working_directory >>
     steps:
       - attach_workspace: *attach_options
       - run: yarn lint
 
   test_sdk_unit:
     executor: base-executor
-    working_directory: *working_dir
+    working_directory: << pipeline.parameters.working_directory >>
     steps:
       - attach_workspace: *attach_options
       - run:
@@ -108,7 +114,7 @@ jobs:
 
   test_sdk_integration:
     executor: base-executor
-    working_directory: *working_dir
+    working_directory: << pipeline.parameters.working_directory >>
     steps:
       - attach_workspace: *attach_options
       - run:
@@ -126,7 +132,7 @@ jobs:
 
   test_dapp_unit:
     executor: base-executor
-    working_directory: *working_dir
+    working_directory: << pipeline.parameters.working_directory >>
     steps:
       - attach_workspace: *attach_options
       - run:
@@ -144,7 +150,7 @@ jobs:
 
   test_dapp_e2e:
     executor: e2e-environment-executor
-    working_directory: *working_dir
+    working_directory: << pipeline.parameters.working_directory >>
     steps:
       - attach_workspace: *attach_options
       - run:
@@ -160,12 +166,12 @@ jobs:
   build_sdk:
     <<: *executor_parameter
     executor: << parameters.executor >>
-    working_directory: *working_dir
+    working_directory: << pipeline.parameters.working_directory >>
     steps:
       - attach_workspace: *attach_options
       - run: yarn workspace raiden-ts build
       - persist_to_workspace:
-          root: *working_dir
+          root: << pipeline.parameters.working_directory >>
           paths:
             - ./*
 
@@ -176,7 +182,7 @@ jobs:
         type: enum
         enum: ["production", "staging", "development", "e2e", "raiden-package"]
     executor: base-executor
-    working_directory: *working_dir
+    working_directory: << pipeline.parameters.working_directory >>
     steps:
       - attach_workspace: *attach_options
       - run:
@@ -189,13 +195,13 @@ jobs:
           path: raiden-dapp/dapp.tar.gz
           destination: dapp.tar.gz
       - persist_to_workspace:
-          root: *working_dir
+          root: << pipeline.parameters.working_directory >>
           paths:
             - ./*
 
   build_cli:
     executor: base-executor
-    working_directory: *working_dir
+    working_directory: << pipeline.parameters.working_directory >>
     steps:
       - attach_workspace: *attach_options
       - run:
@@ -213,12 +219,12 @@ jobs:
 
   generate_documentation:
     executor: base-executor
-    working_directory: *working_dir
+    working_directory: << pipeline.parameters.working_directory >>
     steps:
       - attach_workspace: *attach_options
       - run: cd docs && ./generate_documentation.sh
       - persist_to_workspace:
-          root: *working_dir
+          root: << pipeline.parameters.working_directory >>
           paths:
             - ./raiden-dapp/dist/docs
 
@@ -228,7 +234,7 @@ jobs:
         description: The public path where to reach deployment (must be correct according to the build mode)
         type: string
     executor: base-executor
-    working_directory: *dapp_working_dir
+    working_directory: << pipeline.parameters.working_directory >>/raiden-dapp
     steps:
       - attach_workspace: *attach_options
       - add_ssh_keys:
@@ -238,7 +244,7 @@ jobs:
 
   publish_artifact:
     executor: base-executor
-    working_directory: *working_dir
+    working_directory: << pipeline.parameters.working_directory >>
     steps:
       - attach_workspace: *attach_options
       - run:
@@ -250,7 +256,7 @@ jobs:
 
   test_sdk_e2e:
     executor: e2e-environment-executor
-    working_directory: *working_dir
+    working_directory: << pipeline.parameters.working_directory >>
     steps:
       - attach_workspace: *attach_options
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,10 +103,10 @@ jobs:
   build_sdk:
     <<: *executor_parameter
     executor: << parameters.executor >>
-    working_directory: << pipeline.parameters.working_directory >>
+    working_directory: << pipeline.parameters.working_directory >>/raiden-ts
     steps:
       - attach_workspace: *attach_options
-      - run: yarn workspace raiden-ts build
+      - run: yarn build
       - persist_to_workspace:
           root: << pipeline.parameters.working_directory >>
           paths:
@@ -119,19 +119,17 @@ jobs:
         type: enum
         enum: ["production", "staging", "development", "e2e", "raiden-package"]
     executor: base-executor
-    working_directory: << pipeline.parameters.working_directory >>
+    working_directory: << pipeline.parameters.working_directory >>/raiden-dapp
     steps:
       - attach_workspace: *attach_options
       - run:
           name: Build dapp
-          command: yarn workspace raiden-dapp build --mode << parameters.mode >>
+          command: yarn build --mode << parameters.mode >>
       - run:
           name: Compress dapp
-          working_directory: raiden-dapp
           command: tar -czvf dapp.tar.gz dist
       - store_artifacts:
-          path: raiden-dapp/dapp.tar.gz
-          destination: dapp.tar.gz
+          path: dapp.tar.gz
       - persist_to_workspace:
           root: << pipeline.parameters.working_directory >>
           paths:
@@ -139,21 +137,22 @@ jobs:
 
   build_cli:
     executor: base-executor
-    working_directory: << pipeline.parameters.working_directory >>
+    working_directory: << pipeline.parameters.working_directory >>/raiden-cli
     steps:
       - attach_workspace: *attach_options
       - run:
           name: Build CLI
-          command: yarn workspace raiden-cli run build && yarn workspace raiden-cli run build:bundle
+          command: yarn run build
+      - run:
+          name: Bundle CLI
+          command: yarn run build:bundle
       - run:
           name: Compress CLI bundle
-          working_directory: raiden-cli
           command: >
             cp -av ./raiden bundle/ ;
             tar -czvf raiden-cli.tar.gz bundle --transform='s/^bundle/raiden-cli/'
       - store_artifacts:
-          path: raiden-cli/raiden-cli.tar.gz
-          destination: raiden-cli.tar.gz
+          path: raiden-cli.tar.gz
 
   lint:
     executor: base-executor
@@ -164,12 +163,12 @@ jobs:
 
   test_sdk_unit:
     executor: base-executor
-    working_directory: << pipeline.parameters.working_directory >>
+    working_directory: << pipeline.parameters.working_directory >>/raiden-ts
     steps:
       - attach_workspace: *attach_options
       - run:
           name: Run unit tests
-          command: yarn workspace raiden-ts run test:unit --ci --runInBand --reporters=default --reporters=jest-junit
+          command: yarn run test:unit --ci --runInBand --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: "reports/junit"
       - store_test_results:
@@ -182,12 +181,12 @@ jobs:
 
   test_sdk_integration:
     executor: base-executor
-    working_directory: << pipeline.parameters.working_directory >>
+    working_directory: << pipeline.parameters.working_directory >>/raiden-ts
     steps:
       - attach_workspace: *attach_options
       - run:
           name: Run integration tests
-          command: yarn workspace raiden-ts run test:integration --ci --runInBand --reporters=default --reporters=jest-junit
+          command: yarn run test:integration --ci --runInBand --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: "reports/junit"
       - store_test_results:
@@ -200,15 +199,14 @@ jobs:
 
   test_sdk_e2e:
     executor: e2e-environment-executor
-    working_directory: << pipeline.parameters.working_directory >>
+    working_directory: << pipeline.parameters.working_directory >>/raiden-ts
     steps:
       - attach_workspace: *attach_options
       - run:
           name: Run end-to-end tests
           command: >
             source /etc/profile.d/smartcontracts.sh &&
-            yarn workspace raiden-ts run test:e2e
-            --ci --runInBand
+            yarn run test:e2e --ci --runInBand
             --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: "reports/junit"
@@ -222,12 +220,12 @@ jobs:
 
   test_dapp_unit:
     executor: base-executor
-    working_directory: << pipeline.parameters.working_directory >>
+    working_directory: << pipeline.parameters.working_directory >>/raiden-dapp
     steps:
       - attach_workspace: *attach_options
       - run:
           name: Run unit tests
-          command: yarn workspace raiden-dapp run test:unit --ci --runInBand --reporters=default --reporters=jest-junit
+          command: yarn run test:unit --ci --runInBand --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: "reports/junit"
       - store_test_results:
@@ -240,18 +238,18 @@ jobs:
 
   test_dapp_e2e:
     executor: e2e-environment-executor
-    working_directory: << pipeline.parameters.working_directory >>
+    working_directory: << pipeline.parameters.working_directory >>/raiden-dapp
     steps:
       - attach_workspace: *attach_options
       - run:
           name: Run e2e tests
-          command: yarn workspace raiden-dapp run test:e2e --headless
+          command: yarn run test:e2e --headless
       - store_test_results:
-          path: raiden-dapp/tests/e2e/results/reports
+          path: tests/e2e/results/reports
       - store_artifacts:
-          path: raiden-dapp/tests/e2e/results/videos
+          path: tests/e2e/results/videos
       - store_artifacts:
-          path: raiden-dapp/tests/e2e/results/screenshots
+          path: tests/e2e/results/screenshots
 
   generate_documentation:
     executor: base-executor
@@ -282,7 +280,7 @@ jobs:
 
   publish_artifact:
     executor: base-executor
-    working_directory: << pipeline.parameters.working_directory >>
+    working_directory: << pipeline.parameters.working_directory >>/raiden-ts
     steps:
       - attach_workspace: *attach_options
       - run:
@@ -290,7 +288,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
       - run:
           name: Publish on npm
-          command: yarn workspace raiden-ts publish
+          command: yarn publish
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ parameters:
     type: string
     default: raiden-{{ .Branch }}-{{ checksum "yarn-lock.yaml" }}
 
+  test_report_directory:
+    type: string
+    default: reports/junit
+
 anchor_1: &attach_options
   at: << pipeline.parameters.working_directory >>
 
@@ -26,7 +30,12 @@ anchor_2: &executor_parameter
       type: executor
       default: base-executor
 
-anchor_3: &run_on_release_tag_only
+anchor_3: &executor_shared_options
+  working_directory: << pipeline.parameters.working_directory >>
+  environment:
+    JEST_JUNIT_OUTPUT_DIR: << pipeline.parameters.test_report_directory >>
+
+anchor_4: &run_on_release_tag_only
   filters:
     tags:
       only: /^v\d+\.\d+\.\d+$/
@@ -35,12 +44,12 @@ anchor_3: &run_on_release_tag_only
 
 executors:
   base-executor:
-    working_directory: << pipeline.parameters.working_directory >>
+    <<: *executor_shared_options
     docker:
       - image: circleci/node:<< pipeline.parameters.base_executor_image_tag >>
 
   e2e-environment-executor:
-    working_directory: << pipeline.parameters.working_directory >>
+    <<: *executor_shared_options
     docker:
       - image: raidennetwork/lightclient-e2e-environment:<< pipeline.parameters.e2e_environment_executor_image_tag >>
 
@@ -64,17 +73,17 @@ commands:
     parameters:
       base_flag:
         type: enum
-        enum: ["sdk", "dapp", "cli"]
+        enum: [sdk, dapp, cli]
       test_kind_flag:
         type: enum
-        enum: ["unit", "integration", "e2e"]
+        enum: [unit, integration, e2e]
     steps:
       - store_test_results:
-          path: reports/junit
+          path: << pipeline.parameters.test_report_directory >>
       - store_artifacts:
-          path: reports/junit
+          path: << pipeline.parameters.test_report_directory >>
       - run:
-          name: "Upload test coverage results to CodeCov"
+          name: Upload test coverage results to CodeCov
           command: >
             bash <(curl -s https://codecov.io/bash) -C $CIRCLE_SHA1
             -F << parameters.base_flag >>
@@ -138,7 +147,7 @@ jobs:
       mode:
         description: Mode to configure the environment of the dApp build
         type: enum
-        enum: ["production", "staging", "development", "e2e", "raiden-package"]
+        enum: [production, staging, development, e2e, raiden-package]
     executor: base-executor
     working_directory: << pipeline.parameters.working_directory >>/raiden-dapp
     steps:
@@ -176,8 +185,8 @@ jobs:
           path: raiden-cli.tar.gz
 
   lint:
-    executor: base-executor
     working_directory: << pipeline.parameters.working_directory >>
+    executor: base-executor
     steps:
       - attach_workspace: *attach_options
       - run: yarn lint
@@ -190,8 +199,6 @@ jobs:
       - run:
           name: Run unit tests
           command: yarn run test:unit --ci --runInBand --reporters=default --reporters=jest-junit
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: "reports/junit"
       - upload_test_results_and_coverage:
           base_flag: sdk
           test_kind_flag: unit
@@ -204,8 +211,6 @@ jobs:
       - run:
           name: Run integration tests
           command: yarn run test:integration --ci --runInBand --reporters=default --reporters=jest-junit
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: "reports/junit"
       - upload_test_results_and_coverage:
           base_flag: sdk
           test_kind_flag: integration
@@ -221,8 +226,6 @@ jobs:
             source /etc/profile.d/smartcontracts.sh &&
             yarn run test:e2e --ci --runInBand
             --reporters=default --reporters=jest-junit
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: "reports/junit"
       - upload_test_results_and_coverage:
           base_flag: sdk
           test_kind_flag: e2e
@@ -235,8 +238,6 @@ jobs:
       - run:
           name: Run unit tests
           command: yarn run test:unit --ci --runInBand --reporters=default --reporters=jest-junit
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: "reports/junit"
       - upload_test_results_and_coverage:
           base_flag: dapp
           test_kind_flag: unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,10 @@ anchor_3: &executor_shared_options
   environment:
     JEST_JUNIT_OUTPUT_DIR: << pipeline.parameters.test_report_directory >>
 
-anchor_4: &run_on_release_tag_only
+anchor_4: &filter_release_tag
   filters:
     tags:
       only: /^v\d+\.\d+\.\d+$/
-    branches:
-      ignore: /.*/
 
 executors:
   base-executor:
@@ -301,12 +299,12 @@ jobs:
 workflows:
   version: 2
   default_workflow:
+    when:
+      not:
+        equal: [master, << pipeline.git.branch >>]
+
     jobs:
-      - install:
-          filters:
-            branches:
-              ignore:
-                - master
+      - install
       - check_licenses:
           requires:
             - install
@@ -334,12 +332,11 @@ workflows:
             - build_dapp
 
   publish_staging:
+    when:
+      equal: [master, << pipeline.git.branch >>]
+
     jobs:
-      - install:
-          filters:
-            branches:
-              only:
-                - master
+      - install
       - build_sdk:
           requires:
             - install
@@ -362,29 +359,38 @@ workflows:
             - build_dapp
 
   publish_production:
+    when:
+      and:
+        - not: << pipeline.git.branch >>
+        - << pipeline.git.tag >>
+
+    # Note:
+    # In constrast to branches, each job that should run on a pipeline triggered
+    # by a new tag must use a tag filter. Else the job does not get executed, no
+    # matter its dependencies or anything else.
     jobs:
       - install:
-          <<: *run_on_release_tag_only
+          <<: *filter_release_tag
       - build_sdk:
-          <<: *run_on_release_tag_only
+          <<: *filter_release_tag
           requires:
             - install
       - build_dapp:
-          <<: *run_on_release_tag_only
+          <<: *filter_release_tag
           mode: production
           requires:
             - build_sdk
       - generate_documentation:
-          <<: *run_on_release_tag_only
+          <<: *filter_release_tag
           requires:
             - build_dapp
       - deploy_gh_pages:
-          <<: *run_on_release_tag_only
+          <<: *filter_release_tag
           public_path: /
           requires:
             - generate_documentation
       - publish_artifact:
-          <<: *run_on_release_tag_only
+          <<: *filter_release_tag
           context: "Raiden Context"
           requires:
             - deploy_gh_pages
@@ -397,6 +403,7 @@ workflows:
             branches:
               only:
                 - master
+
     jobs:
       - install:
           executor: e2e-environment-executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
       - attach_workspace: *attach_options
       - run:
           name: Run unit tests
-          command: yarn run test:unit --ci --runInBand --reporters=default --reporters=jest-junit
+          command: yarn run test:unit --ci --runInBand
       - upload_test_results_and_coverage:
           base_flag: sdk
           test_kind_flag: unit
@@ -208,7 +208,7 @@ jobs:
       - attach_workspace: *attach_options
       - run:
           name: Run integration tests
-          command: yarn run test:integration --ci --runInBand --reporters=default --reporters=jest-junit
+          command: yarn run test:integration --ci --runInBand
       - upload_test_results_and_coverage:
           base_flag: sdk
           test_kind_flag: integration
@@ -223,7 +223,6 @@ jobs:
           command: >
             source /etc/profile.d/smartcontracts.sh &&
             yarn run test:e2e --ci --runInBand
-            --reporters=default --reporters=jest-junit
       - upload_test_results_and_coverage:
           base_flag: sdk
           test_kind_flag: e2e
@@ -235,7 +234,7 @@ jobs:
       - attach_workspace: *attach_options
       - run:
           name: Run unit tests
-          command: yarn run test:unit --ci --runInBand --reporters=default --reporters=jest-junit
+          command: yarn run test:unit --ci --runInBand
       - upload_test_results_and_coverage:
           base_flag: dapp
           test_kind_flag: unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,17 @@
 version: 2.1
 
-var_1: &working_dir ~/src
-var_2: &dapp_working_dir ~/src/raiden-dapp
+var_2: &cache_key raiden-{{ .Branch }}-{{ checksum "pnpm-lock.yaml" }}
+var_1: &docker_image raidennetwork/lightclient-node-pnpm:latest
+var_3: &working_dir ~/src
+var_4: &dapp_working_dir ~/src/raiden-dapp
 
-anchor_1: &attach_options
+anchor_1: &package_lock_key
+  key: *cache_key
+
+anchor_2: &attach_options
   at: *working_dir
 
-anchor_2: &executor_parameter
+anchor_3: &executor_parameter
   parameters:
     executor:
       type: executor
@@ -31,7 +36,7 @@ executors:
       - image: raidennetwork/lightclient-e2e-environment:latest
 
 jobs:
-  checkout:
+  install:
     <<: *executor_parameter
     executor: << parameters.executor >>
     working_directory: *working_dir
@@ -39,8 +44,19 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
+      - restore_cache:
+          name: Restore Yarn Package Cache
+          keys:
+            - raiden-v1-yarn-{{ checksum "yarn.lock" }}
+            - raiden-v1-yarn-
+      - run: pnpm install --prefer-frozen-lockfile
+          name: Save Yarn Package Cache
+          key: raiden-v1-yarn-{{ checksum "yarn.lock" }}
+          paths:
+            - ./node_modules
+            - ~/.cache # Cypress stores its stuff here.
       - persist_to_workspace:
-          root: .
+          root: *working_dir
           paths:
             - ./*
 
@@ -64,29 +80,6 @@ jobs:
       - run:
           name: Check CLI Licenses
           command: cd ~/src/raiden-cli && license-checker --production --onlyAllow 'MIT;BSD;Apache;MPL;LGPL;ZPL;ISC;WTFPL;Unlicense' --excludePackages 'uuid@2.0.1' --excludePrivatePackages # uuid@2.0.1 has an issue with the license information but it is licensed under MIT
-
-  install:
-    <<: *executor_parameter
-    executor: << parameters.executor >>
-    working_directory: *working_dir
-    steps:
-      - attach_workspace: *attach_options
-      - restore_cache:
-          name: Restore Yarn Package Cache
-          keys:
-            - raiden-v1-yarn-{{ checksum "yarn.lock" }}
-            - raiden-v1-yarn-
-      - run: yarn install
-      - save_cache:
-          name: Save Yarn Package Cache
-          key: raiden-v1-yarn-{{ checksum "yarn.lock" }}
-          paths:
-            - ./node_modules
-            - ~/.cache # Cypress stores its stuff here.
-      - persist_to_workspace:
-          root: *working_dir
-          paths:
-            - ./*
 
   lint:
     executor: base-executor
@@ -281,14 +274,11 @@ workflows:
   version: 2
   default_workflow:
     jobs:
-      - checkout:
+      - install:
           filters:
             branches:
               ignore:
                 - master
-      - install:
-          requires:
-            - checkout
       - check_licenses:
           requires:
             - install
@@ -317,14 +307,11 @@ workflows:
 
   publish_staging:
     jobs:
-      - checkout:
+      - install:
           filters:
             branches:
               only:
                 - master
-      - install:
-          requires:
-            - checkout
       - build_sdk:
           requires:
             - install
@@ -348,12 +335,8 @@ workflows:
 
   publish_production:
     jobs:
-      - checkout:
-          <<: *run_on_release_tag_only
       - install:
           <<: *run_on_release_tag_only
-          requires:
-            - checkout
       - build_sdk:
           <<: *run_on_release_tag_only
           requires:
@@ -387,12 +370,8 @@ workflows:
               only:
                 - master
     jobs:
-      - checkout:
-          executor: e2e-environment-executor
       - install:
           executor: e2e-environment-executor
-          requires:
-            - checkout
       - build_sdk:
           executor: e2e-environment-executor
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,82 +100,6 @@ jobs:
       - check-license:
           directory: raiden-cli
 
-  lint:
-    executor: base-executor
-    working_directory: << pipeline.parameters.working_directory >>
-    steps:
-      - attach_workspace: *attach_options
-      - run: yarn lint
-
-  test_sdk_unit:
-    executor: base-executor
-    working_directory: << pipeline.parameters.working_directory >>
-    steps:
-      - attach_workspace: *attach_options
-      - run:
-          name: Run unit tests
-          command: yarn workspace raiden-ts run test:unit --ci --runInBand --reporters=default --reporters=jest-junit
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: "reports/junit"
-      - store_test_results:
-          path: reports/junit
-      - store_artifacts:
-          path: reports/junit
-      - run:
-          name: "Upload coverage"
-          command: bash <(curl -s https://codecov.io/bash) -F sdk_unit -F sdk -C $CIRCLE_SHA1
-
-  test_sdk_integration:
-    executor: base-executor
-    working_directory: << pipeline.parameters.working_directory >>
-    steps:
-      - attach_workspace: *attach_options
-      - run:
-          name: Run unit tests
-          command: yarn workspace raiden-ts run test:integration --ci --runInBand --reporters=default --reporters=jest-junit
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: "reports/junit"
-      - store_test_results:
-          path: reports/junit
-      - store_artifacts:
-          path: reports/junit
-      - run:
-          name: "Upload coverage"
-          command: bash <(curl -s https://codecov.io/bash) -F sdk_integration -F sdk -C $CIRCLE_SHA1
-
-  test_dapp_unit:
-    executor: base-executor
-    working_directory: << pipeline.parameters.working_directory >>
-    steps:
-      - attach_workspace: *attach_options
-      - run:
-          name: Run unit tests
-          command: yarn workspace raiden-dapp run test:unit --ci --runInBand --reporters=default --reporters=jest-junit
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: "reports/junit"
-      - store_test_results:
-          path: reports/junit
-      - store_artifacts:
-          path: reports/junit
-      - run:
-          name: "Upload coverage"
-          command: bash <(curl -s https://codecov.io/bash) -F dapp -C $CIRCLE_SHA1
-
-  test_dapp_e2e:
-    executor: e2e-environment-executor
-    working_directory: << pipeline.parameters.working_directory >>
-    steps:
-      - attach_workspace: *attach_options
-      - run:
-          name: Run e2e tests
-          command: yarn workspace raiden-dapp run test:e2e --headless
-      - store_test_results:
-          path: raiden-dapp/tests/e2e/results/reports
-      - store_artifacts:
-          path: raiden-dapp/tests/e2e/results/videos
-      - store_artifacts:
-          path: raiden-dapp/tests/e2e/results/screenshots
-
   build_sdk:
     <<: *executor_parameter
     executor: << parameters.executor >>
@@ -231,6 +155,104 @@ jobs:
           path: raiden-cli/raiden-cli.tar.gz
           destination: raiden-cli.tar.gz
 
+  lint:
+    executor: base-executor
+    working_directory: << pipeline.parameters.working_directory >>
+    steps:
+      - attach_workspace: *attach_options
+      - run: yarn lint
+
+  test_sdk_unit:
+    executor: base-executor
+    working_directory: << pipeline.parameters.working_directory >>
+    steps:
+      - attach_workspace: *attach_options
+      - run:
+          name: Run unit tests
+          command: yarn workspace raiden-ts run test:unit --ci --runInBand --reporters=default --reporters=jest-junit
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: "reports/junit"
+      - store_test_results:
+          path: reports/junit
+      - store_artifacts:
+          path: reports/junit
+      - run:
+          name: "Upload coverage"
+          command: bash <(curl -s https://codecov.io/bash) -F sdk_unit -F sdk -C $CIRCLE_SHA1
+
+  test_sdk_integration:
+    executor: base-executor
+    working_directory: << pipeline.parameters.working_directory >>
+    steps:
+      - attach_workspace: *attach_options
+      - run:
+          name: Run integration tests
+          command: yarn workspace raiden-ts run test:integration --ci --runInBand --reporters=default --reporters=jest-junit
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: "reports/junit"
+      - store_test_results:
+          path: reports/junit
+      - store_artifacts:
+          path: reports/junit
+      - run:
+          name: "Upload coverage"
+          command: bash <(curl -s https://codecov.io/bash) -F sdk_integration -F sdk -C $CIRCLE_SHA1
+
+  test_sdk_e2e:
+    executor: e2e-environment-executor
+    working_directory: << pipeline.parameters.working_directory >>
+    steps:
+      - attach_workspace: *attach_options
+      - run:
+          name: Run end-to-end tests
+          command: >
+            source /etc/profile.d/smartcontracts.sh &&
+            yarn workspace raiden-ts run test:e2e
+            --ci --runInBand
+            --reporters=default --reporters=jest-junit
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: "reports/junit"
+      - store_test_results:
+          path: reports/junit
+      - store_artifacts:
+          path: reports/junit
+      - run:
+          name: "Upload coverage"
+          command: bash <(curl -s https://codecov.io/bash) -F sdk_e2e -F sdk -C $CIRCLE_SHA1
+
+  test_dapp_unit:
+    executor: base-executor
+    working_directory: << pipeline.parameters.working_directory >>
+    steps:
+      - attach_workspace: *attach_options
+      - run:
+          name: Run unit tests
+          command: yarn workspace raiden-dapp run test:unit --ci --runInBand --reporters=default --reporters=jest-junit
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: "reports/junit"
+      - store_test_results:
+          path: reports/junit
+      - store_artifacts:
+          path: reports/junit
+      - run:
+          name: "Upload coverage"
+          command: bash <(curl -s https://codecov.io/bash) -F dapp -C $CIRCLE_SHA1
+
+  test_dapp_e2e:
+    executor: e2e-environment-executor
+    working_directory: << pipeline.parameters.working_directory >>
+    steps:
+      - attach_workspace: *attach_options
+      - run:
+          name: Run e2e tests
+          command: yarn workspace raiden-dapp run test:e2e --headless
+      - store_test_results:
+          path: raiden-dapp/tests/e2e/results/reports
+      - store_artifacts:
+          path: raiden-dapp/tests/e2e/results/videos
+      - store_artifacts:
+          path: raiden-dapp/tests/e2e/results/screenshots
+
   generate_documentation:
     executor: base-executor
     working_directory: << pipeline.parameters.working_directory >>
@@ -270,28 +292,6 @@ jobs:
           name: Publish on npm
           command: yarn workspace raiden-ts publish
 
-  test_sdk_e2e:
-    executor: e2e-environment-executor
-    working_directory: << pipeline.parameters.working_directory >>
-    steps:
-      - attach_workspace: *attach_options
-      - run:
-          name: Run end-to-end tests
-          command: >
-            source /etc/profile.d/smartcontracts.sh &&
-            yarn workspace raiden-ts run test:e2e
-            --ci --runInBand
-            --reporters=default --reporters=jest-junit
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: "reports/junit"
-      - store_test_results:
-          path: reports/junit
-      - store_artifacts:
-          path: reports/junit
-      - run:
-          name: "Upload coverage"
-          command: bash <(curl -s https://codecov.io/bash) -F sdk_e2e -F sdk -C $CIRCLE_SHA1
-
 workflows:
   version: 2
   default_workflow:
@@ -307,14 +307,14 @@ workflows:
       - build_sdk:
           requires:
             - install
-      - lint:
-          requires:
-            - build_sdk
       - build_dapp:
           mode: development
           requires:
             - build_sdk
       - build_cli:
+          requires:
+            - build_sdk
+      - lint:
           requires:
             - build_sdk
       - test_sdk_unit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,9 +58,9 @@ commands:
           name: Check License for << parameters.directory >>
           working_directory: << pipeline.parameters.working_directory>>/<< parameters.directory >>
           command: >
-            license-checker --production
+            npx license-checker@25.0.1
+            --production
             --onlyAllow 'MIT;BSD;Apache;MPL;LGPL;ZPL;ISC;WTFPL;Unlicense'
-            --excludePackages 'uuid@2.0.1'
             --excludePrivatePackages # uuid@2.0.1 has an issue with the license information but it is licensed under MIT
 
   upload_test_results_and_coverage:
@@ -114,13 +114,6 @@ jobs:
     working_directory: ~/
     steps:
       - attach_workspace: *attach_options
-      # TODO: Export installation into Dockerfile?
-      - run:
-          name: Update $PATH
-          command: echo 'export PATH=$PATH:$HOME/node_modules/.bin' >> $BASH_ENV
-      - run:
-          name: Install license checker
-          command: npm install license-checker@25.0.1
       - check-license:
           directory: raiden-ts
       - check-license:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ commands:
   check-license:
     parameters:
       directory:
+        description: The sub-directory at the working directory where to check for licenses
         type: string
     steps:
       - run:
@@ -58,6 +59,26 @@ commands:
             --onlyAllow 'MIT;BSD;Apache;MPL;LGPL;ZPL;ISC;WTFPL;Unlicense'
             --excludePackages 'uuid@2.0.1'
             --excludePrivatePackages # uuid@2.0.1 has an issue with the license information but it is licensed under MIT
+
+  upload_test_results_and_coverage:
+    parameters:
+      base_flag:
+        type: enum
+        enum: ["sdk", "dapp", "cli"]
+      test_kind_flag:
+        type: enum
+        enum: ["unit", "integration", "e2e"]
+    steps:
+      - store_test_results:
+          path: reports/junit
+      - store_artifacts:
+          path: reports/junit
+      - run:
+          name: "Upload test coverage results to CodeCov"
+          command: >
+            bash <(curl -s https://codecov.io/bash) -C $CIRCLE_SHA1
+            -F << parameters.base_flag >>
+            -F << parameters.base_flag >>.<< parameters.test_kind_flag >>
 
 jobs:
   install:
@@ -171,13 +192,9 @@ jobs:
           command: yarn run test:unit --ci --runInBand --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: "reports/junit"
-      - store_test_results:
-          path: reports/junit
-      - store_artifacts:
-          path: reports/junit
-      - run:
-          name: "Upload coverage"
-          command: bash <(curl -s https://codecov.io/bash) -F sdk_unit -F sdk -C $CIRCLE_SHA1
+      - upload_test_results_and_coverage:
+          base_flag: sdk
+          test_kind_flag: unit
 
   test_sdk_integration:
     executor: base-executor
@@ -189,13 +206,9 @@ jobs:
           command: yarn run test:integration --ci --runInBand --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: "reports/junit"
-      - store_test_results:
-          path: reports/junit
-      - store_artifacts:
-          path: reports/junit
-      - run:
-          name: "Upload coverage"
-          command: bash <(curl -s https://codecov.io/bash) -F sdk_integration -F sdk -C $CIRCLE_SHA1
+      - upload_test_results_and_coverage:
+          base_flag: sdk
+          test_kind_flag: integration
 
   test_sdk_e2e:
     executor: e2e-environment-executor
@@ -210,13 +223,9 @@ jobs:
             --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: "reports/junit"
-      - store_test_results:
-          path: reports/junit
-      - store_artifacts:
-          path: reports/junit
-      - run:
-          name: "Upload coverage"
-          command: bash <(curl -s https://codecov.io/bash) -F sdk_e2e -F sdk -C $CIRCLE_SHA1
+      - upload_test_results_and_coverage:
+          base_flag: sdk
+          test_kind_flag: e2e
 
   test_dapp_unit:
     executor: base-executor
@@ -228,13 +237,9 @@ jobs:
           command: yarn run test:unit --ci --runInBand --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: "reports/junit"
-      - store_test_results:
-          path: reports/junit
-      - store_artifacts:
-          path: reports/junit
-      - run:
-          name: "Upload coverage"
-          command: bash <(curl -s https://codecov.io/bash) -F dapp -C $CIRCLE_SHA1
+      - upload_test_results_and_coverage:
+          base_flag: dapp
+          test_kind_flag: unit
 
   test_dapp_e2e:
     executor: e2e-environment-executor
@@ -244,6 +249,8 @@ jobs:
       - run:
           name: Run e2e tests
           command: yarn run test:e2e --headless
+      # TODO: Check how we can make this unified with how other jobs upload
+      # the test results (overwrite Cypress directory config via cli parameters)
       - store_test_results:
           path: tests/e2e/results/reports
       - store_artifacts:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 logs
 .DS_Store
+junit.xml

--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -125,5 +125,11 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/raiden-network/light-client.git"
+  },
+  "jest": {
+    "reporters": [
+      "default",
+      "jest-junit"
+    ]
   }
 }

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -222,12 +222,7 @@
     "coverageDirectory": ".coverage",
     "reporters": [
       "default",
-      [
-        "jest-junit",
-        {
-          "outputDirectory": ".coverage"
-        }
-      ]
+      "jest-junit"
     ],
     "globals": {
       "ts-jest": {


### PR DESCRIPTION
Fixes _everything_. :stuck_out_tongue_winking_eye:  

**Short description**

Our CircleCI configuration has become quite big. I guess that is the case for any mono-repo at some point in time. Though we experienced some issues recently, getting confronted with a little messy setup of our workflows and jobs.
While fixing our recent issue I read a lot of CircleCI documentation and learned a couple of new features they support. I think they can help to make our configuration more clean again and help to avoid future issues. Although this is not the end of the road (list of ideas follows), this should be enough to get its own PR. Future improvements I eventually continue to do voluntary in my free time. So no worries I would waste time.
I tested all of my changes for each step over and over again with a CircleCI pipeline setup for my fork of the project. Thereby I'm for example that the workflows are still triggered correctly and the fixes solve what they promise. As always should each commit message include enough information to understand all changes and their reasoning.


Thinks I would like to fix:

There is the feature of layered Docker images for an executor in CircleCI. This allows to use a base image where all jobs get executed inside and all others just offer services to the first one. This pretty much exactly what we need. The base image provides everything to get all projects installed, build, tested, ... The second image provides all services for a full features end-to-end test environment. At the moment this image must also make sure the projects can be build and run inside. And even worse: the jobs need to be parametrized to differ the used executor. This leads to some overhead in the configuration of CircleCI, the end-to-end image and also ugly (and not meaningful) auto-generated job names (thanks CircleCI). Unfortunately it does not work for the moment for multiple reasons. First do the SDK e2e tests need the environment file of the deployment infos, which residence in the e2e image. But eventually CircleCI injects the Docker socket into the base layer image and allows us to copy it from there inside a job. Anyways the second layer image always stops for some reason. According to CircleCI there is a non-zero exit code. From the logs the container works fine (on a first glance) and no errors are reported.

I still think that separating the logic into different workflows makes sense. I prefer this solution over a single workflow that has a lot of if-else-filter-... It makes it super hard to get what happens when under which condition. Workflows now have a single condition/trigger that makes it super easy to read. Unfortunately does this lead to a lot of copy-pasted code, since all of these workflows have a lot in common. I would love to make this re-usable and more pleasant to read/understand. YAML anchors are not solution. They would eventually make it worse and after all they could not handle the job parameters. It would be great to export a few of the current jobs as commands and then have jobs which orchestrate multiple of them with shared parameters. But this would remove the ability to parallelize many of these jobs (then commands). There are options to split a jobs its steps, but this appears quite complex and I'm not even sure it works for this case (meant to split tests over multiple machines to speed them up). So I don't know how to continue here.

