### PR TITLE
Bump NodeJS to v14 LTS

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,4 +1,0 @@
-FROM circleci/node:12-browsers
-
-RUN curl -sL https://unpkg.com/@pnpm/self-installer | sudo node
-RUN pnpm config set store-dir ~/.pnpm-store

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,6 +1,6 @@
 # CircleCI docker images
 
-The image is based on the circleci/node:12-browsers docker image, but also contains pnpm.
+The image is based on the circleci/node:lts-browsers docker image, i.e. the current/active NodeJS LTS image, which also comes with `yarn` pre-installed.
 
 ## Updating the images
 If you need to update the image, e.g. you need to use a new version of the base image with a newer version of node, you have to follow the instructions bellow.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,18 @@
 version: 2.1
 
-var_1: &docker_image raidennetwork/lightclient-node-pnpm:latest
-var_2: &cache_key raiden-{{ .Branch }}-{{ checksum "yarn.lock" }}
-var_3: &working_dir ~/src
-var_4: &dapp_working_dir ~/src/raiden-dapp
+var_1: &working_dir ~/src
+var_2: &dapp_working_dir ~/src/raiden-dapp
 
-anchor_1: &package_lock_key
-  key: *cache_key
-
-anchor_2: &attach_options
+anchor_1: &attach_options
   at: *working_dir
 
-anchor_3: &executor_parameter
+anchor_2: &executor_parameter
   parameters:
     executor:
       type: executor
       default: base-executor
 
-anchor_4: &run_on_release_tag_only
+anchor_3: &run_on_release_tag_only
   filters:
     tags:
       only: /^v\d+\.\d+\.\d+$/
@@ -28,7 +23,7 @@ executors:
   base-executor:
     working_directory: *working_dir
     docker:
-      - image: *docker_image
+      - image: circleci/node:lts-browsers
 
   e2e-environment-executor:
     working_directory: *working_dir
@@ -76,11 +71,17 @@ jobs:
     working_directory: *working_dir
     steps:
       - attach_workspace: *attach_options
-      - restore_cache: *package_lock_key
+      - restore_cache:
+          name: Restore Yarn Package Cache
+          keys:
+            - raiden-v1-yarn-{{ checksum "yarn.lock" }}
+            - raiden-v1-yarn-
       - run: yarn install
       - save_cache:
-          <<: *package_lock_key
+          name: Save Yarn Package Cache
+          key: raiden-v1-yarn-{{ checksum "yarn.lock" }}
           paths:
+            - ./node_modules
             - ~/.cache # Cypress stores its stuff here.
       - persist_to_workspace:
           root: *working_dir
@@ -263,8 +264,8 @@ jobs:
           name: Run end-to-end tests
           command: >
             source /etc/profile.d/smartcontracts.sh &&
-            yarn workspace raiden-ts run test:e2e --
-            --ci --runInBand --forceExit
+            yarn workspace raiden-ts run test:e2e
+            --ci --runInBand
             --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: "reports/junit"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [12.x]
+        node-version: [14.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/e2e-environment/Dockerfile
+++ b/e2e-environment/Dockerfile
@@ -39,14 +39,14 @@ ARG CONTRACTS_VERSION
 ARG CONTRACTS_PACKAGE_VERSION
 ARG GETH_VERSION
 
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends supervisor python3-virtualenv libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
-RUN apt-get clean
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends supervisor python3-virtualenv libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 
-ENV NODE_VERSION 12.16.1
-# https://github.com/nodejs/docker-node/blob/5351774b970cd32b80fc0c47a8abff5ba155fccc/12/stretch/Dockerfile#L8
+# https://github.com/nodejs/docker-node/blob/master/14/buster/Dockerfile#L8
+ENV NODE_VERSION 14.15.0
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   && case "${dpkgArch##*-}" in \
     amd64) ARCH='x64';; \
@@ -60,16 +60,16 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   # gpg keys listed at https://github.com/nodejs/node#release-keys
   && set -ex \
   && for key in \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-    77984A986EBC2AA786BC0F66B01FBB92821C587A \
-    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
     4ED778F539E3634C779C87C6D7062848A1AB005C \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    1C050899334244A8AF75E53792EF661D867B9DFA \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
     A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+    108F52B48DB57BB0CC439B2997B01419BD92F80A \
     B9E2F5981AA6E0CD28160D9FF13993A75599653C \
   ; do \
     gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
@@ -86,6 +86,26 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
   # smoke tests
   && node --version \
   && npm --version
+
+ENV YARN_VERSION 1.22.5
+RUN set -ex \
+  && for key in \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
+  ; do \
+    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  # smoke test
+  && yarn --version
 
 ENV SERVER_NAME=localhost
 ENV PASSWORD_FILE=/opt/passwd

--- a/e2e-environment/run-e2e-tests.sh
+++ b/e2e-environment/run-e2e-tests.sh
@@ -27,6 +27,8 @@ docker run --detach --rm \
   raidennetwork/lightclient-e2e-environment \
   >/dev/null
 
+sleep 5
+
 echo "Getting DEPLOYMENT_INFO from docker image '$DOCKER_CONTAINER_NAME' ..."
 docker cp "$DOCKER_CONTAINER_NAME":/opt/deployment/deployment_private_net.json "$DEPLOYMENT_INFO_DIR/"
 docker cp "$DOCKER_CONTAINER_NAME":/opt/deployment/deployment_services_private_net.json "$DEPLOYMENT_INFO_DIR/"
@@ -36,8 +38,8 @@ export DEPLOYMENT_INFO="${DEPLOYMENT_INFO_DIR}/deployment_private_net.json"
 export DEPLOYMENT_SERVICES_INFO="${DEPLOYMENT_INFO_DIR}/deployment_services_private_net.json"
 source "${DEPLOYMENT_INFO_DIR}/smartcontracts.sh"
 
-echo "Run end-to-end tests for dApp..."
-pnpm run test:e2e -- "$@"
+echo "Run end-to-end tests for $( basename $( realpath . ) )..."
+yarn run test:e2e "$@"
 
 echo "Getting the service logs..."
 docker cp "$DOCKER_CONTAINER_NAME":/var/log/supervisor/. ./logs/

--- a/raiden-cli/README.md
+++ b/raiden-cli/README.md
@@ -21,7 +21,7 @@ The goal of the CLI is provide a HTTP REST server that is fully compatible with 
 
 The CLI is considered experimental and mostly used for testing internally, not yet stable enough for production usage. Be aware that not all endpoints the specification defines are already implemented yet.
 
-It requires the latest [Node.js LTS (12.x - Erbium)](https://github.com/nodejs/Release)
+It requires the latest [Node.js LTS (14.x - Fermium)](https://github.com/nodejs/Release)
 
 > **INFO:** The Light Client SDK, dApp and CLI are **work in progress** and can only be used on the Ethereum **Testnets**.
 

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -3,14 +3,19 @@
 ## [Unreleased]
 ### Fixed
 - [#2240] Handle network problems when connecting to the Eth node gracefully
+- [#2312] Call WebRTC's connection.close() on teardown
 
 ### Changed
 - [#1707] Upgrade ethers to v5
 - [#2289] Switch to yarn from pnpm
+- [#2311] Bump NodeJS requirement to v14 LTS
+- [#2312] Make Raiden.stop() async, resolves when DB finished flushing
 
 [#1707]: https://github.com/raiden-network/light-client/issues/1707
 [#2240]: https://github.com/raiden-network/light-client/issues/2240
 [#2289]: https://github.com/raiden-network/light-client/pull/2289
+[#2311]: https://github.com/raiden-network/light-client/issues/2311
+[#2312]: https://github.com/raiden-network/light-client/pull/2312
 
 ## [0.12.0] - 2020-10-22
 ### Fixed

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -447,10 +447,11 @@ export class Raiden {
   /**
    * Triggers all epics to be unsubscribed
    */
-  public stop(): void {
+  public async stop(): Promise<void> {
     // start still can't be called again, but turns this.started to false
     // this.epicMiddleware is set to null by latest$'s complete callback
     if (this.started) this.store.dispatch(raidenShutdown({ reason: ShutdownReason.STOP }));
+    if (this.started !== undefined) await this.deps.db.busy$.toPromise();
   }
 
   /**

--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -412,8 +412,7 @@ function listenDataChannel(
         ).pipe(
           finalize(() => {
             dataChannel.close();
-            // FIXME: https://github.com/node-webrtc/node-webrtc/issues/636
-            // connection.close();
+            connection.close();
           }),
         ),
       ),

--- a/raiden-ts/tests/e2e/e2e.spec.ts
+++ b/raiden-ts/tests/e2e/e2e.spec.ts
@@ -1,5 +1,4 @@
 import { OpenMode, promises as fs } from 'fs';
-import { filter } from 'rxjs/operators';
 import { BigNumber } from '@ethersproject/bignumber';
 import { Wallet } from '@ethersproject/wallet';
 import type { Signer } from '@ethersproject/abstract-signer';
@@ -72,9 +71,8 @@ describe('e2e', () => {
     raiden.start();
   });
 
-  afterAll((done) => {
-    raiden.events$.pipe(filter((value) => value.type === 'raiden/shutdown')).subscribe(done);
-    raiden.stop();
+  afterAll(async () => {
+    await raiden.stop();
   });
 
   test('account is funded', async () => {

--- a/raiden-ts/tests/integration/raiden.spec.ts
+++ b/raiden-ts/tests/integration/raiden.spec.ts
@@ -174,7 +174,7 @@ describe('Raiden', () => {
 
   afterEach(async () => {
     let _raiden;
-    while ((_raiden = raidens.pop())) _raiden.stop();
+    while ((_raiden = raidens.pop())) await _raiden.stop();
     httpBackend.stop();
     fetch.mockRestore();
     await flushPromises();

--- a/raiden-ts/tsconfig.cjs.json
+++ b/raiden-ts/tsconfig.cjs.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist:cjs",
-    "module": "commonjs"
+    "module": "CommonJS"
   }
 }

--- a/raiden-ts/tsconfig.json
+++ b/raiden-ts/tsconfig.json
@@ -1,15 +1,16 @@
 {
   "compilerOptions": {
-    "target": "ES2019",
-    "module": "ESNext",
+    "target": "ES2020",
+    "module": "ES2020",
     "moduleResolution": "node",
-    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "strict": true,
     "sourceMap": true,
     "declaration": true,
     "pretty": true,
-    "lib": ["ES2019", "dom"],
+    "lib": ["ES2020", "dom"],
     "baseUrl": ".",
     "outDir": "./dist/"
   },


### PR DESCRIPTION
Fixes #2311 
~~Fixes `#2227`~~
Fixes #2262 

**Short description**
Also:
- Some fixes for proper `yarn` cache management on CircleCI
- Call `close()` on [WebRTC connection](https://github.com/raiden-network/light-client/blob/dde6594a55c4cb14e0268c9e9493de09404682a8/raiden-ts/src/transport/epics/webrtc.ts#L415-L416); ensures the connection is properly teared down, as `wrtc` doesn't segfault on close anymore on Node v14, allowing proper teardown of RTC channels
  - Edit: the apparent infinite loop bug on `wrtc` is still present on this branch/node14, so #2227 isn't solved, but this improves  it and specially the connection teardown phase
- It was noticed the e2e tests were trying to shutdown before last db flush, which made it fail even though it could exit properly; to fix this, `Raiden.stop` was made asynchronous, and resolves after `db` is properly flushed and gracefully closed;
  - This shouldn't be needed on browsers, they're fast enough; only on `memory` adapter on integration/e2e tests this could be seen
- With both issues above fixed, we can now have proper teardown of e2e SDK tests; there were some infra issues, which were also addressed on this PR: now, e2e tests complete and exit cleanly! :tada: 

![image](https://user-images.githubusercontent.com/587021/97910091-fc5fd100-1d27-11eb-9ebb-000762a889a8.png)


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
