### PR TITLE
Fix overflows and add expiration checks

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -2,18 +2,20 @@
 
 ## [Unreleased]
 ### Fixed
+- [#2058] Check some potential overflows when handling received messages
 - [#2240] Handle network problems when connecting to the Eth node gracefully
-- [#2312] Call WebRTC's connection.close() on teardown
 - [#2299] Don't acknowledge SecretReveals if receiving is disabled
+- [#2312] Call WebRTC's connection.close() on teardown
 
 ### Changed
 - [#1707] Upgrade ethers to v5
 - [#2289] Switch to yarn from pnpm
+- [#2297] Add logs when ignoring incoming transfers
 - [#2311] Bump NodeJS requirement to v14 LTS
 - [#2312] Make Raiden.stop() async, resolves when DB finished flushing
-- [#2297] Add logs when ignoring incoming transfers
 
 [#1707]: https://github.com/raiden-network/light-client/issues/1707
+[#2058]: https://github.com/raiden-network/light-client/issues/2058
 [#2240]: https://github.com/raiden-network/light-client/issues/2240
 [#2289]: https://github.com/raiden-network/light-client/pull/2289
 [#2297]: https://github.com/raiden-network/light-client/issues/2297

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -131,20 +131,36 @@ function makeAndSignTransfer$(
     'expiration too soon',
   );
 
-  // fee is added to the lock amount, check for overflow
-  const amountWithFee = decode(
-    UInt(32),
-    action.payload.value.add(fee),
-    'overflow of locked amount with fee',
-  );
+  // fee is added to the lock amount; overflow is checked on locksSum below
+  const amountWithFee = action.payload.value.add(fee) as UInt<32>;
+  const expiration = BigNumber.from(
+    action.payload.expiration ||
+      Math.min(
+        state.blockNumber + revealTimeout * 2,
+        state.blockNumber + channel.settleTimeout - confirmationBlocks,
+      ),
+  ) as UInt<32>;
+  assert(expiration.lte(state.blockNumber + channel.settleTimeout), [
+    'expiration too far in the future',
+    {
+      expiration: expiration.toString(),
+      blockNumber: state.blockNumber,
+      settleTimeout: channel.settleTimeout,
+      revealTimeout,
+    },
+  ]);
   const lock: Lock = {
     amount: amountWithFee,
-    expiration: BigNumber.from(
-      action.payload.expiration || state.blockNumber + revealTimeout * 2,
-    ) as UInt<32>,
+    expiration,
     secrethash: action.meta.secrethash,
   };
-  const locksroot = getLocksroot([...channel.own.locks, lock]);
+  const locks = [...channel.own.locks, lock];
+  const locksSum = totalLocked(locks);
+  assert(
+    UInt(32).is(channel.own.balanceProof.transferredAmount.add(locksSum)),
+    'overflow on future transferredAmount',
+  );
+  const locksroot = getLocksroot(locks);
 
   log.info(
     'Signing transfer of value',
@@ -168,7 +184,7 @@ function makeAndSignTransfer$(
     channel_identifier: BigNumber.from(channel.id) as UInt<32>,
     nonce: channel.own.nextNonce,
     transferred_amount: channel.own.balanceProof.transferredAmount,
-    locked_amount: channel.own.balanceProof.lockedAmount.add(lock.amount) as UInt<32>,
+    locked_amount: locksSum,
     locksroot,
     payment_identifier: action.payload.paymentId,
     token: channel.token,
@@ -269,9 +285,11 @@ function makeAndSignUnlock$(
       token_network_address: locked.token_network_address,
       channel_identifier: locked.channel_identifier,
       nonce: channel.own.nextNonce,
-      transferred_amount: channel.own.balanceProof.transferredAmount.add(
-        locked.lock.amount,
-      ) as UInt<32>,
+      transferred_amount: decode(
+        UInt(32),
+        channel.own.balanceProof.transferredAmount.add(locked.lock.amount),
+        'overflow on transferredAmount',
+      ),
       locked_amount: channel.own.balanceProof.lockedAmount.sub(locked.lock.amount) as UInt<32>,
       locksroot: getLocksroot(withoutLock(channel.own, secrethash)),
       payment_identifier: locked.payment_identifier,
@@ -467,14 +485,28 @@ function receiveTransferSigned(
         locked.transferred_amount.eq(channel.partner.balanceProof.transferredAmount),
         'transferredAmount mismatch',
       );
-      assert(locked.locked_amount.eq(totalLocked(locks)), 'lockedAmount mismatch');
+      const locksSum = totalLocked(locks);
+      assert(locked.locked_amount.eq(locksSum), 'lockedAmount mismatch');
+      assert(
+        UInt(32).is(channel.partner.balanceProof.transferredAmount.add(locksSum)),
+        'overflow on future transferredAmount',
+      );
 
       const { partnerCapacity } = channelAmounts(channel);
       assert(
         locked.lock.amount.lte(partnerCapacity),
         'balanceProof total amount bigger than capacity',
       );
-      // don't mind expiration, accept expired transfers to apply state change and stay in sync
+      assert(locked.lock.expiration.lte(state.blockNumber + channel.settleTimeout), [
+        'expiration too far in the future',
+        {
+          expiration: locked.lock.expiration.toString(),
+          blockNumber: state.blockNumber,
+          settleTimeout: channel.settleTimeout,
+          revealTimeout,
+        },
+      ]);
+      // accept expired transfers, to apply state change and stay in sync
       // with partner, so we can receive later LockExpired and transfers on top of it
 
       assert(locked.recipient === address, "Received transfer isn't for us");

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -124,15 +124,13 @@ function makeAndSignTransfer$(
 
   const tokenNetwork = action.payload.tokenNetwork;
   const channel = getOpenChannel(state, { tokenNetwork, partner });
+
   assert(
     !action.payload.expiration ||
       // require mediated transfers to have at least confirmationBlocks before danger zone
       action.payload.expiration >= state.blockNumber + revealTimeout + confirmationBlocks,
     'expiration too soon',
   );
-
-  // fee is added to the lock amount; overflow is checked on locksSum below
-  const amountWithFee = action.payload.value.add(fee) as UInt<32>;
   const expiration = BigNumber.from(
     action.payload.expiration ||
       Math.min(
@@ -150,7 +148,8 @@ function makeAndSignTransfer$(
     },
   ]);
   const lock: Lock = {
-    amount: amountWithFee,
+    // fee is added to the lock amount; overflow is checked on locksSum below
+    amount: action.payload.value.add(fee) as UInt<32>,
     expiration,
     secrethash: action.meta.secrethash,
   };

--- a/raiden-ts/tests/unit/epics/send.spec.ts
+++ b/raiden-ts/tests/unit/epics/send.spec.ts
@@ -138,7 +138,7 @@ describe('send transfer', () => {
     expect(raiden.output).toContainEqual(
       transfer.failure(
         expect.objectContaining({
-          message: expect.stringContaining('overflow of locked amount with fee'),
+          message: expect.stringContaining('overflow'),
         }),
         meta,
       ),


### PR DESCRIPTION
Fixes #2058 
Fixes #2059 
Fixes #2063 

**Short description**
Adds overflow checks when sending (and mediating) and receiving transfers. Also, require expirations to not be after settleTimeout blocks in the future, so they always expire before channel can get closed and settled.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
