### PR TITLE
Fix potential undesired handling of SecretReveal if transfer receiving is disabled

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -4,16 +4,20 @@
 ### Fixed
 - [#2240] Handle network problems when connecting to the Eth node gracefully
 - [#2312] Call WebRTC's connection.close() on teardown
+- [#2299] Don't acknowledge SecretReveals if receiving is disabled
 
 ### Changed
 - [#1707] Upgrade ethers to v5
 - [#2289] Switch to yarn from pnpm
 - [#2311] Bump NodeJS requirement to v14 LTS
 - [#2312] Make Raiden.stop() async, resolves when DB finished flushing
+- [#2297] Add logs when ignoring incoming transfers
 
 [#1707]: https://github.com/raiden-network/light-client/issues/1707
 [#2240]: https://github.com/raiden-network/light-client/issues/2240
 [#2289]: https://github.com/raiden-network/light-client/pull/2289
+[#2297]: https://github.com/raiden-network/light-client/issues/2297
+[#2299]: https://github.com/raiden-network/light-client/issues/2299
 [#2311]: https://github.com/raiden-network/light-client/issues/2311
 [#2312]: https://github.com/raiden-network/light-client/pull/2312
 

--- a/raiden-ts/src/transfers/epics/secret.ts
+++ b/raiden-ts/src/transfers/epics/secret.ts
@@ -193,11 +193,14 @@ export function transferSecretRevealEpic(
  *
  * @param action$ - Observable of RaidenActions
  * @param state$ - Observable of RaidenStates
+ * @param deps - Epics dependencies
+ * @param deps.config$ - Config observable
  * @returns Observable of output actions for this epic
  */
 export function transferSecretRevealedEpic(
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
+  { config$ }: RaidenEpicDeps,
 ): Observable<transferUnlock.request | transferSecret> {
   return action$.pipe(
     // we don't require Signed SecretReveal, nor even check sender for persisting the secret
@@ -235,6 +238,9 @@ export function transferSecretRevealedEpic(
         );
       }
     }),
+    // enable this epic only if/while/when receiving is enabled, to avoid being forced handling
+    // undesired reveals
+    takeIf(config$.pipe(map(({ caps }) => getCap(caps, Capabilities.RECEIVE)))),
   );
 }
 


### PR DESCRIPTION
Fixes #2297 
Fixes #2299 

**Short description**
If we had receiving disabled, upon receiving a transfer, we would simply not continue with the protocol by requesting the secret from initiator, **but** if a malicious actor wanted to trigger us to still receive a transfer (maybe to trigger us to waste SVT on monitoring or waste on on-chain secret registers), they could still Reveal to us (even without a request) and we would accept and continue with the protocol (unlock, etc). This PR fixes it by ensuring we don't handle reveals at all if receiving is disabled.
Also, we add proper logs in case we ignore a received transfer, so it's easier to debug why it got ignored.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
