### PR TITLE
Return 409 for failed transfers in payments API endpoint

### DIFF
--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- [#2314] Return proper error codes for transfer failures
+
+[#2314]: https://github.com/raiden-network/light-client/pull/2336
 
 ## [0.12.0] - 2020-10-22
 ### Changed

--- a/raiden-cli/src/routes/payments.ts
+++ b/raiden-cli/src/routes/payments.ts
@@ -8,6 +8,7 @@ import {
   isInvalidParameterError,
   validateOptionalAddressParameter,
   isInsuficientFundsError,
+  isTransferFailedError,
 } from '../utils/validation';
 
 export enum ApiPaymentEvent {
@@ -90,6 +91,8 @@ async function doTransfer(this: Cli, request: Request, response: Response, next:
       response.status(400).send(error.message);
     } else if (isInsuficientFundsError(error)) {
       response.status(402).send(error.message);
+    } else if (isTransferFailedError(error)) {
+      response.status(409).send(error.message);
     } else if (isConflictError(error)) {
       const pfsErrorDetail = error.details?.errors ? ` (${error.details.errors})` : '';
       response.status(409).json({ message: error.message, details: pfsErrorDetail });

--- a/raiden-cli/src/utils/validation.ts
+++ b/raiden-cli/src/utils/validation.ts
@@ -80,6 +80,23 @@ export function isTransactionWouldFailError(error: Error): boolean {
 }
 
 /**
+ * Checks if error is related to a failed transfer
+ *
+ * @param error - Error to test
+ * @returns True if error signals failed transfer
+ */
+export function isTransferFailedError(error: Error): boolean {
+  return [
+    ErrorCodes.XFER_ALREADY_COMPLETED,
+    ErrorCodes.XFER_CHANNEL_CLOSED_PREMATURELY,
+    ErrorCodes.XFER_EXPIRED,
+    ErrorCodes.XFER_INVALID_SECRETREQUEST,
+    ErrorCodes.XFER_REFUNDED,
+    ErrorCodes.XFER_REGISTERSECRET_TX_FAILED,
+  ].includes(error.message);
+}
+
+/**
  * @param error - Error to test
  * @returns True if error is a Conflict error
  */


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2314 

**Short description**

Those errors weren't handles gracefully and instead showed a internal server error (500).

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
