### PR TITLE
Handle Matrix 500 erros in `matrixMessageSend[Global]Epic`

### DIFF
--- a/raiden-ts/src/transport/epics/helpers.ts
+++ b/raiden-ts/src/transport/epics/helpers.ts
@@ -152,7 +152,7 @@ export function waitMemberAndSend$<C extends { msgtype: string; body: string }>(
         withLatestFrom(config$),
         mergeMap(([err, { pollingInterval }], count) => {
           // always retry rate-limit errors
-          if (count < RETRY_COUNT - 1 || err?.httpStatus === 429) {
+          if (count < RETRY_COUNT - 1 || [429, 500].includes(err?.httpStatus)) {
             log.warn(`messageSend error, retrying ${count + 1}/${RETRY_COUNT}`, err);
             return timer(pollingInterval);
           } else return throwError(err); // give up


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Part of #2314

**Short description**

Handle and retry matrix 500 errors and retry them.


**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
