### PR TITLE
dApp: Prolonged duration for snackbar

### DIFF
--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -30,8 +30,8 @@
     "backup-state": {
       "icon": "notification_state_backup",
       "title": "Backup State",
-      "description": "Backup state to not risk loosing funds",
-      "link": "Backup state menu"
+      "description": "Backup your state to not risk loosing funds",
+      "link": "Click here to go to the backup state menu"
     },
     "ms-balance-proof": {
       "title": "Balance proof submitted",

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -29,7 +29,7 @@
     "no-notifications": "No notifications",
     "backup-state": {
       "icon": "notification_state_backup",
-      "title": "Backup State",
+      "title": "Backup your state!",
       "description": "Backup your state to not risk loosing funds",
       "link": "Click here to go to the backup state menu"
     },

--- a/raiden-dapp/src/views/TransferRoute.vue
+++ b/raiden-dapp/src/views/TransferRoute.vue
@@ -14,17 +14,17 @@
 import { Component, Vue } from 'vue-property-decorator';
 import { mapState, mapGetters } from 'vuex';
 import { BigNumber, constants } from 'ethers';
-import { NotificationPayload } from '../store/notifications/types';
-import { NotificationImportance } from '../store/notifications/notification-importance';
 import { NotificationContext } from '../store/notifications/notification-context';
+import { NotificationImportance } from '../store/notifications/notification-importance';
+import { NotificationPayload } from '../store/notifications/types';
 import TransferHeaders from '@/components/transfer/TransferHeaders.vue';
 import TransferInputs from '@/components/transfer/TransferInputs.vue';
 import TransactionList from '@/components/transaction-history/TransactionList.vue';
 import NoTokens from '@/components/NoTokens.vue';
 import NoChannelsDialog from '@/components/dialogs/NoChannelsDialog.vue';
-import { RaidenChannel } from 'raiden-ts';
 import { RouteNames } from '@/router/route-names';
 import { Token, TokenModel } from '@/model/types';
+import { RaidenChannel } from 'raiden-ts';
 
 const ONE_DAY = new Date(0).setUTCHours(24);
 
@@ -64,6 +64,7 @@ export default class TransferRoute extends Vue {
       link: this.$t('notifications.backup-state.link') as string,
       dappRoute: RouteNames.ACCOUNT_BACKUP,
       description: this.$t('notifications.backup-state.description') as string,
+      duration: 60000,
       importance: NotificationImportance.HIGH,
       context: NotificationContext.WARNING,
     } as NotificationPayload;


### PR DESCRIPTION
Fixes #2178 

**Short description**
Adds a duration of 60 seconds to backup state notification snackar as discussed with @christianbrb .

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to the dApp with an empty local storage to trigger the backup state notification.