### PR TITLE
Feature/dapp handle notification confirmation state

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -12,9 +12,12 @@
 
 ### Changed
 
+- [#2334] Blockchain related notifications handle confirmation status updates
+
 [#2178]: https://github.com/raiden-network/light-client/issues/2178
 [#2285]: https://github.com/raiden-network/light-client/issues/2285
 [#2274]: https://github.com/raiden-network/light-client/issues/2274
+[#2334]: https://github.com/raiden-network/light-client/issues/2334
 
 ## [0.12.0] - 2020-10-22
 

--- a/raiden-dapp/src/components/notification-panel/NotificationCard.vue
+++ b/raiden-dapp/src/components/notification-panel/NotificationCard.vue
@@ -13,15 +13,12 @@
           :description="notification.description"
         />
         <div
-          v-if="notification.txConfirmationBlock"
+          v-if="showConfirmationCounter"
           class="notification-card__content__details__block-count"
         >
-          <span v-if="blockCountInProgress">
+          <span>
             {{ $t('notifications.block-count-progress') }}
-            {{ notification.txConfirmationBlock - blockNumber }}
-          </span>
-          <span v-else>
-            {{ $t('notifications.channel-open.success.block-count-success') }}
+            {{ blocksUntilTxConfirmation }}
           </span>
         </div>
         <span
@@ -66,20 +63,23 @@ const { mapMutations } = createNamespacedHelpers('notifications');
   },
 })
 export default class NotificationCard extends Vue {
-  notificationDelete!: (id: number) => void;
   blockNumber!: number;
+  notificationDelete!: (id: number) => void;
 
   @Prop({ required: true })
   notification!: NotificationPayload;
 
-  get blockCountInProgress(): boolean {
-    if (this.notification.txConfirmationBlock) {
-      return (
-        !this.notification.txConfirmed && this.notification.txConfirmationBlock > this.blockNumber
-      );
-    } else {
-      return false;
+  get blocksUntilTxConfirmation(): number | undefined {
+    const { txConfirmationBlock } = this.notification;
+
+    if (txConfirmationBlock) {
+      return txConfirmationBlock - this.blockNumber;
     }
+    // Else notification is not related to a blockchain transaction
+  }
+
+  get showConfirmationCounter(): boolean {
+    return this.blocksUntilTxConfirmation !== undefined && this.blocksUntilTxConfirmation > 0;
   }
 
   linkRoute() {

--- a/raiden-dapp/src/components/notification-panel/NotificationDescriptionDisplay.vue
+++ b/raiden-dapp/src/components/notification-panel/NotificationDescriptionDisplay.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Prop, Watch, Vue } from 'vue-property-decorator';
 import AddressDisplay from '@/components/AddressDisplay.vue';
 
 @Component({
@@ -27,12 +27,13 @@ export default class NotificationDescriptionDisplay extends Vue {
   @Prop({ required: true })
   description!: string;
 
-  isAddress(address: string): boolean {
-    return this.addressRegEx.test(address);
+  @Watch('description', { immediate: true })
+  updateSplitDescription(newDescription: string): void {
+    this.splitDescription = newDescription.split(this.addressRegEx);
   }
 
-  mounted() {
-    this.splitDescription = this.description.split(this.addressRegEx);
+  isAddress(address: string): boolean {
+    return this.addressRegEx.test(address);
   }
 }
 </script>

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -27,6 +27,11 @@
   },
   "notifications": {
     "no-notifications": "No notifications",
+    "clear": "Clear",
+    "block-count-progress": "Blocks until confirmation: ",
+    "tx-reorged-failure-reason": "The transaction could not get confirmed due to a reorg of the blockchain!",
+    "tx-state-confirmed": "confirmed",
+    "tx-state-pending": "not confirmed yet",
     "backup-state": {
       "icon": "notification_state_backup",
       "title": "Backup your state!",
@@ -56,8 +61,6 @@
         }
       }
     },
-    "clear": "Clear",
-    "block-count-progress": "Blocks remaining: ",
     "settlement": {
       "icon": "notification_settle",
       "success": {
@@ -73,11 +76,11 @@
       "icon": "notification_channels",
       "success": {
         "title": "Channel Open",
-        "description": "Open channel with {partner}.",
-        "block-count-success": "Channel successfully opened"
+        "description": "Open channel with {partner} is {state}."
       },
       "failure": {
-        "title": "Channel Open Failure"
+        "title": "Channel Open Failure",
+        "description": "{reason}"
       }
     }
   },

--- a/raiden-dapp/src/store/notifications/mutations.ts
+++ b/raiden-dapp/src/store/notifications/mutations.ts
@@ -1,4 +1,5 @@
 import { MutationTree } from 'vuex';
+import { NotificationImportance } from './notification-importance';
 import { NotificationContext } from './notification-context';
 import {
   NotificationPayload,
@@ -34,6 +35,7 @@ export const mutations: MutationTree<NotificationsState> = {
       received: new Date(),
       display,
       context: payload.context ?? NotificationContext.NONE,
+      importance: payload.importance ?? NotificationImportance.LOW,
       duration: payload.duration ?? 5000,
     };
 

--- a/raiden-dapp/src/store/notifications/types.d.ts
+++ b/raiden-dapp/src/store/notifications/types.d.ts
@@ -15,7 +15,6 @@ export interface NotificationPayload {
   readonly received: Date;
   readonly txConfirmationBlock?: number;
   readonly txHash?: string;
-  readonly txConfirmed?: boolean;
   display: boolean;
 }
 

--- a/raiden-dapp/tests/unit/data/mock-data.ts
+++ b/raiden-dapp/tests/unit/data/mock-data.ts
@@ -178,6 +178,5 @@ export class TestData {
     received: new Date('June 5, 1986'),
     txConfirmationBlock: 123,
     txHash: '0xTxHash',
-    txConfirmed: undefined,
   };
 }

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -954,27 +954,52 @@ describe('RaidenService', () => {
 
     expect(store.commit).toHaveBeenCalledWith('notifications/notificationAddOrReplace', {
       title: 'notifications.channel-open.failure.title',
-      description: 'error message',
+      description: 'notifications.channel-open.failure.description',
       icon: 'notifications.channel-open.icon',
-      context: NotificationContext.NONE,
       importance: NotificationImportance.HIGH,
     });
   });
 
-  test('notify that channel open success', async () => {
+  test('notify that channel open succeed with state pending', async () => {
     expect.assertions(1);
     const subject = new BehaviorSubject({});
     (raiden as any).events$ = subject;
     await setupSDK();
-    (store.getters as any) = {
-      udcToken: {},
-    };
+    (store.state as any) = { config: { confirmationBlocks: 5 } };
     subject.next({
       type: 'channel/open/success',
       payload: {
         id: 0,
         txHash: '0xTxHash',
-        txBlock: '0TxBlock',
+        txBlock: 0,
+        confirmed: undefined,
+      },
+      meta: { tokenNetwork: '0xTokenNetwork', partner: '0xPartner' },
+    });
+    await flushPromises();
+
+    expect(store.commit).toHaveBeenCalledWith('notifications/notificationAddOrReplace', {
+      title: 'notifications.channel-open.success.title',
+      description: 'notifications.channel-open.success.description',
+      icon: 'notifications.channel-open.icon',
+      txHash: '0xTxHash',
+      txConfirmationBlock: 5,
+      importance: NotificationImportance.HIGH,
+    });
+  });
+
+  test('notify that channel open succeed with state confirmed', async () => {
+    expect.assertions(1);
+    const subject = new BehaviorSubject({});
+    (raiden as any).events$ = subject;
+    await setupSDK();
+    (store.state as any) = { config: { confirmationBlocks: 5 } };
+    subject.next({
+      type: 'channel/open/success',
+      payload: {
+        id: 0,
+        txHash: '0xTxHash',
+        txBlock: 0,
         confirmed: true,
       },
       meta: { tokenNetwork: '0xTokenNetwork', partner: '0xPartner' },
@@ -984,11 +1009,36 @@ describe('RaidenService', () => {
       title: 'notifications.channel-open.success.title',
       description: 'notifications.channel-open.success.description',
       icon: 'notifications.channel-open.icon',
-      context: NotificationContext.NONE,
-      importance: NotificationImportance.HIGH,
-      txConfirmationBlock: 0,
       txHash: '0xTxHash',
-      txConfirmed: true,
+      txConfirmationBlock: 5,
+      importance: NotificationImportance.HIGH,
+    });
+  });
+
+  test('notify that channel open failed when confirmation is false', async () => {
+    expect.assertions(1);
+    const subject = new BehaviorSubject({});
+    (raiden as any).events$ = subject;
+    await setupSDK();
+    (store.state as any) = { config: { confirmationBlocks: 5 } };
+    subject.next({
+      type: 'channel/open/success',
+      payload: {
+        id: 0,
+        txHash: '0xTxHash',
+        txBlock: 0,
+        confirmed: false,
+      },
+      meta: { tokenNetwork: '0xTokenNetwork', partner: '0xPartner' },
+    });
+
+    expect(store.commit).toHaveBeenCalledWith('notifications/notificationAddOrReplace', {
+      title: 'notifications.channel-open.failure.title',
+      description: 'notifications.channel-open.failure.description',
+      icon: 'notifications.channel-open.icon',
+      txHash: '0xTxHash',
+      txConfirmationBlock: 5,
+      importance: NotificationImportance.HIGH,
     });
   });
 });

--- a/raiden-dapp/tests/unit/store/notifications/mutations.spec.ts
+++ b/raiden-dapp/tests/unit/store/notifications/mutations.spec.ts
@@ -1,22 +1,34 @@
-import { TestData } from '../../data/mock-data';
+import { generateNotificationPayload } from '../../utils/data-generator';
 import { mutations } from '@/store/notifications/mutations';
-import { NotificationPayload, NotificationsState } from '@/store/notifications/types';
+import { NotificationsState } from '@/store/notifications/types';
+import { NotificationContext } from '@/store/notifications/notification-context';
+import { NotificationImportance } from '@/store/notifications/notification-importance';
+
+const notificationIdentifier = 1;
+const notificationPayload = generateNotificationPayload();
+
+function createNotificationState(
+  newNotifications = false,
+  baseNotificationPayload = notificationPayload,
+): NotificationsState {
+  return {
+    notifications: {
+      [notificationIdentifier]: {
+        ...baseNotificationPayload,
+        id: notificationIdentifier,
+        display: true,
+      },
+    },
+    newNotifications,
+  };
+}
 
 describe('notifications store mutations', () => {
-  const notification = TestData.notifications;
-
-  const createNotificationState = (newNotifications = false): NotificationsState => {
-    return {
-      notifications: { 1: notification },
-      newNotifications,
-    };
-  };
-
   test('can delete notification', () => {
     const state = createNotificationState();
-    const id = notification.id;
 
-    mutations.notificationDelete(state, id);
+    mutations.notificationDelete(state, notificationIdentifier);
+
     expect(state.notifications).toMatchObject({});
   });
 
@@ -25,36 +37,92 @@ describe('notifications store mutations', () => {
     expect(state.newNotifications).toBe(true);
 
     mutations.notificationsViewed(state);
+
     expect(state.newNotifications).toBe(false);
   });
 
   test('can add new notifications', () => {
     const state = createNotificationState();
-    const newNotification: NotificationPayload = {
-      ...notification,
-      txHash: '0xNewTxHash',
-    };
+    const newNotificationPayload = generateNotificationPayload();
 
-    mutations.notificationAddOrReplace(state, newNotification);
+    expect(Object.keys(state.notifications).length).toBe(1);
+
+    mutations.notificationAddOrReplace(state, newNotificationPayload);
+
     expect(Object.keys(state.notifications).length).toBe(2);
     expect(state.notifications).toMatchObject({ 1: { id: 1 }, 2: { id: 2 } });
   });
 
-  test('can update notifications', () => {
+  test('can add new notifications which gets received date set automatically', () => {
     const state = createNotificationState();
-    const updatedNotification: NotificationPayload = {
-      ...notification,
-      txConfirmationBlock: 1234,
-    };
+    const newNotificationPayload = generateNotificationPayload();
 
-    mutations.notificationAddOrReplace(state, notification);
-    expect(state.notifications).toMatchObject({
-      1: { txConfirmationBlock: 123 },
+    expect(newNotificationPayload.received).toBeUndefined();
+
+    mutations.notificationAddOrReplace(state, newNotificationPayload);
+
+    const addedNotification = state.notifications[2];
+    expect(addedNotification.received).not.toBeUndefined();
+  });
+
+  test('can add new notification with automatic defaults', () => {
+    const state = createNotificationState();
+    const newNotificationPayload = generateNotificationPayload();
+
+    expect(newNotificationPayload.context).toBeUndefined();
+    expect(newNotificationPayload.importance).toBeUndefined();
+    expect(newNotificationPayload.duration).toBeUndefined();
+
+    mutations.notificationAddOrReplace(state, newNotificationPayload);
+
+    const addedNotification = state.notifications[2];
+    expect(addedNotification.context).toBe(NotificationContext.NONE);
+    expect(addedNotification.importance).toBe(NotificationImportance.LOW);
+    expect(addedNotification.duration).toBe(5000);
+  });
+
+  test('can add new notification with overwritten defaults', () => {
+    const state = createNotificationState();
+    const newNotificationPayload = generateNotificationPayload({
+      context: NotificationContext.INFO,
+      importance: NotificationImportance.HIGH,
+      duration: 100000,
     });
 
-    mutations.notificationAddOrReplace(state, updatedNotification);
-    expect(state.notifications).toMatchObject({
-      1: { txConfirmationBlock: 1234 },
-    });
+    mutations.notificationAddOrReplace(state, newNotificationPayload);
+
+    const addedNotification = state.notifications[2];
+    expect(addedNotification.context).toBe(NotificationContext.INFO);
+    expect(addedNotification.importance).toBe(NotificationImportance.HIGH);
+    expect(addedNotification.duration).toBe(100000);
+  });
+
+  test('can update notification with same transaction hash', () => {
+    const txHash = 'txHash';
+    const notificationPayloadWithTxHash = { ...notificationPayload, txHash };
+    const state = createNotificationState(undefined, notificationPayloadWithTxHash);
+
+    expect(Object.keys(state.notifications).length).toBe(1);
+    expect(state.notifications[notificationIdentifier].display).toBe(true);
+    expect(state.notifications[notificationIdentifier].title).toBe(
+      notificationPayloadWithTxHash.title,
+    );
+
+    const updatedNotificationPayload = { ...notificationPayloadWithTxHash, title: 'New Title' };
+    mutations.notificationAddOrReplace(state, updatedNotificationPayload);
+
+    expect(Object.keys(state.notifications).length).toBe(1);
+    expect(state.notifications[notificationIdentifier].display).toBe(false);
+    expect(state.notifications[notificationIdentifier].title).toBe('New Title');
+  });
+
+  test('can clear all notifications', () => {
+    const state = createNotificationState();
+
+    expect(Object.keys(state.notifications).length).toBe(1);
+
+    mutations.clear(state);
+
+    expect(Object.keys(state.notifications).length).toBe(0);
   });
 });

--- a/raiden-dapp/tests/unit/utils/data-generator.ts
+++ b/raiden-dapp/tests/unit/utils/data-generator.ts
@@ -2,6 +2,7 @@ import times from 'lodash/times';
 import { BigNumber, constants } from 'ethers';
 import { RaidenTransfer, Address, RaidenChannel, ChannelState } from 'raiden-ts';
 import { Token } from '@/model/types';
+import { NotificationPayload } from '@/store/notifications/types';
 
 const HEXADECIMAL_CHARACTERS = '0123456789abcdefABCDEF';
 const ALPHABET_CHARACTERS = 'abcdefghijklmnopqrstuvwxyz';
@@ -81,7 +82,7 @@ export function generateTransfer(
  * @returns RaidenChannel mocked object
  */
 export function generateChannel(
-  partialChannel: Partial<RaidenChannel>,
+  partialChannel: Partial<RaidenChannel> = {},
   token?: Token,
 ): RaidenChannel {
   return {
@@ -99,4 +100,18 @@ export function generateChannel(
     ownWithdrawable: BigNumber.from(10 ** 8),
     ...partialChannel,
   } as RaidenChannel;
+}
+
+/**
+ * @param partialPayload - NotificationPayload overrides
+ * @returns NotificationPayload mocked object
+ */
+export function generateNotificationPayload(
+  partialPayload: Partial<NotificationPayload> = {},
+): NotificationPayload {
+  return {
+    title: 'Test Nofication',
+    description: 'Used for unit tests',
+    ...partialPayload,
+  } as NotificationPayload;
 }


### PR DESCRIPTION
Fixes #2334

**Short description**
I'm not too happy with the implementation. I'm not sure if it is related to the in general RaidenService notification pushing code or.... I'm open to change everything.

Please give me feedback if this PR should continue and extend the other notifications that are blockchain related. We haven't done it at all for now, also not for the recent features.

**Definition of Done**

- [X] Steps to manually test the change have been documented
- [X] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Open a new channel
2. Open right away (ignore loading pop-up) to the notifications
3. Observe the counter and description of the notification

There is no easy way to test a real blockchain reorg scenario...
