### PR TITLE
Handle JSON wallets with trimmed IVs

### DIFF
--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## [Unreleased]
 ### Fixed
 - [#2314] Return proper error codes for transfer failures
+- [#2344] Handle JSON wallets with trimmed IVs
 
 [#2314]: https://github.com/raiden-network/light-client/pull/2336
+[#2344]: https://github.com/raiden-network/light-client/issues/2336
 
 ## [0.12.0] - 2020-10-22
 ### Changed


### PR DESCRIPTION
Fixes #2344 

**Short description**
SP has the bad habit of stripping leading zeroes from JSON encrypted wallet's IVs, which caused trouble when `aes-js` expected it to strictly have 16-bytes. This PR handles this specific error by padding it to the expected size and retrying decrypting the file.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
