### PR TITLE
dApp: Customizable privacy policy

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Fixed
+
+### Added
+
+- [#1693] Customizable privacy policy
+
+### Changed
+
+[#1693]: https://github.com/raiden-network/light-client/issues/1693
+
 ## [0.13.0] - 2020-11-10
 
 ### Fixed

--- a/raiden-dapp/src/App.vue
+++ b/raiden-dapp/src/App.vue
@@ -14,8 +14,8 @@
         </v-main>
       </div>
     </div>
-    <div class="policy">
-      <a href="https://raiden.network/privacy.html" target="_blank">
+    <div v-if="imprint" class="policy">
+      <a :href="imprint" target="_blank">
         {{ $t('application.privacy-policy') }}
       </a>
     </div>
@@ -42,6 +42,10 @@ import NotificationSnackbar from '@/components/notification-panel/NotificationSn
   },
 })
 export default class App extends Mixins(NavigationMixin) {
+  get imprint(): string | undefined {
+    return process.env.VUE_APP_IMPRINT;
+  }
+
   destroyed() {
     this.$raiden.disconnect();
   }

--- a/raiden-dapp/tests/unit/app.spec.ts
+++ b/raiden-dapp/tests/unit/app.spec.ts
@@ -6,47 +6,63 @@ import Vue from 'vue';
 import VueRouter from 'vue-router';
 import Vuex from 'vuex';
 import Vuetify from 'vuetify';
-import Mocked = jest.Mocked;
 import store from '@/store/index';
 import RaidenService from '@/services/raiden-service';
 import App from '@/App.vue';
+import Mocked = jest.Mocked;
 
 Vue.use(VueRouter);
 Vue.use(Vuex);
 Vue.use(Vuetify);
 
-describe('App.vue', () => {
-  let wrapper: Wrapper<App>;
-  let vuetify: Vuetify;
-  let router: Mocked<VueRouter>;
-  let $raiden: RaidenService;
+let vuetify: Vuetify;
+let router: Mocked<VueRouter>;
+let $raiden: RaidenService;
 
-  beforeEach(() => {
-    vuetify = new Vuetify();
-    router = new VueRouter() as Mocked<VueRouter>;
-    router.push = jest.fn().mockResolvedValue(null);
-    $raiden = new RaidenService(store);
-    $raiden.disconnect = jest.fn();
+const createWrapper = (imprint: string): Wrapper<App> => {
+  if (imprint) {
+    process.env.VUE_APP_IMPRINT = imprint;
+  } else {
+    delete process.env.VUE_APP_IMPRINT;
+  }
 
-    wrapper = shallowMount(App, {
-      vuetify,
-      store,
-      stubs: ['router-view', 'v-dialog'],
-      mocks: {
-        $router: router,
-        $raiden: $raiden,
-        $t: (msg: string) => msg,
-      },
-    });
+  vuetify = new Vuetify();
+  router = new VueRouter() as Mocked<VueRouter>;
+  router.push = jest.fn().mockResolvedValue(null);
+  $raiden = new RaidenService(store);
+  $raiden.disconnect = jest.fn();
+
+  return shallowMount(App, {
+    vuetify,
+    store,
+    stubs: ['router-view', 'v-dialog'],
+    mocks: {
+      $router: router,
+      $raiden: $raiden,
+      $t: (msg: string) => msg,
+    },
   });
+};
 
-  test('displays privacy policy', () => {
+describe('App.vue', () => {
+  test('displays privacy policy if imprint env variable is set', () => {
+    const wrapper = createWrapper('https://custom-imprint.test');
     const privacyPolicy = wrapper.find('.policy');
+    const privacyPolicyUrl = privacyPolicy.find('a').attributes().href;
 
     expect(privacyPolicy.text()).toBe('application.privacy-policy');
+    expect(privacyPolicyUrl).toBe('https://custom-imprint.test');
+  });
+
+  test('does not display privacy policy if imprint env variable is not set', () => {
+    const wrapper = createWrapper('');
+    const privacyPolicy = wrapper.find('.policy');
+
+    expect(privacyPolicy.exists()).toBe(false);
   });
 
   test('disconnects on destruction', () => {
+    const wrapper = createWrapper('');
     wrapper.vm.$destroy();
 
     expect($raiden.disconnect).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Fixes #1693 

**Short description**
Allows for custom privacy policy to be added by setting the `VUE_APP_IMPRINT` env variable to any url.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Set env variable to see privacy policy in footer. By default nothing is displayed.
