### PR TITLE
sdk: Don't close webRTC connection

### DIFF
--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -412,7 +412,8 @@ function listenDataChannel(
         ).pipe(
           finalize(() => {
             dataChannel.close();
-            connection.close();
+            // FIXME: https://github.com/node-webrtc/node-webrtc/issues/636
+            // connection.close();
           }),
         ),
       ),


### PR DESCRIPTION
Fixes # 

**Short description**

The teardown of the connection still doesn't work properly and
introduces scenario failures when nodes shut down.

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
