### PR TITLE
Workaround wrtc segfault on teardown by exiting after stop resolves

### DIFF
--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- [#2361] Workaround wrtc segfault on teardown
+
+[#2361]: https://github.com/raiden-network/light-client/issues/2361
 
 ## [0.13.0] - 2020-11-10
 ### Fixed

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -418,6 +418,7 @@ export class Raiden {
       'raiden-ts': Raiden.version,
       'raiden-contracts': Raiden.contractVersion,
       config: this.config,
+      versions: process?.versions,
     });
 
     // Set `epicMiddleware` to `null`, this indicates the instance is not running.

--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -411,7 +411,6 @@ function listenDataChannel(
           ),
         ).pipe(
           finalize(() => {
-            dataChannel.close();
             connection.close();
           }),
         ),

--- a/raiden-ts/tests/integration/raiden.spec.ts
+++ b/raiden-ts/tests/integration/raiden.spec.ts
@@ -586,7 +586,10 @@ describe('Raiden', () => {
       ).resolves.toMatchObject({
         // test edge case 1: channel closed at stop block is picked up correctly
         [token]: {
-          [partner]: { state: ChannelState.closed, closeBlock },
+          [partner]: {
+            state: expect.toBeOneOf([ChannelState.closed, ChannelState.settleable]),
+            closeBlock,
+          },
         },
         // test edge case 2: channel opened at restart block is picked up correctly
         [newToken]: { [partner]: { state: ChannelState.open, openBlock: restartBlock } },


### PR DESCRIPTION
Fixes #2361

**Short description**
On NodeJS 14+, fortunately, the process does not segfault on closing connection, so we can keep it (as it's correct), but does on teardown due to a double-free. The workaround is to force-exit the process when shutting down after stop resolves (db flushes), but before it tries to teardown on its own (which still causes the segfault).

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (CLI)**

1. Run 2 nodes connected to each other
2. Wait for the RTC connection to be established
3. Tells one of them to shutdown (either via SIGINT/SIGTERM or `POST /api/v1/shutdown`)
4. Check process exits cleanly, as well as partner after telling it to shutdown.
