### PR TITLE
Shut down if database is deleted

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- [#2360] Properly error & shutdown if database gets deleted at runtime
+
+[#2360]: https://github.com/raiden-network/light-client/issues/2360
 
 ## [0.13.0] - 2020-11-10
 ### Fixed

--- a/raiden-ts/src/db/types.ts
+++ b/raiden-ts/src/db/types.ts
@@ -34,6 +34,7 @@ export interface RaidenDatabaseMeta {
 
 export type RaidenDatabaseOptions = {
   log?: logging.Logger;
+  versionchanged?: boolean;
 } & (
   | PouchDB.Configuration.LocalDatabaseConfiguration
   | PouchDB.Configuration.RemoteDatabaseConfiguration
@@ -43,6 +44,7 @@ export interface RaidenDatabase extends PouchDB.Database {
   storageKeys: Set<string>;
   busy$: BehaviorSubject<boolean>;
   constructor: RaidenDatabaseConstructor;
+  __opts: RaidenDatabaseOptions;
 }
 
 export type RaidenDatabaseConstructor = (new (

--- a/raiden-ts/src/errors.json
+++ b/raiden-ts/src/errors.json
@@ -71,6 +71,7 @@
   "RDN_INVALID_SECRETHASH": "Invalid provided secrethash.",
   "RDN_SECRET_SECRETHASH_MISMATCH": "Provided secrethash must match the sha256 hash of provided secret.",
   "RDN_UNKNOWN_TRANSFER": "Unknown transfer.",
+  "RDN_DATABASE_DELETED": "Database deleted!",
 
   "DTA_NEGATIVE_NUMBER": "Encountered negative number while encoding to HEX string.",
   "DTA_NUMBER_TOO_LARGE": "Encountered a number that is too large to be encoded.",

--- a/raiden-ts/src/global.d.ts
+++ b/raiden-ts/src/global.d.ts
@@ -13,5 +13,6 @@ declare module 'abort-controller/polyfill';
 declare module 'wrtc'; // types provided by @types/webrtc
 
 declare module 'pouchdb-adapter-indexeddb';
+declare module 'pouchdb-debug';
 
 declare type Mutable<T> = { -readonly [P in keyof T]: T[P] };


### PR DESCRIPTION
Fixes #2360 

**Short description**
Improved by https://github.com/pouchdb/pouchdb/pull/8230 , but should already be mergeable before that.

So far, `persister` errors were just logged and ignored. This PR handles it, and properly shuts down the SDK if they happen, since they aren't expected. Also, it checks properly that the database version didn't change and errors if so, which is one indicator that the database got deleted. The linked upstream PR should also throw on the async `db.info()` call, ensuring the state machine doesn't proceed if state got cleared.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

0. Install linked PR as dependency
1. Run a new dApp, see its state be created
2. While dApp is connected, clear state
3. See SDK shutdown on next state change attempt
