### PR TITLE
Fix Raiden Account tokens not showing up for withdrawal

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+- [#2376] Fix Raiden Account tokens not showing up for withdrawal
 
 ### Added
 
@@ -16,8 +17,9 @@
 
 [#1693]: https://github.com/raiden-network/light-client/issues/1693
 [#2308]: https://github.com/raiden-network/light-client/issues/2308
-[#2369]: https://github.com/raiden-network/light-client/issues/2369
 [#2307]: https://github.com/raiden-network/light-client/issues/2307
+[#2369]: https://github.com/raiden-network/light-client/issues/2369
+[#2376]: https://github.com/raiden-network/light-client/issues/2376
 
 ## [0.13.0] - 2020-11-10
 

--- a/raiden-dapp/src/components/account/Withdrawal.vue
+++ b/raiden-dapp/src/components/account/Withdrawal.vue
@@ -151,6 +151,7 @@ export default class Withdrawal extends Mixins(BlockieMixin, NavigationMixin) {
   withdraw: Token | null = null;
 
   async mounted() {
+    await this.$raiden.fetchAndUpdateTokenData();
     const allTokens = uniqBy(this.allTokens.concat(this.udcToken), (token) => token.address);
     const updatedTokenBalances = await Promise.all(
       allTokens.map(async (token) => ({

--- a/raiden-dapp/src/components/dialogs/ChannelDepositDialog.vue
+++ b/raiden-dapp/src/components/dialogs/ChannelDepositDialog.vue
@@ -111,8 +111,9 @@ export default class ChannelDepositDialog extends Vue {
     this.updateDeposit();
   }
 
-  private updateDeposit() {
+  private async updateDeposit() {
     this.deposit = (this.token.decimals ?? 18) === 0 ? '0' : '0.0';
+    await this.$raiden.fetchAndUpdateTokenData([this.token.address]);
   }
 
   @Emit()

--- a/raiden-dapp/src/components/dialogs/ChannelWithdrawDialog.vue
+++ b/raiden-dapp/src/components/dialogs/ChannelWithdrawDialog.vue
@@ -114,8 +114,9 @@ export default class ChannelWithdrawDialog extends Vue {
     this.updateWithdraw();
   }
 
-  private updateWithdraw() {
+  private async updateWithdraw() {
     this.withdraw = (this.token.decimals ?? 18) === 0 ? '0' : '0.0';
+    await this.$raiden.fetchAndUpdateTokenData([this.token.address]);
   }
 
   @Emit()

--- a/raiden-dapp/src/components/dialogs/MintDialog.vue
+++ b/raiden-dapp/src/components/dialogs/MintDialog.vue
@@ -52,6 +52,10 @@ export default class MintDialog extends Vue {
   error: Error | RaidenError | null = null;
   amount = '1';
 
+  async mount() {
+    await this.$raiden.fetchAndUpdateTokenData([this.token.address]);
+  }
+
   @Emit()
   cancel() {
     this.error = null;

--- a/raiden-dapp/src/components/tokens/TokenList.vue
+++ b/raiden-dapp/src/components/tokens/TokenList.vue
@@ -28,6 +28,10 @@ export default class TokenList extends Vue {
   forwardTokenSelection(token: Token): Token {
     return token;
   }
+
+  async mounted() {
+    await this.$raiden.fetchAndUpdateTokenData();
+  }
 }
 </script>
 

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -44,7 +44,6 @@ const _defaultState: RootState = {
   accessDenied: DeniedReason.UNDEFINED,
   channels: {},
   tokens: {},
-  tokenAddresses: [],
   transfers: {},
   presences: {},
   network: PlaceHolderNetwork,
@@ -131,9 +130,6 @@ const store: StoreOptions<CombinedStoreState> = {
           state.tokens[address] = { ...state.tokens[address], ...token };
         else state.tokens = { ...state.tokens, [address]: token };
     },
-    updateTokenAddresses(state: RootState, addresses: string[]) {
-      state.tokenAddresses = [...addresses];
-    },
     updatePresence(state: RootState, presence: Presences) {
       state.presences = { ...state.presences, ...presence };
     },
@@ -196,14 +192,12 @@ const store: StoreOptions<CombinedStoreState> = {
       );
     },
     allTokens: (state: RootState): Token[] =>
-      Object.values(state.tokens)
-        .filter((token) => state.tokenAddresses.includes(token.address))
-        .sort((a: Token, b: Token) => {
-          if (hasNonZeroBalance(a, b)) {
-            return (b.balance! as BigNumber).gt(a.balance! as BigNumber) ? 1 : -1;
-          }
-          return a.symbol && b.symbol ? a.symbol.localeCompare(b.symbol) : 0;
-        }),
+      Object.values(state.tokens).sort((a: Token, b: Token) => {
+        if (hasNonZeroBalance(a, b)) {
+          return (b.balance! as BigNumber).gt(a.balance! as BigNumber) ? 1 : -1;
+        }
+        return a.symbol && b.symbol ? a.symbol.localeCompare(b.symbol) : 0;
+      }),
     channels: (state: RootState) => (tokenAddress: string) => {
       let channels: RaidenChannel[] = [];
       const tokenChannels = state.channels[tokenAddress];

--- a/raiden-dapp/src/types.d.ts
+++ b/raiden-dapp/src/types.d.ts
@@ -20,7 +20,6 @@ export interface RootState {
   accessDenied: DeniedReason;
   channels: RaidenChannels;
   tokens: Tokens;
-  tokenAddresses: string[];
   network: providers.Network;
   presences: Presences;
   transfers: Transfers;

--- a/raiden-dapp/tests/unit/components/account/withdrawal.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/withdrawal.spec.ts
@@ -28,6 +28,7 @@ function createWrapper(
   $raiden = {
     getTokenBalance: jest.fn().mockResolvedValue(tokenBalance),
     transferOnChainTokens: jest.fn(),
+    fetchAndUpdateTokenData: jest.fn().mockResolvedValue(undefined),
   };
 
   const state = {

--- a/raiden-dapp/tests/unit/components/channels/channels-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/channels/channels-dialog.spec.ts
@@ -29,6 +29,7 @@ describe('ChannelDialogs.vue', () => {
   function createWrapper() {
     vuetify = new Vuetify();
     $raiden = new RaidenService(store) as Mocked<RaidenService>;
+    $raiden.fetchAndUpdateTokenData = jest.fn();
     return mount(ChannelDialogs, {
       vuetify,
       store,

--- a/raiden-dapp/tests/unit/components/dialogs/channel-deposit-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/dialogs/channel-deposit-dialog.spec.ts
@@ -27,6 +27,9 @@ describe('ChannelDeposit.vue', () => {
       stubs: ['raiden-dialog'],
       mocks: {
         $t: (msg: string) => msg,
+        $raiden: {
+          fetchAndUpdateTokenData: jest.fn(),
+        },
       },
     });
   });

--- a/raiden-dapp/tests/unit/components/dialogs/channel-withdraw-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/dialogs/channel-withdraw-dialog.spec.ts
@@ -28,6 +28,9 @@ describe('ChannelWithdraw.vue', () => {
       stubs: ['raiden-dialog'],
       mocks: {
         $t: (msg: string) => msg,
+        $raiden: {
+          fetchAndUpdateTokenData: jest.fn(),
+        },
       },
     });
   });

--- a/raiden-dapp/tests/unit/components/notification-panel/notification-card.spec.ts
+++ b/raiden-dapp/tests/unit/components/notification-panel/notification-card.spec.ts
@@ -26,6 +26,9 @@ describe('NotificationCard.vue', () => {
       mocks: {
         $router: router,
         $t: (msg: string) => msg,
+        $raiden: {
+          fetchAndUpdateTokenData: jest.fn(),
+        },
       },
       propsData: { notification: TestData.notifications },
     });

--- a/raiden-dapp/tests/unit/components/overlays/token-overlay.spec.ts
+++ b/raiden-dapp/tests/unit/components/overlays/token-overlay.spec.ts
@@ -27,6 +27,9 @@ function createWrapper(tokenAddressParameter = '0xToken'): Wrapper<TokenOverlay>
     $identicon: $identicon(),
     $t: (msg: string) => msg,
     $route: { params: { token: tokenAddressParameter } },
+    $raiden: {
+      fetchAndUpdateTokenData: jest.fn(),
+    },
   };
 
   const wrapper = mount(TokenOverlay, {

--- a/raiden-dapp/tests/unit/components/tokens/token-list.spec.ts
+++ b/raiden-dapp/tests/unit/components/tokens/token-list.spec.ts
@@ -30,6 +30,9 @@ function createWrapper(
   const mocks = {
     $identicon: $identicon(),
     $t: (msg: string) => msg,
+    $raiden: {
+      fetchAndUpdateTokenData: jest.fn(),
+    },
   };
 
   return mount(TokenList, {

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -582,40 +582,6 @@ describe('RaidenService', () => {
         });
         expect(store.commit).toHaveBeenCalledWith('loadComplete');
       });
-
-      test('checks for the connected token balances when it receives a new block event', async () => {
-        expect.assertions(2);
-
-        providerMock.mockResolvedValue(mockProvider);
-        const subject = new BehaviorSubject({});
-        const testToken = {
-          address: mockToken1 as Address,
-          decimals: 18,
-          name: 'Token 1',
-          symbol: 'TKN1',
-        };
-        raiden.getTokenBalance = jest.fn().mockResolvedValue(constants.One);
-        raiden.getTokenList = jest.fn().mockResolvedValue([mockToken1 as Address]);
-        raiden.getTokenInfo = jest.fn().mockResolvedValue(testToken);
-        (raiden as any).events$ = subject;
-
-        await raidenService.connect();
-        await flushPromises();
-        store.commit.mockReset();
-        subject.next({ type: 'block/new', payload: { blockNumber: 123 } });
-        await flushPromises();
-
-        expect(store.commit).toBeCalledWith(
-          'updateTokens',
-          expect.objectContaining({
-            [mockToken1]: {
-              ...testToken,
-              balance: constants.One,
-            },
-          }),
-        );
-        expect(store.commit).toBeCalledWith('updateBlock', 123);
-      });
     });
 
     test('loads the token list', async () => {
@@ -632,10 +598,6 @@ describe('RaidenService', () => {
       store.commit.mockReset();
       await raidenService.fetchTokenList();
       await flushPromises();
-      expect(store.commit).toHaveBeenCalledWith(
-        'updateTokenAddresses',
-        expect.arrayContaining([mockToken1, mockToken2]),
-      );
       expect(store.commit).toHaveBeenCalledWith(
         'updateTokens',
         expect.objectContaining({

--- a/raiden-dapp/tests/unit/store.spec.ts
+++ b/raiden-dapp/tests/unit/store.spec.ts
@@ -132,9 +132,6 @@ describe('store', () => {
   });
 
   test('the allTokens getter returns the cached tokens as an array', () => {
-    const tokenAddresses: string[] = ['0x456', '0x123', '0x789', '0x789'];
-    store.commit('updateTokenAddresses', tokenAddresses);
-
     const tokens: Tokens = {
       '0x123': {
         address: '0x123',


### PR DESCRIPTION
Fixes #2376

**Short description**
There was a `tokenAddresses` which weren't being updated before accessing the `SelectToken` screen. This PR fixes that by removing that and using directly the list of tokens in `store.state.tokens`. It also removes updating the token balances on every block, which can be quite heavy on our Infura usage, and instead do it once when accessing balance-showing screens.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Check bug doesn't happen
