### PR TITLE
dapp: apply design changes to account withdrawal

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -12,10 +12,12 @@
 ### Changed
 
 - [#2369] Overall re-design of accounts UDC screen
+- [#2307] Enhanced user flow and information for withdrawal screen
 
 [#1693]: https://github.com/raiden-network/light-client/issues/1693
 [#2308]: https://github.com/raiden-network/light-client/issues/2308
 [#2369]: https://github.com/raiden-network/light-client/issues/2369
+[#2307]: https://github.com/raiden-network/light-client/issues/2307
 
 ## [0.13.0] - 2020-11-10
 

--- a/raiden-dapp/src/assets/info-gray.svg
+++ b/raiden-dapp/src/assets/info-gray.svg
@@ -1,0 +1,5 @@
+<svg width="19" height="18" viewBox="0 0 19 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.5 16.5C13.6421 16.5 17 13.1421 17 9C17 4.85786 13.6421 1.5 9.5 1.5C5.35786 1.5 2 4.85786 2 9C2 13.1421 5.35786 16.5 9.5 16.5Z" stroke="#7A7A80" stroke-width="1.33" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.5 12V9" stroke="#7A7A80" stroke-width="1.33" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.5 6H9.5075" stroke="#7A7A80" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/raiden-dapp/src/components/account/Withdrawal.vue
+++ b/raiden-dapp/src/components/account/Withdrawal.vue
@@ -1,15 +1,30 @@
 <template>
   <v-container>
-    <v-row align="center" justify="center">
-      <v-col cols="12">
-        <div class="withdrawal__description">
-          {{ $t('withdrawal.title') }}
+    <v-row justify="center">
+      <v-col cols="10">
+        <div class="withdrawal__info-box">
+          <img
+            class="mr-2 mt-1"
+            :src="require('@/assets/info-gray.svg')"
+            height="18px"
+            width="18px"
+          />
+
+          <span>
+            {{ $t('withdrawal.title') }}
+
+            <a class="withdrawal__info-box__link" @click="navigateToUDC">
+              {{ $t('withdrawal.navigation-link-title') }}
+            </a>
+          </span>
         </div>
       </v-col>
     </v-row>
+
     <v-row v-if="loading" class="withdrawal__loading">
       <spinner />
     </v-row>
+
     <v-row
       v-else-if="balances.length === 0"
       data-cy="withdrawal_empty"
@@ -30,10 +45,10 @@
     </v-row>
     <v-row v-else align="center" justify="center">
       <v-col cols="10">
-        <v-list data-cy="withdrawal_tokens" class="withdrawal__tokens" flat>
+        <v-list data-cy="withdrawal_tokens" class="withdrawal__token-list" flat>
           <template v-for="(token, index) in balances">
-            <v-list-item :key="token.address">
-              <v-list-item-avatar class="withdrawal__tokens__icon">
+            <v-list-item :key="token.address" class="withdrawal__token-list__item">
+              <v-list-item-avatar class="withdrawal__token-list__item__icon">
                 <img
                   :src="$blockie(token.address)"
                   :alt="$t('withdrawal.blockie-alt')"
@@ -41,34 +56,22 @@
                 />
               </v-list-item-avatar>
               <v-list-item-content>
-                <v-list-item-title class="withdrawal__tokens__name">
+                <v-list-item-title class="withdrawal__token-list__item__name">
                   {{ token.name || '' }}
                 </v-list-item-title>
-                <v-list-item-subtitle class="withdrawal__tokens__address">
+                <v-list-item-subtitle class="withdrawal__token-list__item__address">
                   <address-display :address="token.address" />
                 </v-list-item-subtitle>
               </v-list-item-content>
               <v-list-item-icon>
-                <amount-display
-                  class="withdrawal__tokens__balance"
-                  :amount="token.balance"
-                  :token="token"
-                />
-                <v-btn
-                  text
-                  icon
+                <div
                   data-cy="withdrawal_tokens_button"
-                  class="withdrawal__tokens__button"
+                  class="withdrawal__token-list__item__button"
                   @click="withdraw = token"
                 >
-                  <v-img
-                    :src="require(`@/assets/withdrawal.svg`)"
-                    max-width="24px"
-                    height="24px"
-                    contain
-                  >
-                  </v-img>
-                </v-btn>
+                  <amount-display :amount="token.balance" :token="token" />
+                  <img :src="require('@/assets/icon-withdraw.svg')" />
+                </div>
               </v-list-item-icon>
             </v-list-item>
             <v-divider v-if="index < balances.length - 1" :key="index" />
@@ -118,6 +121,7 @@ import { BigNumber, constants } from 'ethers';
 import { Token } from '@/model/types';
 import AddressDisplay from '@/components/AddressDisplay.vue';
 import BlockieMixin from '@/mixins/blockie-mixin';
+import NavigationMixin from '@/mixins/navigation-mixin';
 import AmountDisplay from '@/components/AmountDisplay.vue';
 import ActionButton from '@/components/ActionButton.vue';
 import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
@@ -137,7 +141,7 @@ import Spinner from '@/components/icons/Spinner.vue';
     ...mapGetters(['allTokens']),
   },
 })
-export default class Withdrawal extends Mixins(BlockieMixin) {
+export default class Withdrawal extends Mixins(BlockieMixin, NavigationMixin) {
   allTokens!: Token[];
   raidenAccountBalance!: string;
   udcToken!: Token;
@@ -185,10 +189,26 @@ export default class Withdrawal extends Mixins(BlockieMixin) {
 <style scoped lang="scss">
 @import '@/scss/colors';
 
+$background-color: #1c1c1c;
+$border-radius: 8px;
+$height: 72px;
+
 .withdrawal {
-  &__description {
-    margin-top: 30px;
-    text-align: center;
+  &__info-box {
+    $color: #7a7a80;
+    display: flex;
+    align-items: flex-start;
+    min-height: $height;
+    padding: 16px;
+    color: $color;
+    background-color: $background-color;
+    border-radius: $border-radius;
+    font-size: 12px;
+
+    &__link {
+      color: $color;
+      text-decoration: underline;
+    }
   }
 
   &__loading,
@@ -196,19 +216,43 @@ export default class Withdrawal extends Mixins(BlockieMixin) {
     min-height: 490px;
   }
 
-  &__tokens {
-    margin-top: 60px;
+  &__token-list {
     background-color: transparent;
 
-    &__balance {
-      margin-right: 12px;
-    }
+    &__item {
+      height: $height;
+      background-color: $background-color;
+      border-radius: $border-radius;
+      font-size: 14px;
+      font-weight: 500;
 
-    &__address {
-      ::v-deep {
-        .address {
-          &__label {
-            color: rgba($color-white, 0.7) !important;
+      &__button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 40px;
+        padding: 8px;
+        border-radius: $border-radius;
+        color: #44ddff;
+        background-color: #182d32;
+
+        &:hover {
+          background-color: #213e45;
+          cursor: pointer;
+        }
+
+        img {
+          margin-left: 5px;
+        }
+      }
+
+      &__address {
+        ::v-deep {
+          .address {
+            &__label {
+              font-weight: normal;
+              color: #a9a9a9 !important;
+            }
           }
         }
       }

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -130,7 +130,8 @@
     }
   },
   "withdrawal": {
-    "title": "Transfer token amount back to your main account.",
+    "title": "Transfer tokens to your main Ethereum account.",
+    "navigation-link-title": "For service tokens, make sure you withdrew them at the UDC screen first.",
     "dialog": {
       "title": "Withdraw {0}",
       "body": "You are about to withdraw {0} from your Raiden account.",

--- a/raiden-dapp/tests/unit/components/account/withdrawal.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/withdrawal.spec.ts
@@ -71,7 +71,7 @@ describe('Withdrawal.vue', () => {
     const wrapper = createWrapper(tokenBalance, raidenBalance);
     await flushPromises();
 
-    wrapper.find('.withdrawal__tokens__button').trigger('click');
+    wrapper.find('.withdrawal__token-list__item__button').trigger('click');
     await wrapper.vm.$nextTick();
 
     const confirmButton = wrapper.findComponent(RaidenDialog).findAll('button').at(1);
@@ -92,7 +92,7 @@ describe('Withdrawal.vue', () => {
     const wrapper = createWrapper(tokenBalance, raidenNoBalance);
     await flushPromises();
 
-    wrapper.find('.withdrawal__tokens__button').trigger('click');
+    wrapper.find('.withdrawal__token-list__item__button').trigger('click');
     await wrapper.vm.$nextTick();
 
     const confirmButton = wrapper.findComponent(RaidenDialog).findAll('button').at(1);


### PR DESCRIPTION
Fixes #2307

**Short description**
This is just some styling, so go ahead and use the PR serve tool to inspect it.

We start to loose control of the both design worlds by Vuetify and our own designs. The code becomes hard to maintain and the application looks weird. Due to the time pressure this continues with this PR. 

**Definition of Done**

- [X] Steps to manually test the change have been documented
- [X] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Go to the account screen and then withdrawals
2. Inspect the design
3. Use the navigation link to go to the UDC screen.
