### PR TITLE
Feature/dapp udc withdrawal navigation in notification

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - [#1693] Customizable privacy policy
 - [#2308] Show status of planned user deposit withdrawals
+- [#2372] Provide navigation link for withdrawn notification
 
 ### Changed
 
@@ -20,6 +21,7 @@
 [#2307]: https://github.com/raiden-network/light-client/issues/2307
 [#2369]: https://github.com/raiden-network/light-client/issues/2369
 [#2376]: https://github.com/raiden-network/light-client/issues/2376
+[#2372]: https://github.com/raiden-network/light-client/issues/2372
 
 ## [0.13.0] - 2020-11-10
 

--- a/raiden-dapp/jest.config.js
+++ b/raiden-dapp/jest.config.js
@@ -21,5 +21,5 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.{ts,vue}', '!**/node_modules/**', '!**/vendor/**'],
   coverageReporters: ['html', 'lcov', 'text-summary'],
-  reporters: ['default', 'jest-junit']
+  reporters: ['default', 'jest-junit'],
 };

--- a/raiden-dapp/jest.config.js
+++ b/raiden-dapp/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  setupFiles: ['./jest.setup.js'],
+  setupFiles: ['./jest.setup.js', 'jest-canvas-mock'],
   setupFilesAfterEnv: ['./jest.setup-after.ts'],
   moduleFileExtensions: ['js', 'jsx', 'json', 'vue', 'ts', 'tsx', 'node'],
   transform: {
@@ -21,5 +21,5 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: ['src/**/*.{ts,vue}', '!**/node_modules/**', '!**/vendor/**'],
   coverageReporters: ['html', 'lcov', 'text-summary'],
-  reporters: ['default', ['jest-junit', { outputDirectory: 'coverage' }]],
+  reporters: ['default', 'jest-junit']
 };

--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -83,6 +83,7 @@
     "eslint-plugin-vuetify": "^1.0.0-beta.7",
     "flush-promises": "^1.0.2",
     "jest": "^26.6.3",
+    "jest-canvas-mock": "^2.3.0",
     "jest-junit": "^12.0.0",
     "material-design-icons-iconfont": "^6.1.0",
     "nyc": "^15.1.0",
@@ -119,11 +120,5 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/raiden-network/light-client.git"
-  },
-  "jest": {
-    "reporters": [
-      "default",
-      "jest-junit"
-    ]
   }
 }

--- a/raiden-dapp/src/assets/notifications/notification_withdrawn.svg
+++ b/raiden-dapp/src/assets/notifications/notification_withdrawn.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M21 15L21 19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21L5 21C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19L3 15" stroke="#7F878D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.7072 11.8284L16.7072 4.75732L9.63611 4.75732" stroke="#7F878D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.7071 4.75739L8.2218 13.2427" stroke="#7F878D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/raiden-dapp/src/assets/planned-udc-withdrawal/navigation-arrow.svg
+++ b/raiden-dapp/src/assets/planned-udc-withdrawal/navigation-arrow.svg
@@ -1,5 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M7.99992 14.6667C11.6818 14.6667 14.6666 11.6819 14.6666 8.00001C14.6666 4.31811 11.6818 1.33334 7.99992 1.33334C4.31802 1.33334 1.33325 4.31811 1.33325 8.00001C1.33325 11.6819 4.31802 14.6667 7.99992 14.6667Z" fill="#00FF66" stroke="#00FF66" stroke-width="1.33" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M8 10.6667L10.6667 8.00001L8 5.33334" stroke="black" stroke-width="1.33" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M5.33325 8H10.6666" stroke="black" stroke-width="1.33" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/raiden-dapp/src/components/PlannedUdcWithdrawalInformation.vue
+++ b/raiden-dapp/src/components/PlannedUdcWithdrawalInformation.vue
@@ -15,8 +15,8 @@
       <img
         class="planned-udc-withdrawal-information__status-icon mr-2"
         :src="require(`@/assets/planned-udc-withdrawal/status-icon-${statusIconName}.svg`)"
-        :width="iconSize"
-        :height="iconSize"
+        width="13px"
+        height="13px"
       />
 
       <amount-display
@@ -27,26 +27,14 @@
 
       <v-spacer />
 
-      <span v-if="isPending" class="planned-udc-withdrawal-information__pending-message">
+      <span v-if="isPending" class="planned-udc-withdrawal-information__message">
         {{ remainingBlocksUntilReady }}
-        {{ $t('udc.information.blocks-remaining') | upperCase }}
+        {{ $t('udc.information.pending-message') | upperCase }}
       </span>
 
-      <a
-        v-if="isReady"
-        class="planned-udc-withdrawal-information__navigation-link d-flex align-center"
-        @click="navigateToWithdrawal"
-      >
-        {{ $t('udc.information.confirmed-navigation-link') | upperCase }}
-
-        <img
-          v-if="isReady"
-          class="ml-2"
-          :src="require(`@/assets/planned-udc-withdrawal/navigation-arrow.svg`)"
-          :width="iconSize"
-          :height="iconSize"
-        />
-      </a>
+      <span v-if="isReady" class="planned-udc-withdrawal-information__message">
+        {{ $t('udc.information.ready-message') | upperCase }}
+      </span>
     </template>
   </div>
 </template>
@@ -70,7 +58,6 @@ export default class PlannedUdcWithdrawalInformation extends NavigationMixin {
   blockNumber!: number;
 
   readonly assetSourceDirectory = '@/assets/planned-udc-withdrawal';
-  readonly iconSize = '13.33px';
 
   get noWithdrawInProgress(): boolean {
     return this.plannedWithdrawal === undefined;
@@ -114,13 +101,8 @@ export default class PlannedUdcWithdrawalInformation extends NavigationMixin {
   }
 
   &--ready {
-    $color: #00ff66;
-    color: $color;
+    color: #00ff66;
     background-color: #003214;
-
-    a {
-      color: $color;
-    }
   }
 
   &__amount {

--- a/raiden-dapp/src/components/account/AccountContent.vue
+++ b/raiden-dapp/src/components/account/AccountContent.vue
@@ -139,10 +139,7 @@ export default class AccountContent extends Mixins(NavigationMixin) {
         },
       });
 
-      const mainAccount = this.$raiden.getMainAccount();
-      const raidenAccount = this.$raiden.getAccount();
-      // if sub key is used
-      if (mainAccount && raidenAccount) {
+      if (this.$raiden.usingSubkey) {
         const raidenAccount = {
           icon: 'account_eth.svg',
           title: this.$t('account-content.menu-items.raiden-account.title') as string,

--- a/raiden-dapp/src/components/notification-panel/NotificationCard.vue
+++ b/raiden-dapp/src/components/notification-panel/NotificationCard.vue
@@ -95,7 +95,7 @@ export default class NotificationCard extends Vue {
 .notification-card {
   background-color: $notification-card-bg;
   border-radius: 16px !important;
-  height: 110px;
+  min-height: 110px;
 
   &__content {
     height: 100%;

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -49,7 +49,7 @@
     },
     "withdrawal": {
       "success": {
-        "title": "User Deposit Withdrawal",
+        "title": "User Deposit Withdraw Planned",
         "description": "A planned withdrawal of {amount} {symbol} was successfully completed withdrawing {withdrawal} {symbol}"
       },
       "failure": {
@@ -60,6 +60,12 @@
           "UDC_WITHDRAW_FAILED": "We could not complete the withdrawal of {amount} {symbol} because the transaction failed."
         }
       }
+    },
+    "withdrawn": {
+      "icon": "notification_withdrawn",
+      "title": "User Deposit Tokens Withdrawn",
+      "description": "{withdrawnAmount} {symbol} ({plannedAmount} planned) have been withdrawn from the user deposit contract.",
+      "link": "Click here to transfer them to your main acccount."
     },
     "settlement": {
       "icon": "notification_settle",

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -153,8 +153,8 @@
     "withdrawal-planned": "The withdrawal from the user deposit has been planned. You will get notified when the withdrawal is complete.",
     "information": {
       "no-withdrawal-in-progress": "No withdrawal in progress",
-      "blocks-remaining": "Blocks remaining...",
-      "confirmed-navigation-link": "ready・continue in withdrawal screen"
+      "pending-message": "Blocks remaining...",
+      "ready-message": "Ready・Tokens get claimed automatically"
     }
   },
   "backup-state": {

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -42,7 +42,7 @@ export default class RaidenService {
   private store: Store<CombinedStoreState>;
   private _userDepositTokenAddress = '';
   private _configuration?: Configuration;
-  private usingSubkey: boolean | undefined;
+  public usingSubkey: boolean | undefined;
 
   private static async createRaiden(
     provider: providers.JsonRpcProvider | providers.ExternalProvider | string,

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -23,6 +23,7 @@ import i18n from '@/i18n';
 import { NotificationPayload } from '@/store/notifications/types';
 import { NotificationContext } from '@/store/notifications/notification-context';
 import { NotificationImportance } from '@/store/notifications/notification-importance';
+import { RouteNames } from '@/router/route-names';
 
 function raidenActionConfirmationValueToStateTranslation(
   confirmationValue: boolean | undefined,
@@ -41,6 +42,7 @@ export default class RaidenService {
   private store: Store<CombinedStoreState>;
   private _userDepositTokenAddress = '';
   private _configuration?: Configuration;
+  private usingSubkey: boolean | undefined;
 
   private static async createRaiden(
     provider: providers.JsonRpcProvider | providers.ExternalProvider | string,
@@ -152,6 +154,7 @@ export default class RaidenService {
 
         this._raiden = raiden;
         this._configuration = configuration;
+        this.usingSubkey = subkey ?? false;
 
         const account = this.getAccount();
         this.store.commit('account', account);
@@ -340,23 +343,34 @@ export default class RaidenService {
     } as NotificationPayload);
   }
 
-  private async notifyWithdrawal(plannedAmount: BigNumber, withdrawal: BigNumber) {
+  private async notifyWithdrawal(amount: BigNumber, withdrawn: BigNumber) {
     // UDC token must be defined here after the initial loading phase.
     const token = this.store.state.userDepositContract.token!;
     const decimals = token.decimals ?? 18;
-    const amount = BalanceUtils.toUnits(plannedAmount, decimals);
-    const withdrawn = BalanceUtils.toUnits(withdrawal, decimals);
+    const plannedAmount = BalanceUtils.toUnits(amount, decimals);
+    const withdrawnAmount = BalanceUtils.toUnits(withdrawn, decimals);
 
-    this.store.commit('notifications/notificationAddOrReplace', {
-      title: i18n.t('notifications.withdrawal.success.title'),
-      description: i18n.t('notifications.withdrawal.success.description', {
-        amount,
-        withdrawn,
+    let notificationPayload = {
+      icon: i18n.t('notifications.withdrawn.icon'),
+      title: i18n.t('notifications.withdrawn.title'),
+      description: i18n.t('notifications.withdrawn.description', {
+        plannedAmount,
+        withdrawnAmount,
         symbol: token.symbol,
       }),
       context: NotificationContext.INFO,
       importance: NotificationImportance.HIGH,
-    } as NotificationPayload);
+    } as NotificationPayload;
+
+    if (this.usingSubkey) {
+      notificationPayload = {
+        ...notificationPayload,
+        link: i18n.t('notifications.withdrawn.link') as string,
+        dappRoute: RouteNames.ACCOUNT_WITHDRAWAL,
+      };
+    }
+
+    this.store.commit('notifications/notificationAddOrReplace', notificationPayload);
   }
 
   private async notifyBalanceProofSend(

--- a/raiden-dapp/tests/unit/components/account/account-content.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/account-content.spec.ts
@@ -38,7 +38,7 @@ async function createWrapper(
   const store = new Vuex.Store({ state, getters });
 
   const $raiden = {
-    getMainAccount: jest.fn(() => '0xMainAccount'),
+    usingSubkey: useSubkey,
     getAccount: jest.fn(() => (useSubkey ? '0xAccount' : undefined)),
   };
 

--- a/raiden-dapp/tests/unit/components/dialogs/udc-withdrawal-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/dialogs/udc-withdrawal-dialog.spec.ts
@@ -4,16 +4,19 @@ jest.mock('@/i18n', () => jest.fn());
 
 import flushPromises from 'flush-promises';
 import { constants, utils } from 'ethers';
-import { mount, Wrapper } from '@vue/test-utils';
+import { shallowMount, Wrapper } from '@vue/test-utils';
 import Vuetify from 'vuetify';
 import Vue from 'vue';
 import { $identicon } from '../../utils/mocks';
+import Filters from '@/filters';
 import store from '@/store';
 import RaidenService from '@/services/raiden-service';
 import Mocked = jest.Mocked;
 import UdcWithdrawalDialog from '@/components/dialogs/UdcWithdrawalDialog.vue';
 
 Vue.use(Vuetify);
+Vue.filter('upperCase', Filters.upperCase);
+
 describe('UdcWithdrawalDialog.vue', function () {
   let wrapper: Wrapper<UdcWithdrawalDialog>;
   let $raiden: Mocked<RaidenService>;
@@ -27,7 +30,7 @@ describe('UdcWithdrawalDialog.vue', function () {
   };
   function createWrapper() {
     const vuetify = new Vuetify();
-    return mount(UdcWithdrawalDialog, {
+    return shallowMount(UdcWithdrawalDialog, {
       vuetify,
       store,
       stubs: ['v-dialog'],

--- a/raiden-dapp/tests/unit/components/planned-udc-withdrawal-information.spec.ts
+++ b/raiden-dapp/tests/unit/components/planned-udc-withdrawal-information.spec.ts
@@ -1,17 +1,12 @@
-jest.mock('vue-router');
-
 import { constants } from 'ethers';
 import Vue from 'vue';
 import Vuetify from 'vuetify';
-import VueRouter from 'vue-router';
 import { shallowMount, Wrapper } from '@vue/test-utils';
 import { generateToken } from '../utils/data-generator';
-import Mocked = jest.Mocked;
 import Filters from '@/filters';
 import { PlannedUdcWithdrawal } from '@/store/user-deposit-contract';
 import PlannedUdcWithdrawalInformation from '@/components/PlannedUdcWithdrawalInformation.vue';
 import AmountDisplay from '@/components/AmountDisplay.vue';
-import { RouteNames } from '@/router/route-names';
 
 Vue.use(Vuetify);
 Vue.filter('upperCase', Filters.upperCase);
@@ -30,8 +25,6 @@ const readyPlannedWithdrawal: PlannedUdcWithdrawal = {
   withdrawBlock: 99,
 };
 
-const $router = new VueRouter() as Mocked<VueRouter>;
-
 function createWrapper(props: {
   plannedWithdrawal?: PlannedUdcWithdrawal;
   blockNumber?: number;
@@ -46,17 +39,12 @@ function createWrapper(props: {
       ...props,
     },
     mocks: {
-      $router,
       $t: (msg: string) => msg,
     },
   });
 }
 
 describe('PlannedUdcWithdrawalInformation.vue', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   test('should show that no withdrawal is in progress if withdraw plan property is missing', () => {
     const wrapper = createWrapper({ plannedWithdrawal: undefined });
 
@@ -69,42 +57,35 @@ describe('PlannedUdcWithdrawalInformation.vue', () => {
     const wrapper = createWrapper({ plannedWithdrawal: pendingPlannedWithdrawal });
     const statusIcon = wrapper.find('.planned-udc-withdrawal-information__status-icon');
     const amountDisplay = wrapper.findComponent(AmountDisplay);
-    const pendingMessage = wrapper.find('.planned-udc-withdrawal-information__pending-message');
+    const message = wrapper.find('.planned-udc-withdrawal-information__message');
 
     expect(statusIcon.exists()).toBe(true);
     expect(amountDisplay.exists()).toBe(true);
-    expect(pendingMessage.exists()).toBe(true);
+    expect(message.exists()).toBe(true);
   });
 
   test('should display correct counter of blocks until being ready for pending planned withdrawal', () => {
     const wrapper = createWrapper({ plannedWithdrawal: pendingPlannedWithdrawal });
-    const pendingMessage = wrapper.find('.planned-udc-withdrawal-information__pending-message');
+    const message = wrapper.find('.planned-udc-withdrawal-information__message');
 
-    expect(pendingMessage.text()).toMatch(/^10\s*UDC\.INFORMATION\.BLOCKS-REMAINING$/);
+    expect(message.text()).toMatch(/^10\s*UDC\.INFORMATION\.PENDING-MESSAGE$/);
   });
 
   test('should display all relevant elements for ready planned withdrawal', () => {
     const wrapper = createWrapper({ plannedWithdrawal: readyPlannedWithdrawal });
     const statusIcon = wrapper.find('.planned-udc-withdrawal-information__status-icon');
     const amountDisplay = wrapper.findComponent(AmountDisplay);
-    const navigationLink = wrapper.find('.planned-udc-withdrawal-information__navigation-link');
+    const message = wrapper.find('.planned-udc-withdrawal-information__message');
 
     expect(statusIcon.exists()).toBe(true);
     expect(amountDisplay.exists()).toBe(true);
-    expect(navigationLink.exists()).toBe(true);
+    expect(message.exists()).toBe(true);
   });
 
-  test('should navigate to withdrawal screen when clicking link on ready planned withdrawal', () => {
+  test('should display correct message for ready planned withdrawal', () => {
     const wrapper = createWrapper({ plannedWithdrawal: readyPlannedWithdrawal });
-    const navigationLink = wrapper.find('.planned-udc-withdrawal-information__navigation-link');
+    const message = wrapper.find('.planned-udc-withdrawal-information__message');
 
-    navigationLink.trigger('click');
-
-    expect($router.push).toHaveBeenCalledTimes(1);
-    expect($router.push).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: RouteNames.ACCOUNT_WITHDRAWAL,
-      }),
-    );
+    expect(message.text()).toBe('UDC.INFORMATION.READY-MESSAGE');
   });
 });

--- a/raiden-dapp/tests/unit/components/transfer/transfer-menus.spec.ts
+++ b/raiden-dapp/tests/unit/components/transfer/transfer-menus.spec.ts
@@ -31,6 +31,9 @@ describe('TransferHeaders.vue', () => {
       mocks: {
         $router: router,
         $t: (msg: string) => msg,
+        $raiden: {
+          fetchAndUpdateTokenData: jest.fn(),
+        },
       },
       propsData: {
         token,

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -1072,6 +1072,9 @@ describe('RaidenService', () => {
     });
 
     test('clears state after confirmed withraw', async () => {
+      (store.state as any) = {
+        userDepositContract: { token: generateToken() },
+      };
       const subject = new BehaviorSubject({});
       (raiden as any).events$ = subject;
       await setupSDK();
@@ -1079,7 +1082,11 @@ describe('RaidenService', () => {
         type: 'udc/withdrawn',
         payload: {
           confirmed: true,
-        },
+          withdrawal: constants.One,
+        }, 
+        meta: {
+          amount: constants.One,
+        }
       });
 
       expect(store.commit).toHaveBeenCalledWith('userDepositContract/clearPlannedWithdrawal');

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -26,6 +26,7 @@ import Mocked = jest.Mocked;
 import { CombinedStoreState } from '@/store';
 import { NotificationImportance } from '@/store/notifications/notification-importance';
 import { NotificationContext } from '@/store/notifications/notification-context';
+import { RouteNames } from '@/router/route-names';
 const { RaidenError, ErrorCodes, Capabilities } = jest.requireActual('raiden-ts');
 
 describe('RaidenService', () => {
@@ -694,7 +695,7 @@ describe('RaidenService', () => {
     });
   });
 
-  test('notify that withdraw was successful', async () => {
+  test('notify that tokens have been withdrawn from user deposit contract', async () => {
     expect.assertions(1);
     (store.state as any) = {
       userDepositContract: { token: generateToken() },
@@ -715,10 +716,42 @@ describe('RaidenService', () => {
     });
 
     expect(store.commit).toHaveBeenCalledWith('notifications/notificationAddOrReplace', {
-      description: 'notifications.withdrawal.success.description',
-      title: 'notifications.withdrawal.success.title',
+      icon: 'notifications.withdrawn.icon',
+      title: 'notifications.withdrawn.title',
+      description: 'notifications.withdrawn.description',
       importance: NotificationImportance.HIGH,
       context: NotificationContext.INFO,
+    });
+  });
+
+  test('notification that tokens have been withdrawn from user deposit contract includes link for subkey', async () => {
+    expect.assertions(1);
+    (store.state as any) = {
+      userDepositContract: { token: generateToken() },
+    };
+    const subject = new BehaviorSubject({});
+    (raiden as any).events$ = subject;
+    await setupSDK({ subkey: true });
+
+    subject.next({
+      type: 'udc/withdrawn',
+      payload: {
+        withdrawal: utils.parseEther('5'),
+        confirmed: true,
+      },
+      meta: {
+        amount: utils.parseEther('5'),
+      },
+    });
+
+    expect(store.commit).toHaveBeenCalledWith('notifications/notificationAddOrReplace', {
+      icon: 'notifications.withdrawn.icon',
+      title: 'notifications.withdrawn.title',
+      description: 'notifications.withdrawn.description',
+      importance: NotificationImportance.HIGH,
+      context: NotificationContext.INFO,
+      link: 'notifications.withdrawn.link',
+      dappRoute: RouteNames.ACCOUNT_WITHDRAWAL,
     });
   });
 

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -1083,10 +1083,10 @@ describe('RaidenService', () => {
         payload: {
           confirmed: true,
           withdrawal: constants.One,
-        }, 
+        },
         meta: {
           amount: constants.One,
-        }
+        },
       });
 
       expect(store.commit).toHaveBeenCalledWith('userDepositContract/clearPlannedWithdrawal');

--- a/raiden-dapp/tests/unit/views/account/withdrawal-route.spec.ts
+++ b/raiden-dapp/tests/unit/views/account/withdrawal-route.spec.ts
@@ -1,4 +1,4 @@
-import { mount, Wrapper } from '@vue/test-utils';
+import { shallowMount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuetify from 'vuetify';
 import { $identicon } from '../../utils/mocks';
@@ -14,7 +14,7 @@ describe('WithdrawalRoute.vue', () => {
   beforeEach(() => {
     vuetify = new Vuetify();
 
-    wrapper = mount(WithdrawalRoute, {
+    wrapper = shallowMount(WithdrawalRoute, {
       vuetify,
       store,
       stubs: ['withdrawal'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6464,7 +6464,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0, color-name@~1.1.4:
+color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -7055,6 +7055,11 @@ cssfilter@0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
   integrity sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=
+
+cssfontparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/cssfontparser/-/cssfontparser-1.2.1.tgz#f4022fc8f9700c68029d542084afbaf425a3f3e3"
+  integrity sha1-9AIvyPlwDGgCnVQghK+69CWj8+M=
 
 cssnano-preset-default@^4.0.0, cssnano-preset-default@^4.0.7:
   version "4.0.7"
@@ -11347,6 +11352,14 @@ javascript-stringify@^2.0.1:
   resolved "https://registry.yarnpkg.com/javascript-stringify/-/javascript-stringify-2.0.1.tgz#6ef358035310e35d667c675ed63d3eb7c1aa19e5"
   integrity sha512-yV+gqbd5vaOYjqlbk16EG89xB5udgjqQF3C5FAORDg4f/IS1Yc5ERCv5e/57yBcfJYw05V5JyIXabhwb75Xxow==
 
+jest-canvas-mock@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/jest-canvas-mock/-/jest-canvas-mock-2.3.0.tgz#50f4cc178ae52c4c0e2ce4fd3a3ad2a41ad4eb36"
+  integrity sha512-3TMyR66VG2MzAW8Negzec03bbcIjVJMfGNvKzrEnbws1CYKqMNkvIJ8LbkoGYfp42tKqDmhIpQq3v+MNLW2A2w==
+  dependencies:
+    cssfontparser "^1.2.1"
+    moo-color "^1.0.2"
+
 jest-changed-files@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.9.0.tgz#08d8c15eb79a7fa3fc98269bc14b451ee82f8039"
@@ -13666,6 +13679,13 @@ moment@2.29.1, moment@^2.22.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
+moo-color@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/moo-color/-/moo-color-1.0.2.tgz#837c40758d2d58763825d1359a84e330531eca64"
+  integrity sha512-5iXz5n9LWQzx/C2WesGFfpE6RLamzdHwsn3KpfzShwbfIqs7stnoEpaNErf/7+3mbxwZ4s8Foq7I0tPxw7BWHg==
+  dependencies:
+    color-name "^1.1.4"
 
 morgan@^1.10.0:
   version "1.10.0"


### PR DESCRIPTION
Fixes #2372

**Short description**
The most relevant part is in the first two commits. The rest is not actually related to this issue. But since the PR was small enough, I decided to include the changes here. In fact they are mostly about removing all warnings from the unit tests and make it more clean again.

__Note:__
Some parts of how we handle notification icons and the payload in general is not too nice. So to get this feature done, I just followed the current structure for now. But I opened new issues to target this problems in general.

**Definition of Done**

- [X] Steps to manually test the change have been documented
- [X] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Initiate an UDC withdrawal plan
2. Wait 100 blocks until the withdrawal plan becomes ready
3. Confirm the new message of the progress info component and that there is no link anymore
4. Wait for the automatic claim and the notification that gets send when the according Tx gets confirmed
5. Confirm that the notification has a navigation link to the account withdrawal screen

1.2. Run the unit tests of the dApp and confirm that there is no red warning output anymore, but just a green wall 