### PR TITLE
Disable receiving if blocks don't arrive in a timeline manner

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -4,7 +4,13 @@
 ### Fixed
 - [#2360] Properly error & shutdown if database gets deleted at runtime
 
+### Added
+- [#1256] Disable receiving if blocks don't arrive in a timely manner
+- [#2395] Calculate and expose Raiden.blockTime$ as observable of average block times
+
+[#1256]: https://github.com/raiden-network/light-client/issues/1256
 [#2360]: https://github.com/raiden-network/light-client/issues/2360
+[#2395]: https://github.com/raiden-network/light-client/pull/2395
 
 ## [0.13.0] - 2020-11-10
 ### Fixed

--- a/raiden-ts/src/constants.ts
+++ b/raiden-ts/src/constants.ts
@@ -1,6 +1,6 @@
 import { hexZeroPad } from '@ethersproject/bytes';
 import { keccak256 } from '@ethersproject/keccak256';
-import { Signature, Hash } from './utils/types';
+import type { Signature, Hash } from './utils/types';
 
 export const SignatureZero = hexZeroPad([], 65) as Signature;
 

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -123,6 +123,10 @@ export class Raiden {
   public config!: RaidenConfig;
   /** RaidenConfig observable (for reactive use)  */
   public config$: Observable<RaidenConfig>;
+  /**
+   * Observable of latest average (10) block times
+   */
+  public blockTime$: Observable<number>;
 
   /**
    * Expose ether's Provider.resolveName for ENS support
@@ -193,6 +197,7 @@ export class Raiden {
     this.state$ = latest$.pipe(pluckDistinct('state'));
     // pipe action, skipping cached
     this.action$ = latest$.pipe(pluckDistinct('action'), skip(1));
+    this.blockTime$ = latest$.pipe(pluckDistinct('blockTime'));
     this.channels$ = this.state$.pipe(pluckDistinct('channels'), map(mapRaidenChannels));
     this.transfers$ = initTransfers$(this.state$, db);
     this.events$ = this.action$.pipe(filter(isActionOf(RaidenEvents)));

--- a/raiden-ts/src/transport/epics/init.ts
+++ b/raiden-ts/src/transport/epics/init.ts
@@ -411,11 +411,11 @@ export function matrixShutdownEpic(
   return matrix$.pipe(
     mergeMap((matrix) =>
       action$.pipe(
-        finalize(() => {
+        finalize(async () => {
           matrix.stopClient();
-          matrix.setPresence({ presence: 'offline', status_msg: '' }).catch(() => {
-            /* stopping, ignore exceptions */
-          });
+          try {
+            await matrix.setPresence({ presence: 'offline', status_msg: '' });
+          } catch (err) {}
         }),
       ),
     ),

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -44,6 +44,7 @@ export interface Latest {
   pfsList: readonly Address[];
   rtc: { [address: string]: RTCDataChannel };
   udcBalance: UInt<32>;
+  blockTime: number;
 }
 
 export interface RaidenEpicDeps {


### PR DESCRIPTION
Fixes #1256

**Short description**
This is done only if receiving is not force-enabled in config, so user's config have precedence. If blocks get stale (i.e. no new blocks after the time were 3 to 4 blocks should have been received), it'll auto-disable receiving until a new block comes.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
