### PR TITLE
Allow batch messages received in wrtc to be processed

### DIFF
--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -397,6 +397,7 @@ function listenDataChannel(
             pluck('data'),
             filter((d: unknown): d is string => typeof d === 'string'),
             filter((line) => line !== pingMsg), // ignore pingMsg, used only to succeed rtcChannel
+            mergeMap((lines) => from(lines.split('\n'))),
             map((line) =>
               messageReceived(
                 {


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

This is a small PR to allow batched messages to be processed. Currently, the Python Client batches messages unconditionally and sends them via any communication channel possible. To be compatible the light client needs to separate the different batched messages and process them one by one. 