### PR TITLE
0.13.0 -> 0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "light-client",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Raiden Light Client monorepo",
   "author": "brainbot labs est.",
   "private": true,

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -7,11 +7,11 @@ if [[ "$#" -ne 1 ]]; then
   exit 1
 fi
 
-cd "$( dirname $0 )"
+cd "$(dirname $0)"
 
-OLD_VERSION=`yarn versions --json | jq -er '.data."light-client"'`
-yarn version $1 --no-git-tag-version
-NEW_VERSION=`yarn versions --json | jq -er '.data."light-client"'`
+OLD_VERSION=$(yarn versions --json | jq -er '.data."light-client"')
+yarn version "--${1}" --no-git-tag-version
+NEW_VERSION=$(yarn versions --json | jq -er '.data."light-client"')
 MESSAGE="$OLD_VERSION -> $NEW_VERSION"
 
 yarn workspace raiden-ts version --no-git-tag-version --new-version "${NEW_VERSION}"

--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [0.14.0] - 2020-11-25
 ### Fixed
 - [#2361] Workaround wrtc segfault on teardown
 
@@ -31,7 +33,8 @@
 [#2054]: https://github.com/raiden-network/light-client/pulls/2054
 
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/raiden-network/light-client/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/raiden-network/light-client/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/raiden-network/light-client/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/raiden-network/light-client/compare/v0.11.0...v0.11.1

--- a/raiden-cli/package.json
+++ b/raiden-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-cli",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Raiden Light Client standalone command-line app",
   "main": "build/index.js",
   "scripts": {

--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [Unreleased]
 
+## [0.14.0] - 2020-11-25
+
 ### Fixed
+
 - [#2376] Fix Raiden Account tokens not showing up for withdrawal
 
 ### Added
@@ -484,7 +487,8 @@
 - Add link to privacy policy.
 - Add basic transfer screen.
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/raiden-network/light-client/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/raiden-network/light-client/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/raiden-network/light-client/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/raiden-network/light-client/compare/v0.11.0...v0.11.1

--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-dapp",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "description": "A dApp that showcases the Raiden Light Client sdk functionality",
   "author": "brainbot labs est.",

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [0.14.0] - 2020-11-25
 ### Fixed
 - [#2360] Properly error & shutdown if database gets deleted at runtime
 
@@ -367,7 +369,8 @@
 - Add protocol message implementation.
 
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/raiden-network/light-client/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/raiden-network/light-client/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/raiden-network/light-client/compare/v0.11.1...v0.12.0
 [0.11.1]: https://github.com/raiden-network/light-client/compare/v0.11.0...v0.11.1

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-ts",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Raiden Light Client Typescript/Javascript SDK",
   "main": "dist:cjs/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
This includes a tiny fix of the `prepare-release.sh` script that had an error due to the wrong conversion to use `yarn`.

---

# :horse_racing: New Raiden Light Client SDK, dApp and CLI Release

> **INFO**: The Light Client SDK, dApp and CLI are **work in progress**, are not
> production-ready, and currently can only be used on the Ethereum **Testnets**.

This minor release version focuses on strengthening the stability of the SDK and
CLI as well as improving the user experience of interacting with the user
deposit contract in the dApp.

## Raiden SDK

### Fixed

- [#2360] Properly error & shutdown if database gets deleted at runtime

### Added

- [#1256] Disable receiving if blocks don't arrive in a timely manner
- [#2395] Calculate and expose Raiden.blockTime$ as observable of average block times

[#1256]: https://github.com/raiden-network/light-client/issues/1256
[#2360]: https://github.com/raiden-network/light-client/issues/2360
[#2395]: https://github.com/raiden-network/light-client/pull/2395

## Raiden dApp

### Fixed

- [#2376] Fix Raiden Account tokens not showing up for withdrawal

### Added

- [#1693] Customizable privacy policy
- [#2308] Show status of planned user deposit withdrawals
- [#2372] Provide navigation link for withdrawn notification

### Changed

- [#2369] Overall re-design of accounts UDC screen
- [#2307] Enhanced user flow and information for withdrawal screen

[#1693]: https://github.com/raiden-network/light-client/issues/1693
[#2308]: https://github.com/raiden-network/light-client/issues/2308
[#2307]: https://github.com/raiden-network/light-client/issues/2307
[#2369]: https://github.com/raiden-network/light-client/issues/2369
[#2376]: https://github.com/raiden-network/light-client/issues/2376
[#2372]: https://github.com/raiden-network/light-client/issues/2372

## Raiden CLI

### Fixed

- [#2361] Workaround wrtc segfault on teardown

[#2361]: https://github.com/raiden-network/light-client/issues/2361
