### PR TITLE
Refactor errors operators, unify retryWhile and better handle network errors

### DIFF
--- a/raiden-ts/src/channels/utils.ts
+++ b/raiden-ts/src/channels/utils.ts
@@ -204,6 +204,7 @@ export const txFailErrors: readonly string[] = [
   'execution failed due to an exception',
   'transaction failed',
   'execution reverted',
+  'cannot estimate gas',
 ];
 
 /**

--- a/raiden-ts/src/transfers/epics/secret.ts
+++ b/raiden-ts/src/transfers/epics/secret.ts
@@ -17,7 +17,7 @@ import {
   endWith,
 } from 'rxjs/operators';
 
-import { assertTx, commonTxErrors } from '../../channels/utils';
+import { assertTx } from '../../channels/utils';
 import { RaidenAction } from '../../actions';
 import { messageSend } from '../../messages/actions';
 import { MessageType, SecretRequest, SecretReveal } from '../../messages/types';
@@ -25,7 +25,7 @@ import { signMessage, isMessageReceivedOfType } from '../../messages/utils';
 import { RaidenState } from '../../state';
 import { RaidenEpicDeps } from '../../types';
 import { isActionOf, isConfirmationResponseOf } from '../../utils/actions';
-import { RaidenError, ErrorCodes, assert } from '../../utils/error';
+import { RaidenError, ErrorCodes, assert, commonTxErrors } from '../../utils/error';
 import { fromEthersEvent, logToContractEvent } from '../../utils/ethers';
 import { pluckDistinct, retryWhile, takeIf } from '../../utils/rx';
 import { Hash, Secret, Signed, UInt, isntNil, untime } from '../../utils/types';

--- a/raiden-ts/src/transfers/epics/withdraw.ts
+++ b/raiden-ts/src/transfers/epics/withdraw.ts
@@ -15,13 +15,13 @@ import {
 } from 'rxjs/operators';
 
 import { Capabilities } from '../../constants';
-import { channelKey, assertTx, commonTxErrors } from '../../channels/utils';
+import { channelKey, assertTx } from '../../channels/utils';
 import { RaidenAction } from '../../actions';
 import { RaidenState } from '../../state';
 import { RaidenEpicDeps } from '../../types';
 import { ChannelState } from '../../channels';
 import { isActionOf } from '../../utils/actions';
-import { assert, ErrorCodes } from '../../utils/error';
+import { assert, ErrorCodes, commonTxErrors } from '../../utils/error';
 import { Signed } from '../../utils/types';
 import { LruCache } from '../../utils/lru';
 import { retryWhile } from '../../utils/rx';

--- a/raiden-ts/src/transfers/epics/withdraw.ts
+++ b/raiden-ts/src/transfers/epics/withdraw.ts
@@ -15,7 +15,7 @@ import {
 } from 'rxjs/operators';
 
 import { Capabilities } from '../../constants';
-import { channelKey, assertTx, retryTx } from '../../channels/utils';
+import { channelKey, assertTx, commonTxErrors } from '../../channels/utils';
 import { RaidenAction } from '../../actions';
 import { RaidenState } from '../../state';
 import { RaidenEpicDeps } from '../../types';
@@ -24,6 +24,7 @@ import { isActionOf } from '../../utils/actions';
 import { assert, ErrorCodes } from '../../utils/error';
 import { Signed } from '../../utils/types';
 import { LruCache } from '../../utils/lru';
+import { retryWhile } from '../../utils/rx';
 import { Processed, MessageType, signMessage, isMessageReceivedOfType } from '../../messages';
 import { messageSend } from '../../messages/actions';
 import { newBlock } from '../../channels/actions';
@@ -199,7 +200,7 @@ export function withdrawSendTxEpic(
               log,
               provider,
             }),
-            retryTx(provider.pollingInterval, undefined, undefined, { log }),
+            retryWhile(provider.pollingInterval, { onErrors: commonTxErrors, log: log.debug }),
           );
         }),
         map(([, receipt]) =>

--- a/raiden-ts/src/transport/epics/init.ts
+++ b/raiden-ts/src/transport/epics/init.ts
@@ -138,7 +138,7 @@ function startMatrixSync(
         mergeMap((filter) => matrix.startClient({ filter })),
         retryWhile(
           exponentialBackoff(config.pollingInterval, config.httpTimeout),
-          (err) => err?.httpStatus !== 429, // retry rate-limit errors only
+          { maxRetries: 10, onErrors: [429] }, // retry rate-limit errors only
         ),
       ),
     ),

--- a/raiden-ts/src/transport/epics/init.ts
+++ b/raiden-ts/src/transport/epics/init.ts
@@ -46,7 +46,7 @@ import { RaidenConfig } from '../../config';
 import { RaidenState } from '../../state';
 import { getServerName } from '../../utils/matrix';
 import { decode } from '../../utils/types';
-import { pluckDistinct, retryAsync$, retryWaitWhile } from '../../utils/rx';
+import { pluckDistinct, retryAsync$, retryWhile } from '../../utils/rx';
 import { exponentialBackoff } from '../../transfers/epics/utils';
 import { matrixSetup } from '../actions';
 import { RaidenMatrixSetup } from '../state';
@@ -136,7 +136,7 @@ function startMatrixSync(
       joinGlobalRooms(config, matrix).pipe(
         mergeMap((roomIds) => createMatrixFilter(matrix, roomIds)),
         mergeMap((filter) => matrix.startClient({ filter })),
-        retryWaitWhile(
+        retryWhile(
           exponentialBackoff(config.pollingInterval, config.httpTimeout),
           (err) => err?.httpStatus !== 429, // retry rate-limit errors only
         ),

--- a/raiden-ts/src/transport/epics/messages.ts
+++ b/raiden-ts/src/transport/epics/messages.ts
@@ -142,10 +142,10 @@ export function matrixMessageGlobalSendEpic(
             '',
           );
         }),
-        retryWhile(
-          exponentialBackoff(config.pollingInterval, config.httpTimeout),
-          (err, count) => ![429, 500].includes(err?.httpStatus) || count > 3,
-        ),
+        retryWhile(exponentialBackoff(config.pollingInterval, config.httpTimeout), {
+          maxRetries: 3,
+          onErrors: [429, 500],
+        }),
         catchError((err) => {
           log.error(
             'Error sending message to global room',

--- a/raiden-ts/src/transport/epics/messages.ts
+++ b/raiden-ts/src/transport/epics/messages.ts
@@ -26,7 +26,7 @@ import {
 
 import { MatrixClient, MatrixEvent, Room } from 'matrix-js-sdk';
 
-import { retryWaitWhile } from '../../utils/rx';
+import { retryWhile } from '../../utils/rx';
 import { RaidenConfig } from '../../config';
 import { Capabilities } from '../../constants';
 import { Signed } from '../../utils/types';
@@ -142,7 +142,7 @@ export function matrixMessageGlobalSendEpic(
             '',
           );
         }),
-        retryWaitWhile(
+        retryWhile(
           exponentialBackoff(config.pollingInterval, config.httpTimeout),
           (err, count) => ![429, 500].includes(err?.httpStatus) || count > 3,
         ),

--- a/raiden-ts/src/transport/epics/presence.ts
+++ b/raiden-ts/src/transport/epics/presence.ts
@@ -243,7 +243,7 @@ export function matrixPresenceUpdateEpic(
           }),
           retryWhile(
             exponentialBackoff(pollingInterval, httpTimeout),
-            (err) => err?.httpStatus !== 429, // retry rate-limit errors only
+            { maxRetries: 10, onErrors: [429] }, // retry rate-limit errors only
           ),
           catchError(
             (err) => (

--- a/raiden-ts/src/transport/epics/presence.ts
+++ b/raiden-ts/src/transport/epics/presence.ts
@@ -33,7 +33,7 @@ import { RaidenEpicDeps } from '../../types';
 import { RaidenAction } from '../../actions';
 import { RaidenState } from '../../state';
 import { getUserPresence } from '../../utils/matrix';
-import { pluckDistinct, retryWaitWhile } from '../../utils/rx';
+import { pluckDistinct, retryWhile } from '../../utils/rx';
 import { matrixPresence } from '../actions';
 import { channelMonitored } from '../../channels/actions';
 import { parseCaps, stringifyCaps } from '../utils';
@@ -241,7 +241,7 @@ export function matrixPresenceUpdateEpic(
               { address: recovered },
             );
           }),
-          retryWaitWhile(
+          retryWhile(
             exponentialBackoff(pollingInterval, httpTimeout),
             (err) => err?.httpStatus !== 429, // retry rate-limit errors only
           ),

--- a/raiden-ts/src/transport/epics/rooms.ts
+++ b/raiden-ts/src/transport/epics/rooms.ts
@@ -171,7 +171,7 @@ export function matrixCreateRoomEpic(
             map(({ room_id: roomId }) => matrixRoom({ roomId }, { address })),
             retryWhile(
               exponentialBackoff(pollingInterval, httpTimeout),
-              (err) => err?.httpStatus !== 429, // retry rate-limit errors only
+              { maxRetries: 10, onErrors: [429] }, // retry rate-limit errors only
             ),
             catchError((err) => (log.error('Error creating room, ignoring', err), EMPTY)),
           ),
@@ -281,7 +281,7 @@ export function matrixHandleInvitesEpic(
         mapTo(matrixRoom({ roomId: member.roomId }, { address: senderPresence.meta.address })),
         retryWhile(
           exponentialBackoff(pollingInterval, httpTimeout),
-          (err) => err?.httpStatus !== 429, // retry rate-limit errors only
+          { maxRetries: 10, onErrors: [429] }, // retry rate-limit errors only
         ),
         catchError((err) => (log.error('Error joining invited room, ignoring', err), EMPTY)),
       ),

--- a/raiden-ts/src/transport/epics/rooms.ts
+++ b/raiden-ts/src/transport/epics/rooms.ts
@@ -35,7 +35,7 @@ import { RaidenState } from '../../state';
 import { channelMonitored } from '../../channels/actions';
 import { messageSend, messageReceived } from '../../messages/actions';
 import { transferSigned } from '../../transfers/actions';
-import { pluckDistinct, retryWaitWhile, takeIf } from '../../utils/rx';
+import { pluckDistinct, retryWhile, takeIf } from '../../utils/rx';
 import { getServerName } from '../../utils/matrix';
 import { Direction } from '../../transfers/state';
 import { exponentialBackoff } from '../../transfers/epics/utils';
@@ -169,7 +169,7 @@ export function matrixCreateRoomEpic(
               }),
             ),
             map(({ room_id: roomId }) => matrixRoom({ roomId }, { address })),
-            retryWaitWhile(
+            retryWhile(
               exponentialBackoff(pollingInterval, httpTimeout),
               (err) => err?.httpStatus !== 429, // retry rate-limit errors only
             ),
@@ -279,7 +279,7 @@ export function matrixHandleInvitesEpic(
       // join room and emit MatrixRoomAction to make it default/first option for sender address
       defer(() => matrix.joinRoom(member.roomId, { syncRoom: true })).pipe(
         mapTo(matrixRoom({ roomId: member.roomId }, { address: senderPresence.meta.address })),
-        retryWaitWhile(
+        retryWhile(
           exponentialBackoff(pollingInterval, httpTimeout),
           (err) => err?.httpStatus !== 429, // retry rate-limit errors only
         ),

--- a/raiden-ts/src/utils/error.ts
+++ b/raiden-ts/src/utils/error.ts
@@ -12,7 +12,7 @@ export type ErrorCodes = keyof typeof ErrorCodes;
 export const ErrorDetails = t.record(t.string, t.union([t.string, t.number, t.boolean, t.null]));
 export interface ErrorDetails extends t.TypeOf<typeof ErrorDetails> {}
 
-export const networkErrors: readonly string[] = ['invalid response'];
+export const networkErrors: readonly string[] = ['invalid response', 'timeout'];
 
 export class RaidenError extends Error {
   public name = 'RaidenError';

--- a/raiden-ts/src/utils/error.ts
+++ b/raiden-ts/src/utils/error.ts
@@ -33,11 +33,11 @@ export function matchError(match: ErrorMatch | ErrorMatches, error: any): boolea
  */
 export function matchError(match: ErrorMatch | ErrorMatches, error?: any) {
   const _errorMatcher = (match: ErrorMatch, error: any): boolean => {
-    return typeof match === 'string'
-      ? error?.message?.includes(match)
-      : typeof match === 'number'
-      ? error?.httpStatus === match
-      : Object.entries(match).every(([k, v]) => error?.[k] === v);
+    let res;
+    if (typeof match === 'string') res = error?.message?.includes(match);
+    else if (typeof match === 'number') res = error?.httpStatus === match;
+    else res = Object.entries(match).every(([k, v]) => error?.[k] === v);
+    return res;
   };
   const errorMatcher = Array.isArray(match)
     ? (error: any): boolean => match.some((m) => _errorMatcher(m, error))

--- a/raiden-ts/src/utils/rx.ts
+++ b/raiden-ts/src/utils/rx.ts
@@ -111,8 +111,8 @@ type PredicateFunc = (err: any, count: number) => boolean | undefined;
  *
  * @param delayMs - Interval or iterator of intervals to wait between retries
  * @param options - Retry options, conditions are ANDed
- * @param options.maxRetries - Throw (give up) after this many retries
- *    (default to 10, pass 0 to retry indefinitely or as long iterator yields positive intervals)
+ * @param options.maxRetries - Throw (give up) after this many retries (defaults to 10,
+ *    pass 0 to retry indefinitely or as long as iterator yields positive intervals)
  * @param options.onErrors - Retry if error.message or error.httpStatus matches any of these
  * @param options.neverOnErrors - Throw if error.message or error.httpStatus matches any of these
  * @param options.predicate - Retry if this function, receiving error+count returns truthy

--- a/raiden-ts/src/utils/rx.ts
+++ b/raiden-ts/src/utils/rx.ts
@@ -109,7 +109,7 @@ export function repeatUntil<T>(
  * @param stopPredicate - Receives error and count, stop retry and throw if returns truthy
  * @returns Operator function to retry if stopPredicate not truthy waiting between retries
  */
-export function retryWaitWhile<T>(
+export function retryWhile<T>(
   delayMs: number | Iterator<number>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   stopPredicate: (err: any, count: number) => boolean | undefined = (_, count) => count >= 10,
@@ -152,7 +152,7 @@ export function retryAsync$<T>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   stopPredicate: (err: any, count: number) => boolean | undefined = (_, count) => count >= 10,
 ): Observable<T> {
-  return defer(func).pipe(retryWaitWhile(delayMs, stopPredicate));
+  return defer(func).pipe(retryWhile(delayMs, stopPredicate));
 }
 
 /**

--- a/raiden-ts/tests/unit/error.spec.ts
+++ b/raiden-ts/tests/unit/error.spec.ts
@@ -1,24 +1,105 @@
-import { txFailErrors, txNonceErrors } from 'raiden-ts/channels/utils';
-import { networkErrorRetryPredicate, networkErrors } from 'raiden-ts/utils/error';
+import { defer } from 'rxjs';
+import { matchError } from 'raiden-ts/utils/error';
+import { retryWhile } from 'raiden-ts/utils/rx';
 
-describe('networkErrorRetryPredicate', () => {
-  test('handles non-error objects correctly', () => {
-    const errorString = 'Test';
-    const errorNumber = 123;
-    const errorObject = { name: 'goerli', chainId: 5 };
+describe('matchError', () => {
+  test('matches error.message substrings', () => {
+    const matcher = ['a randomError'];
+    const randomError = new Error('this is a randomError');
+    expect(matchError(matcher, randomError)).toBe(true);
+    // also tests matcher return
+    expect(matchError(matcher)(randomError)).toBe(true);
 
-    expect(networkErrorRetryPredicate(errorString)).toBe(true);
-    expect(networkErrorRetryPredicate(errorNumber)).toBe(true);
-    expect(networkErrorRetryPredicate(errorObject)).toBe(true);
+    const anotherError = new Error('this is another error');
+    expect(matchError(matcher, anotherError)).toBe(false);
+    expect(matchError(matcher)(anotherError)).toBe(false);
   });
 
-  test('returns `False` for network errors only', () => {
-    const networkError = Error(networkErrors[0]);
-    const nonceError = Error(txNonceErrors[0]);
-    const failError = Error(txFailErrors[0]);
+  test('matches error.httpStatus', () => {
+    const matcher = [429, 500];
+    const rateError = Object.assign(new Error('Invalid http status code'), { httpStatus: 429 });
+    expect(matchError(matcher, rateError)).toBe(true);
+    expect(matchError(matcher)(rateError)).toBe(true);
 
-    expect(networkErrorRetryPredicate(networkError)).toBe(false);
-    expect(networkErrorRetryPredicate(nonceError)).toBe(true);
-    expect(networkErrorRetryPredicate(failError)).toBe(true);
+    const notFoundError = Object.assign(new Error('Not found'), { httpStatus: 404 });
+    expect(matchError(matcher, notFoundError)).toBe(false);
+    expect(matchError(matcher)(notFoundError)).toBe(false);
+  });
+
+  test('matches properties', () => {
+    const matcher = [{ code: 'timeout' }];
+    const timeoutError = Object.assign(new Error('Timeout occurred'), { code: 'timeout' });
+    expect(matchError(matcher, timeoutError)).toBe(true);
+    expect(matchError(matcher)(timeoutError)).toBe(true);
+
+    const nonCodeTimeout = new Error('timeout');
+    expect(matchError(matcher, nonCodeTimeout)).toBe(false);
+    expect(matchError(matcher)(nonCodeTimeout)).toBe(false);
+  });
+});
+
+describe('retryWhile', () => {
+  const error = new Error('defaultError');
+  const errorMock = jest.fn();
+  const error$ = defer(errorMock);
+
+  beforeEach(() => {
+    errorMock.mockRestore();
+    errorMock.mockRejectedValue(error);
+  });
+
+  test('give up after maxRetries', async () => {
+    const start = Date.now();
+    await expect(error$.pipe(retryWhile(5, { maxRetries: 7 })).toPromise()).rejects.toThrow(error);
+    expect(errorMock).toHaveBeenCalledTimes(8);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(7 * 5);
+  });
+
+  test('retry only onError', async () => {
+    const anotherError = new Error('anotherError');
+    errorMock.mockRejectedValueOnce(anotherError);
+    await expect(
+      error$.pipe(retryWhile(5, { onErrors: ['another'] })).toPromise(),
+    ).rejects.toThrow(error);
+    expect(errorMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('retry until neverOnError', async () => {
+    const anotherError = new Error('anotherError');
+    errorMock.mockRejectedValueOnce(anotherError);
+    await expect(
+      error$.pipe(retryWhile(5, { neverOnErrors: ['default'] })).toPromise(),
+    ).rejects.toThrow(error);
+    expect(errorMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('retry only on predicate, succeeds 2nd time', async () => {
+    const anotherError = new Error('anotherError');
+    errorMock.mockRejectedValueOnce(anotherError);
+    errorMock.mockResolvedValueOnce(37);
+    const predicate = jest.fn((err) => err === anotherError);
+    await expect(error$.pipe(retryWhile(5, { predicate })).toPromise()).resolves.toBe(37);
+    expect(errorMock).toHaveBeenCalledTimes(2);
+    expect(predicate).toHaveBeenCalledTimes(1);
+  });
+
+  test('give up on stopPredicate, logs error', async () => {
+    const anotherError = new Error('anotherError');
+    errorMock.mockRejectedValueOnce(anotherError);
+    const stopPredicate = jest.fn((err) => err === error);
+    const log = jest.fn();
+    await expect(error$.pipe(retryWhile(5, { stopPredicate, log })).toPromise()).rejects.toThrow(
+      error,
+    );
+    expect(errorMock).toHaveBeenCalledTimes(2);
+    expect(stopPredicate).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenCalledTimes(2);
+  });
+
+  test('give up when iterator depletes', async () => {
+    const arr = [5, 4, 3];
+    const iter = arr[Symbol.iterator]();
+    await expect(error$.pipe(retryWhile(iter)).toPromise()).rejects.toThrow(error);
+    expect(errorMock).toHaveBeenCalledTimes(4);
   });
 });


### PR DESCRIPTION
Fixes #2388 
Fixes #2394 
Fixes #2402 
Fixes #2404 

**Short description**
Refactors our `retryAsync$`, `retryWhile` operators and utils to better align with each other, and to support more ways for matching errors, simplifying code which uses them. With that, we added network `timeout` errors and another revert estimation error to the lists of retriable errors, which should help on the issues above.
Most of this is internal implementation only, so shouldn't affect users, and therefore doesn't deserve a changelog entry.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. All of the above are covered by tests
