### PR TITLE
Bugfix/dapp notification icon unefined

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- [#2391] Fix notification icon handling for special scenarios
+
+[#2391]: https://github.com/raiden-network/light-client/issues/2391
+
+
 ## [0.14.0] - 2020-11-25
 
 ### Fixed

--- a/raiden-dapp/src/assets/notifications/notification_fallback.svg
+++ b/raiden-dapp/src/assets/notifications/notification_fallback.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 8C18 6.4087 17.3679 4.88258 16.2426 3.75736C15.1174 2.63214 13.5913 2 12 2C10.4087 2 8.88258 2.63214 7.75736 3.75736C6.63214 4.88258 6 6.4087 6 8C6 15 3 17 3 17H21C21 17 18 15 18 8Z" stroke="#7F878D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.73 21C13.5542 21.3031 13.3019 21.5547 12.9982 21.7295C12.6946 21.9044 12.3504 21.9965 12 21.9965C11.6496 21.9965 11.3054 21.9044 11.0018 21.7295C10.6982 21.5547 10.4458 21.3031 10.27 21" stroke="#7F878D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/raiden-dapp/src/components/notification-panel/NotificationCard.vue
+++ b/raiden-dapp/src/components/notification-panel/NotificationCard.vue
@@ -2,7 +2,7 @@
   <v-card data-cy="notification_card" class="notification-card" flat>
     <v-row class="notification-card__content" no-gutters>
       <v-avatar class="notification-card__content__icon" size="44" rounded>
-        <img :src="require(`@/assets/notifications/${notification.icon}.svg`)" />
+        <img :src="require(`@/assets/notifications/${iconName}.svg`)" />
       </v-avatar>
       <div class="notification-card__content__details">
         <span class="notification-card__content__details__title">
@@ -68,6 +68,10 @@ export default class NotificationCard extends Vue {
 
   @Prop({ required: true })
   notification!: NotificationPayload;
+
+  get iconName(): string {
+    return this.notification.icon ?? 'notification_fallback';
+  }
 
   get blocksUntilTxConfirmation(): number | undefined {
     const { txConfirmationBlock } = this.notification;

--- a/raiden-dapp/tests/unit/components/notification-panel/notification-card.spec.ts
+++ b/raiden-dapp/tests/unit/components/notification-panel/notification-card.spec.ts
@@ -1,10 +1,11 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 jest.mock('vue-router');
 
 import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuetify from 'vuetify';
 import VueRouter from 'vue-router';
-import Vuex  from 'vuex';
+import Vuex from 'vuex';
 import { TestData } from '../../data/mock-data';
 import Mocked = jest.Mocked;
 import { RouteNames } from '@/router/route-names';
@@ -20,9 +21,7 @@ const $router = new VueRouter() as Mocked<VueRouter>;
 const $raiden = { fetchAndUpdateTokenData: jest.fn() };
 const notificationDelete = jest.fn((_id: number) => null);
 
-function createWrapper(
-  notification = TestData.notifications
-): Wrapper<NotificationCard> {
+function createWrapper(notification = TestData.notifications): Wrapper<NotificationCard> {
   const state = { blockNumber: 100 };
   const notificationsModule = {
     namespaced: true,
@@ -31,7 +30,7 @@ function createWrapper(
 
   const store = new Vuex.Store({
     state,
-    modules: { notifications: notificationsModule }
+    modules: { notifications: notificationsModule },
   });
 
   return mount(NotificationCard, {
@@ -119,5 +118,19 @@ describe('NotificationCard.vue', () => {
     await wrapper.vm.$nextTick();
 
     expect(notificationDelete).toHaveBeenCalledTimes(1);
+  });
+
+  test('displays icon as specified in the notification payload', () => {
+    const wrapper = createWrapper({ ...TestData.notifications, icon: 'notification_channels' });
+
+    // TODO:  It would be cooler if it was possible to check the applied image source.
+    expect((wrapper.vm as any).iconName).toBe('notification_channels');
+  });
+
+  test('displays fallbacl icon if the notification payload does not define one', () => {
+    const wrapper = createWrapper({ ...TestData.notifications, icon: undefined });
+
+    // TODO:  It would be cooler if it was possible to check the applied image source.
+    expect((wrapper.vm as any).iconName).toBe('notification_fallback');
   });
 });

--- a/raiden-dapp/tests/unit/components/notification-panel/notification-card.spec.ts
+++ b/raiden-dapp/tests/unit/components/notification-panel/notification-card.spec.ts
@@ -1,46 +1,65 @@
+jest.mock('vue-router');
+
 import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuetify from 'vuetify';
 import VueRouter from 'vue-router';
+import Vuex  from 'vuex';
 import { TestData } from '../../data/mock-data';
 import Mocked = jest.Mocked;
 import { RouteNames } from '@/router/route-names';
 import Filters from '@/filters';
 import NotificationCard from '@/components/notification-panel/NotificationCard.vue';
-import store from '@/store';
 
 Vue.use(Vuetify);
+Vue.use(Vuex);
 Vue.filter('formatDate', Filters.formatDate);
 
-describe('NotificationCard.vue', () => {
-  let wrapper: Wrapper<NotificationCard>;
-  let vuetify: Vuetify;
-  let router: Mocked<VueRouter>;
+const vuetify = new Vuetify();
+const $router = new VueRouter() as Mocked<VueRouter>;
+const $raiden = { fetchAndUpdateTokenData: jest.fn() };
+const notificationDelete = jest.fn((_id: number) => null);
 
+function createWrapper(
+  notification = TestData.notifications
+): Wrapper<NotificationCard> {
+  const state = { blockNumber: 100 };
+  const notificationsModule = {
+    namespaced: true,
+    mutations: { notificationDelete },
+  };
+
+  const store = new Vuex.Store({
+    state,
+    modules: { notifications: notificationsModule }
+  });
+
+  return mount(NotificationCard, {
+    vuetify,
+    store,
+    mocks: {
+      $router,
+      $raiden,
+      $t: (msg: string) => msg,
+    },
+    propsData: { notification },
+  });
+}
+
+describe('NotificationCard.vue', () => {
   beforeEach(() => {
-    vuetify = new Vuetify();
-    router = new VueRouter() as Mocked<VueRouter>;
-    wrapper = mount(NotificationCard, {
-      vuetify,
-      store,
-      mocks: {
-        $router: router,
-        $t: (msg: string) => msg,
-        $raiden: {
-          fetchAndUpdateTokenData: jest.fn(),
-        },
-      },
-      propsData: { notification: TestData.notifications },
-    });
+    jest.resetAllMocks();
   });
 
   test('displays notification title', () => {
+    const wrapper = createWrapper();
     const notificationTitle = wrapper.find('.notification-card__content__details__title');
 
     expect(notificationTitle.text()).toBe('Channel Settlement');
   });
 
   test('displays notification description', () => {
+    const wrapper = createWrapper();
     const { wrappers } = wrapper
       .find('.notification-card__content__details__description')
       .findAll('p');
@@ -58,44 +77,47 @@ describe('NotificationCard.vue', () => {
   });
 
   test('displays block count progress if supported by notification ', () => {
+    const wrapper = createWrapper();
     const notificationBlockCount = wrapper.find(
       '.notification-card__content__details__block-count',
     );
 
-    expect(notificationBlockCount.text()).toContain('123');
+    expect(notificationBlockCount.text()).toContain('23');
     expect(notificationBlockCount.text()).toContain('notifications.block-count-progress');
   });
 
   test('displays link if link is in notification', () => {
+    const wrapper = createWrapper();
     const notificationLink = wrapper.find('.notification-card__content__details__link');
 
     expect(notificationLink.text()).toContain('Visit the Withdrawal menu');
   });
 
   test('clicking link in notification routes user', () => {
-    router.push = jest.fn().mockResolvedValue(null);
-
+    const wrapper = createWrapper();
     const notificationLink = wrapper.find('.notification-card__content__details__link');
+
     notificationLink.trigger('click');
 
-    expect(router.push).toHaveBeenCalledTimes(1);
-    expect(router.push).toHaveBeenCalledWith(
+    expect($router.push).toHaveBeenCalledTimes(1);
+    expect($router.push).toHaveBeenCalledWith(
       expect.objectContaining({ name: RouteNames.ACCOUNT_WITHDRAWAL }),
     );
   });
 
   test('displays correctly formatted date', () => {
+    const wrapper = createWrapper();
     const notificationReceived = wrapper.find('.notification-card__content__details__received');
 
     expect(notificationReceived.text()).toBe('6/5/1986 12:00:00 AM');
   });
 
   test('clicking "trash"-icon calls method for deleting notification', async () => {
-    store.commit('notifications/notificationAddOrReplace', TestData.notifications);
+    const wrapper = createWrapper();
     const deleteNotificationButton = wrapper.find('button');
     deleteNotificationButton.trigger('click');
     await wrapper.vm.$nextTick();
 
-    expect(Object.keys(store.state.notifications.notifications)).toHaveLength(0);
+    expect(notificationDelete).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Fixes #2391

**Short description**
The first commit includes some test refactors in preparation, so just read the commit individually.
The icon was provided by Sash.
Unfortunately it is not really possible to actually test the rendered icon. But the test do fail if the icon related asset could not been resolved.

**Definition of Done**

- [X] Steps to manually test the change have been documented
- [X] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. The only notification without an icon atm is the balance prove sent one.
2. Manipulate the open channel notification to do not use an icon.
