### PR TITLE
Add suggestedPartners method

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- [#211] 'suggestPartners' method to fetch suggested partners from PFS
+
+[#211]: https://github.com/raiden-network/light-client/issues/211
 
 ## [0.14.0] - 2020-11-25
 ### Fixed

--- a/raiden-ts/src/db/types.ts
+++ b/raiden-ts/src/db/types.ts
@@ -1,20 +1,10 @@
 import { BehaviorSubject } from 'rxjs';
-import type { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import type logging from 'loglevel';
 
 import type { TransferState } from '../transfers/state';
-import { Address } from '../utils/types';
+import { Address, Decodable } from '../utils/types';
 
-// type helper to recursively map values assignable to BigNumber as BigNumberish;
-// to ensure a [de]serialized BigNumber from db (`{_hex:"0x"}`) isn't used as BigNumber directly
-// and should be decoded first (unless somewhere accepting BigNumberish, e.g. BigNumber methods)
-type AsBigNumberish<T> = T extends BigNumber
-  ? BigNumberish
-  : T extends boolean | string | number | null | symbol
-  ? T
-  : { [K in keyof T]: AsBigNumberish<T[K]> };
-
-export interface TransferStateish extends AsBigNumberish<TransferState> {
+export interface TransferStateish extends Decodable<TransferState> {
   _rev: string;
 }
 

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -68,15 +68,15 @@ import {
 import { pathFind, udcWithdraw, udcDeposit } from './services/actions';
 import {
   Paths,
-  RaidenPaths,
   PFS,
-  RaidenPFS,
   IOU,
   SuggestedPartner,
   SuggestedPartners,
+  RaidenPaths,
+  RaidenPFS,
 } from './services/types';
 import { pfsListInfo } from './services/utils';
-import { Address, Secret, Storage, Hash, UInt, decode } from './utils/types';
+import { Address, Secret, Storage, Hash, UInt, decode, Decodable } from './utils/types';
 import { isActionOf, asyncActionToPromise, isResponseOf } from './utils/actions';
 import { pluckDistinct } from './utils/rx';
 import {
@@ -350,7 +350,7 @@ export class Raiden {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     storage?: { state?: any; storage?: Storage; adapter?: any; prefix?: string },
     contractsOrUDCAddress?: ContractsInfo | string,
-    config?: { [k: string]: unknown },
+    config?: Decodable<PartialRaidenConfig>,
     subkey?: true,
   ): Promise<InstanceType<R>> {
     let provider: JsonRpcProvider;

--- a/raiden-ts/src/services/types.ts
+++ b/raiden-ts/src/services/types.ts
@@ -84,3 +84,16 @@ export interface IOU extends t.TypeOf<typeof IOU> {}
 export const LastIOUResults = t.readonly(t.type({ last_iou: Signed(IOU) }));
 
 export interface LastIOUResults extends t.TypeOf<typeof LastIOUResults> {}
+
+export const SuggestedPartner = t.readonly(
+  t.type({
+    address: Address,
+    capacity: UInt(32),
+    centrality: t.union([t.number, t.string]),
+    score: t.union([t.number, t.string]),
+    uptime: t.union([t.number, t.string]),
+  }),
+  'SuggestedPartner',
+);
+export interface SuggestedPartner extends t.TypeOf<typeof SuggestedPartner> {}
+export const SuggestedPartners = t.array(SuggestedPartner, 'SuggestedPartners');

--- a/raiden-ts/src/services/types.ts
+++ b/raiden-ts/src/services/types.ts
@@ -1,6 +1,5 @@
 import * as t from 'io-ts';
-import type { BigNumberish } from '@ethersproject/bignumber';
-import { Address, Int, Signed, UInt } from '../utils/types';
+import { Address, Decodable, Int, Signed, UInt } from '../utils/types';
 
 /**
  * Codec for PFS API returned data
@@ -38,7 +37,7 @@ export type Paths = t.TypeOf<typeof Paths>;
 /**
  * Public Raiden interface for routes data
  */
-export type RaidenPaths = { readonly path: readonly string[]; readonly fee: BigNumberish }[];
+export type RaidenPaths = Decodable<Paths>;
 
 /**
  * A PFS server/service instance info
@@ -57,13 +56,7 @@ export interface PFS extends t.TypeOf<typeof PFS> {}
 /**
  * Public Raiden interface for PFS info
  */
-export interface RaidenPFS {
-  address: string;
-  url: string;
-  rtt: number;
-  price: BigNumberish;
-  token: string;
-}
+export type RaidenPFS = Decodable<PFS>;
 
 /**
  * An IOU used to pay the services

--- a/raiden-ts/src/utils/types.ts
+++ b/raiden-ts/src/utils/types.ts
@@ -3,7 +3,7 @@ import * as t from 'io-ts';
 import { Either, isLeft, Right } from 'fp-ts/lib/Either';
 import { PathReporter } from 'io-ts/lib/PathReporter';
 
-import { BigNumber } from '@ethersproject/bignumber';
+import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import { getAddress } from '@ethersproject/address';
 import { isHexString, hexDataLength } from '@ethersproject/bytes';
 import { Two, Zero } from '@ethersproject/constants';
@@ -343,3 +343,20 @@ export function last<T extends any[]>(arr: T): Last<T> {
 export function bnMax<T extends BigNumber>(...args: [T, ...T[]]): T {
   return args.reduce((a, b) => (a.lt(b) ? b : a));
 }
+
+/**
+ * Type helper to recursively map decodable properties to their simpler encoded types;
+ * This allows e.g. types decodable as BigNumbers to be passed in [recursive] properties where
+ * BigNumbers are expected at runtime, as long as the object is decoded/validated before use.
+ */
+export type Decodable<T> = T extends BigNumber
+  ? BigNumberish
+  : T extends string
+  ? string
+  : T extends boolean
+  ? boolean
+  : T extends number
+  ? number
+  : T extends null | symbol
+  ? T
+  : { [K in keyof T]: Decodable<T[K]> };


### PR DESCRIPTION
SDK part of #211 

**Short description**
Adds a `Raiden.suggestPartners` method, which fetches and validates the suggested partners from PFS.

It also fixes a small issue when not all environment variables were set, partial config handled to `Raiden.create` contained `undefined` values which overwrote default ones. Now, this gets properly cleaned before creating default config, allowing the dApp to be served with something like `--mode=testnet` to skip loading demoenv001 variables.

This was required because current demo001 PFS doesn't support suggested partners.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. On development mode, get the SDK instance on DevTools console (e.g. in a var named `raiden`)
2. call the method to get the response: `await raiden.suggestPartners('0x59105441977ecD9d805A4f5b060E34676F50F806')`
