### PR TITLE
Bugfix/dapp transfer history intersection observer too greedy

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### Fixed
 
 - [#2391] Fix notification icon handling for special scenarios
+- [#2410] Fix transfer history list not showing third entry initially
 
 [#2391]: https://github.com/raiden-network/light-client/issues/2391
+[#2410]: https://github.com/raiden-network/light-client/issues/2410
 
 
 ## [0.14.0] - 2020-11-25

--- a/raiden-dapp/src/components/transaction-history/TransactionList.vue
+++ b/raiden-dapp/src/components/transaction-history/TransactionList.vue
@@ -10,7 +10,7 @@
           :key="index"
           class="transaction-history__transactions__list__item"
         >
-          <v-lazy transition="fade-transition" :options="{ threshold: 0.7 }" min-height="74">
+          <v-lazy transition="fade-transition" :options="{ threshold: 0.5 }" min-height="74">
             <transaction :transfer="transfer" />
           </v-lazy>
         </div>


### PR DESCRIPTION
Fixes #2410

**Short description**
This was simply a configuration of the threshold option for the intersection observer.

**Definition of Done**

- [X] Steps to manually test the change have been documented
- [X] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Serve the build of this PR
2. Make sure you have at least 3 transfers made
3. Verify that there are three transfer list items shown on initial loading of the transfer screen
