### PR TITLE
dApp: sort transactions latest first in transaction list

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Fixed
 
+- [#2415] Fix sorting latest transaction on top in transactions list
 - [#2391] Fix notification icon handling for special scenarios
 - [#2410] Fix transfer history list not showing third entry initially
 
+[#2415]: https://github.com/raiden-network/light-client/issues/2415
 [#2391]: https://github.com/raiden-network/light-client/issues/2391
 [#2410]: https://github.com/raiden-network/light-client/issues/2410
 

--- a/raiden-dapp/src/components/transaction-history/TransactionList.vue
+++ b/raiden-dapp/src/components/transaction-history/TransactionList.vue
@@ -23,9 +23,9 @@
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import { mapState } from 'vuex';
 import { Transfers } from '../../types';
-import { RaidenTransfer } from 'raiden-ts';
 import { Token } from '@/model/types';
 import Transaction from '@/components/transaction-history/Transaction.vue';
+import { RaidenTransfer } from 'raiden-ts';
 
 @Component({
   components: {
@@ -53,8 +53,7 @@ export default class TransactionLists extends Vue {
 
   get orderedTransfers(): RaidenTransfer[] {
     return this.filteredTransfersForToken.sort(
-      (a: RaidenTransfer, b: RaidenTransfer) =>
-        b.changedAt.getMilliseconds() - a.changedAt.getMilliseconds(),
+      (a: RaidenTransfer, b: RaidenTransfer) => b.changedAt.getTime() - a.changedAt.getTime(),
     );
   }
 }

--- a/raiden-dapp/tests/unit/components/transaction-history/transaction-list.spec.ts
+++ b/raiden-dapp/tests/unit/components/transaction-history/transaction-list.spec.ts
@@ -1,19 +1,23 @@
 import { shallowMount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuetify from 'vuetify';
-import { generateToken, generateTransfer } from '../../utils/data-generator';
-import { RaidenTransfer } from 'raiden-ts';
+import { generateToken, generateTransfer, TRANSFER_DATES } from '../../utils/data-generator';
 import Transaction from '@/components/transaction-history/Transaction.vue';
 import TransactionList from '@/components/transaction-history/TransactionList.vue';
 import { Token } from '@/model/types';
 import { Transfers } from '@/types';
+import { RaidenTransfer } from 'raiden-ts';
 
 Vue.use(Vuetify);
 
 describe('TransactionList.vue', () => {
   const vuetify = new Vuetify();
   const token = generateToken();
-  const transfers = [generateTransfer({}, token), generateTransfer({}, token)];
+  const transfers = [
+    generateTransfer({ changedAt: TRANSFER_DATES[1] }, token),
+    generateTransfer({ changedAt: TRANSFER_DATES[2] }, token),
+    generateTransfer({ changedAt: TRANSFER_DATES[0] }, token),
+  ];
 
   const createWrapper = (
     tokenProp?: Token,
@@ -38,7 +42,7 @@ describe('TransactionList.vue', () => {
     const wrapper = createWrapper();
     const transactionEntries = wrapper.findAllComponents(Transaction);
 
-    expect(transactionEntries.length).toEqual(2);
+    expect(transactionEntries.length).toEqual(3);
   });
 
   test('transaction list applies token filter', () => {

--- a/raiden-dapp/tests/unit/components/transaction-history/transaction.spec.ts
+++ b/raiden-dapp/tests/unit/components/transaction-history/transaction.spec.ts
@@ -70,7 +70,6 @@ describe('Transaction.vue', () => {
   test('transaction item display correctly formatted date', () => {
     const wrapper = createWrapper();
     const transactionTimeStamp = wrapper.find('.transaction__item__details-left__time-stamp');
-    expect(transactionTimeStamp.text()).toContain('6/5/1986');
-    expect(transactionTimeStamp.text()).toContain('11:59:59 PM');
+    expect(transactionTimeStamp.text()).toContain('6/5/1986 11:00:00 PM');
   });
 });

--- a/raiden-dapp/tests/unit/utils/data-generator.ts
+++ b/raiden-dapp/tests/unit/utils/data-generator.ts
@@ -1,12 +1,18 @@
 import times from 'lodash/times';
 import { BigNumber, constants } from 'ethers';
-import { RaidenTransfer, Address, RaidenChannel, ChannelState } from 'raiden-ts';
 import { Token } from '@/model/types';
 import { NotificationPayload } from '@/store/notifications/types';
+import { RaidenTransfer, Address, RaidenChannel, ChannelState } from 'raiden-ts';
 
 const HEXADECIMAL_CHARACTERS = '0123456789abcdefABCDEF';
 const ALPHABET_CHARACTERS = 'abcdefghijklmnopqrstuvwxyz';
 const NUMBER_CHARACTERS = '0123456789';
+
+export const TRANSFER_DATES = [
+  new Date('June 5, 1986 21:00:00:700'),
+  new Date('June 5, 1986 22:00:00:900'),
+  new Date('June 5, 1986 23:00:00:800'),
+];
 
 function getRandomString(charSet: string, length: number, prefix = ''): string {
   let output = prefix;
@@ -66,7 +72,7 @@ export function generateTransfer(
     key: getRandomTransactionKey(),
     token: token ? (token.address as Address) : getRandomEthereumAddress(),
     amount: BigNumber.from(10 ** 8),
-    changedAt: new Date('June 5, 1986 23:59:59'),
+    changedAt: new Date('June 5, 1986 23:00:00'),
     direction: 'sent',
     partner: getRandomEthereumAddress(),
     initiator: getRandomEthereumAddress(),


### PR DESCRIPTION
Fixes #2415

**Short description**
Fixes issues with transactions in the transactions list appearing in random order. Now the get sorted latest first.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Make some transfers and check the order of them.
2.
