### PR TITLE
Shorter expiration

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -12,16 +12,21 @@
 ### Added
 
 - [#211] Hub proposal when connecting to new token network
-- [#2435] Sync indicator when connecting to dApp
 - [#2379] Illustrations for info overlays
+- [#2435] Sync indicator when connecting to dApp
+
+### Changed
+
+- [#2409] Lower default payment expiration to 1.1 × reveal timeout
 
 [#211]: https://github.com/raiden-network/light-client/issues/211
-[#2435]: https://github.com/raiden-network/light-client/issues/2435
 [#2379]: https://github.com/raiden-network/light-client/issues/2379
-[#2415]: https://github.com/raiden-network/light-client/issues/2415
 [#2391]: https://github.com/raiden-network/light-client/issues/2391
+[#2409]: https://github.com/raiden-network/light-client/issues/2409
 [#2410]: https://github.com/raiden-network/light-client/issues/2410
+[#2415]: https://github.com/raiden-network/light-client/issues/2415
 [#2426]: https://github.com/raiden-network/light-client/issues/2426
+[#2435]: https://github.com/raiden-network/light-client/issues/2435
 
 ## [0.14.0] - 2020-11-25
 

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -74,6 +74,9 @@ export default class RaidenService {
           ...(process.env.VUE_APP_CONFIRMATION_BLOCKS && +process.env.VUE_APP_CONFIRMATION_BLOCKS
             ? { confirmationBlocks: +process.env.VUE_APP_CONFIRMATION_BLOCKS }
             : undefined),
+          ...(process.env.VUE_APP_EXPIRY_FACTOR && +process.env.VUE_APP_EXPIRY_FACTOR
+            ? { expiryFactor: +process.env.VUE_APP_EXPIRY_FACTOR }
+            : undefined),
         },
         subkey,
       );

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -5,7 +5,12 @@
 - [#211] 'suggestPartners' method to fetch suggested partners from PFS
 - [#2417] Make 'start' async, introduce 'synced' promise, both resolves when syncing finishes
 
+### Changed
+
+- [#2409] Lower default payment expiration to 1.1 × reveal timeout
+
 [#211]: https://github.com/raiden-network/light-client/issues/211
+[#2409]: https://github.com/raiden-network/light-client/issues/2409
 [#2417]: https://github.com/raiden-network/light-client/pull/2417
 
 ## [0.14.0] - 2020-11-25

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -62,6 +62,7 @@ export const RaidenConfig = t.readonly(
       matrixServerLookup: t.string,
       revealTimeout: t.number,
       settleTimeout: t.number,
+      expiryFactor: t.number, // must be >= 1.1
       httpTimeout: t.number,
       discoveryRoom: t.union([t.string, t.null]),
       pfsRoom: t.union([t.string, t.null]),
@@ -126,6 +127,7 @@ export function makeDefaultConfig(
     matrixServerLookup: matrixServerInfos,
     settleTimeout: 500,
     revealTimeout: 50,
+    expiryFactor: 2.0,
     httpTimeout: 30e3,
     discoveryRoom: `raiden_${networkName}_discovery`,
     pfsRoom: `raiden_${networkName}_path_finding`,

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -127,7 +127,7 @@ export function makeDefaultConfig(
     matrixServerLookup: matrixServerInfos,
     settleTimeout: 500,
     revealTimeout: 50,
-    expiryFactor: 2.0,
+    expiryFactor: 1.1, // must be >= 1.1
     httpTimeout: 30e3,
     discoveryRoom: `raiden_${networkName}_discovery`,
     pfsRoom: `raiden_${networkName}_path_finding`,

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -127,9 +127,7 @@ function makeAndSignTransfer$(
   const channel = getOpenChannel(state, { tokenNetwork, partner });
 
   assert(
-    !action.payload.expiration ||
-      // require mediated transfers to have at least confirmationBlocks before danger zone
-      action.payload.expiration >= state.blockNumber + revealTimeout + confirmationBlocks,
+    !action.payload.expiration || action.payload.expiration > state.blockNumber + revealTimeout,
     'expiration too soon',
   );
   const expiration = BigNumber.from(

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -101,6 +101,7 @@ function getOpenChannel(
  * @param config - Config object
  * @param config.revealTimeout - The reveal timeout for the transfer.
  * @param config.confirmationBlocks - Confirmations block config
+ * @param config.expiryFactor - The factor that the reveal timeouts gets multiplied with to calculate the lock expiration
  * @param deps - {@link RaidenEpicDeps}
  * @param deps.log - Logger instance
  * @param deps.address - Our address
@@ -111,7 +112,7 @@ function getOpenChannel(
 function makeAndSignTransfer$(
   state: RaidenState,
   action: transfer.request,
-  { revealTimeout, confirmationBlocks }: RaidenConfig,
+  { revealTimeout, confirmationBlocks, expiryFactor }: RaidenConfig,
   { log, address, network, signer }: RaidenEpicDeps,
 ): Observable<transferSecret | transferSigned> {
   // assume paths are valid and recipient is first hop of first route
@@ -134,7 +135,7 @@ function makeAndSignTransfer$(
   const expiration = BigNumber.from(
     action.payload.expiration ||
       Math.min(
-        state.blockNumber + revealTimeout * 2,
+        state.blockNumber + Math.round(revealTimeout * expiryFactor),
         state.blockNumber + channel.settleTimeout - confirmationBlocks,
       ),
   ) as UInt<32>;

--- a/raiden-ts/tests/unit/epics/send.spec.ts
+++ b/raiden-ts/tests/unit/epics/send.spec.ts
@@ -64,6 +64,7 @@ describe('send transfer', () => {
     const [raiden, partner] = await makeRaidens(2);
     await ensureChannelIsDeposited([raiden, partner]);
 
+    const requestBlock = raiden.deps.provider.blockNumber;
     const request = transfer.request(
       {
         tokenNetwork,
@@ -87,7 +88,9 @@ describe('send transfer', () => {
       lock: {
         secrethash,
         amount: value.add(fee),
-        expiration: expect.any(BigNumber),
+        expiration: BigNumber.from(Math.round(1.1 * raiden.config.revealTimeout)).add(
+          requestBlock,
+        ),
       },
       signature: expect.any(String),
     });


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2409 

**Short description**

Instead of hard-coding the lock expiry to 2 times the reveal timeout, this introduces the `expiryFactor`, which multiplied with the reveal timeout returns the lock expiry.

~~An alternative would be to use absolute block numbers here, I can change that if people don't like the relative value.~~

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
