### PR TITLE
dApp: Make confirmation blocks setting configurable

### DIFF
--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -71,6 +71,9 @@ export default class RaidenService {
           ...(process.env.VUE_APP_SETTLE_TIMEOUT && +process.env.VUE_APP_SETTLE_TIMEOUT
             ? { settleTimeout: +process.env.VUE_APP_SETTLE_TIMEOUT }
             : undefined),
+          ...(process.env.VUE_APP_CONFIRMATION_BLOCKS && +process.env.VUE_APP_CONFIRMATION_BLOCKS
+            ? { confirmationBlocks: +process.env.VUE_APP_CONFIRMATION_BLOCKS }
+            : undefined),
         },
         subkey,
       );


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2432

**Short description**

Use the `VUE_APP_CONFIRMATION_BLOCKS` env variable to overwrite the default block confirmation value.

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
