### PR TITLE
dapp: Display overall capacity in TransferRoute view

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#2415] Fix sorting latest transaction on top in transactions list
 - [#2391] Fix notification icon handling for special scenarios
 - [#2410] Fix transfer history list not showing third entry initially
+- [#2426] Display total available capacity in transfer view
 
 ### Added
 
@@ -16,6 +17,7 @@
 [#2415]: https://github.com/raiden-network/light-client/issues/2415
 [#2391]: https://github.com/raiden-network/light-client/issues/2391
 [#2410]: https://github.com/raiden-network/light-client/issues/2410
+[#2426]: https://github.com/raiden-network/light-client/issues/2426
 
 
 ## [0.14.0] - 2020-11-25

--- a/raiden-dapp/src/components/transfer/TransferHeaders.vue
+++ b/raiden-dapp/src/components/transfer/TransferHeaders.vue
@@ -43,7 +43,7 @@
       {{ $t('transfer.transfer-menus.no-channels') }}
     </span>
     <span v-else>
-      <amount-display exact-amount :amount="capacity" :token="token" />
+      <amount-display exact-amount :amount="totalCapacity" :token="token" />
     </span>
     <token-overlay v-if="showTokenOverlay" @cancel="showTokenOverlay = false" />
     <channel-deposit-dialog
@@ -62,7 +62,7 @@
 <script lang="ts">
 import { Component, Prop, Mixins } from 'vue-property-decorator';
 import { mapGetters } from 'vuex';
-import { BigNumber, constants } from 'ethers';
+import { BigNumber } from 'ethers';
 import NavigationMixin from '../../mixins/navigation-mixin';
 import AmountDisplay from '@/components/AmountDisplay.vue';
 import TokenOverlay from '@/components/overlays/TokenOverlay.vue';
@@ -94,11 +94,9 @@ export default class TransferHeaders extends Mixins(NavigationMixin) {
   @Prop({ required: true })
   token!: Token;
   @Prop({ required: true })
-  capacity!: BigNumber;
-
-  get noChannels(): boolean {
-    return this.capacity === constants.Zero;
-  }
+  noChannels!: boolean;
+  @Prop({ required: true })
+  totalCapacity!: BigNumber;
 
   depositDialogOpen() {
     this.showDepositDialog = true;

--- a/raiden-dapp/src/components/transfer/TransferHeaders.vue
+++ b/raiden-dapp/src/components/transfer/TransferHeaders.vue
@@ -21,7 +21,7 @@
         <div class="transfer-menus__dot-menu__menu">
           <v-btn
             text
-            :disabled="noChannels"
+            :disabled="noChannelOrCapacity"
             data-cy="transfer_menus_dot_menu_menu_deposit"
             class="transfer-menus__dot-menu__menu__deposit"
             @click="depositDialogOpen()"
@@ -39,7 +39,7 @@
         </div>
       </v-menu>
     </div>
-    <span v-if="noChannels">
+    <span v-if="noChannelOrCapacity">
       {{ $t('transfer.transfer-menus.no-channels') }}
     </span>
     <span v-else>
@@ -62,7 +62,7 @@
 <script lang="ts">
 import { Component, Prop, Mixins } from 'vue-property-decorator';
 import { mapGetters } from 'vuex';
-import { BigNumber } from 'ethers';
+import { BigNumber, constants } from 'ethers';
 import NavigationMixin from '../../mixins/navigation-mixin';
 import AmountDisplay from '@/components/AmountDisplay.vue';
 import TokenOverlay from '@/components/overlays/TokenOverlay.vue';
@@ -104,6 +104,10 @@ export default class TransferHeaders extends Mixins(NavigationMixin) {
 
   depositDialogClosed() {
     this.showDepositDialog = false;
+  }
+
+  get noChannelOrCapacity(): boolean {
+    return this.noChannels || this.totalCapacity.lte(constants.Zero);
   }
 
   /* istanbul ignore next */

--- a/raiden-dapp/src/components/transfer/TransferInputs.vue
+++ b/raiden-dapp/src/components/transfer/TransferInputs.vue
@@ -40,7 +40,7 @@
           hide-error-label
           :disabled="noChannels"
           :token="token"
-          :max="capacity"
+          :max="maxChannelCapacity"
           :placeholder="$t('transfer.amount-placeholder')"
           @input-error="amountError = $event"
         />
@@ -58,7 +58,7 @@
 <script lang="ts">
 import { Component, Prop, Watch, Mixins } from 'vue-property-decorator';
 import { mapState, mapGetters } from 'vuex';
-import { BigNumber, constants } from 'ethers';
+import { BigNumber } from 'ethers';
 import { VForm } from 'vuetify/lib';
 import NavigationMixin from '../../mixins/navigation-mixin';
 import AddressInput from '@/components/AddressInput.vue';
@@ -93,7 +93,9 @@ export default class TransferInputs extends Mixins(NavigationMixin) {
   @Prop({ required: true })
   token!: Token;
   @Prop({ required: true })
-  capacity!: BigNumber;
+  noChannels!: boolean;
+  @Prop({ required: true })
+  maxChannelCapacity!: BigNumber;
 
   $refs!: {
     transfer: VForm;
@@ -124,10 +126,6 @@ export default class TransferInputs extends Mixins(NavigationMixin) {
     if (this.token.decimals === 0 && this.amount.indexOf('.') > -1) {
       this.amount = this.amount.split('.')[0];
     }
-  }
-
-  get noChannels(): boolean {
-    return this.capacity === constants.Zero;
   }
 
   get blockedHubs(): string[] {

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -6,7 +6,6 @@ import flatMap from 'lodash/flatMap';
 import filter from 'lodash/filter';
 import clone from 'lodash/clone';
 import reduce from 'lodash/reduce';
-import orderBy from 'lodash/orderBy';
 import isEqual from 'lodash/isEqual';
 import isEmpty from 'lodash/isEmpty';
 import { BigNumber, providers } from 'ethers';
@@ -225,7 +224,15 @@ const store: StoreOptions<CombinedStoreState> = {
     channelWithBiggestCapacity: (_, getters) => (tokenAddress: string) => {
       const channels: RaidenChannel[] = getters.channels(tokenAddress);
       const openChannels = channels.filter((value) => value.state === ChannelState.open);
-      return orderBy(openChannels, ['capacity'], ['desc'])[0];
+
+      const ordered = openChannels.sort((a, b) => {
+        const diff = a.capacity.sub(b.capacity);
+        if (diff.lt(0)) return 1;
+        else if (diff.gt(0)) return -1;
+        else return 0;
+      });
+
+      return ordered[0];
     },
     pendingTransfers: ({ transfers }: RootState) =>
       Object.keys(transfers)

--- a/raiden-dapp/tests/unit/components/transfer/transfer-inputs.spec.ts
+++ b/raiden-dapp/tests/unit/components/transfer/transfer-inputs.spec.ts
@@ -40,7 +40,8 @@ describe('TransferInputs.vue', () => {
     },
     propsData: {
       token,
-      capacity: constants.One,
+      noChannels: false,
+      maxChannelCapacity: constants.One,
     },
   });
 

--- a/raiden-dapp/tests/unit/components/transfer/transfer-menus.spec.ts
+++ b/raiden-dapp/tests/unit/components/transfer/transfer-menus.spec.ts
@@ -21,7 +21,10 @@ describe('TransferHeaders.vue', () => {
   let router: Mocked<VueRouter>;
   const token = generateToken();
 
-  const createWrapper = (capacity: BigNumber): Wrapper<TransferHeaders> => {
+  const createWrapper = (
+    noChannels: boolean,
+    totalCapacity: BigNumber,
+  ): Wrapper<TransferHeaders> => {
     router = new VueRouter() as Mocked<VueRouter>;
 
     return mount(TransferHeaders, {
@@ -37,34 +40,35 @@ describe('TransferHeaders.vue', () => {
       },
       propsData: {
         token,
-        capacity,
+        noChannels,
+        totalCapacity,
       },
     });
   };
 
   test('displays "no open channels" if channel capacity is zero', () => {
-    const wrapper = createWrapper(constants.Zero);
+    const wrapper = createWrapper(true, constants.Zero);
     const amountDisplay = wrapper.findAll('span').at(3);
 
     expect(amountDisplay.text()).toContain('transfer.transfer-menus.no-channels');
   });
 
   test('disables deposit button if channel capacity is zero', () => {
-    const wrapper = createWrapper(constants.Zero);
+    const wrapper = createWrapper(false, constants.Zero);
     const depositButton = wrapper.find('.transfer-menus__dot-menu__menu__deposit');
 
     expect(depositButton.attributes()['disabled']).toBe('disabled');
   });
 
   test('displays amount if channel has capacity', () => {
-    const wrapper = createWrapper(constants.One);
+    const wrapper = createWrapper(false, constants.One);
     const amountDisplay = wrapper.findAll('span').at(3);
 
     expect(amountDisplay.find('div').text()).toContain('0.000001');
   });
 
-  test('deposit button is enabled if channel has capacity', () => {
-    const wrapper = createWrapper(constants.One);
+  test('deposit button is enabled if channel has capacityxxxx', () => {
+    const wrapper = createWrapper(false, constants.One);
     const depositButton = wrapper.find('.transfer-menus__dot-menu__menu__deposit');
 
     expect(depositButton.attributes()).not.toMatchObject(
@@ -73,7 +77,7 @@ describe('TransferHeaders.vue', () => {
   });
 
   test('deposit button opens deposit dialog', async () => {
-    const wrapper = createWrapper(constants.One);
+    const wrapper = createWrapper(false, constants.One);
     const depositButton = wrapper.find('.transfer-menus__dot-menu__menu__deposit');
 
     depositButton.trigger('click');
@@ -87,7 +91,7 @@ describe('TransferHeaders.vue', () => {
   });
 
   test('clicking change token button displays token overlay', async () => {
-    const wrapper = createWrapper(constants.One);
+    const wrapper = createWrapper(false, constants.One);
 
     const tokenSelectButton = wrapper.findAll('span').at(0);
 
@@ -101,7 +105,7 @@ describe('TransferHeaders.vue', () => {
   test('clicking channels button navigates to channels screen', async () => {
     router.push = jest.fn().mockImplementation(() => Promise.resolve());
 
-    const wrapper = createWrapper(constants.One);
+    const wrapper = createWrapper(false, constants.One);
     const channelsButton = wrapper.find('.transfer-menus__dot-menu__menu__channels');
 
     channelsButton.trigger('click');

--- a/raiden-dapp/tests/unit/store.spec.ts
+++ b/raiden-dapp/tests/unit/store.spec.ts
@@ -263,6 +263,30 @@ describe('store', () => {
     });
   });
 
+  test('return the channel with the biggest capacity when there are multiple channels open, once more', () => {
+    const smallerChannel = {
+      ...TestData.openChannel,
+      capacity: BigNumber.from('0x09407931E1D4A000'), // 0.666666 T
+      partner: '0xaDBa6B0CC7176De032A887232EB59Bb3B1402103',
+    };
+    const biggestChannel = {
+      ...TestData.openChannel,
+      capacity: BigNumber.from('0x0DE0B6B3A7640000'), // 1 T
+      partner: '0xaDBa6B0CC7176De032A887232EB59Bb3B1402103',
+    };
+    const mockChannels = {
+      '0xd0A1E359811322d97991E03f863a0C30C2cF029C': {
+        '0x1D36124C90f53d491b6832F1c073F43E2550E35b': smallerChannel,
+        '0x82641569b2062B545431cF6D7F0A418582865ba7': TestData.settlingChannel,
+        '0xaDBa6B0CC7176De032A887232EB59Bb3B1402103': biggestChannel,
+      },
+    };
+    store.commit('updateChannels', mockChannels);
+    expect(
+      store.getters.channelWithBiggestCapacity('0xd0A1E359811322d97991E03f863a0C30C2cF029C'),
+    ).toEqual(biggestChannel);
+  });
+
   test('the channels getter returns an empty array when the token has no channels', () => {
     const channels = {
       '0xd0A1E359811322d97991E03f863a0C30C2cF029C': {},

--- a/raiden-dapp/tests/unit/views/transfer-route.spec.ts
+++ b/raiden-dapp/tests/unit/views/transfer-route.spec.ts
@@ -52,6 +52,7 @@ describe('TransferRoute.vue', () => {
       // This simplified version that expects one open channel per token none
       channelWithBiggestCapacity: () => (tokenAddress: string) =>
         channels.filter(({ token }) => token === tokenAddress)?.[0] ?? null,
+      channels: () => (_: string) => channels,
       openChannels: () => channels,
     };
     const mutations = {
@@ -85,7 +86,7 @@ describe('TransferRoute.vue', () => {
     expect(wrapper.findComponent(TransactionList).exists()).toBe(false);
   });
 
-  test('do not displays no tokens component if there are no tokens, but rest', () => {
+  test('does not display no tokens component if there are no tokens, but rest', () => {
     const wrapper = createWrapper();
     expect(wrapper.findComponent(NoTokens).exists()).toBe(false);
     expect(wrapper.findComponent(TransferHeaders).exists()).toBe(true);
@@ -93,7 +94,7 @@ describe('TransferRoute.vue', () => {
     expect(wrapper.findComponent(TransactionList).exists()).toBe(true);
   });
 
-  test('show dialog if there are no open channels', () => {
+  test('shows dialog if there are no open channels', () => {
     const wrapper = createWrapper(token.address, [token], []);
     expect(wrapper.findComponent(NoChannelsDialog).exists()).toBe(true);
   });
@@ -115,12 +116,12 @@ describe('TransferRoute.vue', () => {
 
   test('component can get channel capacity from route parameter', () => {
     const wrapper = createWrapper();
-    expect((wrapper.vm as any).capacity).toEqual(channel.capacity);
+    expect((wrapper.vm as any).totalCapacity).toEqual(channel.capacity);
   });
 
   test('capacity is zero if there is the token is undefined', () => {
     const wrapper = createWrapper('', [], []);
-    expect((wrapper.vm as any).capacity).toEqual(constants.Zero);
+    expect((wrapper.vm as any).totalCapacity).toEqual(constants.Zero);
   });
 
   test('notifies about backing up state if user has never been notified', () => {


### PR DESCRIPTION
This makes the displayed amount more intuitive and changes with
received/sent transfers. The amount validation in transfer view input is
still validated with the biggest channel capacity.

This also removes incorrect `noChannels` properties from
`TransferHeaders` and `TransferInputs` components.

It also includes a fix for the `channelWithBiggestCapacity` store
getter, whcih didn't order the channel correctly.

Fixes #2426


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Open two channels
2. Check that the transfer view displays the sum of the capacities in both channels
