### PR TITLE
dApp: sync indicator when connecting to dApp

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -10,8 +10,10 @@
 
 ### Added
 
+- [#2435] Sync indicator when connecting to dApp
 - [#2379] Illustrations for info overlays
 
+[#2435]: https://github.com/raiden-network/light-client/issues/2435
 [#2379]: https://github.com/raiden-network/light-client/issues/2379
 [#2415]: https://github.com/raiden-network/light-client/issues/2415
 [#2391]: https://github.com/raiden-network/light-client/issues/2391

--- a/raiden-dapp/src/components/ActionButton.vue
+++ b/raiden-dapp/src/components/ActionButton.vue
@@ -24,6 +24,12 @@
       >
         {{ text }}
         <v-icon v-if="arrow" right>keyboard_arrow_right</v-icon>
+        <template v-if="syncing" #loader>
+          <div class="action-button__syncing">
+            <span>{{ $t('home.connect-button-syncing') }}</span>
+            <v-progress-linear class="action-button__syncing__indicator" indeterminate rounded />
+          </div>
+        </template>
       </v-btn>
     </v-col>
   </v-row>
@@ -38,6 +44,9 @@ export default class ActionButton extends Vue {
 
   @Prop({ required: true })
   text!: string;
+
+  @Prop({ type: Boolean, default: false })
+  syncing!: boolean;
 
   @Prop({ type: Boolean, default: false })
   loading!: boolean;
@@ -143,6 +152,17 @@ export default class ActionButton extends Vue {
     bottom: 0;
     left: 0;
     width: 100%;
+  }
+
+  &__syncing {
+    display: flex;
+    flex-direction: column;
+    font-size: 14px;
+
+    &__indicator {
+      margin-top: 4px;
+      width: 100px;
+    }
   }
 }
 

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -51,6 +51,7 @@
   "home": {
     "welcome": "Welcome to the Raiden dApp",
     "connect-button": "Connect",
+    "connect-button-syncing": "Syncing",
     "disclaimer": "The Raiden dApp is a reference implementation of the Raiden Light Client SDK. It is work in progress and can only be used on Ethereum testnets.",
     "getting-started": {
       "description": "Read the {0} for detailed information on how to use the Raiden dApp.",

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -3,16 +3,6 @@ import { BigNumber, BigNumberish, utils, constants, providers } from 'ethers';
 import { ObservedValueOf } from 'rxjs';
 import { exhaustMap, filter } from 'rxjs/operators';
 import asyncPool from 'tiny-async-pool';
-import {
-  Capabilities,
-  ChangeEvent,
-  ErrorCodes,
-  EventTypes,
-  Raiden,
-  RaidenError,
-  RaidenPaths,
-  RaidenPFS,
-} from 'raiden-ts';
 import { Tokens } from '@/types';
 import { CombinedStoreState } from '@/store';
 import { Web3Provider } from '@/services/web3-provider';
@@ -24,6 +14,16 @@ import { NotificationPayload } from '@/store/notifications/types';
 import { NotificationContext } from '@/store/notifications/notification-context';
 import { NotificationImportance } from '@/store/notifications/notification-importance';
 import { RouteNames } from '@/router/route-names';
+import {
+  Capabilities,
+  ChangeEvent,
+  ErrorCodes,
+  EventTypes,
+  Raiden,
+  RaidenError,
+  RaidenPaths,
+  RaidenPFS,
+} from 'raiden-ts';
 
 function raidenActionConfirmationValueToStateTranslation(
   confirmationValue: boolean | undefined,
@@ -261,7 +261,7 @@ export default class RaidenService {
           return ''; // Some engines like Chrome expect this.
         });
 
-        raiden.start();
+        await raiden.start();
         this.store.commit('balance', await this.getBalance());
         if (subkey) {
           this.store.commit('raidenAccountBalance', await this.getBalance(raiden.address));

--- a/raiden-dapp/src/views/Home.vue
+++ b/raiden-dapp/src/views/Home.vue
@@ -41,6 +41,7 @@
       class="home__connect-button"
       :text="$t('home.connect-button')"
       :loading="connecting"
+      syncing
       :enabled="!connecting"
       sticky
       @click="connect"


### PR DESCRIPTION
Fixes #2435 

**Short description**
Adds an indicator on the home screen connect button to inform user that syncing is in progress upon connecting.
![sync](https://user-images.githubusercontent.com/43838780/102204870-b0797d80-3eca-11eb-8c1d-3c70a31b666b.gif)


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to the dApp
