### PR TITLE
Send messages preemptively and use RTC channel as presence complement

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -10,7 +10,11 @@
 ### Changed
 - [#2409] Lower default payment expiration to 1.1 × reveal timeout
 
+### Fixed
+- [#2352] Presence bug, transport fixes and performance improvements
+
 [#211]: https://github.com/raiden-network/light-client/issues/211
+[#2352]: https://github.com/raiden-network/light-client/issues/2352
 [#2409]: https://github.com/raiden-network/light-client/issues/2409
 [#2417]: https://github.com/raiden-network/light-client/pull/2417
 [#2444]: https://github.com/raiden-network/light-client/issues/2444

--- a/raiden-ts/src/constants.ts
+++ b/raiden-ts/src/constants.ts
@@ -29,3 +29,5 @@ export const CapsFallback = {
   [Capabilities.WEBRTC]: 0,
   [Capabilities.TO_DEVICE]: 0,
 } as const;
+
+export const RAIDEN_DEVICE_ID = 'RAIDEN';

--- a/raiden-ts/src/messages/actions.ts
+++ b/raiden-ts/src/messages/actions.ts
@@ -11,7 +11,10 @@ export const messageSend = createAsyncAction(
   'message/send/request',
   'message/send/success',
   'message/send/failure',
-  t.type({ message: t.union([t.string, Signed(Message)]) }),
+  t.intersection([
+    t.type({ message: t.union([t.string, Signed(Message)]) }),
+    t.partial({ msgtype: t.string }),
+  ]),
   t.union([t.undefined, t.partial({ via: t.string })]),
 );
 export namespace messageSend {
@@ -43,6 +46,7 @@ export const messageReceived = createAction(
       message: t.union([Message, Signed(Message)]),
       userId: t.string,
       roomId: t.string,
+      msgtype: t.string,
     }),
   ]),
   t.type({ address: Address }),

--- a/raiden-ts/src/messages/actions.ts
+++ b/raiden-ts/src/messages/actions.ts
@@ -15,7 +15,7 @@ export const messageSend = createAsyncAction(
     t.type({ message: t.union([t.string, Signed(Message)]) }),
     t.partial({ msgtype: t.string }),
   ]),
-  t.union([t.undefined, t.partial({ via: t.string, tookMs: t.number })]),
+  t.union([t.undefined, t.type({ via: t.string, tookMs: t.number, retries: t.number })]),
 );
 export namespace messageSend {
   export interface request extends ActionType<typeof messageSend.request> {}

--- a/raiden-ts/src/messages/actions.ts
+++ b/raiden-ts/src/messages/actions.ts
@@ -15,7 +15,7 @@ export const messageSend = createAsyncAction(
     t.type({ message: t.union([t.string, Signed(Message)]) }),
     t.partial({ msgtype: t.string }),
   ]),
-  t.union([t.undefined, t.partial({ via: t.string })]),
+  t.union([t.undefined, t.partial({ via: t.string, tookMs: t.number })]),
 );
 export namespace messageSend {
   export interface request extends ActionType<typeof messageSend.request> {}

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -126,7 +126,7 @@ function fetchLastIou$(
         },
       ).pipe(
         timeout(httpTimeout),
-        retryWhile(intervalFromConfig(config$), { onErrors: [429, 500, 'timeout', 'Timeout'] }),
+        retryWhile(intervalFromConfig(config$), { onErrors: [...networkErrors, 'TimeoutError'] }),
       ),
     ),
     withLatestFrom(latest$.pipe(pluck('state', 'blockNumber')), config$),
@@ -1284,7 +1284,7 @@ function requestPfs$(
   }).pipe(
     timeout(httpTimeout),
     retryWhile(intervalFromConfig(of(config)), {
-      onErrors: [429, 500, 'timeout', 'Timeout'],
+      onErrors: [...networkErrors, 'TimeoutError'],
     }),
     mergeMap(async (pfsResponse) => ({
       pfsResponse,

--- a/raiden-ts/src/transport/epics/init.ts
+++ b/raiden-ts/src/transport/epics/init.ts
@@ -136,6 +136,14 @@ function startMatrixSync(
       joinGlobalRooms(config, matrix).pipe(
         mergeMap((roomIds) => createMatrixFilter(matrix, roomIds)),
         mergeMap((filter) => matrix.startClient({ filter })),
+        mergeMap(() => {
+          // after [15-45]s (default) random delay after starting, update/reload presence
+          return timer(Math.round((Math.random() + 0.5) * config.httpTimeout)).pipe(
+            mergeMap(async () =>
+              matrix.setPresence({ presence: 'online', status_msg: Date.now().toString() }),
+            ),
+          );
+        }),
         retryWhile(
           intervalFromConfig(config$),
           { maxRetries: 10, onErrors: [429] }, // retry rate-limit errors only

--- a/raiden-ts/src/transport/epics/init.ts
+++ b/raiden-ts/src/transport/epics/init.ts
@@ -45,6 +45,7 @@ import { RaidenEpicDeps } from '../../types';
 import { RaidenAction } from '../../actions';
 import { intervalFromConfig, RaidenConfig } from '../../config';
 import { RaidenState } from '../../state';
+import { RAIDEN_DEVICE_ID } from '../../constants';
 import { getServerName } from '../../utils/matrix';
 import { decode } from '../../utils/types';
 import { pluckDistinct, retryAsync$, retryWhile } from '../../utils/rx';
@@ -53,8 +54,6 @@ import { RaidenMatrixSetup } from '../state';
 import { Caps } from '../types';
 import { stringifyCaps } from '../utils';
 import { globalRoomNames } from './helpers';
-
-const DEVICE_ID = 'RAIDEN';
 
 /**
  * Joins the global broadcast rooms and returns the room ids.
@@ -255,7 +254,7 @@ function setupMatrixClient$(
               matrix.login('m.login.password', {
                 identifier: { type: 'm.id.user', user: username },
                 password,
-                device_id: DEVICE_ID,
+                device_id: RAIDEN_DEVICE_ID,
               }),
             ).pipe(
               catchError(async (err) => {
@@ -263,7 +262,7 @@ function setupMatrixClient$(
                   .registerRequest({
                     username,
                     password,
-                    device_id: DEVICE_ID,
+                    device_id: RAIDEN_DEVICE_ID,
                   })
                   .catch(constant(err)) as Promise<LoginPayload>;
                 // if register fails, throws login error as it's more informative

--- a/raiden-ts/src/transport/epics/messages.ts
+++ b/raiden-ts/src/transport/epics/messages.ts
@@ -83,13 +83,10 @@ export function matrixMessageSendEpic(
           const msgtype = actions[0].payload.msgtype ?? 'm.text';
           const body = actions.map((action) => getMessageBody(action.payload.message)).join('\n');
           const content = { body, msgtype };
-          const start = Date.now();
           // wait for address to be monitored, online & have joined a non-global room with us
           return waitMemberAndSend$(peer, 'm.room.message', content, deps).pipe(
-            mergeMap((via) =>
-              actions.map((action) =>
-                messageSend.success({ via, tookMs: Date.now() - start }, action.meta),
-              ),
+            mergeMap((success) =>
+              actions.map((action) => messageSend.success(success, action.meta)),
             ),
             catchError((err) => {
               deps.log.error('messageSend error', err, actions[0].meta);

--- a/raiden-ts/src/transport/epics/messages.ts
+++ b/raiden-ts/src/transport/epics/messages.ts
@@ -53,6 +53,7 @@ import { RaidenState } from '../../state';
 import { getServerName } from '../../utils/matrix';
 import { LruCache } from '../../utils/lru';
 import { getPresenceByUserId, getCap } from '../utils';
+import { networkErrors } from '../../utils/error';
 import { globalRoomNames, roomMatch, getRoom$, parseMessage } from './helpers';
 
 function getMessageBody(message: string | Signed<Message>): string {
@@ -141,7 +142,7 @@ function sendAndWait$<C extends { msgtype: string; body: string }>(
     }),
     retryWhile(intervalFromConfig(config$), {
       maxRetries: 3,
-      onErrors: [429, 500],
+      onErrors: networkErrors,
       log: log.warn,
     }),
     take(1),
@@ -218,7 +219,7 @@ function sendGlobalMessages(
       retries++;
       return matrix.sendEvent(room.roomId, 'm.room.message', { body, msgtype: 'm.text' }, '');
     }),
-    retryWhile(intervalFromConfig(config$), { maxRetries: 3, onErrors: [429, 500] }),
+    retryWhile(intervalFromConfig(config$), { maxRetries: 3, onErrors: networkErrors }),
     tap(() =>
       log.info('messageGlobalSend success', {
         tookMs: Date.now() - start,

--- a/raiden-ts/src/transport/epics/presence.ts
+++ b/raiden-ts/src/transport/epics/presence.ts
@@ -20,6 +20,7 @@ import minBy from 'lodash/minBy';
 import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
+import getOr from 'lodash/fp/getOr';
 import { getAddress } from '@ethersproject/address';
 import { verifyMessage } from '@ethersproject/wallet';
 import { MatrixClient, MatrixEvent, User } from 'matrix-js-sdk';
@@ -97,7 +98,7 @@ function searchAddressPresence$(
     // updates, and sort by most recently seen user
     map((presences) => {
       if (!presences.length) throw new RaidenError(ErrorCodes.TRNS_NO_VALID_USER, { address });
-      return minBy(presences, 'last_active_ago')!;
+      return minBy(presences, getOr(Number.POSITIVE_INFINITY, 'last_active_ago'))!;
     }),
     map(({ presence, user_id: userId, avatar_url }) =>
       matrixPresence.success(

--- a/raiden-ts/src/transport/epics/presence.ts
+++ b/raiden-ts/src/transport/epics/presence.ts
@@ -218,7 +218,7 @@ function fetchPresence$(
     }),
     retryWhile(intervalFromConfig(config$), { onErrors: [429] }),
     catchError((err) => {
-      log.warn('Error validating presence event, ignoring', user.userId, err);
+      log.warn('Error validating presence event, ignoring', user.userId, event, err);
       return EMPTY;
     }),
   );

--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -164,7 +164,7 @@ function matrixWebrtcEvents$<T extends RtcEventType>(
 
 type RtcConnPair = readonly [RTCPeerConnection, RTCDataChannel];
 function isRtcConnPair(value: unknown): value is RtcConnPair {
-  return Array.isArray(value) && value.length === 2 && value[0] instanceof RTCPeerConnection;
+  return Array.isArray(value) && value.length === 2 && value[1]?.readyState;
 }
 
 // setup candidates$ handlers

--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -54,7 +54,7 @@ import { RaidenConfig } from '../../config';
 import { messageReceived, messageSend } from '../../messages/actions';
 import { RaidenState } from '../../state';
 import { matrixPresence, rtcChannel } from '../actions';
-import { getCap } from '../utils';
+import { getCap, getSortedAddresses } from '../utils';
 import { makeMessageId } from '../../transfers/utils';
 import { isResponseOf } from '../../utils/actions';
 import { matchError } from '../../utils/error';
@@ -422,11 +422,6 @@ function listenDataChannel(
     );
     return merge(sendReq$, handleChannel$);
   };
-}
-
-type AddressPair = [Address, Address];
-function getSortedAddresses(...addresses: AddressPair) {
-  return addresses.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())) as AddressPair;
 }
 
 function makeCallId(our: Address, partner: Address) {

--- a/raiden-ts/src/transport/utils.ts
+++ b/raiden-ts/src/transport/utils.ts
@@ -5,6 +5,7 @@ import memoize from 'lodash/memoize';
 import { RaidenAction } from '../actions';
 import { Capabilities, CapsFallback } from '../constants';
 import { jsonParse } from '../utils/data';
+import { Address } from '../utils/types';
 import { Presences, Caps, CapsPrimitive } from './types';
 import { matrixPresence } from './actions';
 
@@ -106,4 +107,14 @@ export function parseCaps(caps?: string | null): Caps | undefined {
  */
 export function getCap<C extends Capabilities>(caps: Caps | undefined | null, cap: C): Caps[C] {
   return caps?.[cap] ?? CapsFallback[cap];
+}
+
+/**
+ * Return addresses sorted in lexical order
+ *
+ * @param addresses - Addresses to sort
+ * @returns Addresses sorted in lexical order
+ */
+export function getSortedAddresses<A extends [Address, ...Address[]]>(...addresses: A) {
+  return addresses.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())) as A;
 }

--- a/raiden-ts/src/transport/utils.ts
+++ b/raiden-ts/src/transport/utils.ts
@@ -115,6 +115,6 @@ export function getCap<C extends Capabilities>(caps: Caps | undefined | null, ca
  * @param addresses - Addresses to sort
  * @returns Addresses sorted in lexical order
  */
-export function getSortedAddresses<A extends [Address, ...Address[]]>(...addresses: A) {
+export function getSortedAddresses<A extends Address[]>(...addresses: A) {
   return addresses.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())) as A;
 }

--- a/raiden-ts/src/utils/error.ts
+++ b/raiden-ts/src/utils/error.ts
@@ -34,7 +34,7 @@ export function matchError(match: ErrorMatch | ErrorMatches, error: any): boolea
 export function matchError(match: ErrorMatch | ErrorMatches, error?: any) {
   const _errorMatcher = (match: ErrorMatch, error: any): boolean => {
     let res;
-    if (typeof match === 'string') res = error?.message?.includes(match);
+    if (typeof match === 'string') res = error?.name === match || error?.message?.includes(match);
     else if (typeof match === 'number') res = error?.httpStatus === match;
     else res = Object.entries(match).every(([k, v]) => error?.[k] === v);
     return res;
@@ -53,6 +53,9 @@ export const networkErrors: ErrorMatches = [
   { code: 'SERVER_ERROR' },
   { code: 'NETWORK_ERROR' },
   { code: 'ENOTFOUND' },
+  429,
+  500,
+  503,
 ];
 export const txNonceErrors: ErrorMatches = [
   'replacement fee too low',

--- a/raiden-ts/src/utils/types.ts
+++ b/raiden-ts/src/utils/types.ts
@@ -292,7 +292,7 @@ export const instanceOf: <C extends Newable>(C: C) => t.Type<InstanceType<C>> = 
   <C extends Newable>(C: C): t.Type<InstanceType<C>> =>
     new t.Type<InstanceType<C>>(
       `instanceOf(${C.name})`,
-      (v): v is InstanceType<C> => v instanceof C,
+      (v): v is InstanceType<C> => 'name' in (v as any) && (v as any).name === C.name,
       (i, c) => (i instanceof C ? t.success<InstanceType<C>>(i) : t.failure(i, c)),
       t.identity,
     ),


### PR DESCRIPTION
Fixes #2303 
Fixes #2352 
Fixes #2433 
Fixes #2443 

**~Short~ Description**
This ended up being larger than expected, since it involved a big transport refactoring and a lot of server and client-side debugging. Fortunately, the end result is very good from my perspective, and adds a lot of performance improvements and preemptive bugfixes:
- Presence bug is fixed: we call `matrix.setPresence` explicitly after a random time after start, which causes a new presence update event to be emitted to all clients and federated servers, refreshing our presence for the rest of the session
  - A similar call is issued whenever capabilities change, since this was the only way to trigger peers to re-fetch our profileInfo and get the up-to-date avatarUrl
- WebRTC signaling messages are send using the standard messaging epics, instead of calling the helpers directly
- Instead of the complex waiting logic we had before sending a message, now messages are always sent as soon as possible, and instead, we hold the `messageSend.success` action, which was waited for before retry loops, until some condition is met which tells us with a higher confidence the message was received, e.g. peer is online
  - Send the messages early allows it to work even if the peer appeared offline, since they would get the message anyway
- The points above allows WebRTC signaling messages and channels to be established even if peers appears offline to each other, while "waiting" for the same conditions as message success action before retrying; the result is that the channels can be now established "asynchronously" (e.g. offer sent while callee was still offline) and while peers look offline to each other
  - Because RTC channel negotiation doesn't depend on the matrix presence anymore, it becomes an additional source of truth for presences: if an RTC channel is established, we consider partner as `online` even if they look offline in matrix
  - Also, now we avoid creating RTC channels with any node we fetch presence for, and instead do it only for neighbors and target/initiator on transfer sends. Hopefully, in the future, we can also remove the later.
- When using rooms, only the lower address creates the room and invite: this streamlines this behavior with PC. While our previous did work fine, it was more prone to races and could take longer to establish a reliable on-matrix communication room.
- Batch and serialize per-address p2p messages and per-room global messages:
  - This can reduce a lot the number of parallel matrix requests, which have shown to bottleneck the transport
  - This also reduces the number of API requests needed, since batching can send multiple messages in a single request
  - Once we get rid of the rooms code and messaging, it can be made even more efficient, since `sendToDevice` can send messages of the same type to multiple recipients in a single API request
- Adds better retries, batchSize and timing data to `messageSend.success` actions and add log calls with these info after a `messageGlobalSend` request is completed.
- Retry some PFS network/server errors (not common, but seen during tests)

Most/all these changes are covered by the current tests. They're mostly under the hood (visible effect is just that transport should work more reliably), so it's hard to test by hand, but the Scenario Player should tell us.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
