### PR TITLE
Adaptative sync

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -4,14 +4,15 @@
 ### Added
 - [#211] 'suggestPartners' method to fetch suggested partners from PFS
 - [#2417] Make 'start' async, introduce 'synced' promise, both resolves when syncing finishes
+- [#2444] Add adaptative sync for chunked getLogs
 
 ### Changed
-
 - [#2409] Lower default payment expiration to 1.1 × reveal timeout
 
 [#211]: https://github.com/raiden-network/light-client/issues/211
 [#2409]: https://github.com/raiden-network/light-client/issues/2409
 [#2417]: https://github.com/raiden-network/light-client/pull/2417
+[#2444]: https://github.com/raiden-network/light-client/issues/2444
 
 ## [0.14.0] - 2020-11-25
 ### Fixed


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2444 

**Short description**
Implement adaptative sync to make it work better e.g. on slower/overloaded geth mainnet nodes.

This algorithm, implemented in `getLogsByChunk$` and then `fromEthersEvent`, starts with a default chunk for `getLogs` calls of `100k`, and if the ETH node can't reply to it (errors), reduce the chunk (range size) by half, retry and then use this new range for the following chunks to be fetched. The minimum is 1k blocks, and if the node can't respond to such small ranges up to a default of 3 retries, it'll give up and throw the last error. We also wait `pollingInterval` (only value available from `provider` only) between **error** retries, in case the node is erroring due to temporary/network errors.

Notice that the default range reduction from 100k -> 1k takes 7 iterations, and the number of retries of `3` is only counted after reaching the `minChunk`, meaning it'll at most retry 10 times before giving up, which then can be considered an irrecoverable error.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
