### PR TITLE
dApp: receiving transfers snackbar

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [#211] Hub proposal when connecting to new token network
 - [#2379] Illustrations for info overlays
 - [#2435] Sync indicator when connecting to dApp
+- [#2399] Hint for user to stay online while receving transfers
 
 ### Changed
 
@@ -35,6 +36,7 @@
 [#2476]: https://github.com/raiden-network/light-client/issues/2476
 [#2448]: https://github.com/raiden-network/light-client/issues/2448
 [#2430]: https://github.com/raiden-network/light-client/issues/2430
+[#2399]: https://github.com/raiden-network/light-client/issues/2399
 
 ## [0.14.0] - 2020-11-25
 

--- a/raiden-dapp/src/App.vue
+++ b/raiden-dapp/src/App.vue
@@ -21,6 +21,7 @@
     </div>
     <offline-snackbar />
     <update-snackbar />
+    <receiving-ongoing-snackbar />
     <notification-snackbar />
   </v-app>
 </template>
@@ -31,6 +32,7 @@ import NavigationMixin from './mixins/navigation-mixin';
 import AppHeader from '@/components/AppHeader.vue';
 import OfflineSnackbar from '@/components/OfflineSnackbar.vue';
 import UpdateSnackbar from '@/components/UpdateSnackbar.vue';
+import ReceivingOngoingSnackbar from '@/components/ReceivingOngoingSnackbar.vue';
 import NotificationSnackbar from '@/components/notification-panel/NotificationSnackbar.vue';
 
 @Component({
@@ -39,6 +41,7 @@ import NotificationSnackbar from '@/components/notification-panel/NotificationSn
     OfflineSnackbar,
     UpdateSnackbar,
     NotificationSnackbar,
+    ReceivingOngoingSnackbar,
   },
 })
 export default class App extends Mixins(NavigationMixin) {

--- a/raiden-dapp/src/components/ReceivingOngoingSnackbar.vue
+++ b/raiden-dapp/src/components/ReceivingOngoingSnackbar.vue
@@ -1,0 +1,71 @@
+<template>
+  <v-snackbar v-model="snackbarVisible" :timeout="-1" color="primary">
+    <span class="receiving-ongoing-snackbar__warning">
+      {{ $t('transfer.receiving-transfer-snackbar') }}
+    </span>
+  </v-snackbar>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Watch } from 'vue-property-decorator';
+import { mapGetters } from 'vuex';
+import { of, Subject, Subscription, timer } from 'rxjs';
+import { debounce, distinctUntilChanged } from 'rxjs/operators';
+import { Transfers } from '@/types';
+import { RaidenTransfer } from 'raiden-ts';
+
+@Component({
+  computed: {
+    ...mapGetters(['pendingTransfers']),
+  },
+})
+export default class ReceivingOngoingSnackbar extends Vue {
+  pendingTransfers!: Transfers;
+  $receivingTransfersPending!: Subject<boolean>;
+  snackbarVisible = false;
+  sub!: Subscription;
+
+  get pendingReceivingTransfers(): RaidenTransfer[] {
+    const pendingTransfers = Object.values(this.pendingTransfers) as RaidenTransfer[];
+    return pendingTransfers.filter((transfer) => transfer.direction === 'received');
+  }
+
+  @Watch('pendingReceivingTransfers')
+  updatedPendingReceivedTransfers(transfers: RaidenTransfer[]) {
+    this.$receivingTransfersPending.next(transfers.length > 0);
+  }
+
+  created(): void {
+    this.$receivingTransfersPending = new Subject<boolean>();
+
+    this.sub = this.$receivingTransfersPending
+      .pipe(
+        distinctUntilChanged(),
+        debounce((pending) => (pending ? of(1) : timer(5000))),
+      )
+      .subscribe((pending) => (this.snackbarVisible = pending));
+  }
+
+  destroyed(): void {
+    this.sub.unsubscribe();
+  }
+}
+</script>
+
+<style scoped lang="scss">
+::v-deep {
+  .v-snack {
+    &__content {
+      text-align: center;
+    }
+  }
+}
+
+.receiving-ongoing-snackbar {
+  &__warning {
+    flex: 1;
+    font-size: 16px;
+    margin-left: 8px;
+  }
+}
+</style>

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -423,6 +423,7 @@
     }
   },
   "transfer": {
+    "receiving-transfer-snackbar": "Receiving transfer, do not close browser.",
     "capacity-label": "Capacity",
     "recipient-label": "Recipient",
     "amount-label": "Amount",

--- a/raiden-dapp/tests/unit/receiving-ongoing-snackbar.spec.ts
+++ b/raiden-dapp/tests/unit/receiving-ongoing-snackbar.spec.ts
@@ -2,17 +2,20 @@ import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
 import Vuex from 'vuex';
 import Vuetify from 'vuetify';
+import { generateTransfer } from './utils/data-generator';
+import { RaidenTransfer } from 'raiden-ts';
 import ReceivingOngoingSnackbar from '@/components/ReceivingOngoingSnackbar.vue';
 
 Vue.use(Vuetify);
 Vue.use(Vuex);
 
-const createWrapper = (
-  receivedTransfer: boolean | undefined = undefined,
-): Wrapper<ReceivingOngoingSnackbar> => {
+const pendingSentTransfer = generateTransfer({ completed: false, direction: 'sent' });
+const pendingReceivedTransfer = generateTransfer({ completed: false, direction: 'received' });
+
+function createWrapper(pendingTransfers: RaidenTransfer[]): Wrapper<ReceivingOngoingSnackbar> {
   const vuetify = new Vuetify();
   const getters = {
-    pendingTransfers: () => ({ 0: { success: receivedTransfer, direction: 'received' } }),
+    pendingTransfers: () => pendingTransfers,
   };
   const store = new Vuex.Store({ getters });
 
@@ -23,20 +26,31 @@ const createWrapper = (
       $t: (msg: string) => msg,
     },
   });
-};
+}
+
+function getSnackbar(wrapper: Wrapper<ReceivingOngoingSnackbar>) {
+  return wrapper.find('.receiving-ongoing-snackbar');
+}
 
 describe('ReceivingOngoingSnackbar.vue', () => {
   test('snackbar is displayed while receiving a transfer', () => {
-    const wrapper = createWrapper();
-    const snackbar = wrapper.find('.v-snack__wrapper');
+    const wrapper = createWrapper([pendingReceivedTransfer]);
+    const snackbar = getSnackbar(wrapper);
 
-    expect(snackbar.attributes('style')).toBe(undefined);
+    expect(snackbar.exists()).toBe(true);
   });
 
-  test('snackbar is not displayed when a transfer has been received', () => {
-    const wrapper = createWrapper(true);
-    const snackbar = wrapper.find('.v-snack__wrapper');
+  test('snackbar is not displayed when a pending transfer is sent', () => {
+    const wrapper = createWrapper([pendingSentTransfer]);
+    const snackbar = getSnackbar(wrapper);
 
-    expect(snackbar.attributes('style')).toContain('display: none');
+    expect(snackbar.exists()).toBe(false);
+  });
+
+  test('snackbar is not displayed if no transfers are pending', () => {
+    const wrapper = createWrapper([]);
+    const snackbar = getSnackbar(wrapper);
+
+    expect(snackbar.exists()).toBe(false);
   });
 });

--- a/raiden-dapp/tests/unit/receiving-ongoing-snackbar.spec.ts
+++ b/raiden-dapp/tests/unit/receiving-ongoing-snackbar.spec.ts
@@ -1,0 +1,42 @@
+import { mount, Wrapper } from '@vue/test-utils';
+import Vue from 'vue';
+import Vuex from 'vuex';
+import Vuetify from 'vuetify';
+import ReceivingOngoingSnackbar from '@/components/ReceivingOngoingSnackbar.vue';
+
+Vue.use(Vuetify);
+Vue.use(Vuex);
+
+const createWrapper = (
+  receivedTransfer: boolean | undefined = undefined,
+): Wrapper<ReceivingOngoingSnackbar> => {
+  const vuetify = new Vuetify();
+  const getters = {
+    pendingTransfers: () => ({ 0: { success: receivedTransfer, direction: 'received' } }),
+  };
+  const store = new Vuex.Store({ getters });
+
+  return mount(ReceivingOngoingSnackbar, {
+    vuetify,
+    store,
+    mocks: {
+      $t: (msg: string) => msg,
+    },
+  });
+};
+
+describe('ReceivingOngoingSnackbar.vue', () => {
+  test('snackbar is displayed while receiving a transfer', () => {
+    const wrapper = createWrapper();
+    const snackbar = wrapper.find('.v-snack__wrapper');
+
+    expect(snackbar.attributes('style')).toBe(undefined);
+  });
+
+  test('snackbar is not displayed when a transfer has been received', () => {
+    const wrapper = createWrapper(true);
+    const snackbar = wrapper.find('.v-snack__wrapper');
+
+    expect(snackbar.attributes('style')).toContain('display: none');
+  });
+});

--- a/raiden-dapp/tests/unit/utils/data-generator.ts
+++ b/raiden-dapp/tests/unit/utils/data-generator.ts
@@ -105,6 +105,7 @@ export function generateChannel(
     balance: constants.Zero,
     capacity: BigNumber.from(10 ** 8),
     ownWithdrawable: BigNumber.from(10 ** 8),
+    completed: true,
     ...partialChannel,
   } as RaidenChannel;
 }


### PR DESCRIPTION
Fixes #2399  

**Short description**
This is the current state of the implementation after a pair-programming session with @andrevmatos and @weilbith . ~~It remains to find suitable RxJS operators to handle the debouncing of the snackbar and~~ most likely the initial tests added will need to be adjusted/extended.

@andrevmatos provided a set of operator that seems to work on initial testing, however the snackbar is taking much longer than the 5000 milliseconds to disappear. This is perhaps related to that transfers at my time of testing were taking exceptionally long time? 

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
