### PR TITLE
Assert suggestPartners array isn't empty to retry next PFS

### DIFF
--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -1469,9 +1469,14 @@ export class Raiden {
           }).pipe(
             timeout(this.config.httpTimeout),
             mergeMap(async (response) => response.text()),
-            map((text) => decode(SuggestedPartners, jsonParse(text))),
+            map((text) => {
+              const suggestions = decode(SuggestedPartners, jsonParse(text));
+              assert(suggestions.length, ['empty partner suggestion from PFS', { pfs: pfs.url }]);
+              return suggestions;
+            }),
             catchError((err) => {
               // store first error and omit to retry next pfs in list
+              this.log.info('Could not fetch PFS suggested partners', pfs, err);
               if (!firstError) firstError = err;
               return EMPTY;
             }),


### PR DESCRIPTION
Fixes #2462

**Short description**
Some PFS request was working, but returning an empty array. This PR asserts the array isn't empty, so the next PFS in queue can be tried as well until finding something useful.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
