### PR TITLE
Bugfix/dapp remember token during navigation

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#2426] Display total available capacity in transfer view
 - [#2431] Disable UDC 'withdraw' button when no eth is is raiden account
 - [#2476] Fix persitence to remember disclaimer acceptance if selected
+- [#2430] Remember token selection during navigation
 
 ### Added
 
@@ -33,6 +34,7 @@
 [#2431]: https://github.com/raiden-network/light-client/issues/2431
 [#2476]: https://github.com/raiden-network/light-client/issues/2476
 [#2448]: https://github.com/raiden-network/light-client/issues/2448
+[#2430]: https://github.com/raiden-network/light-client/issues/2430
 
 ## [0.14.0] - 2020-11-25
 

--- a/raiden-dapp/src/mixins/navigation-mixin.ts
+++ b/raiden-dapp/src/mixins/navigation-mixin.ts
@@ -7,13 +7,22 @@ export default class NavigationMixin extends Vue {
     this.$router.push({
       name: RouteNames.SELECT_HUB,
       params: {
-        token: token,
+        token,
       },
     });
   }
 
   navigateToHome() {
     this.$router.push({ name: RouteNames.HOME });
+  }
+
+  navigateToTransfer(token: string) {
+    this.$router.push({
+      name: RouteNames.TRANSFER,
+      params: {
+        token,
+      },
+    });
   }
 
   navigateToOpenChannel(token: string, partner: string) {
@@ -116,16 +125,19 @@ export default class NavigationMixin extends Vue {
           this.$route.params.amount,
         );
         break;
-      case RouteNames.TRANSFER:
       case RouteNames.CHANNELS:
+        this.navigateToTransfer(this.$route.params.token);
+        break;
       case RouteNames.SELECT_TOKEN:
-        this.navigateToHome();
+        this.$router.go(-1); // Preserve current token without knowing it.
         break;
       case RouteNames.SELECT_HUB:
         this.navigateToTokenSelect();
         break;
       case RouteNames.OPEN_CHANNEL:
         this.navigateToSelectHub(this.$route.params.token);
+        break;
+      default:
         break;
     }
   }

--- a/raiden-dapp/tests/unit/components/app-header.spec.ts
+++ b/raiden-dapp/tests/unit/components/app-header.spec.ts
@@ -49,6 +49,9 @@ const createWrapper = (
         meta: {
           title: 'title',
         },
+        params: {
+          token: '0xtoken',
+        },
       },
     },
   });
@@ -69,7 +72,10 @@ describe('AppHeader.vue', () => {
     expect(router.push).toHaveBeenCalledTimes(1);
     expect(router.push).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: RouteNames.HOME,
+        name: RouteNames.TRANSFER,
+        params: {
+          token: '0xtoken',
+        },
       }),
     );
   });

--- a/raiden-dapp/tests/unit/components/mixins/navigation-mixin.spec.ts
+++ b/raiden-dapp/tests/unit/components/mixins/navigation-mixin.spec.ts
@@ -155,28 +155,12 @@ describe('NavigationMixin', () => {
   });
 
   describe('back navigation', () => {
-    test('from select target', async () => {
-      wrapper.vm.$route.name = RouteNames.TRANSFER;
-      wrapper.vm.onBackClicked();
-
-      expect(router.push).toHaveBeenCalledTimes(1);
-      expect(router.push).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: RouteNames.HOME,
-        }),
-      );
-    });
-
     test('from select token', async () => {
       wrapper.vm.$route.name = RouteNames.SELECT_TOKEN;
       wrapper.vm.onBackClicked();
 
-      expect(router.push).toHaveBeenCalledTimes(1);
-      expect(router.push).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: RouteNames.HOME,
-        }),
-      );
+      expect(router.go).toHaveBeenCalledTimes(1);
+      expect(router.go).toHaveBeenCalledWith(-1);
     });
 
     test('from select hub', async () => {
@@ -193,12 +177,18 @@ describe('NavigationMixin', () => {
 
     test('from channels', async () => {
       wrapper.vm.$route.name = RouteNames.CHANNELS;
+      wrapper.vm.$route.params = {
+        token: '0xtoken',
+      };
       wrapper.vm.onBackClicked();
 
       expect(router.push).toHaveBeenCalledTimes(1);
       expect(router.push).toHaveBeenCalledWith(
         expect.objectContaining({
-          name: RouteNames.HOME,
+          name: RouteNames.TRANSFER,
+          params: {
+            token: '0xtoken',
+          },
         }),
       );
     });


### PR DESCRIPTION
Fixes #2430 

**Short description**
This just tweaks the back button navigation function to remember the selected token.
While doing this I recognized that sometimes we still assume the home route it the home route. But unfortunately it is the transfer route. This just works as the navigation guard automatically forwards the user if he is already connected. This should not be the way to go for. After all this is just another indicator that we should finally rename our home and transfer route to better reflect their purpose.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Go to the transfer route
2. Select a different token (not the first one!)
3. Go to the channel list view of the token
4. Navigate back using the back button of the header
5. Verify that the same token is still selected, not the automatic first one (you should also see the token as parameter in the browser address bar)
6. Go to connect a new token
7. Navigate back as before and repeat the verification
