### PR TITLE
Feature/dapp notification snackbar is clickable

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [#2379] Illustrations for info overlays
 - [#2435] Sync indicator when connecting to dApp
 - [#2399] Hint for user to stay online while receving transfers
+- [#2458] Click on notification snackbar to open notification panel
 
 ### Changed
 
@@ -37,6 +38,7 @@
 [#2448]: https://github.com/raiden-network/light-client/issues/2448
 [#2430]: https://github.com/raiden-network/light-client/issues/2430
 [#2399]: https://github.com/raiden-network/light-client/issues/2399
+[#2458]: https://github.com/raiden-network/light-client/issues/2458
 
 ## [0.14.0] - 2020-11-25
 

--- a/raiden-dapp/tests/unit/components/notification-panel/notification-snackbar.spec.ts
+++ b/raiden-dapp/tests/unit/components/notification-panel/notification-snackbar.spec.ts
@@ -1,47 +1,105 @@
+jest.mock('vue-router');
 import { mount, Wrapper } from '@vue/test-utils';
 import Vue from 'vue';
+import Vuex from 'vuex';
 import Vuetify from 'vuetify';
+import VueRouter from 'vue-router';
 import { TestData } from '../../data/mock-data';
-import store from '@/store';
 import Filters from '@/filters';
 import NotificationSnackbar from '@/components/notification-panel/NotificationSnackbar.vue';
+import { RouteNames } from '@/router/route-names';
 
+Vue.use(Vuex);
 Vue.use(Vuetify);
 Vue.filter('formatDate', Filters.formatDate);
 
-describe('NotificationSnackbar.vue', () => {
-  let wrapper: Wrapper<NotificationSnackbar>;
-  let vuetify: Vuetify;
+const $router = new VueRouter() as jest.Mocked<VueRouter>;
+const setNotificationShown = jest.fn();
+const mutations = { setNotificationShown };
 
+async function createWrapper(
+  notificationQueue = [TestData.notifications],
+): Promise<Wrapper<NotificationSnackbar>> {
+  const vuetify = new Vuetify();
+  const getters = {
+    notificationQueue: () => notificationQueue,
+  };
+
+  const notificationsModule = {
+    namespaced: true,
+    getters,
+    mutations,
+  };
+
+  const store = new Vuex.Store({ modules: { notifications: notificationsModule } });
+  const wrapper = mount(NotificationSnackbar, {
+    vuetify,
+    store,
+    mocks: {
+      $router,
+    },
+  });
+  await wrapper.vm.$nextTick();
+  return wrapper;
+}
+
+describe('NotificationSnackbar.vue', () => {
   beforeEach(() => {
-    vuetify = new Vuetify();
-    wrapper = mount(NotificationSnackbar, {
-      vuetify,
-      store,
-      mocks: {
-        $t: (msg: string) => msg,
-      },
-    });
-    store.commit('notifications/clear');
+    jest.resetAllMocks();
   });
 
-  test('displays notifications', async () => {
-    expect.assertions(1);
-    store.commit('notifications/notificationAddOrReplace', TestData.notifications);
-    await wrapper.vm.$nextTick();
-    await wrapper.vm.$nextTick();
-    expect(wrapper.find('.notification-area__title').text()).toMatch('Channel Settlement');
+  test('does not show if there are no to display notifications', async () => {
+    const wrapper = await createWrapper([]);
+    const snackbar = wrapper.find('.notification-snackbar');
+
+    expect(snackbar.exists()).toBe(false);
+  });
+
+  test('shows notification if the queue is not empty and notification should be shown', async () => {
+    const wrapper = await createWrapper();
+    const snackbar = wrapper.find('.notification-snackbar');
+    const title = wrapper.get('.notification-snackbar__area__title');
+
+    expect(snackbar.exists()).toBe(true);
+    expect(title.text()).toBe('Channel Settlement');
   });
 
   test('dismisses notification on button click', async () => {
-    expect.assertions(1);
-    const notificationId = TestData.notifications.id;
+    const wrapper = await createWrapper();
+    const button = wrapper.get('button');
 
-    store.commit('notifications/notificationAddOrReplace', TestData.notifications);
+    button.trigger('click');
     await wrapper.vm.$nextTick();
-    wrapper.find('button').trigger('click');
-    await wrapper.vm.$nextTick();
+    const snackbar = wrapper.find('.notification-snackbar');
 
-    expect(store.state.notifications.notifications[notificationId].display).toBeFalsy();
+    expect(snackbar.exists()).toBe(false);
+    expect(setNotificationShown).toHaveBeenCalledTimes(1);
+    expect(setNotificationShown).toHaveBeenNthCalledWith(1, {}, TestData.notifications.id);
+  });
+
+  test('navigate to notification panel on content click', async () => {
+    const wrapper = await createWrapper();
+    const content = wrapper.get('.notification-snackbar__area');
+
+    content.trigger('click');
+
+    expect($router.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: RouteNames.NOTIFICATIONS,
+      }),
+    );
+  });
+
+  test('dismisses notification on content click', async () => {
+    const wrapper = await createWrapper();
+    const content = wrapper.get('.notification-snackbar__area');
+
+    content.trigger('click');
+    await wrapper.vm.$nextTick();
+    const snackbar = wrapper.find('.notification-snackbar');
+
+    expect(snackbar.exists()).toBe(false);
+    expect(setNotificationShown).toHaveBeenCalledTimes(1);
+    expect(setNotificationShown).toHaveBeenNthCalledWith(1, {}, TestData.notifications.id);
   });
 });

--- a/raiden-dapp/tests/unit/data/mock-data.ts
+++ b/raiden-dapp/tests/unit/data/mock-data.ts
@@ -171,7 +171,7 @@ export class TestData {
     icon: 'notification_settle',
     link: 'Visit the Withdrawal menu',
     dappRoute: RouteNames.ACCOUNT_WITHDRAWAL,
-    display: false,
+    display: true,
     duration: 5000,
     importance: NotificationImportance.HIGH,
     context: NotificationContext.NONE,


### PR DESCRIPTION
Fixes #2458

**Short description**
This does (so far) not handle the request to make the snackbar centered. This still needs clarification by the issuer @christianbrb 
The most time/work of this PR was invested into refactoring the unit tests (as we agreed to do this when ever we stumble over it) and make the component properly testable (e.g. see conditional rendering in addition to Vuetifies snackbar model variable).

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Trigger a notification (e.g. simply use the backup notification if you haven't used the dApp this day already)
2. Click on the snackbar (everything just not the close button)
3. Verify that the notification panel has opened
4. Verify that the snackbar itself got hidden immeditately
