### PR TITLE
Feature/dapp align design of open channel route

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Changed
 
 - [#2409] Lower default payment expiration to 1.1 × reveal timeout
+- [#2448] Align basic route design in open channel user flow
 
 [#211]: https://github.com/raiden-network/light-client/issues/211
 [#2379]: https://github.com/raiden-network/light-client/issues/2379
@@ -31,6 +32,7 @@
 [#2435]: https://github.com/raiden-network/light-client/issues/2435
 [#2431]: https://github.com/raiden-network/light-client/issues/2431
 [#2476]: https://github.com/raiden-network/light-client/issues/2476
+[#2448]: https://github.com/raiden-network/light-client/issues/2448
 
 ## [0.14.0] - 2020-11-25
 

--- a/raiden-dapp/src/views/OpenChannelRoute.vue
+++ b/raiden-dapp/src/views/OpenChannelRoute.vue
@@ -15,7 +15,6 @@
         limit
       />
     </div>
-    <divider />
     <div class="open-channel__token-information">
       <token-information :token="token" />
     </div>
@@ -27,12 +26,13 @@
         <address-display :address="partner" />
       </div>
     </div>
-    <action-button
-      data-cy="open_channel_button"
-      class="open-channel__button"
-      :enabled="valid"
-      :text="$t('open-channel.open-button')"
-    />
+    <div class="open-channel__button">
+      <action-button
+        data-cy="open_channel_button"
+        :enabled="valid"
+        :text="$t('open-channel.open-button')"
+      />
+    </div>
     <open-channel-dialog
       :visible="loading"
       :steps="steps"
@@ -197,6 +197,9 @@ export default class OpenChannelRoute extends Mixins(NavigationMixin) {
 </script>
 
 <style scoped lang="scss">
+@import '@/scss/colors';
+@import '@/scss/mixins';
+
 .open-channel {
   display: flex;
   flex-direction: column;
@@ -207,8 +210,15 @@ export default class OpenChannelRoute extends Mixins(NavigationMixin) {
   &__amount {
     display: flex;
     flex-direction: column;
-    height: 300px;
+    height: 200px;
     justify-content: center;
+  }
+
+  &__token-information,
+  &__hub {
+    background-color: $transfer-screen-bg-color;
+    border-radius: 8px;
+    min-height: 48px;
   }
 
   &__token-information {
@@ -232,7 +242,30 @@ export default class OpenChannelRoute extends Mixins(NavigationMixin) {
   }
 
   &__button {
-    margin-top: 110px;
+    align-items: flex-end;
+    display: flex;
+    flex: 1;
+    margin-bottom: 38px;
+
+    @include respond-to(handhelds) {
+      flex: none;
+      margin-bottom: none;
+
+      ::v-deep {
+        .col-10 {
+          padding-top: 28px;
+          @include respond-to(handhelds) {
+            min-width: 100%;
+          }
+        }
+
+        .v-btn {
+          @include respond-to(handhelds) {
+            min-width: 100%;
+          }
+        }
+      }
+    }
   }
 }
 </style>


### PR DESCRIPTION
Fixes #2448

**Short description**
Comparison of the select hub route (right) and open channel route (left). See the issue for an image of the current design.

![channel-to-hub-comparison](https://user-images.githubusercontent.com/12543647/103352075-85d01d00-4aa5-11eb-864a-04b9b786b289.jpg)

Note that this continues the code base split of two design patterns and its side effects.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Just open a new channel and follow the flow up to where getting asked for a value to deposit.
2. Verify the design, especially compared to the previous screen.
