### PR TITLE
Bugfix/dapp disclaimer appears again even it should not

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [#2410] Fix transfer history list not showing third entry initially
 - [#2426] Display total available capacity in transfer view
 - [#2431] Disable UDC 'withdraw' button when no eth is is raiden account
+- [#2476] Fix persitence to remember disclaimer acceptance if selected
 
 ### Added
 
@@ -29,6 +30,7 @@
 [#2426]: https://github.com/raiden-network/light-client/issues/2426
 [#2435]: https://github.com/raiden-network/light-client/issues/2435
 [#2431]: https://github.com/raiden-network/light-client/issues/2431
+[#2476]: https://github.com/raiden-network/light-client/issues/2476
 
 ## [0.14.0] - 2020-11-25
 

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -79,14 +79,18 @@ const settingsLocalStorage = new VuexPersistence<RootState>({
   key: 'raiden_dapp_settings',
 });
 
-const miscellaneousLocalStorage = new VuexPersistence<RootState>({
+const disclaimerLocalStorage = new VuexPersistence<RootState>({
   reducer: (state) => ({
     disclaimerAccepted: state.persistDisclaimerAcceptance ? state.disclaimerAccepted : false,
-    stateBackupReminderDateMs: state.stateBackupReminderDateMs,
   }),
-  filter: (mutation) =>
-    mutation.type === 'acceptDisclaimer' || mutation.type === 'updateStateBackupReminderDate',
-  key: 'miscellaneous',
+  filter: (mutation) => mutation.type === 'acceptDisclaimer',
+  key: 'disclaimer',
+});
+
+const backupReminderLocalStorage = new VuexPersistence<RootState>({
+  reducer: (state) => ({ stateBackupReminderDateMs: state.stateBackupReminderDateMs }),
+  filter: (mutation) => mutation.type === 'updateStateBackupReminderDate',
+  key: 'backupReminder',
 });
 
 export type CombinedStoreState = RootState & {
@@ -256,7 +260,11 @@ const store: StoreOptions<CombinedStoreState> = {
       return !!state.settings.useRaidenAccount;
     },
   },
-  plugins: [settingsLocalStorage.plugin, miscellaneousLocalStorage.plugin],
+  plugins: [
+    settingsLocalStorage.plugin,
+    disclaimerLocalStorage.plugin,
+    backupReminderLocalStorage.plugin,
+  ],
   modules: {
     notifications,
     userDepositContract,


### PR DESCRIPTION
Fixes #2476

**Short description**
See the commit message for the details or also the issue where I wrote down my findings.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Clear the `miscellaneous` key in you local storage of the application
2. Reload the application
3. Accept the disclaimer and also select to remember the decision.
4. Continue to connect until the backup reminder notification get shown
5. Reload and connect again
6. Verify that the disclaimer was not shown (as before with the bug)
7. Make sure the backup notification gets not shown
8. Clear the `backupReminder` key in you local storage of the application to trigger the backup reminder again (after reload)
9. Reload and connect again
10. Verify that the disclaimer was still not shown (the bug does it show here)
11. The backup reminder notification should pop-up again after being connected