### PR TITLE
cli: integrate readme to the global documentation

### DIFF
--- a/raiden-ts/typedoc.json
+++ b/raiden-ts/typedoc.json
@@ -94,6 +94,15 @@
             "source": "./docs-source/account.md"
           }
         ]
+      },
+      {
+        "title": "Using the Raiden CLI",
+        "pages": [
+          {
+            "title": "Overview",
+            "source": "../raiden-cli/README.md"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
Fixes #2397

**Short description**
This just adds a new page group to the typedoc configuration to integrate the CLI main README as the overview page.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Generate the docs (`yarn workspace raiden-ts docs`)
2. Serve the generated docs locally (e.g. `npx serve raiden-ts/docs`)
3. Open the docs in the web-browser and watch-out for the CLI part
