### PR TITLE
dapp: Fix TransferHeader behaviour with no available capacity

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#2431] Disable UDC 'withdraw' button when no eth is is raiden account
 - [#2476] Fix persitence to remember disclaimer acceptance if selected
 - [#2430] Remember token selection during navigation
+- [#2474] Fix TransferHeader behaviour with no available capacity
 
 ### Added
 
@@ -39,6 +40,7 @@
 [#2430]: https://github.com/raiden-network/light-client/issues/2430
 [#2399]: https://github.com/raiden-network/light-client/issues/2399
 [#2458]: https://github.com/raiden-network/light-client/issues/2458
+[#2474]: https://github.com/raiden-network/light-client/issues/2474
 
 ## [0.14.0] - 2020-11-25
 

--- a/raiden-dapp/src/components/transfer/TransferHeaders.vue
+++ b/raiden-dapp/src/components/transfer/TransferHeaders.vue
@@ -21,7 +21,7 @@
         <div class="transfer-menus__dot-menu__menu">
           <v-btn
             text
-            :disabled="noChannelOrCapacity"
+            :disabled="noChannels"
             data-cy="transfer_menus_dot_menu_menu_deposit"
             class="transfer-menus__dot-menu__menu__deposit"
             @click="depositDialogOpen()"
@@ -39,7 +39,7 @@
         </div>
       </v-menu>
     </div>
-    <span v-if="noChannelOrCapacity">
+    <span v-if="noChannels">
       {{ $t('transfer.transfer-menus.no-channels') }}
     </span>
     <span v-else>
@@ -62,7 +62,7 @@
 <script lang="ts">
 import { Component, Prop, Mixins } from 'vue-property-decorator';
 import { mapGetters } from 'vuex';
-import { BigNumber, constants } from 'ethers';
+import { BigNumber } from 'ethers';
 import NavigationMixin from '../../mixins/navigation-mixin';
 import AmountDisplay from '@/components/AmountDisplay.vue';
 import TokenOverlay from '@/components/overlays/TokenOverlay.vue';
@@ -104,10 +104,6 @@ export default class TransferHeaders extends Mixins(NavigationMixin) {
 
   depositDialogClosed() {
     this.showDepositDialog = false;
-  }
-
-  get noChannelOrCapacity(): boolean {
-    return this.noChannels || this.totalCapacity.lte(constants.Zero);
   }
 
   /* istanbul ignore next */

--- a/raiden-dapp/tests/unit/components/transfer/transfer-headers.spec.ts
+++ b/raiden-dapp/tests/unit/components/transfer/transfer-headers.spec.ts
@@ -46,18 +46,18 @@ describe('TransferHeaders.vue', () => {
     });
   };
 
-  test('displays "no open channels" if channel capacity is zero', () => {
+  test('displays "no open channels" if no channels exist', () => {
     const wrapper = createWrapper(true, constants.Zero);
     const amountDisplay = wrapper.findAll('span').at(3);
 
     expect(amountDisplay.text()).toContain('transfer.transfer-menus.no-channels');
   });
 
-  test('disables deposit button if channel capacity is zero', () => {
+  test('displays zero amount if channel has no capacity', () => {
     const wrapper = createWrapper(false, constants.Zero);
-    const depositButton = wrapper.find('.transfer-menus__dot-menu__menu__deposit');
+    const amountDisplay = wrapper.findAll('span').at(3);
 
-    expect(depositButton.attributes()['disabled']).toBe('disabled');
+    expect(amountDisplay.find('div').text()).toContain('0');
   });
 
   test('displays amount if channel has capacity', () => {
@@ -67,7 +67,23 @@ describe('TransferHeaders.vue', () => {
     expect(amountDisplay.find('div').text()).toContain('0.000001');
   });
 
-  test('deposit button is enabled if channel has capacityxxxx', () => {
+  test('disables deposit button if no channels exist', () => {
+    const wrapper = createWrapper(true, constants.Zero);
+    const depositButton = wrapper.find('.transfer-menus__dot-menu__menu__deposit');
+
+    expect(depositButton.attributes()['disabled']).toBe('disabled');
+  });
+
+  test('enables deposit button if channel capacity is zero', () => {
+    const wrapper = createWrapper(false, constants.Zero);
+    const depositButton = wrapper.find('.transfer-menus__dot-menu__menu__deposit');
+
+    expect(depositButton.attributes()).not.toMatchObject(
+      expect.objectContaining({ disabled: 'disabled' }),
+    );
+  });
+
+  test('enables deposit button if channel has capacity', () => {
     const wrapper = createWrapper(false, constants.One);
     const depositButton = wrapper.find('.transfer-menus__dot-menu__menu__deposit');
 


### PR DESCRIPTION
Fixes #2474 

**Short description**

The component showed `No open channels` even though channels existed
because it also checked for available capacity.

It also incorrectly disabled the `Deposit` button for such channels.

This commit also renames the file to make the filename match the tested
component.


**Definition of Done**

- [x] Steps to manually test the change have been documented

- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**
- See issue description
