### PR TITLE
Transport and types improvements

### DIFF
--- a/raiden-ts/src/transport/epics/presence.ts
+++ b/raiden-ts/src/transport/epics/presence.ts
@@ -1,4 +1,4 @@
-import { Observable, of, EMPTY, fromEvent, defer } from 'rxjs';
+import { Observable, of, EMPTY, fromEvent, defer, combineLatest } from 'rxjs';
 import {
   catchError,
   filter,
@@ -26,13 +26,13 @@ import { MatrixClient, MatrixEvent } from 'matrix-js-sdk';
 
 import { assert } from '../../utils';
 import { RaidenError, ErrorCodes } from '../../utils/error';
-import { Address, isntNil } from '../../utils/types';
+import { Address } from '../../utils/types';
 import { isActionOf } from '../../utils/actions';
 import { RaidenEpicDeps } from '../../types';
 import { RaidenAction } from '../../actions';
 import { RaidenState } from '../../state';
 import { getUserPresence } from '../../utils/matrix';
-import { pluckDistinct, retryWhile } from '../../utils/rx';
+import { retryWhile } from '../../utils/rx';
 import { matrixPresence } from '../actions';
 import { channelMonitored } from '../../channels/actions';
 import { parseCaps, stringifyCaps } from '../utils';
@@ -50,17 +50,17 @@ const userRe = /^@(0x[0-9a-f]{40})[.:]/i;
  * @param address - Address of interest
  * @param opts - Options
  * @param opts.log - Logger instance
+ * @param opts.config$ - Config observable
  * @returns Observable of user with most recent presence
  */
 function searchAddressPresence$(
   matrix: MatrixClient,
   address: Address,
-  { log }: { log: RaidenEpicDeps['log'] },
+  { log, config$ }: Pick<RaidenEpicDeps, 'log' | 'config$'>,
 ) {
-  return defer(() =>
-    // search for any user containing the address of interest in its userId
-    matrix.searchUserDirectory({ term: address.toLowerCase() }),
-  ).pipe(
+  // search for any user containing the address of interest in its userId
+  return defer(async () => matrix.searchUserDirectory({ term: address.toLowerCase() })).pipe(
+    retryWhile(intervalFromConfig(config$), { onErrors: [429, 500] }),
     // for every result matches, verify displayName signature is address of interest
     mergeMap(function* ({ results }) {
       for (const user of results) {
@@ -76,12 +76,18 @@ function searchAddressPresence$(
         yield user;
       }
     }),
-    mergeMap((user) =>
-      getUserPresence(matrix, user.user_id)
-        .then((presence) => ({ ...presence, ...user }))
-        .catch((err) => (log.info('Error fetching user presence, ignoring:', err), undefined)),
+    mergeMap(
+      (user) =>
+        defer(async () => getUserPresence(matrix, user.user_id)).pipe(
+          map((presence) => ({ ...presence, ...user })),
+          retryWhile(intervalFromConfig(config$), { onErrors: [429, 500] }),
+          catchError((err) => {
+            log.info('Error fetching user presence, ignoring:', err);
+            return EMPTY;
+          }),
+        ),
+      3, // max parallelism on these requests
     ),
-    filter(isntNil),
     toArray(),
     // for all matched/verified users, get its presence through dedicated API
     // it's required because, as the user events could already have been handled
@@ -93,6 +99,18 @@ function searchAddressPresence$(
       if (!presences.length) throw new RaidenError(ErrorCodes.TRNS_NO_VALID_USER, { address });
       return minBy(presences, 'last_active_ago')!;
     }),
+    map(({ presence, user_id: userId, avatar_url }) =>
+      matrixPresence.success(
+        {
+          userId,
+          available: AVAILABLE.includes(presence),
+          ts: Date.now(),
+          caps: parseCaps(avatar_url),
+        },
+        { address },
+      ),
+    ),
+    catchError((err) => of(matrixPresence.failure(err, { address }))),
   );
 }
 
@@ -110,12 +128,13 @@ function searchAddressPresence$(
  * @param deps.matrix$ - MatrixClient async subject
  * @param deps.latest$ - Latest values
  * @param deps.log - Logger instance
+ * @param deps.config$ - Config observable
  * @returns Observable of presence updates or fail action
  */
 export function matrixMonitorPresenceEpic(
   action$: Observable<RaidenAction>,
   {}: Observable<RaidenState>,
-  { matrix$, latest$, log }: RaidenEpicDeps,
+  { matrix$, latest$, config$, log }: RaidenEpicDeps,
 ): Observable<matrixPresence.success | matrixPresence.failure> {
   return action$.pipe(
     filter(isActionOf(matrixPresence.request)),
@@ -124,33 +143,23 @@ export function matrixMonitorPresenceEpic(
     groupBy(({ action }) => action.meta.address),
     mergeMap((grouped$) =>
       grouped$.pipe(
-        withLatestFrom(latest$.pipe(pluckDistinct('presences'))),
+        withLatestFrom(latest$),
         // if we're already fetching presence for this address, no need to fetch again
-        exhaustMap(([{ action, matrix }, presences]) =>
-          action.meta.address in presences
-            ? // we already monitored/saw this user's presence
-              of(presences[action.meta.address])
-            : searchAddressPresence$(matrix, action.meta.address, { log }).pipe(
-                map(({ presence, user_id: userId, avatar_url }) =>
-                  matrixPresence.success(
-                    {
-                      userId,
-                      available: AVAILABLE.includes(presence),
-                      ts: Date.now(),
-                      caps: parseCaps(avatar_url),
-                    },
-                    action.meta,
-                  ),
-                ),
-                catchError((err) => of(matrixPresence.failure(err, action.meta))),
-              ),
-        ),
+        exhaustMap(([{ action, matrix }, { presences }]) => {
+          // we already monitored/saw this user's presence
+          if (action.meta.address in presences) return of(presences[action.meta.address]);
+          return searchAddressPresence$(matrix, action.meta.address, { log, config$ });
+        }),
       ),
     ),
   );
 }
 
 const comparePresencesFields = ['userId', 'available', 'caps'] as const;
+type PresenceContent = ReturnType<typeof getUserPresence> extends PromiseLike<infer U> ? U : never;
+type MatrixPresenceEvent = Omit<MatrixEvent, 'getContent'> & {
+  getContent: () => PresenceContent;
+};
 
 /**
  * Monitor peers matrix presence from User.presence events
@@ -171,19 +180,25 @@ export function matrixPresenceUpdateEpic(
   {}: Observable<RaidenState>,
   { log, matrix$, latest$, config$ }: RaidenEpicDeps,
 ): Observable<matrixPresence.success> {
+  // observable of all addresses whose presence monitoring was requested since init
+  const toMonitor$ = action$.pipe(
+    filter(matrixPresence.request.is),
+    scan((toMonitor, request) => toMonitor.add(request.meta.address), new Set<Address>()),
+    startWith(new Set<Address>()),
+  );
   return matrix$
     .pipe(
       // when matrix finishes initialization, register to matrix presence events
       switchMap((matrix) =>
         // matrix's 'User.presence' sometimes fail to fire, but generic 'event' is always fired,
         // and User (retrieved via matrix.getUser) is up-to-date before 'event' emits
-        fromEvent<MatrixEvent>(matrix, 'event').pipe(
+        fromEvent<MatrixPresenceEvent>(matrix, 'event').pipe(
           filter((event) => event.getType() === 'm.presence'),
           map((event) => ({ event, matrix })),
         ),
       ),
       // parse peer address from userId
-      map(({ event, matrix }) => {
+      mergeMap(function* ({ event, matrix }) {
         try {
           // as 'event' is emitted after user is (created and) updated, getUser always returns it
           const user = matrix.getUser(event.getSender());
@@ -193,27 +208,23 @@ export function matrixPresenceUpdateEpic(
           // getAddress will convert any valid address into checksummed-format
           const address = getAddress(peerAddress) as Address | undefined;
           assert(address);
-          return { matrix, user, address, event };
+          yield { matrix, user, address, event };
         } catch (err) {}
       }),
-      // filter out events without userId in the right format (startWith hex-address)
-      filter(isntNil),
-      withLatestFrom(
-        // observable of all addresses whose presence monitoring was requested since init
-        action$.pipe(
-          filter(matrixPresence.request.is),
-          scan((toMonitor, request) => toMonitor.add(request.meta.address), new Set<Address>()),
-          startWith(new Set<Address>()),
-        ),
-      ),
+      withLatestFrom(toMonitor$),
       // filter out events from users we don't care about
       // i.e.: presence monitoring never requested
       filter(([{ address }, toMonitor]) => toMonitor.has(address)),
-      mergeMap(([{ matrix, user, address }]) =>
-        defer(async () =>
+      mergeMap(([{ matrix, user, address, event }]) =>
+        combineLatest([
           // always fetch profile info, to get up-to-date displayname, avatar_url & presence
-          Promise.all([matrix.getProfileInfo(user.userId), getUserPresence(matrix, user.userId)]),
-        ).pipe(
+          defer(async () => matrix.getProfileInfo(user.userId)),
+          defer(async () =>
+            AVAILABLE.includes(event.getContent().presence)
+              ? event.getContent()
+              : getUserPresence(matrix, user.userId),
+          ),
+        ]).pipe(
           map(([profile, { presence, last_active_ago }]) => {
             // errors raised here will be logged and ignored on catchError below
             assert(profile?.displayname, 'no displayname');
@@ -305,12 +316,21 @@ export function matrixUpdateCapsEpic(
     pluck('caps'),
     distinctUntilChanged(isEqual),
     skip(1), // skip replay(1) and act only on changes
-    mergeMap((caps) => matrix$.pipe(map((matrix) => [caps, matrix] as const))),
-    mergeMap(async ([caps, matrix]) =>
-      matrix.setAvatarUrl(caps && !isEmpty(caps) ? stringifyCaps(caps) : '').catch(() => {
-        /* ignore http errors */
-      }),
+    switchMap((caps) =>
+      matrix$.pipe(
+        mergeMap((matrix) =>
+          defer(async () =>
+            matrix.setAvatarUrl(caps && !isEmpty(caps) ? stringifyCaps(caps) : ''),
+          ).pipe(
+            // trigger immediate presence updates on peers
+            mergeMap(async () =>
+              matrix.setPresence({ presence: 'online', status_msg: Date.now().toString() }),
+            ),
+          ),
+        ),
+        retryWhile(intervalFromConfig(config$)),
+        ignoreElements(),
+      ),
     ),
-    ignoreElements(),
   );
 }

--- a/raiden-ts/src/utils/error.ts
+++ b/raiden-ts/src/utils/error.ts
@@ -51,6 +51,7 @@ export const networkErrors: ErrorMatches = [
   'missing response',
   { code: 'TIMEOUT' },
   { code: 'SERVER_ERROR' },
+  { code: 'NETWORK_ERROR' },
 ];
 export const txNonceErrors: ErrorMatches = [
   'replacement fee too low',


### PR DESCRIPTION
Some commits offloaded from #2453 

**Short description**
- Ensure `deviceId` is set also for the fallback `matrix.register` call (preparation for enforcing it on `sendToDeviceMessage`
- Consider a peer with an established `RTC` channel as `online` complementary to matrix's presence
- `setPresence` upon capability changes to ensure peer's presence update is triggered
- Split some complex presence logic on their own functions, and simplify some types

None of this is worth changelog entries nor compatibility-breaking, just implementation details but preparation for what's seen on the other PR.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
