### PR TITLE
Revert "deps: Update dependency source-map-loader to v2"

### DIFF
--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -89,7 +89,7 @@
     "nyc": "^15.1.0",
     "sass": "^1.32.0",
     "sass-loader": "^10.1.0",
-    "source-map-loader": "^2.0.0",
+    "source-map-loader": "^1.1.3",
     "stylelint": "^13.8.0",
     "stylelint-config-recommended-scss": "^4.2.0",
     "stylelint-scss": "^3.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17167,14 +17167,17 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-loader@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-2.0.0.tgz#6651dc5a46beb2b914abacd00b8f9dd0e7757820"
-  integrity sha512-DJLK+gR9hlx+58yGU54EDAQZzR/TksgrtvRtyEBWnd5DR7O4n0RgdyO/KBwJ76zF+wDiFRT/1vdV3SdLUR68Lg==
+source-map-loader@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-1.1.3.tgz#7dbc2fe7ea09d3e43c51fd9fc478b7f016c1f820"
+  integrity sha512-6YHeF+XzDOrT/ycFJNI53cgEsp/tHTMl37hi7uVyqFAlTXW109JazaQCkbc+jjoL2637qkH1amLi+JzrIpt5lA==
   dependencies:
     abab "^2.0.5"
     iconv-lite "^0.6.2"
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
     source-map "^0.6.1"
+    whatwg-mimetype "^2.3.0"
 
 source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.3"


### PR DESCRIPTION
This reverts commit 5a799b04357a9df3409bb8c0ede5bf7712b4849f.

**Short description**
In https://github.com/raiden-network/light-client/pull/2470 we updated `source-map-loader` to 2.0 (https://github.com/webpack-contrib/source-map-loader/releases/tag/v2.0.0), which requires `webpack` 5.x. However, we still use webpack 4.x.

Andre asked to add a regression test, but I couldn't find something simple as this only happens with the interactive `vue-cli-service serve` command.

webpack upgrade issue is in https://github.com/raiden-network/light-client/issues/2481

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
