### PR TITLE
Feature/change orgin URL for subkey generation

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [#2435] Sync indicator when connecting to dApp
 - [#2399] Hint for user to stay online while receving transfers
 - [#2458] Click on notification snackbar to open notification panel
+- [#2446] Add `VUE_APP_SUBKEY_ORIGIN_URL` env variable to recover backups
 
 ### Changed
 
@@ -41,6 +42,7 @@
 [#2399]: https://github.com/raiden-network/light-client/issues/2399
 [#2458]: https://github.com/raiden-network/light-client/issues/2458
 [#2474]: https://github.com/raiden-network/light-client/issues/2474
+[#2446]: https://github.com/raiden-network/light-client/issues/2446
 
 ## [0.14.0] - 2020-11-25
 

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -79,6 +79,7 @@ export default class RaidenService {
             : undefined),
         },
         subkey,
+        process.env.VUE_APP_SUBKEY_ORIGIN_URL,
       );
     } catch (e) {
       throw new RaidenInitializationFailed(e);

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#211] 'suggestPartners' method to fetch suggested partners from PFS
 - [#2417] Make 'start' async, introduce 'synced' promise, both resolves when syncing finishes
 - [#2444] Add adaptative sync for chunked getLogs
+- [#2446] Add parameter for subkey generation to overwrite origin URL
 
 ### Changed
 - [#2409] Lower default payment expiration to 1.1 × reveal timeout
@@ -13,6 +14,7 @@
 [#2409]: https://github.com/raiden-network/light-client/issues/2409
 [#2417]: https://github.com/raiden-network/light-client/pull/2417
 [#2444]: https://github.com/raiden-network/light-client/issues/2444
+[#2446]: https://github.com/raiden-network/light-client/issues/2446
 
 ## [0.14.0] - 2020-11-25
 ### Fixed

--- a/raiden-ts/docs-source/installing-dapp.md
+++ b/raiden-ts/docs-source/installing-dapp.md
@@ -24,3 +24,24 @@ yarn workspace raiden-dapp run serve
 Once the development server has been started, navigate to `http://localhost:8080` to start using the Raiden dApp.
 
 > Note that for the Raiden dApp to work it requires MetaMask or some other Web3 provider (wallet apps with dApp support) to be installed on your browser.
+
+## Recover Backup locally
+
+You might have a backup by a dApp instance that was provided by a service that
+is not available anymore. You can not import this backup to another dApp
+provider if you were using a Raiden subkey (configuration option). The subkey
+generation is dependent on the origin URL which is serving the dApp and the
+Ethereum chain it is connected to. Therefore this will result into a different
+key for each dApp provider and chain.
+
+To still being able to recover your backup you can run the dApp locally and tell
+it to act like it would be served by a specific origin. Therefore you need to
+edit the `raiden-dapp/.env.development` file and add the following line:
+
+```sh
+VUE_APP_SUBKEY_ORIGIN_URL=https://<url-of-old-service>
+```
+
+Afterwards continue to run the dApp locally [as describe
+earlier](#install-and-run-the-dapp). Remember that you need to restart the dApp
+if you have it already running to reload the environment variables.

--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -95,10 +95,11 @@ export const getContracts = (network: Network): ContractsInfo => {
  *
  * @param network - Network to include in message
  * @param main - Main signer to derive subkey from
+ * @param originUrl - URL of the origin to generate the subkey for
  * @returns Subkey's signer & address
  */
-async function genSubkey(network: Network, main: Signer) {
-  const url = globalThis?.location?.origin ?? 'unknown';
+async function genSubkey(network: Network, main: Signer, originUrl?: string) {
+  const url = originUrl ?? globalThis?.location?.origin ?? 'unknown';
   const message = `=== RAIDEN SUBKEY GENERATION ===
 
 Network: ${getNetworkName(network).toUpperCase()}
@@ -121,12 +122,14 @@ Signing this message at any other address WILL give it FULL control of this subk
  * @param account - an account used for signing
  * @param provider - a provider
  * @param subkey - Whether to generate a subkey
+ * @param subkeyOriginUrl - URL of the origin to generate a subkey for
  * @returns a [[Signer]] or [[Wallet]] that can be used for signing
  */
 export const getSigner = async (
   account: string | number | Signer,
   provider: JsonRpcProvider,
   subkey?: boolean,
+  subkeyOriginUrl?: string,
 ) => {
   let signer;
   let address: Address;
@@ -169,7 +172,11 @@ export const getSigner = async (
 
   if (subkey) {
     main = { signer, address };
-    ({ signer, address } = await genSubkey(await provider.getNetwork(), main.signer));
+    ({ signer, address } = await genSubkey(
+      await provider.getNetwork(),
+      main.signer,
+      subkeyOriginUrl,
+    ));
   }
 
   return { signer, address, main };

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -385,6 +385,8 @@ export class Raiden {
    * @param contractsOrUDCAddress - Contracts deployment info, or UserDeposit contract address
    * @param config - Raiden configuration
    * @param subkey - Whether to use a derived subkey or not
+   * @param subkeyOriginUrl - URL of origin to generate a subkey for (defaults
+   *    to global context)
    * @returns Promise to Raiden SDK client instance
    */
   public static async create<R extends typeof Raiden>(
@@ -396,6 +398,7 @@ export class Raiden {
     contractsOrUDCAddress?: ContractsInfo | string,
     config?: Decodable<PartialRaidenConfig>,
     subkey?: true,
+    subkeyOriginUrl?: string,
   ): Promise<InstanceType<R>> {
     let provider: JsonRpcProvider;
     if (typeof connection === 'string') {
@@ -424,7 +427,7 @@ export class Raiden {
       contractsInfo = contractsOrUDCAddress;
     }
 
-    const { signer, address, main } = await getSigner(account, provider, subkey);
+    const { signer, address, main } = await getSigner(account, provider, subkey, subkeyOriginUrl);
 
     // Build initial state or parse from database
     const { state, db } = await getState(


### PR DESCRIPTION
Fixes #2446

**Short description**
Details of the design decision in the commit messages. Else a pretty simple and small PR...

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Add the `VUE_APP_SUBKEY_ORIGIN_URL` variable to the `.env.development` file and assign any random value to it.
2. Serve the dApp locally
3. Access the dApp in the web-browser and attempt to connect
4. Verify that the message that you should sign for the subkey generation includes the URL you have specified before