### PR TITLE
Show better message when PFS doesn't suggest partners

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#2476] Fix persitence to remember disclaimer acceptance if selected
 - [#2430] Remember token selection during navigation
 - [#2474] Fix TransferHeader behaviour with no available capacity
+- [#2485] Show better message in case the PFS doesn't suggest partners
 
 ### Added
 
@@ -43,6 +44,7 @@
 [#2458]: https://github.com/raiden-network/light-client/issues/2458
 [#2474]: https://github.com/raiden-network/light-client/issues/2474
 [#2446]: https://github.com/raiden-network/light-client/issues/2446
+[#2485]: https://github.com/raiden-network/light-client/issues/2485
 
 ## [0.14.0] - 2020-11-25
 

--- a/raiden-dapp/src/components/HubList.vue
+++ b/raiden-dapp/src/components/HubList.vue
@@ -2,8 +2,11 @@
   <div class="hub-list">
     <span class="hub-list__header">{{ $t('hub-list.header') }}</span>
     <spinner v-if="loadingHubs" class="hub-list__loading" />
-    <div v-else-if="!loadingHubs && !suggestedHubs.length" class="hub-list__no-hubs">
+    <div v-else-if="!loadingHubs && requestFailed" class="hub-list__no-hubs">
       {{ $t('hub-list.error') }}
+    </div>
+    <div v-else-if="!loadingHubs && suggestedHubs.length === 0" class="hub-list__no-hubs">
+      {{ $t('hub-list.no-results') }}
     </div>
     <div v-for="(suggestedHub, index) in suggestedHubs.slice(0, 3)" v-else :key="index">
       <div class="hub-list__item">
@@ -44,6 +47,7 @@ import { SuggestedPartner } from '@/types';
 export default class HubList extends Vue {
   truncate = Filters.truncate;
   loadingHubs = true;
+  requestFailed = false;
   suggestedHubs: SuggestedPartner[] = [];
   selectedHub = '';
 
@@ -59,6 +63,7 @@ export default class HubList extends Vue {
     try {
       this.suggestedHubs = await this.$raiden.getSuggestedPartners(this.tokenAddress);
     } catch (err) {
+      this.requestFailed = true;
     } finally {
       this.loadingHubs = false;
     }

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -535,7 +535,8 @@
   },
   "hub-list": {
     "header": "Current top 3 suggested hubs (best first)",
-    "error": "Error: List cannot be fetched",
+    "error": "Error: List of hubs cannot be fetched from the Pathfinding Service.",
+    "no-results": "In this token network, the Pathfinding Service does not find a node which is online. Try again later.",
     "select-button": "Select"
   },
   "open-channel": {


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2485

**Short description**

- Make the sdk return an empty list when no PFS returns suggested partners
- Display a better message in the dApp in this case


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Select a token where it's unlikely that nodes are online in the network (like any older scenario player token)
2. Check that the PFS request is done and return an empty list
3. Check that the suggested peers list displays a message mentioning that no nodes are suggested.
