### PR TITLE
Enable Redux DevTools Browser Extension

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - [#211] 'suggestPartners' method to fetch suggested partners from PFS
+- [#485] Enable the Redux DevTools Extension in development for monitoring the Redux store
 - [#2417] Make 'start' async, introduce 'synced' promise, both resolves when syncing finishes
 - [#2444] Add adaptative sync for chunked getLogs
 - [#2446] Add parameter for subkey generation to overwrite origin URL
@@ -15,6 +16,7 @@
 - [#2352] Presence bug, transport fixes and performance improvements
 
 [#211]: https://github.com/raiden-network/light-client/issues/211
+[#485]: https://github.com/raiden-network/light-client/issues/485
 [#2352]: https://github.com/raiden-network/light-client/issues/2352
 [#2409]: https://github.com/raiden-network/light-client/issues/2409
 [#2417]: https://github.com/raiden-network/light-client/pull/2417

--- a/raiden-ts/docs-source/SDK-Development.md
+++ b/raiden-ts/docs-source/SDK-Development.md
@@ -264,6 +264,7 @@ The SDK being a TypeScript/JavaScript library, debugging it can use a lot of the
 6. State can be inspected and even edited as a JSON (while the SDK is **not** running) from the app's `localStorage`, in the `Storage` or `Application` tabs.
 7. While most epics variables and dependencies aren't persisted in the Raiden instance, but only used contextually in its epic, one can log them in any step and access it by right-clicking in the logged out object. If the need arises, the [RaidenEpicDeps](https://github.com/raiden-network/light-client/blob/84afc0939d267e99636147e8241d7bda4f55cbb1/raiden/src/types.ts#L32) object can be saved in a `Raiden` property in the constructor and acessed from the console as well, giving full access to the instance details and variables.
 8. Looking at the in-browser sourcecode can be tricky, as even with proper maps, it'll be the `webpack`ed version of the `tsc`ed sourcecode. Comparing the sources in `webpack-internal` to the actual `.ts` sourcecode can give good hints on what's failing.
+9. The Redux store can be visualized and even be modified with the Redux DevTools Extension. Install it for [Firefox](https://addons.mozilla.org/en-US/firefox/addon/reduxdevtools/) or [Chrome](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd) and go to the `Redux` tab in your Dev Tools.
 
 ### With tests
 

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -103,6 +103,7 @@
     "pouchdb": "^7.2.2",
     "pouchdb-find": "^7.2.2",
     "redux": "^4.0.5",
+    "redux-devtools-extension": "^2.13.8",
     "redux-logger": "^3.0.6",
     "redux-observable": "^1.2.0",
     "rxjs": "^6.6.3",

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -9,7 +9,7 @@ import { MatrixClient } from 'matrix-js-sdk';
 import { applyMiddleware, createStore, Store } from 'redux';
 import { createEpicMiddleware, EpicMiddleware } from 'redux-observable';
 import { createLogger } from 'redux-logger';
-import { composeWithDevTools } from 'redux-devtools-extension/logOnlyInProduction';
+import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
 
 import constant from 'lodash/constant';
 import memoize from 'lodash/memoize';

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -9,6 +9,7 @@ import { MatrixClient } from 'matrix-js-sdk';
 import { applyMiddleware, createStore, Store } from 'redux';
 import { createEpicMiddleware, EpicMiddleware } from 'redux-observable';
 import { createLogger } from 'redux-logger';
+import { composeWithDevTools } from 'redux-devtools-extension/logOnlyInProduction';
 
 import constant from 'lodash/constant';
 import memoize from 'lodash/memoize';
@@ -326,7 +327,9 @@ export class Raiden {
       raidenReducer,
       // workaround for redux's PreloadedState issues with branded values
       state as any, // eslint-disable-line @typescript-eslint/no-explicit-any
-      applyMiddleware(loggerMiddleware, persisterMiddleware, this.epicMiddleware),
+      composeWithDevTools(
+        applyMiddleware(loggerMiddleware, persisterMiddleware, this.epicMiddleware),
+      ),
     );
 
     this.synced = this.action$

--- a/yarn.lock
+++ b/yarn.lock
@@ -16193,6 +16193,11 @@ redeyed@~2.1.0:
   dependencies:
     esprima "~4.0.0"
 
+redux-devtools-extension@^2.13.8:
+  version "2.13.8"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz#37b982688626e5e4993ff87220c9bbb7cd2d96e1"
+  integrity sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==
+
 redux-logger@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"


### PR DESCRIPTION
Fixes #485 

**Short description**
The [Redux DevTools browser extension](https://github.com/zalmoxisus/redux-devtools-extension) can be used to visualize the store and modify the state for development purposes.
See the linked issue for a screenshot of the light client's visualization.

In production the extension is restricted by the logging only mode.
@andrevmatos Let me know if you have any concerns exposing the store in production.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Download the browser extension for you browser
2. Run the light client and open the Redux DevTools
3. Make some state changes by sending a transfer or any other action and check the updated monitors.
