### PR TITLE
change typedoc to version 0.19.2 to avoid breaking changes for now an…

### DIFF
--- a/raiden-ts/docs-source/hub-selection-channel-opening.md
+++ b/raiden-ts/docs-source/hub-selection-channel-opening.md
@@ -8,11 +8,11 @@ Once you sign the MetaMask prompt to create a Raiden Account you will come to a 
 
 ---
 
-![Select-Hub](https://user-images.githubusercontent.com/15123108/102077805-e0277780-3e2f-11eb-86ab-cdbf060aba6b.gif 'Select Hub gif')
+![Select-Hub](https://user-images.githubusercontent.com/15123108/103350295-824c8e00-4ac5-11eb-86e5-99aec9533d8e.gif 'Select Hub gif')
 
 ## Select Hub
 
-![Select-Hub-screen](https://user-images.githubusercontent.com/15123108/102077868-faf9ec00-3e2f-11eb-8a5d-a5df28c4f860.png 'Select Hub screen')
+![Select-Hub-screen](https://user-images.githubusercontent.com/15123108/103347552-4e6d6a80-4abd-11eb-869f-2d98e65caf2a.png 'Select Hub screen')
 
 On the _Select Hub_ screen There are two tokens available which will briefly be described here:
 
@@ -28,20 +28,20 @@ If well connected hubs are available for the token network, a list of the top th
 
 ## Mint or Acquire Tokens
 
-![Mint-SVT-TTT](https://user-images.githubusercontent.com/15123108/102077942-15cc6080-3e30-11eb-964b-90e0441fa6e7.png 'Mint SVT and TTT tokens')
+![Mint-SVT-TTT](https://user-images.githubusercontent.com/15123108/103345560-b6b94d80-4ab7-11eb-847a-d8f08bc96c23.png 'Mint SVT and TTT tokens')
 
 Minting tokens can only be done on testnets.
 On Goerli, for instance, that would be the _SVT_ and _TTT_ token (or any other token which supports minting).
 
 On mainnet, the tokens needs to be acquired independently. The dApp assists in this by providing a link to Uniswap where tokens can be exchanged.
 
-![After-minting-select-hub](https://user-images.githubusercontent.com/15123108/102078028-41e7e180-3e30-11eb-90bf-9c5b7df8ed2c.png 'After minting select hub screen')
+![After-minting-select-hub](https://user-images.githubusercontent.com/15123108/103347569-59c09600-4abd-11eb-9197-5d9a7e628267.png 'After minting select hub screen')
 
 After minting the screen should look something like above.
 
 ## Opening a Channel With the Hub
 
-![select-hub-button-click](https://user-images.githubusercontent.com/15123108/102078097-5b892900-3e30-11eb-9061-10205ee6fd78.gif 'Select hub button click')
+![select-hub-button-click](https://user-images.githubusercontent.com/15123108/103350414-e66f5200-4ac5-11eb-8339-5e3ecb564d5f.gif 'Select hub button click')
 
 After entering the address of the hub click on _Select hub_ and on the next screen enter the amount to be allocated in the channel. Sign the required transactions on MetaMask. When a channel has been opened you will end up on the _Transfer_ screen.
 

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -67,7 +67,7 @@
     "tiny-async-pool": "^1.2.0",
     "ts-jest": "^26.4.4",
     "typechain": "^4.0.1",
-    "typedoc": "^0.20.14",
+    "typedoc": "0.19.2",
     "typedoc-plugin-pages": "^1.1.0",
     "typescript": "^4.1.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6459,7 +6459,7 @@ colorette@^1.2.1:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
   integrity sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
 
-colors@^1.1.2, colors@^1.4.0:
+colors@^1.1.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -10113,7 +10113,7 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-highlight.js@^10.0.0:
+highlight.js@^10.0.0, highlight.js@^10.2.0:
   version "10.5.0"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.5.0.tgz#3f09fede6a865757378f2d9ebdcbc15ba268f98f"
   integrity sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw==
@@ -13172,7 +13172,7 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^1.2.5:
+marked@^1.1.1:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.7.tgz#6e14b595581d2319cdcf033a24caaf41455a01fb"
   integrity sha512-No11hFYcXr/zkBvL6qFmAp1z6BKY3zqLMHny/JN/ey+al7qwCM2+CMBL9BOgqMxZU36fz4cCWfn2poWIf7QRXA==
@@ -14352,13 +14352,6 @@ onetime@^5.1.0:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
-
-onigasm@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/onigasm/-/onigasm-2.2.5.tgz#cc4d2a79a0fa0b64caec1f4c7ea367585a676892"
-  integrity sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==
-  dependencies:
-    lru-cache "^5.1.1"
 
 open@^6.3.0:
   version "6.4.0"
@@ -17039,31 +17032,6 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shiki-languages@^0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/shiki-languages/-/shiki-languages-0.2.7.tgz#7230b675b96d37a36ac1bf995525375ce69f3924"
-  integrity sha512-REmakh7pn2jCn9GDMRSK36oDgqhh+rSvJPo77sdWTOmk44C5b0XlYPwJZcFOMJWUZJE0c7FCbKclw4FLwUKLRw==
-  dependencies:
-    vscode-textmate "^5.2.0"
-
-shiki-themes@^0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/shiki-themes/-/shiki-themes-0.2.7.tgz#6e04451d832152e0fc969876a7bd926b3963c1f2"
-  integrity sha512-ZMmboDYw5+SEpugM8KGUq3tkZ0vXg+k60XX6NngDK7gc1Sv6YLUlanpvG3evm57uKJvfXsky/S5MzSOTtYKLjA==
-  dependencies:
-    json5 "^2.1.0"
-    vscode-textmate "^5.2.0"
-
-shiki@^0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.2.7.tgz#d2547548ed8742673730e1e4bbe792a77c445540"
-  integrity sha512-bwVc7cdtYYHEO9O+XJ8aNOskKRfaQd5Y4ovLRfbQkmiLSUaR+bdlssbZUUhbQ0JAFMYcTcJ5tjG5KtnufttDHQ==
-  dependencies:
-    onigasm "^2.2.5"
-    shiki-languages "^0.2.7"
-    shiki-themes "^0.2.7"
-    vscode-textmate "^5.2.0"
-
 shortid@^2.2.15:
   version "2.2.16"
   resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.16.tgz#b742b8f0cb96406fd391c76bfc18a67a57fe5608"
@@ -18705,17 +18673,17 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.12.1.tgz#6c4a759f9dc365b4021579587b3773deb6fb6eeb"
-  integrity sha512-6PEvV+/kWAJeUwEtrKgIsZQSbybW5DGCr6s2mMjHsDplpgN8iBHI52UbA+2C+c2TMCxBNMK9TMS6pdeIdwsLSw==
-
 typedoc-default-themes@^0.10.1:
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz#743380a80afe62c5ef92ca1bd4abe2ac596be4d2"
   integrity sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==
   dependencies:
     lunr "^2.3.8"
+
+typedoc-default-themes@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz#1bc55b7c8d1132844616ff6f570e1e2cd0eb7343"
+  integrity sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==
 
 typedoc-plugin-pages@^1.1.0:
   version "1.1.0"
@@ -18725,22 +18693,22 @@ typedoc-plugin-pages@^1.1.0:
     compare-versions "^3.6.0"
     typedoc-default-themes "^0.10.1"
 
-typedoc@^0.20.14:
-  version "0.20.14"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.20.14.tgz#894ff71841a4abbe8f46cf52f3cc96c9d68328dc"
-  integrity sha512-9bsZp5/qkl+gDSv9DRvHbfbY8Sr0tD8fKx7hNIvcluxeAFzBCEo9o0qDCdLUZw+/axbfd9TaqHvSuCVRu+YH6Q==
+typedoc@0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.19.2.tgz#842a63a581f4920f76b0346bb80eb2a49afc2c28"
+  integrity sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==
   dependencies:
-    colors "^1.4.0"
     fs-extra "^9.0.1"
     handlebars "^4.7.6"
+    highlight.js "^10.2.0"
     lodash "^4.17.20"
     lunr "^2.3.9"
-    marked "^1.2.5"
+    marked "^1.1.1"
     minimatch "^3.0.0"
     progress "^2.0.3"
+    semver "^7.3.2"
     shelljs "^0.8.4"
-    shiki "^0.2.7"
-    typedoc-default-themes "0.12.1"
+    typedoc-default-themes "^0.11.4"
 
 typescript@^4.1.3:
   version "4.1.3"
@@ -19221,11 +19189,6 @@ vscode-languageserver@^5.1.0:
   dependencies:
     vscode-languageserver-protocol "3.14.1"
     vscode-uri "^1.0.6"
-
-vscode-textmate@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-5.2.0.tgz#01f01760a391e8222fe4f33fbccbd1ad71aed74e"
-  integrity sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==
 
 vscode-uri@1.0.6:
   version "1.0.6"


### PR DESCRIPTION
change typedoc to version 0.19.2 to avoid breaking changes for now and change images for the screens.

[Typedoc](https://github.com/TypeStrong/typedoc/releases/tag/v0.20.0) version `0.20.0` introduces breaking changes so even the [typedoc-plugin-pages](https://github.com/mipatterson/typedoc-plugin-pages) the plugin that we use to build the our markdown pages will not work. So I thought its not worth moving to new version so soon. We can wait for the plugins and other stuff to migrate and then migrate 

https://github.com/TypeStrong/typedoc/releases/tag/v0.20.0

https://github.com/mipatterson/typedoc-plugin-pages
**Thank you for submitting this pull request :)**

Fixes # 

**Short description**


**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
