### PR TITLE
Fix shutdown logic and wait for background tasks

### DIFF
--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -4,7 +4,11 @@
 ### Added
 - [#2417] Register sensible endpoints on 'synced' SDK promise, updates /status API accordingly
 
+### Changed
+- [#2505] Wait for background tasks to gracefully complete before exiting
+
 [#2417]: https://github.com/raiden-network/light-client/pull/2417
+[#2505]: https://github.com/raiden-network/light-client/pull/2505
 
 ## [0.14.0] - 2020-11-25
 ### Fixed

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 - [#2409] Lower default payment expiration to 1.1 × reveal timeout
+- [#2505] Properly shut down epics on stop and wait for teardown/cleanup tasks
 
 ### Fixed
 - [#2352] Presence bug, transport fixes and performance improvements
@@ -19,6 +20,7 @@
 [#2417]: https://github.com/raiden-network/light-client/pull/2417
 [#2444]: https://github.com/raiden-network/light-client/issues/2444
 [#2446]: https://github.com/raiden-network/light-client/issues/2446
+[#2505]: https://github.com/raiden-network/light-client/pull/2505
 
 ## [0.14.0] - 2020-11-25
 ### Fixed

--- a/raiden-ts/src/channels/actions.ts
+++ b/raiden-ts/src/channels/actions.ts
@@ -15,6 +15,10 @@ const ChannelId = t.type({
 export const newBlock = createAction('block/new', t.type({ blockNumber: t.number }));
 export interface newBlock extends ActionType<typeof newBlock> {}
 
+/* A new blockTime (average time between latest X blocks) was detected */
+export const blockTime = createAction('block/time', t.type({ blockTime: t.number }));
+export interface blockTime extends ActionType<typeof blockTime> {}
+
 /**
  * A new token network is detected in the TokenNetworkRegistry instance
  * fromBlock is only set on the first time, to fetch and handle past events

--- a/raiden-ts/src/transfers/epics/init.ts
+++ b/raiden-ts/src/transfers/epics/init.ts
@@ -22,7 +22,7 @@ import { RaidenEpicDeps } from '../../types';
 import { matrixPresence } from '../../transport/actions';
 import { getCap } from '../../transport/utils';
 import { Hash, untime } from '../../utils/types';
-import { distinctRecordValues, pluckDistinct } from '../../utils/rx';
+import { completeWith, distinctRecordValues, pluckDistinct } from '../../utils/rx';
 import {
   transferExpire,
   transferSigned,
@@ -213,6 +213,7 @@ export function transferClearCompletedEpic(
             startWith({ meta: pick(['secrethash', 'direction'], transfer) }),
           ),
         ),
+        completeWith(action$),
         // after some time with no action for this transfer going through (e.g. Processed retries)
         debounceTime(3 * httpTimeout),
         map(({ meta }) => transferClear(undefined, meta)), // clear transfer

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -43,7 +43,7 @@ import { RaidenState } from '../../state';
 import { RaidenEpicDeps } from '../../types';
 import { isActionOf } from '../../utils/actions';
 import { LruCache } from '../../utils/lru';
-import { pluckDistinct } from '../../utils/rx';
+import { completeWith, pluckDistinct } from '../../utils/rx';
 import { Hash, Signed, UInt, Int, Address, untime, decode } from '../../utils/types';
 import { RaidenError, ErrorCodes } from '../../utils/error';
 import { Capabilities } from '../../constants';
@@ -1084,7 +1084,7 @@ export function transferGenerateAndSignEnvelopeMessageEpic(
   deps: RaidenEpicDeps,
 ) {
   const processedCache = new LruCache<string, Signed<Processed>>(32);
-  const state$ = deps.latest$.pipe(pluckDistinct('state')); // replayed(1)' state$
+  const state$ = deps.latest$.pipe(pluckDistinct('state'), completeWith(action$)); // replayed(1)' state$
   return merge(
     action$.pipe(
       filter(

--- a/raiden-ts/src/transfers/epics/secret.ts
+++ b/raiden-ts/src/transfers/epics/secret.ts
@@ -27,7 +27,7 @@ import { RaidenEpicDeps } from '../../types';
 import { isActionOf, isConfirmationResponseOf } from '../../utils/actions';
 import { RaidenError, ErrorCodes, assert, commonTxErrors } from '../../utils/error';
 import { fromEthersEvent, logToContractEvent } from '../../utils/ethers';
-import { pluckDistinct, retryWhile, takeIf } from '../../utils/rx';
+import { completeWith, pluckDistinct, retryWhile, takeIf } from '../../utils/rx';
 import { Hash, Secret, Signed, UInt, isntNil, untime } from '../../utils/types';
 import { getCap } from '../../transport/utils';
 import {
@@ -318,6 +318,7 @@ export function monitorSecretRegistryEpic(
         confirmationBlocks,
       ),
     ),
+    completeWith(state$),
     map(logToContractEvent<[Hash, Secret, Event]>(secretRegistryContract)),
     filter(isntNil),
     withLatestFrom(state$, config$),

--- a/raiden-ts/src/transfers/epics/utils.ts
+++ b/raiden-ts/src/transfers/epics/utils.ts
@@ -4,7 +4,7 @@ import { filter, ignoreElements, take } from 'rxjs/operators';
 
 import { messageSend } from '../../messages/actions';
 import { isResponseOf } from '../../utils/actions';
-import { repeatUntil } from '../../utils/rx';
+import { completeWith, repeatUntil } from '../../utils/rx';
 import { RaidenAction } from '../../actions';
 import {
   MessageType,
@@ -73,6 +73,7 @@ export function retrySendUntil$(
 ): Observable<messageSend.request> {
   return dispatchAndWait$(action$, send, isResponseOf(messageSend, send.meta)).pipe(
     repeatUntil(notifier, delayMs),
+    completeWith(action$),
   );
 }
 

--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -46,7 +46,7 @@ import { MatrixClient } from 'matrix-js-sdk';
 import { Capabilities } from '../../constants';
 import { Address, decode, isntNil } from '../../utils/types';
 import { jsonParse, jsonStringify } from '../../utils/data';
-import { timeoutFirst } from '../../utils/rx';
+import { completeWith, timeoutFirst } from '../../utils/rx';
 import { RaidenEpicDeps } from '../../types';
 import { RaidenAction } from '../../actions';
 import { dispatchAndWait$, exponentialBackoff } from '../../transfers/epics/utils';
@@ -585,6 +585,7 @@ export function rtcConnectEpic(
             !!getCap(caps, Capabilities.WEBRTC),
         ),
         switchMap(([action, config]) => handlePresenceChange$(action, action$, config, deps)),
+        completeWith(action$),
       ),
     ),
   );

--- a/raiden-ts/tests/unit/epics/send.spec.ts
+++ b/raiden-ts/tests/unit/epics/send.spec.ts
@@ -116,6 +116,7 @@ describe('send transfer', () => {
       channel: channelUniqueKey(getChannel(raiden, partner)),
       secrethash,
     });
+    await sleep(100);
 
     expectChannelsAreInSync([raiden, partner]);
   });

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -499,16 +499,16 @@ describe('matrixPresenceUpdateEpic', () => {
     const partnerMatrix = (await partner.deps.matrix$.toPromise()) as jest.Mocked<MatrixClient>;
 
     raiden.store.dispatch(matrixPresence.request(undefined, { address: partner.address }));
-    await sleep();
+    await sleep(raiden.config.httpTimeout);
     expect(raiden.output).toContainEqual(
       matrixPresence.success(
         expect.objectContaining({ available: true, userId: partnerMatrix.getUserId()! }),
         { address: partner.address },
       ),
     );
-    raiden.output = [];
+    raiden.output.splice(0, raiden.output.length);
 
-    matrix.getProfileInfo.mockRejectedValueOnce(new Error('could not get user profile'));
+    matrix.getProfileInfo.mockRejectedValue(new Error('could not get user profile'));
     matrix.emit('event', {
       getType: () => 'm.presence',
       getSender: () => partnerMatrix.getUserId(),
@@ -847,7 +847,7 @@ describe('matrixMessageSendEpic', () => {
       ),
     );
 
-    await sleep(raiden.config.httpTimeout);
+    await sleep(100);
     expect(raiden.output).toContainEqual(
       messageSend.success(expect.objectContaining({ via: expect.stringMatching(/^!/) }), {
         address: partner.address,
@@ -887,7 +887,7 @@ describe('matrixMessageSendEpic', () => {
       messageSend.request({ message }, { address: partner.address, msgId: message }),
     );
 
-    await sleep(3 * raiden.config.httpTimeout);
+    await sleep(200);
     expect(raiden.output).toContainEqual(
       messageSend.failure(expect.objectContaining({ message: 'Failed 4' }), {
         address: partner.address,


### PR DESCRIPTION
Fixes #2483 
Based on #2453 

**Short description**
The bug was triggered by the removal of a wait between transfer completed and cli node stop on that scenario. It was caused by the CLI not waiting gracefully for all background tasks to be sent before exiting, and then the `MonitoringRequest` could not make it to the global room.
This PR ensures the SDK properly waits (up to httpTimeout=30s) for all epics to flush and complete their pending tasks before waiting for the database to finish writing and then exit, and also that the CLI honors this instead of forcefully exiting.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. MS1 passes
