### PR TITLE
sdk: Add '502: gateway error' to network errors

### DIFF
--- a/raiden-ts/src/utils/error.ts
+++ b/raiden-ts/src/utils/error.ts
@@ -55,6 +55,7 @@ export const networkErrors: ErrorMatches = [
   { code: 'ENOTFOUND' },
   429,
   500,
+  502,
   503,
 ];
 export const txNonceErrors: ErrorMatches = [


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2506 

**Short description**

In the nightly run the node encountered a `502 error: Bad Gateway`. As this can always happen, we should retry.

