### PR TITLE
Disable mediation in cli

### DIFF
--- a/raiden-cli/src/config.json
+++ b/raiden-cli/src/config.json
@@ -1,13 +1,4 @@
 {
-  "matrixServer": "https://transport.demo001.env.raiden.network",
-  "pfs": "https://pfs.demo001.env.raiden.network",
   "pfsSafetyMargin": 1.1,
-  "caps": {
-    "Delivery": 0,
-    "Receive": 1,
-    "Mediate": 1,
-    "webRTC": 1,
-    "toDevice": 1
-  },
   "autoSettle": true
 }

--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -5,7 +5,7 @@ import inquirer from 'inquirer';
 import yargs from 'yargs/yargs';
 import { LocalStorage } from 'node-localstorage';
 import { Wallet, ethers } from 'ethers';
-import { Raiden, Address, RaidenConfig, assert, UInt } from 'raiden-ts';
+import { Raiden, Address, RaidenConfig, assert, UInt, Capabilities } from 'raiden-ts';
 
 import DISCLAIMER from './disclaimer.json';
 import DEFAULT_RAIDEN_CONFIG from './config.json';
@@ -16,6 +16,7 @@ import { setupLoglevel } from './utils/logging';
 function parseArguments() {
   const argv = yargs(process.argv.slice(2));
   return argv
+    .env('RAIDEN')
     .usage('Usage: $0 [options]')
     .options({
       datadir: {
@@ -132,8 +133,13 @@ function parseArguments() {
         default: false,
         desc: "Enables monitoring if there's a UDC deposit",
       },
+      enableMediation: {
+        type: 'boolean',
+        default: false,
+        desc: 'Enables support for mediated payments (unsupported).',
+        hidden: true, // hidden from help because not officially supported
+      },
     })
-    .env('RAIDEN')
     .help()
     .alias('h', 'help')
     .version()
@@ -268,6 +274,15 @@ async function createRaidenConfig(
     config = { ...config, pfs: argv.pathfindingServiceAddress };
 
   if (!argv.enableMonitoring) config = { ...config, monitoringReward: null };
+
+  if (argv.enableMediation)
+    config = {
+      ...config,
+      caps: {
+        ...config.caps,
+        [Capabilities.MEDIATE]: 1,
+      },
+    };
 
   return config;
 }


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Part of #2378 

**Short description**

- Disable mediation by default in CLI
- Add hidden `--enable-mediation` flag


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Build CLI
2. Check that mediation is disabled by default
3. Check that passing `--enable-mediation` enables mediation capability
4. Check that setting `RAIDEN_ENABLE_MEDIATION=true` sets mediation capability
