### PR TITLE
Fix default config caps merging

### DIFF
--- a/raiden-cli/raiden
+++ b/raiden-cli/raiden
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+set -a
+ENV="$( dirname $0 )/.env"
+[ -e "$ENV" ] && . "${ENV}"
+
 RAIDEN="$( dirname $0 )/index.js"
 [ ! -e "$RAIDEN" ] && RAIDEN="$( dirname $0 )/build/index.js"
 [ ! -e "$RAIDEN" ] && RAIDEN="$( dirname $0 )/bundle/index.js"

--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -216,11 +216,17 @@ function createLocalStorage(name: string): LocalStorage {
   return localStorage;
 }
 
+function unrefTimeout(timeout: number | NodeJS.Timeout) {
+  if (typeof timeout === 'number') return;
+  timeout.unref();
+}
+
 function shutdownServer(this: Cli): void {
   if (this.server?.listening) {
     this.log.info('Closing server...');
     this.server.close();
   }
+  unrefTimeout(setTimeout(() => process.exit(0), 10000));
 }
 
 function shutdownRaiden(this: Cli): void {

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -123,11 +123,22 @@ export function makeDefaultConfig(
       ? 'https://raw.githubusercontent.com/raiden-network/raiden-service-bundle/master/known_servers/known_servers-production-v1.2.0.json'
       : 'https://raw.githubusercontent.com/raiden-network/raiden-service-bundle/master/known_servers/known_servers-development-v1.2.0.json';
 
+  // merge caps independently
+  const caps =
+    overwrites?.caps === null
+      ? null
+      : {
+          [Capabilities.DELIVERY]: 0,
+          [Capabilities.MEDIATE]: 0,
+          [Capabilities.WEBRTC]: 1,
+          [Capabilities.TO_DEVICE]: 1,
+          ...overwrites?.caps,
+        };
   return {
     matrixServerLookup: matrixServerInfos,
     settleTimeout: 500,
     revealTimeout: 50,
-    expiryFactor: 1.1, // must be >= 1.1
+    expiryFactor: 1.1, // must be > 1.0
     httpTimeout: 30e3,
     discoveryRoom: `raiden_${networkName}_discovery`,
     pfsRoom: `raiden_${networkName}_path_finding`,
@@ -142,18 +153,13 @@ export function makeDefaultConfig(
     // SVT also uses 18 decimals, like Ether, so parseEther works
     monitoringReward: parseEther('5') as UInt<32>,
     logger: 'info',
-    caps: {
-      [Capabilities.DELIVERY]: 0,
-      [Capabilities.MEDIATE]: 0,
-      [Capabilities.WEBRTC]: 1,
-      [Capabilities.TO_DEVICE]: 1,
-    },
     fallbackIceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
     rateToSvt: {},
     pollingInterval: 5000,
     minimumAllowance: MaxUint256 as UInt<32>,
     autoSettle: false,
     ...overwrites,
+    caps, // merged caps overwrites 'overwrites.caps'
   };
 }
 

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -1239,7 +1239,12 @@ export async function makeRaiden(
       revealTimeout: 50,
       confirmationBlocks: 5,
       logger: 'debug',
-      caps: { [Capabilities.DELIVERY]: 0, [Capabilities.WEBRTC]: 0, [Capabilities.MEDIATE]: 1 },
+      caps: {
+        [Capabilities.DELIVERY]: 0,
+        [Capabilities.WEBRTC]: 0,
+        [Capabilities.TO_DEVICE]: 0,
+        [Capabilities.MEDIATE]: 1,
+      },
     },
   );
   const latest$ = new ReplaySubject<Latest>(1);


### PR DESCRIPTION
**Short description**
Fixes a small issue with how config overwrites (passed e.g. by CLI as param for `Raiden.create`) got merged into `defaultConfig`. Previously, it merged them directly, which made partially specified `caps` overwrite the whole `config.caps` mapping. This caused a bug since #2509 where only `Receive` and `Mediate` caps would be set if `--enable-mediation` command flag was used, i.e. all other default caps like `webRTC`, `Delivery`, etc, would be unset. The fix is to properly merge the `config.caps` defaultConfig separately from the rest of the config (which usually overwrite whole property values per key).

Also, this PR:
- allows `raiden-cli/raiden` shell script wrapper to read env vars from `raiden-cli/.env` file in order to ease testing instead of writing long long command lines for constantly present options.
- ensures the CLI exits if the SDK did cleanly (in case some handler got lost for some reason)
- fix a small case where a webRTC caller's `RTCPeerConnection` instance wouldn't be properly closed and would prevent the CLI from exiting on its own

No need for changelog entry, since the bug wasn't released.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Run CLI with `--enable-mediation` option
2. Ensure `webRTC` and other flags are still set.
3. Wait for a caller to send an `offer`, Ctrl+C it and checks it exits cleanly after a few seconds
