### PR TITLE
chore: Ignore typedoc updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,7 @@
       "packagePatterns": [
         "*"
       ],
+      "excludePackageNames": ["typedoc"],
       "updateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance", "rollback", "bump"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",


### PR DESCRIPTION
This was pulled into https://github.com/raiden-network/light-client/pull/2508 , so let's ignore it for now.

See `renovate` options here: https://docs.renovatebot.com/configuration-options/