### PR TITLE
Refactor config epics

### DIFF
--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -286,6 +286,7 @@ async function createRaidenConfig(
       ...config,
       caps: {
         ...config.caps,
+        [Capabilities.RECEIVE]: 1,
         [Capabilities.MEDIATE]: 1,
       },
     };

--- a/raiden-ts/src/actions.ts
+++ b/raiden-ts/src/actions.ts
@@ -19,6 +19,7 @@ import * as TransportActions from './transport/actions';
 import * as MessagesActions from './messages/actions';
 import * as TransfersActions from './transfers/actions';
 import * as ServicesActions from './services/actions';
+import { Caps } from './transport/types';
 
 export const raidenShutdown = createAction(
   'raiden/shutdown',
@@ -35,6 +36,12 @@ export interface raidenShutdown extends ActionType<typeof raidenShutdown> {}
 
 export const raidenConfigUpdate = createAction('raiden/config/update', PartialRaidenConfig);
 export interface raidenConfigUpdate extends ActionType<typeof raidenConfigUpdate> {}
+
+export const raidenConfigCaps = createAction(
+  'raiden/config/caps',
+  t.type({ caps: t.union([Caps, t.null]) }),
+);
+export interface raidenConfigCaps extends ActionType<typeof raidenConfigCaps> {}
 
 export const raidenStarted = createAction('raiden/started');
 export interface raidenStarted extends ActionType<typeof raidenStarted> {}

--- a/raiden-ts/src/channels/actions.ts
+++ b/raiden-ts/src/channels/actions.ts
@@ -19,6 +19,9 @@ export interface newBlock extends ActionType<typeof newBlock> {}
 export const blockTime = createAction('block/time', t.type({ blockTime: t.number }));
 export interface blockTime extends ActionType<typeof blockTime> {}
 
+export const blockStale = createAction('block/stale', t.type({ stale: t.boolean }));
+export interface blockStale extends ActionType<typeof blockStale> {}
+
 /**
  * A new token network is detected in the TokenNetworkRegistry instance
  * fromBlock is only set on the first time, to fetch and handle past events

--- a/raiden-ts/src/epics.ts
+++ b/raiden-ts/src/epics.ts
@@ -143,7 +143,7 @@ export function getLatest$(
   { defaultConfig }: Pick<RaidenEpicDeps, 'defaultConfig'>,
 ): Observable<Latest> {
   const initialUdcBalance = MaxUint256 as UInt<32>;
-  const iniitialStale = false;
+  const initialStale = false;
   const udcBalance$ = action$.pipe(
     filter(udcDeposit.success.is),
     pluck('payload', 'balance'),
@@ -159,7 +159,7 @@ export function getLatest$(
   const stale$ = action$.pipe(
     filter(blockStale.is),
     pluck('payload', 'stale'),
-    startWith(iniitialStale),
+    startWith(initialStale),
   );
   const caps$ = merge(
     state$.pipe(
@@ -169,7 +169,7 @@ export function getLatest$(
         mergeCaps(
           dynamicCaps({
             udcBalance: initialUdcBalance,
-            stale: iniitialStale,
+            stale: initialStale,
             config: { monitoringReward: monitoringReward ?? defaultConfig.monitoringReward },
           }),
           defaultConfig.caps,

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -45,6 +45,7 @@ export interface Latest {
   rtc: { [address: string]: RTCDataChannel };
   udcBalance: UInt<32>;
   blockTime: number;
+  stale: boolean;
 }
 
 export interface RaidenEpicDeps {

--- a/raiden-ts/tests/integration/raiden.spec.ts
+++ b/raiden-ts/tests/integration/raiden.spec.ts
@@ -340,14 +340,13 @@ describe('Raiden', () => {
         block_number: expect.any(Number),
       },
     });
-    // ensure Raiden.constructor set pollingInterval in the end as per 'config', before 'start'
-    expect(provider.pollingInterval).toBe(config.pollingInterval);
 
     logging.warn('Starting raiden1', raiden1.address);
     // test Raiden.started, not yet started
     expect(raiden1.started).toBeUndefined();
     raiden1.start();
     expect(raiden1.started).toBe(true);
+    expect(provider.pollingInterval).toBe(config.pollingInterval);
     await raiden1.stop();
     expect(raiden1.started).toBe(false);
 

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -627,6 +627,7 @@ export function raidenEpicDeps(): MockRaidenEpicDeps {
       rtc: {},
       udcBalance: Zero as UInt<32>,
       blockTime: 1e3,
+      stale: false,
     }),
     config$ = latest$.pipe(pluckDistinct('config'));
 


### PR DESCRIPTION
Fixes #2524 

**Short description**
- Refactor config `caps` updates into its own epic
- Refactor latest `stale` state into its own epic
- Refactor `log.setLevel` and `provider.pollingInterval` from config into its own epic 
- Force-enable receiving when mediation is enabled in CLI

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
