### PR TITLE
sdk: disable push rules on matrix init

### DIFF
--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -108,7 +108,7 @@ describe('initMatrixEpic', () => {
   afterEach(() => jest.restoreAllMocks());
 
   test('matrix stored setup', async () => {
-    expect.assertions(4);
+    expect.assertions(5);
 
     const userId = `@${raiden.address.toLowerCase()}:${matrixServer}`;
     const displayName = await raiden.deps.signer.signMessage(userId);
@@ -130,6 +130,12 @@ describe('initMatrixEpic', () => {
     const matrix = (await raiden.deps.matrix$.toPromise()) as jest.Mocked<MatrixClient>;
 
     expect(raiden.output).toContainEqual(matrixSetup(setupPayload));
+    expect(matrix.setPushRuleEnabled).toHaveBeenCalledWith(
+      'global',
+      'override',
+      '.m.rule.master',
+      true,
+    );
     // ensure if stored setup works, servers list don't need to be fetched
     expect(fetch).not.toHaveBeenCalled();
 

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -769,6 +769,7 @@ function mockedMatrixCreateClient({
         };
       },
     ),
+    setPushRuleEnabled: jest.fn(async () => true),
     searchUserDirectory: jest.fn(async ({ term }) => ({
       results: Object.values(mockedMatrixUsers)
         .filter((u) => u.userId.includes(term))


### PR DESCRIPTION
Fixes #2528

**Short description**
We _enable_ the rule to _disable push notifications_ for our client. 

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
