### PR TITLE
sdk: fix rtcChannel action not being properly validated

### DIFF
--- a/raiden-ts/src/utils/types.ts
+++ b/raiden-ts/src/utils/types.ts
@@ -292,7 +292,7 @@ export const instanceOf: <C extends Newable>(C: C) => t.Type<InstanceType<C>> = 
   <C extends Newable>(C: C): t.Type<InstanceType<C>> =>
     new t.Type<InstanceType<C>>(
       `instanceOf(${C.name})`,
-      (v): v is InstanceType<C> => 'name' in (v as any) && (v as any).name === C.name,
+      (v): v is InstanceType<C> => (v as any)?.constructor?.name === C.name,
       (i, c) => (i instanceof C ? t.success<InstanceType<C>>(i) : t.failure(i, c)),
       t.identity,
     ),


### PR DESCRIPTION
**Short description**

Fixes a bug which didn't get released, where `rtcChannel` action would not be picked up by latest$'s `rtc$` observable due to `instanceOf` custom codec validating `object.name` instead of `object.constructor.name`, in replacement of `instanceof` operator usage, which led to issues when mocking in the tests.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Check WebRTC channel is properly used when using dApp's between 2 LCs
