### PR TITLE
cli: set expiryFactor to 2.0

### DIFF
--- a/raiden-cli/src/config.json
+++ b/raiden-cli/src/config.json
@@ -1,4 +1,5 @@
 {
   "pfsSafetyMargin": 1.1,
+  "expiryFactor": 2.0,
   "autoSettle": true
 }

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -26,6 +26,8 @@ const RTCIceServer = t.type({ urls: t.union([t.string, t.array(t.string)]) });
  *    After intializing a [[Raiden]] instance, the matrix server can't be changed later on.
  * - revealTimeout - Timeout for secrets to be revealed
  * - settleTimeout - Timeout for channels to be settled
+ * - expiryFactor - Multiply revealTimeout to get how far in the future
+ *    transfer expiration block should be
  * - httpTimeout - Used in http fetch requests
  * - discoveryRoom - Discovery Room to auto-join, use null to disable
  * - pfsRoom - PFS Room to auto-join and send PFSCapacityUpdate to, use null to disable
@@ -62,7 +64,7 @@ export const RaidenConfig = t.readonly(
       matrixServerLookup: t.string,
       revealTimeout: t.number,
       settleTimeout: t.number,
-      expiryFactor: t.number, // must be >= 1.1
+      expiryFactor: t.number, // must be > 1.0
       httpTimeout: t.number,
       discoveryRoom: t.union([t.string, t.null]),
       pfsRoom: t.union([t.string, t.null]),


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2537

**Short description**
Sets CLI's default expiryFactor and improve SDK's documentation of this config option

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
