### PR TITLE
cli: Disable monitoring by default

### DIFF
--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -130,7 +130,7 @@ function parseArguments() {
       },
       enableMonitoring: {
         type: 'boolean',
-        default: true,
+        default: false,
         desc: "Enables monitoring if there's a UDC deposit",
       },
       enableMediation: {


### PR DESCRIPTION
**Short description**

Set `--enableMonitoring` to `false` by default. This is similar to https://github.com/raiden-network/light-client/pull/2538 , where we're moving closer to the python clients defaults.


**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
