### PR TITLE
Wait for Capacity Update global messages to be sent before resolving deposit and openChannel requests

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changed
 - [#2409] Lower default payment expiration to 1.1 × reveal timeout
 - [#2505] Properly shut down epics on stop and wait for teardown/cleanup tasks
+- [#2536] Wait for global messages before resolving deposits and channel open request
 
 ### Fixed
 - [#2352] Presence bug, transport fixes and performance improvements
@@ -25,6 +26,7 @@
 [#2444]: https://github.com/raiden-network/light-client/issues/2444
 [#2446]: https://github.com/raiden-network/light-client/issues/2446
 [#2505]: https://github.com/raiden-network/light-client/pull/2505
+[#2536]: https://github.com/raiden-network/light-client/issues/2536
 
 ## [0.14.0] - 2020-11-25
 ### Fixed

--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -577,19 +577,16 @@ export async function getState(
  * @param state$ - Observable of RaidenStates
  * @param opts - Options
  * @param opts.meta - channelId on which to wait for a deposit
- * @param opts.config - RaidenConfig to check pfsRoom from
+ * @param opts.config - RaidenConfig to check if PFS is enabled
  * @returns Promise for undefined or messageGlobalSend.success action
  */
 export async function waitForPFSCapacityUpdate(
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-  {
-    meta,
-    config,
-  }: { meta: channelDeposit.request['meta']; config: Pick<RaidenConfig, 'pfsRoom'> },
+  { meta, config }: { meta: channelDeposit.request['meta']; config: RaidenConfig },
 ) {
   const pfsRoom = config.pfsRoom;
-  if (!pfsRoom) return;
+  if (!pfsRoom || config.pfs === null) return;
   const postMeta: messageGlobalSend.request['meta'] = { roomName: '', msgId: '' };
   return asyncActionToPromise(
     messageGlobalSend,

--- a/raiden-ts/src/messages/actions.ts
+++ b/raiden-ts/src/messages/actions.ts
@@ -24,12 +24,19 @@ export namespace messageSend {
 }
 
 /** One-shot send payload.message to a global room in transport */
-export const messageGlobalSend = createAction(
-  'message/global/send',
-  t.type({ message: t.union([t.string, Signed(Message)]) }),
-  t.type({ roomName: t.string }),
+export const messageGlobalSend = createAsyncAction(
+  t.type({ roomName: t.string, msgId: t.string }),
+  'message/global/send/request',
+  'message/global/send/success',
+  'message/global/send/failure',
+  t.type({ message: Signed(Message) }),
+  t.union([t.undefined, t.type({ via: t.string, tookMs: t.number, retries: t.number })]),
 );
-export interface messageGlobalSend extends ActionType<typeof messageGlobalSend> {}
+export namespace messageGlobalSend {
+  export interface request extends ActionType<typeof messageGlobalSend.request> {}
+  export interface success extends ActionType<typeof messageGlobalSend.success> {}
+  export interface failure extends ActionType<typeof messageGlobalSend.failure> {}
+}
 
 /**
  * payload.message was received on payload.ts (timestamp) from meta.address

--- a/raiden-ts/src/services/epics.ts
+++ b/raiden-ts/src/services/epics.ts
@@ -253,7 +253,10 @@ export function pfsCapacityUpdateEpic(
         pairwise(), // skips first emission on startup
         withLatestFrom(config$),
         // ignore actions if channel not open or while/if config.pfsRoom isn't set
-        filter(([[, channel], { pfsRoom }]) => channel.state === ChannelState.open && !!pfsRoom),
+        filter(
+          ([[, channel], { pfsRoom, pfs }]) =>
+            channel.state === ChannelState.open && !!pfsRoom && pfs !== null,
+        ),
         debounce(
           ([[prev, cur], { httpTimeout }]) =>
             cur.own.locks.length > prev.own.locks.length ||

--- a/raiden-ts/src/utils/actions.ts
+++ b/raiden-ts/src/utils/actions.ts
@@ -3,7 +3,7 @@
 import * as t from 'io-ts';
 import isMatchWith from 'lodash/isMatchWith';
 import { Observable } from 'rxjs';
-import { filter, first, map } from 'rxjs/operators';
+import { filter, first, map, take } from 'rxjs/operators';
 
 import { assert } from '../utils';
 import { RaidenError, ErrorCodes } from '../utils/error';
@@ -568,12 +568,13 @@ export async function asyncActionToPromise<
           ? isConfirmationResponseOf<AAC>(asyncAction, meta)
           : isResponseOf<AAC>(asyncAction, meta),
       ),
-      first(
+      filter(
         (action) =>
           confirmed === undefined ||
           !asyncAction.success.is(action) ||
           'confirmed' in action.payload,
       ),
+      take(1),
       map((action) => {
         if (asyncAction.failure.is(action))
           throw action.payload as ActionType<AAC['failure']>['payload'];

--- a/raiden-ts/src/utils/actions.ts
+++ b/raiden-ts/src/utils/actions.ts
@@ -3,7 +3,7 @@
 import * as t from 'io-ts';
 import isMatchWith from 'lodash/isMatchWith';
 import { Observable } from 'rxjs';
-import { filter, first, map, take } from 'rxjs/operators';
+import { filter, map, take } from 'rxjs/operators';
 
 import { assert } from '../utils';
 import { RaidenError, ErrorCodes } from '../utils/error';

--- a/raiden-ts/tests/unit/epics/monitor.spec.ts
+++ b/raiden-ts/tests/unit/epics/monitor.spec.ts
@@ -95,7 +95,7 @@ describe('monitorRequestEpic', () => {
     const partnerBP = getChannel(raiden, partner).partner.balanceProof;
 
     expect(raiden.output).toContainEqual(
-      messageGlobalSend(
+      messageGlobalSend.request(
         {
           message: {
             type: MessageType.MONITOR_REQUEST,
@@ -115,7 +115,7 @@ describe('monitorRequestEpic', () => {
             signature: expect.any(String),
           },
         },
-        { roomName: expect.stringMatching(/_monitoring$/) },
+        { roomName: raiden.config.monitoringRoom!, msgId: expect.any(String) },
       ),
     );
   });
@@ -138,7 +138,7 @@ describe('monitorRequestEpic', () => {
     const partnerBP = getChannel(raiden, partner).partner.balanceProof;
 
     expect(raiden.output).toContainEqual(
-      messageGlobalSend(
+      messageGlobalSend.request(
         {
           message: {
             type: MessageType.MONITOR_REQUEST,
@@ -158,7 +158,7 @@ describe('monitorRequestEpic', () => {
             signature: expect.any(String),
           },
         },
-        { roomName: expect.stringMatching(/_monitoring$/) },
+        { roomName: raiden.config.monitoringRoom!, msgId: expect.any(String) },
       ),
     );
   });
@@ -198,7 +198,7 @@ describe('monitorRequestEpic', () => {
     await waitBlock();
 
     expect(raiden.output).not.toContainEqual(
-      messageGlobalSend(
+      messageGlobalSend.request(
         { message: expect.objectContaining({ type: MessageType.MONITOR_REQUEST }) },
         expect.anything(),
       ),
@@ -216,7 +216,7 @@ describe('monitorRequestEpic', () => {
     await waitBlock();
 
     expect(raiden.output).not.toContainEqual(
-      messageGlobalSend(
+      messageGlobalSend.request(
         { message: expect.objectContaining({ type: MessageType.MONITOR_REQUEST }) },
         expect.anything(),
       ),
@@ -255,7 +255,7 @@ describe('monitorRequestEpic', () => {
     await waitBlock();
 
     expect(raiden.output).not.toContainEqual(
-      messageGlobalSend(
+      messageGlobalSend.request(
         { message: expect.objectContaining({ type: MessageType.MONITOR_REQUEST }) },
         expect.anything(),
       ),
@@ -296,7 +296,7 @@ describe('monitorRequestEpic', () => {
     await waitBlock();
 
     expect(raiden.output).not.toContainEqual(
-      messageGlobalSend(
+      messageGlobalSend.request(
         { message: expect.objectContaining({ type: MessageType.MONITOR_REQUEST }) },
         expect.anything(),
       ),
@@ -329,7 +329,7 @@ describe('monitorRequestEpic', () => {
     await waitBlock();
 
     expect(raiden.output).not.toContainEqual(
-      messageGlobalSend(
+      messageGlobalSend.request(
         { message: expect.objectContaining({ type: MessageType.MONITOR_REQUEST }) },
         expect.anything(),
       ),

--- a/raiden-ts/tests/unit/epics/path.spec.ts
+++ b/raiden-ts/tests/unit/epics/path.spec.ts
@@ -1012,7 +1012,7 @@ describe('PFS: pfsCapacityUpdateEpic', () => {
     await ensureChannelIsOpen([raiden, partner]);
 
     expect(raiden.output).not.toContainEqual(
-      messageGlobalSend(
+      messageGlobalSend.request(
         { message: expect.objectContaining({ type: MessageType.PFS_CAPACITY_UPDATE }) },
         expect.anything(),
       ),
@@ -1021,7 +1021,7 @@ describe('PFS: pfsCapacityUpdateEpic', () => {
     await ensureChannelIsDeposited([raiden, partner], deposit);
 
     expect(raiden.output).toContainEqual(
-      messageGlobalSend(
+      messageGlobalSend.request(
         {
           message: expect.objectContaining({
             type: MessageType.PFS_CAPACITY_UPDATE,
@@ -1031,7 +1031,7 @@ describe('PFS: pfsCapacityUpdateEpic', () => {
             signature: expect.any(String),
           }),
         },
-        { roomName: expect.stringMatching(pfsRoom) },
+        { roomName: pfsRoom, msgId: expect.any(String) },
       ),
     );
   });
@@ -1048,7 +1048,7 @@ describe('PFS: pfsCapacityUpdateEpic', () => {
     await ensureChannelIsDeposited([raiden, partner], deposit);
 
     expect(raiden.output).not.toContainEqual(
-      messageGlobalSend(
+      messageGlobalSend.request(
         { message: expect.objectContaining({ type: MessageType.PFS_CAPACITY_UPDATE }) },
         expect.anything(),
       ),
@@ -1074,7 +1074,7 @@ describe('PFS: pfsFeeUpdateEpic', () => {
     const channel = getChannel(raiden, partner);
 
     expect(raiden.output).toContainEqual(
-      messageGlobalSend(
+      messageGlobalSend.request(
         {
           message: {
             type: MessageType.PFS_FEE_UPDATE,
@@ -1089,7 +1089,7 @@ describe('PFS: pfsFeeUpdateEpic', () => {
             signature: expect.any(String),
           },
         },
-        { roomName: expect.stringContaining('path_finding') },
+        { roomName: raiden.config.pfsRoom!, msgId: expect.any(String) },
       ),
     );
   });
@@ -1114,7 +1114,7 @@ describe('PFS: pfsFeeUpdateEpic', () => {
     expect(signerSpy).toHaveBeenCalledTimes(1);
     expect(raiden.output).not.toContainEqual(raidenShutdown(expect.anything()));
     expect(raiden.output).not.toContainEqual(
-      messageGlobalSend(
+      messageGlobalSend.request(
         { message: expect.objectContaining({ type: MessageType.PFS_FEE_UPDATE }) },
         expect.anything(),
       ),
@@ -1136,7 +1136,7 @@ describe('PFS: pfsFeeUpdateEpic', () => {
     await ensureChannelIsClosed([raiden, partner]);
     await waitBlock();
     expect(raiden.output).not.toContainEqual(
-      messageGlobalSend(
+      messageGlobalSend.request(
         { message: expect.objectContaining({ type: MessageType.PFS_FEE_UPDATE }) },
         expect.anything(),
       ),

--- a/raiden-ts/tests/unit/epics/receive.spec.ts
+++ b/raiden-ts/tests/unit/epics/receive.spec.ts
@@ -397,9 +397,7 @@ describe('receive transfers', () => {
       // "wrong" secret/secrethash
       const secret_ = makeSecret();
       const secrethash_ = getSecrethash(secret_);
-      const promise = raiden.deps.latest$
-        .pipe(pluck('action'), first(transferExpire.failure.is))
-        .toPromise();
+      const promise = raiden.action$.pipe(first(transferExpire.failure.is)).toPromise();
       raiden.store.dispatch(
         messageReceived(
           {

--- a/raiden-ts/tests/unit/epics/send.spec.ts
+++ b/raiden-ts/tests/unit/epics/send.spec.ts
@@ -470,7 +470,7 @@ describe('transferRetryMessageEpic', () => {
 
     const sentState = await pendingTransfer([raiden, partner]);
 
-    await sleep(2 * raiden.config.pollingInterval);
+    await sleep(raiden.config.httpTimeout);
     const sentCount = raiden.output
       .filter(messageSend.request.is)
       .filter((r) => LockedTransfer.is(r.payload.message)).length;

--- a/raiden-ts/tests/unit/fixtures.ts
+++ b/raiden-ts/tests/unit/fixtures.ts
@@ -1,37 +1,26 @@
 import {
-  makeMatrix,
-  MockRaidenEpicDeps,
   MockedRaiden,
   makeAddress,
   makeHash,
   waitBlock,
   providersEmit,
   makeLog,
+  sleep,
 } from './mocks';
 
-import { Subject } from 'rxjs';
-import { exhaustMap, first, pluck, scan } from 'rxjs/operators';
-import { Wallet } from '@ethersproject/wallet';
-import { AddressZero, Zero, HashZero } from '@ethersproject/constants';
+import { exhaustMap, first, pluck } from 'rxjs/operators';
+import { Zero, HashZero } from '@ethersproject/constants';
 import { BigNumber } from '@ethersproject/bignumber';
 import { defaultAbiCoder } from '@ethersproject/abi';
 
 import { Address, Hash, Int, UInt, Secret } from 'raiden-ts/utils/types';
-import { Processed, MessageType } from 'raiden-ts/messages/types';
 import {
-  makeMessageId,
   makePaymentId,
   makeSecret,
   getSecrethash,
   transferKey,
   getTransfer,
 } from 'raiden-ts/transfers/utils';
-import { IOU } from 'raiden-ts/services/types';
-import { RaidenState } from 'raiden-ts/state';
-import { pluckDistinct } from 'raiden-ts/utils/rx';
-import { RaidenAction } from 'raiden-ts/actions';
-import { raidenReducer } from 'raiden-ts/reducer';
-import { getLatest$ } from 'raiden-ts/epics';
 import { channelKey } from 'raiden-ts/channels/utils';
 import { tokenMonitored } from 'raiden-ts/channels/actions';
 import { ChannelState, Channel } from 'raiden-ts/channels';
@@ -40,110 +29,6 @@ import { transfer, transferSecret, transferUnlock } from 'raiden-ts/transfers/ac
 import { assert } from 'raiden-ts/utils';
 import { isResponseOf } from 'raiden-ts/utils/actions';
 import { matrixPresence } from 'raiden-ts/transport/actions';
-
-/**
- * Composes several constants used across epics
- *
- * @param depsMock - RaidenEpicDeps mock object constructed through raidenEpicDeps
- * @returns Diverse constant values and objects
- */
-export function epicFixtures(depsMock: MockRaidenEpicDeps) {
-  const wallet = new Wallet('0x3333333333333333333333333333333333333333333333333333333333333333'),
-    token = '0x0000000000000000000000000000000000010001' as Address,
-    tokenNetwork = '0x0000000000000000000000000000000000020001' as Address,
-    partner = wallet.address as Address,
-    target = '0x0100000000000000000000000000000000000005' as Address,
-    tokenNetworkContract = depsMock.getTokenNetworkContract(tokenNetwork),
-    tokenContract = depsMock.getTokenContract(token),
-    settleTimeout = 500,
-    channelId = 17,
-    isFirstParticipant = true,
-    matrixServer = 'matrix.raiden.test',
-    userId = `@${depsMock.address.toLowerCase()}:${matrixServer}`,
-    accessToken = 'access_token',
-    deviceId = 'device_id',
-    displayName = 'display_name',
-    partnerRoomId = `!partnerRoomId:${matrixServer}`,
-    partnerUserId = `@${partner.toLowerCase()}:${matrixServer}`,
-    targetUserId = `@${target.toLowerCase()}:${matrixServer}`,
-    matrix = makeMatrix(userId, matrixServer),
-    txHash = '0x0000000000000000000000000000000000000020111111111111111111111111' as Hash,
-    processed: Processed = { type: MessageType.PROCESSED, message_identifier: makeMessageId() },
-    paymentId = makePaymentId(),
-    fee = BigNumber.from(3) as Int<32>,
-    paths = [{ path: [partner], fee }],
-    metadata = { routes: [{ route: [partner] }] },
-    pfsAddress = '0x0900000000000000000000000000000000000009' as Address,
-    pfsTokenAddress = '0x0800000000000000000000000000000000000008' as Address,
-    pfsInfoResponse = {
-      message: 'pfs message',
-      network_info: {
-        chain_id: depsMock.network.chainId,
-        token_network_registry_address: depsMock.contractsInfo.TokenNetworkRegistry.address,
-      },
-      operator: 'pfs operator',
-      payment_address: pfsAddress,
-      price_info: 2,
-      version: '0.4.1',
-    },
-    iou = {
-      sender: depsMock.address,
-      receiver: pfsAddress,
-      one_to_n_address: '0x0A0000000000000000000000000000000000000a' as Address,
-      chain_id: BigNumber.from(depsMock.network.chainId) as UInt<32>,
-      expiration_block: BigNumber.from(3232341) as UInt<32>,
-      amount: BigNumber.from(100) as UInt<32>,
-    } as IOU,
-    key = channelKey({ tokenNetwork, partner }),
-    action$ = new Subject<RaidenAction>(),
-    state$ = new Subject<RaidenState>();
-
-  let initialState!: RaidenState;
-  depsMock.latest$.pipe(pluckDistinct('state'), first()).subscribe((s) => (initialState = s));
-
-  action$.pipe(scan((s, a) => raidenReducer(s, a), initialState)).subscribe(state$);
-  getLatest$(action$, state$, depsMock).subscribe(depsMock.latest$);
-
-  depsMock.registryContract.token_to_token_networks.mockImplementation(async (_token) =>
-    _token === token ? tokenNetwork : AddressZero,
-  );
-
-  return {
-    token,
-    tokenNetwork,
-    partner,
-    target,
-    matrix,
-    channelId,
-    settleTimeout,
-    isFirstParticipant,
-    tokenContract,
-    tokenNetworkContract,
-    accessToken,
-    deviceId,
-    displayName,
-    partnerRoomId,
-    partnerUserId,
-    targetUserId,
-    matrixServer,
-    userId,
-    txHash,
-    state: initialState,
-    partnerSigner: wallet,
-    processed,
-    paymentId,
-    fee,
-    paths,
-    metadata,
-    pfsAddress,
-    pfsTokenAddress,
-    pfsInfoResponse,
-    iou,
-    key,
-    action$,
-    state$,
-  };
-}
 
 // fixture constants
 export const token = makeAddress();
@@ -325,6 +210,7 @@ export async function ensureChannelIsClosed([raiden, partner]: [
   );
   await waitBlock(closeBlock);
   await waitBlock(closeBlock + confirmationBlocks + 1); // confirmation
+  await sleep();
   if (raiden.started)
     assert(closedStates.includes(getChannel(raiden, partner)?.state), 'Raiden channel not closed');
   if (partner.started)


### PR DESCRIPTION
Fixes #2536 

**Short description**
This should help in case sending these messages gets slowed down, to prevent transfers which are started right after it from being done before PFS has the opportunity to detect these updates, which should happen only on scripted environments like the SP.

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
