### PR TITLE
cli: Enable 'Receive' capability by default

### DIFF
--- a/raiden-cli/src/config.json
+++ b/raiden-cli/src/config.json
@@ -1,5 +1,8 @@
 {
   "pfsSafetyMargin": 1.1,
   "expiryFactor": 2.0,
-  "autoSettle": true
+  "autoSettle": true,
+  "caps": {
+    "Receive": 1
+  }
 }


### PR DESCRIPTION
Before this was only enabled if monitoring was enabled and enough
service tokens were avialable. As we're striving to follow the python
clients behaviour as close as possible we're enabling receiving by
default.


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Start CLI without `--enable-mediation`
2. Check that `RECEIVE` cap is enabled
