### PR TITLE
dApp: adjusting account screen on mobile

### DIFF
--- a/raiden-dapp/src/components/account/AccountContent.vue
+++ b/raiden-dapp/src/components/account/AccountContent.vue
@@ -22,28 +22,24 @@
         </v-col>
       </v-row>
       <v-row class="account-content__account-details__eth" no-gutters>
-        <v-col cols="2">
+        <v-row no-gutters>
           <span class="account-content__account-details__eth__account">
             {{ $t('account-content.account.main') }}
           </span>
-        </v-col>
-        <v-col cols="10">
           <span class="account-content__account-details__eth__balance">
             {{ accountBalance | decimals }}
           </span>
-        </v-col>
+        </v-row>
       </v-row>
       <v-row v-if="usingRaidenAccount" class="account-content__account-details__eth" no-gutters>
-        <v-col cols="2">
+        <v-row no-gutters>
           <span class="account-content__account-details__eth__account">
             {{ $t('account-content.account.raiden') }}
           </span>
-        </v-col>
-        <v-col cols="10">
           <span class="account-content__account-details__eth__balance">
             {{ raidenAccountBalance | decimals }}
           </span>
-        </v-col>
+        </v-row>
       </v-row>
     </div>
     <v-list two-line class="account-content__menu">
@@ -241,9 +237,7 @@ export default class AccountContent extends Mixins(NavigationMixin) {
 
     &__eth {
       &__balance {
-        @include respond-to(handhelds) {
-          margin-left: 30px;
-        }
+        margin-left: 12px;
       }
 
       &__account,
@@ -256,7 +250,7 @@ export default class AccountContent extends Mixins(NavigationMixin) {
 
   &__menu {
     background-color: transparent;
-    margin-top: 50px;
+    margin-top: 20px;
 
     ::v-deep {
       ::before {

--- a/raiden-dapp/src/views/account/AccountRoot.vue
+++ b/raiden-dapp/src/views/account/AccountRoot.vue
@@ -23,7 +23,12 @@ export default class AccountRoot extends Vue {}
 </script>
 
 <style scoped lang="scss">
+@import '@/scss/scroll';
+
 .account-root {
+  overflow-y: auto;
+  @extend .themed-scrollbar;
+
   &__identicon {
     align-self: center;
     border-bottom: solid 1px #707070;


### PR DESCRIPTION
**Short description**
Before/after:
![account](https://user-images.githubusercontent.com/43838780/107936649-2cec1380-6f83-11eb-9fe6-ff220d47cb32.png)


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. View the account screen on various mobile sizes, i.e. by using the Chrome dev tools.
