### PR TITLE
Bugfix/dapp transfer eth screen mobile chaos

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -5,8 +5,12 @@
 ### Fixed
 
 - [#2420] Fix withdraw and deposit button for channels on mobile
+- [#2421] Fix account menu on mobile devices by making it scrollable
+- [#2422] Fix broken layout on RaidenAccount screen for mobile virtual keyboard
 
 [#2420]: https://github.com/raiden-network/light-client/issues/2420
+[#2421]: https://github.com/raiden-network/light-client/issues/2421
+[#2422]: https://github.com/raiden-network/light-client/issues/2422
 
 ## [0.15.0] - 2021-01-26
 

--- a/raiden-dapp/src/components/account/AccountContent.vue
+++ b/raiden-dapp/src/components/account/AccountContent.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="account-content">
     <div v-if="!loading && defaultAccount">
-      <v-row class="account-content__account-details" no-gutters>
-        <v-col cols="2">
+      <v-row class="account-content__account-details" dense>
+        <v-col cols="3">
           <span class="account-content__account-details__address">
             {{ $t('account-content.address') }}
           </span>
         </v-col>
-        <v-col cols="10">
+        <v-col cols="9">
           <span class="account-content__account-details__address">
             <address-display
               class="account-content__account-details__address__desktop"
@@ -21,25 +21,25 @@
           </span>
         </v-col>
       </v-row>
-      <v-row class="account-content__account-details__eth" no-gutters>
-        <v-col cols="2">
+      <v-row class="account-content__account-details__eth" dense>
+        <v-col cols="3">
           <span class="account-content__account-details__eth__account">
             {{ $t('account-content.account.main') }}
           </span>
         </v-col>
-        <v-col cols="10">
+        <v-col cols="9">
           <span class="account-content__account-details__eth__balance">
             {{ accountBalance | decimals }}
           </span>
         </v-col>
       </v-row>
-      <v-row v-if="usingRaidenAccount" class="account-content__account-details__eth" no-gutters>
-        <v-col cols="2">
+      <v-row v-if="usingRaidenAccount" class="account-content__account-details__eth" dense>
+        <v-col cols="3">
           <span class="account-content__account-details__eth__account">
             {{ $t('account-content.account.raiden') }}
           </span>
         </v-col>
-        <v-col cols="10">
+        <v-col cols="9">
           <span class="account-content__account-details__eth__balance">
             {{ raidenAccountBalance | decimals }}
           </span>
@@ -209,6 +209,10 @@ export default class AccountContent extends Mixins(NavigationMixin) {
 
 .account-content {
   margin: 0 64px 0 64px;
+
+  @include respond-to(handhelds) {
+    margin: 0 30px 0 30px;
+  }
 
   &__account-details {
     margin-top: 20px;

--- a/raiden-dapp/src/components/account/AccountContent.vue
+++ b/raiden-dapp/src/components/account/AccountContent.vue
@@ -211,7 +211,7 @@ export default class AccountContent extends Mixins(NavigationMixin) {
   margin: 0 64px 0 64px;
 
   &__account-details {
-    margin-top: 30px;
+    margin-top: 20px;
 
     &__title {
       font-size: 16px;
@@ -256,7 +256,7 @@ export default class AccountContent extends Mixins(NavigationMixin) {
 
   &__menu {
     background-color: transparent;
-    margin-top: 50px;
+    margin-top: 25px;
 
     ::v-deep {
       ::before {
@@ -290,7 +290,7 @@ export default class AccountContent extends Mixins(NavigationMixin) {
       }
 
       &:nth-of-type(3) {
-        margin-bottom: 50px;
+        margin-bottom: 40px;
       }
     }
   }

--- a/raiden-dapp/src/views/AccountRoute.vue
+++ b/raiden-dapp/src/views/AccountRoute.vue
@@ -5,13 +5,16 @@
       <div class="account-route__header">
         <header-content @show-info="showInfoOverlay = true" @navigate-back="navigateBack()" />
       </div>
-      <router-view />
-      <div v-if="version" class="account-route__footer">
-        <span>{{ $t('versions.sdk', { version }) }}</span>
-        <span class="account-route__footer__contracts-version">
-          {{ $t('versions.contracts', { version: contractVersion }) }}
-        </span>
-      </div>
+      <v-main>
+        <router-view />
+
+        <div v-if="version" class="account-route__footer">
+          <span>{{ $t('versions.sdk', { version }) }}</span>
+          <span class="account-route__footer__contracts-version">
+            {{ $t('versions.contracts', { version: contractVersion }) }}
+          </span>
+        </div>
+      </v-main>
     </div>
   </div>
 </template>
@@ -51,6 +54,7 @@ export default class AccountRoute extends Mixins(NavigationMixin) {
 <style lang="scss" scoped>
 @import '@/scss/mixins';
 @import '@/scss/colors';
+@import '@/scss/scroll';
 
 #account-route-wrapper {
   align-items: center;
@@ -58,6 +62,7 @@ export default class AccountRoute extends Mixins(NavigationMixin) {
   height: 100%;
   position: absolute;
   z-index: 20;
+
   @include respond-to(handhelds) {
     height: 100vh;
     width: 100%;
@@ -72,6 +77,9 @@ export default class AccountRoute extends Mixins(NavigationMixin) {
   height: 844px;
   margin-top: 25px;
   width: 620px;
+  overflow-y: auto;
+  @extend .themed-scrollbar;
+
   @include respond-to(handhelds) {
     border-radius: 0;
     height: 100vh;

--- a/raiden-dapp/src/views/AccountRoute.vue
+++ b/raiden-dapp/src/views/AccountRoute.vue
@@ -2,19 +2,21 @@
   <div id="account-route-wrapper">
     <div class="account-route">
       <info-overlay v-if="showInfoOverlay" @close-overlay="showInfoOverlay = false" />
+
       <div class="account-route__header">
         <header-content @show-info="showInfoOverlay = true" @navigate-back="navigateBack()" />
       </div>
+
       <v-main>
         <router-view />
-
-        <div v-if="version" class="account-route__footer">
-          <span>{{ $t('versions.sdk', { version }) }}</span>
-          <span class="account-route__footer__contracts-version">
-            {{ $t('versions.contracts', { version: contractVersion }) }}
-          </span>
-        </div>
       </v-main>
+
+      <div v-if="version" class="account-route__footer">
+        <span>{{ $t('versions.sdk', { version }) }}</span>
+        <span class="account-route__footer__contracts-version">
+          {{ $t('versions.contracts', { version: contractVersion }) }}
+        </span>
+      </div>
     </div>
   </div>
 </template>

--- a/raiden-dapp/src/views/account/AccountRoot.vue
+++ b/raiden-dapp/src/views/account/AccountRoot.vue
@@ -23,6 +23,8 @@ export default class AccountRoot extends Vue {}
 </script>
 
 <style scoped lang="scss">
+@import '@/scss/mixins';
+
 .account-root {
   &__identicon {
     align-self: center;
@@ -30,6 +32,10 @@ export default class AccountRoot extends Vue {}
     justify-content: center;
     margin: 0 64px 0 64px;
     padding-bottom: 30px;
+
+    @include respond-to(handhelds) {
+      margin: 0 30px 0 30px;
+    }
   }
 
   ::v-deep {

--- a/raiden-dapp/src/views/account/RaidenAccount.vue
+++ b/raiden-dapp/src/views/account/RaidenAccount.vue
@@ -10,7 +10,7 @@
         </span>
       </v-row>
       <v-row no-gutters justify="center">
-        <v-col cols="3" class="raiden-account__column">
+        <v-col cols="4" md="3" class="raiden-account__column">
           <div class="raiden-account__column__card">
             <span v-if="isFromMainToRaidenAccount" class="raiden-account__column__card__title">
               {{ $t('general.main-account') }}
@@ -33,12 +33,16 @@
             </div>
           </div>
         </v-col>
-        <v-col cols="3" class="raiden-account__column" @click="toggleDirection">
+        <v-col cols="2" class="raiden-account__column" @click="toggleDirection">
           <v-btn icon>
-            <v-img width="90px" height="84px" :src="require('@/assets/eth_transfer_arrow.svg')" />
+            <v-img
+              width="70px"
+              height="64px"
+              :src="require('../../assets/eth_transfer_arrow.svg')"
+            />
           </v-btn>
         </v-col>
-        <v-col cols="3" class="raiden-account__column">
+        <v-col cols="4" md="3" class="raiden-account__column">
           <div class="raiden-account__column__card">
             <span v-if="isFromMainToRaidenAccount" class="raiden-account__column__card__title">
               {{ $t('general.raiden-account') }}
@@ -58,27 +62,29 @@
         </v-col>
       </v-row>
       <v-row no-gutters justify="center" class="raiden-account__amount-input">
-        <amount-input
-          v-model="amount"
-          data-cy="raiden_account_amount_input_field"
-          class="raiden-account__amount-input__field"
-          :token="token"
-          :max="maximumAmount"
-          limit
-        />
-        <v-btn icon large class="raiden-account__amount-input__toggle" @click="toggleDirection">
-          <v-icon large color="primary">mdi-autorenew</v-icon>
-        </v-btn>
+        <v-col cols="8" md="7">
+          <amount-input
+            v-model="amount"
+            data-cy="raiden_account_amount_input_field"
+            class="raiden-account__amount-input__field"
+            :token="token"
+            :max="maximumAmount"
+            limit
+          />
+        </v-col>
+        <v-col cols="2" md="1">
+          <v-btn icon class="raiden-account__amount-input__toggle" @click="toggleDirection">
+            <v-icon large color="primary">mdi-autorenew</v-icon>
+          </v-btn>
+        </v-col>
       </v-row>
-      <v-row no-gutters justify="center" class="raiden-account__transfer-button">
-        <action-button
-          data-cy="raiden_account_transfer_button_button"
-          class="raiden-account__transfer-button__button"
-          full-width
-          :enabled="valid"
-          :text="$t('general.buttons.transfer')"
-        />
-      </v-row>
+      <action-button
+        data-cy="raiden_account_transfer_button_button"
+        class="raiden-account__transfer-button"
+        :enabled="valid"
+        :text="$t('general.buttons.transfer')"
+        full-width
+      />
     </v-form>
     <v-row
       v-else-if="error"
@@ -190,7 +196,7 @@ export default class RaidenAccount extends Vue {
   &__title {
     font-size: 18px;
     margin-top: 50px;
-    padding-bottom: 75px;
+    padding-bottom: 50px;
     text-align: center;
   }
 
@@ -206,7 +212,7 @@ export default class RaidenAccount extends Vue {
       display: flex;
       flex-direction: column;
       height: 140px;
-      width: 140px;
+      width: 100%; // Required to get grid alignment
 
       &__title {
         padding-top: 20px;
@@ -235,26 +241,6 @@ export default class RaidenAccount extends Vue {
         to {
           transform: rotate(360deg);
         }
-      }
-    }
-  }
-
-  &__transfer-button {
-    margin-top: 115px;
-    margin-left: 80px;
-    margin-right: 90px;
-    @include respond-to(handhelds) {
-      margin-left: 40px;
-      margin-right: 40px;
-    }
-
-    ::v-deep {
-      .col-10 {
-        flex: 1;
-        max-width: 100%;
-      }
-      .v-btn {
-        border-radius: 8px;
       }
     }
   }


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2422
Fixes #2421 (added later to make use of closing issue automatically)

**Short description**
The current usage of the account route as second route view is madness. It is absolute crazy. But as fixing this is a lot of work, this is just a workaround for the issues. The root cause is that the viewport size changes, when a mobile virtual keyboard gets shown. Thereby the content does not fit anymore and a the result the layout is messed and more.

I did some additional minor design changes to make it look not so compressed on mobile.

This also fixes #2421 and eventually makes #2563 obsolete. The downside is, that my scrolling applies to the whole application route container, including the header. This eventually looks ugly. This might be fixable, but just drives us even further into the madness of how the routes are organized. So I did not add it. @taleldayekh please decide on this. I can't think objectively here. If we take this over your PR, please remind me to extend the CHANGELOG for this issue as well.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [x] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Open dApp (e.g. with PR serve tool)
2. Switch to mobile view and select a mobile phone by Google (e.g. Nexus 5X, maybe needs to be added to the list) as those support tests with virtual keyboards
2. Connect and open the account route
3. Make sure you can scroll down the menu entries without a broken background (issue #2421)
4. Select the `Raiden Account`entry/button
5. On the mobile view header bar of the dev tools, click on the rotating phone and select `Portrait - Keyboard`
6. Make sure everything looks fine and you can enter an ETH amount
