### PR TITLE
dApp: adding disconnect button

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -8,6 +8,11 @@
 - [#2421] Fix account menu on mobile devices by making it scrollable
 - [#2422] Fix broken layout on RaidenAccount screen for mobile virtual keyboard
 
+### Added
+
+- [#1515] Button for disconnecting the dApp
+
+[#1515]: https://github.com/raiden-network/light-client/issues/1515
 [#2420]: https://github.com/raiden-network/light-client/issues/2420
 [#2421]: https://github.com/raiden-network/light-client/issues/2421
 [#2422]: https://github.com/raiden-network/light-client/issues/2422

--- a/raiden-dapp/src/components/account/AccountContent.vue
+++ b/raiden-dapp/src/components/account/AccountContent.vue
@@ -74,6 +74,11 @@
         </v-icon>
       </v-list-item>
     </v-list>
+    <div v-if="isConnected" class="account-content__disconnect">
+      <span class="account-content__disconnect__button" @click="disconnect()">
+        {{ $t('account-content.disconnect-button') }}
+      </span>
+    </div>
   </div>
 </template>
 
@@ -108,6 +113,11 @@ export default class AccountContent extends Mixins(NavigationMixin) {
   accountBalance!: string;
   raidenAccountBalance!: string;
   isConnected!: boolean;
+
+  async disconnect() {
+    await this.$raiden.disconnect();
+    this.$store.commit('reset');
+  }
 
   mounted() {
     this.menuItems = [
@@ -296,6 +306,15 @@ export default class AccountContent extends Mixins(NavigationMixin) {
       &:nth-of-type(3) {
         margin-bottom: 40px;
       }
+    }
+  }
+
+  &__disconnect {
+    height: 42px;
+    text-align: center;
+    &__button {
+      color: $primary-color;
+      cursor: pointer;
     }
   }
 }

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -178,6 +178,7 @@
   "account-content": {
     "account-details": "Account Details",
     "address": "Address:",
+    "disconnect-button": "Disconnect",
     "account": {
       "main": "Main ETH:",
       "raiden": "Raiden ETH:"

--- a/raiden-dapp/tests/unit/components/account/account-content.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/account-content.spec.ts
@@ -200,4 +200,36 @@ describe('AccountContent.vue', () => {
       }),
     );
   });
+
+  test('displays "Disconnect" button when connected', async () => {
+    const wrapper = await createWrapper(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false,
+      undefined,
+    );
+    const disconnectButton = wrapper.find('.account-content__disconnect__button');
+
+    expect(disconnectButton.exists()).toBe(false);
+  });
+
+  test('does not display "Disconnect" button when not connected', async () => {
+    const wrapper = await createWrapper();
+    const disconnectButton = wrapper.find('.account-content__disconnect__button');
+
+    expect(disconnectButton.exists()).toBe(true);
+  });
+
+  test('Clicking "Disconnect" button triggers disconnect method', async () => {
+    const wrapper = await createWrapper();
+    (wrapper.vm as any).disconnect = jest.fn();
+    const disconnectButton = wrapper.find('.account-content__disconnect__button');
+
+    disconnectButton.trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect((wrapper.vm as any).disconnect).toHaveBeenCalled();
+  });
 });

--- a/raiden-dapp/tests/unit/components/account/account-content.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/account-content.spec.ts
@@ -60,6 +60,10 @@ async function createWrapper(
   return wrapper;
 }
 
+const getDisconnectButton = (wrapper: Wrapper<AccountContent>): Wrapper<AccountContent> => {
+  return wrapper.find('.account-content__disconnect__button');
+};
+
 describe('AccountContent.vue', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -201,7 +205,7 @@ describe('AccountContent.vue', () => {
     );
   });
 
-  test('displays "Disconnect" button when connected', async () => {
+  test('does not display "Disconnect" button when not connected', async () => {
     const wrapper = await createWrapper(
       undefined,
       undefined,
@@ -210,14 +214,21 @@ describe('AccountContent.vue', () => {
       false,
       undefined,
     );
-    const disconnectButton = wrapper.find('.account-content__disconnect__button');
+    const disconnectButton = getDisconnectButton(wrapper);
 
     expect(disconnectButton.exists()).toBe(false);
   });
 
-  test('does not display "Disconnect" button when not connected', async () => {
-    const wrapper = await createWrapper();
-    const disconnectButton = wrapper.find('.account-content__disconnect__button');
+  test('displays "Disconnect" button when connected', async () => {
+    const wrapper = await createWrapper(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+      undefined,
+    );
+    const disconnectButton = getDisconnectButton(wrapper);
 
     expect(disconnectButton.exists()).toBe(true);
   });
@@ -225,7 +236,7 @@ describe('AccountContent.vue', () => {
   test('Clicking "Disconnect" button triggers disconnect method', async () => {
     const wrapper = await createWrapper();
     (wrapper.vm as any).disconnect = jest.fn();
-    const disconnectButton = wrapper.find('.account-content__disconnect__button');
+    const disconnectButton = getDisconnectButton(wrapper);
 
     disconnectButton.trigger('click');
     await wrapper.vm.$nextTick();


### PR DESCRIPTION
Fixes #1515 

**Short description**
Adds a disconnect button at the bottom of the Account screen that is available when a user is connected to the dApp. Clicking the button stops Raiden and resets the state.

<img width="609" alt="Screenshot 2021-02-18 at 17 36 45" src="https://user-images.githubusercontent.com/43838780/108389396-e9f2a000-720f-11eb-81ea-b6e374091ba9.png">


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to the dApp and pop open the Account screen.
2. Click the Disconnect button at the bottom of the screen.
