### PR TITLE
Remove p2p matrix rooms

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -5,9 +5,15 @@
 - [#2581] `config.pfsSafetyMargin` now also accepts a `[f, a]` pair, which will add `f*fee + a*amount` on top of PFS's estimated fee, if one wants finer-grain control on safety margin which is added on the transfer to be initiated.
 
 ### Changed
+- [#2536] Wait for global messages before resolving deposits and channel open request
 - [#2550] **BREAKING** remove migration of legacy state at localStorage during creation
 
+### Removed
+- [#2567] **BREAKING** Remove support for peer-to-peer communication through Matrix rooms; now supports only `toDevice` and WebRTC channels.
+
+[#2536]: https://github.com/raiden-network/light-client/issues/2536
 [#2550]: https://github.com/raiden-network/light-client/issues/2550
+[#2567]: https://github.com/raiden-network/light-client/issues/2567
 [#2581]: https://github.com/raiden-network/light-client/pull/2581
 
 ## [0.15.0] - 2021-01-26
@@ -21,7 +27,6 @@
 ### Changed
 - [#2409] Lower default payment expiration to 1.1 × reveal timeout
 - [#2505] Properly shut down epics on stop and wait for teardown/cleanup tasks
-- [#2536] Wait for global messages before resolving deposits and channel open request
 
 ### Fixed
 - [#2352] Presence bug, transport fixes and performance improvements
@@ -34,7 +39,6 @@
 [#2444]: https://github.com/raiden-network/light-client/issues/2444
 [#2446]: https://github.com/raiden-network/light-client/issues/2446
 [#2505]: https://github.com/raiden-network/light-client/pull/2505
-[#2536]: https://github.com/raiden-network/light-client/issues/2536
 
 ## [0.14.0] - 2020-11-25
 ### Fixed

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -41,8 +41,6 @@ const RTCIceServer = t.type({ urls: t.union([t.string, t.array(t.string)]) });
  * - pfsMaxPaths - Limit number of paths requested from PFS for a route.
  * - pfsMaxFee - Maximum fee we're willing to pay a PFS for a route (in SVT/RDN wei)
  * - pfsIouTimeout - Number of blocks to timeout an IOU to a PFS.
- * - matrixExcessRooms - Keep this much rooms for a single user of interest (partner, target).
- *    Leave LRU beyond this threshold.
  * - confirmationBlocks - How many blocks to wait before considering a transaction as confirmed
  * - monitoringReward - Reward to be paid to MS, in SVT/RDN; use Zero or null to disable
  * - logger - String specifying the console log level of redux-logger. Use '' to silence.
@@ -75,7 +73,6 @@ export const RaidenConfig = t.readonly(
       pfsMaxPaths: t.number,
       pfsMaxFee: UInt(32),
       pfsIouTimeout: t.number,
-      matrixExcessRooms: t.number,
       confirmationBlocks: t.number,
       monitoringReward: t.union([t.null, UInt(32)]),
       logger: t.keyof({
@@ -147,7 +144,6 @@ export function makeDefaultConfig(
     pfsRoom: `raiden_${networkName}_path_finding`,
     monitoringRoom: `raiden_${networkName}_monitoring`,
     pfs: '', // empty string = auto mode
-    matrixExcessRooms: 3,
     pfsSafetyMargin: 1.0, // multiplier
     pfsMaxPaths: 3,
     pfsMaxFee: parseEther('0.05') as UInt<32>, // in SVT/RDN, 18 decimals

--- a/raiden-ts/src/constants.ts
+++ b/raiden-ts/src/constants.ts
@@ -28,7 +28,7 @@ export const CapsFallback = {
   [Capabilities.RECEIVE]: 1,
   [Capabilities.MEDIATE]: 1,
   [Capabilities.WEBRTC]: 0,
-  [Capabilities.TO_DEVICE]: 0,
+  [Capabilities.TO_DEVICE]: 1,
 } as const;
 
 export const RAIDEN_DEVICE_ID = 'RAIDEN';

--- a/raiden-ts/src/messages/actions.ts
+++ b/raiden-ts/src/messages/actions.ts
@@ -41,7 +41,7 @@ export namespace messageGlobalSend {
 
 /**
  * payload.message was received on payload.ts (timestamp) from meta.address
- * payload.userId and payload.roomId are optional and specific to matrix transport, as sender info
+ * payload.userId is optional and specific to matrix transport, as sender info
  */
 export const messageReceived = createAction(
   'message/received',
@@ -53,7 +53,6 @@ export const messageReceived = createAction(
     t.partial({
       message: t.union([Message, Signed(Message)]),
       userId: t.string,
-      roomId: t.string,
       msgtype: t.string,
     }),
   ]),

--- a/raiden-ts/src/state.ts
+++ b/raiden-ts/src/state.ts
@@ -24,13 +24,7 @@ const _RaidenState = t.readonly(
     channels: t.readonly(t.record(ChannelKey, Channel)),
     oldChannels: t.readonly(t.record(t.string, Channel)),
     tokens: t.readonly(t.record(t.string /* token: Address */, Address)),
-    transport: t.readonly(
-      t.partial({
-        server: t.string,
-        setup: RaidenMatrixSetup,
-        rooms: t.readonly(t.record(t.string /* partner: Address */, t.array(t.string))),
-      }),
-    ),
+    transport: t.readonly(t.partial({ server: t.string, setup: RaidenMatrixSetup })),
     transfers: t.readonly(t.record(t.string /*: key: TransferKey */, TransferState)),
     iou: t.readonly(
       t.record(

--- a/raiden-ts/src/transport/actions.ts
+++ b/raiden-ts/src/transport/actions.ts
@@ -36,18 +36,6 @@ export namespace matrixPresence {
   export interface failure extends ActionType<typeof matrixPresence.failure> {}
 }
 
-/* payload.roomId must go front on meta.address's room queue */
-export const matrixRoom = createAction('matrix/room', t.type({ roomId: t.string }), NodeId);
-export interface matrixRoom extends ActionType<typeof matrixRoom> {}
-
-/* payload.roomId must be excluded from meta.address room queue, if present */
-export const matrixRoomLeave = createAction(
-  'matrix/room/leave',
-  t.type({ roomId: t.string }),
-  NodeId,
-);
-export interface matrixRoomLeave extends ActionType<typeof matrixRoomLeave> {}
-
 export const rtcChannel = createAction(
   'rtc/channel',
   t.union([t.undefined, instanceOf(RTCDataChannel)]),

--- a/raiden-ts/src/transport/epics/rooms.ts
+++ b/raiden-ts/src/transport/epics/rooms.ts
@@ -1,348 +1,24 @@
-import type { MatrixClient, MatrixEvent, Room, RoomMember } from 'matrix-js-sdk';
+import type { Room } from 'matrix-js-sdk';
 import type { Observable } from 'rxjs';
-import { combineLatest, defer, EMPTY, from, fromEvent, of, timer } from 'rxjs';
-import {
-  catchError,
-  delayWhen,
-  distinct,
-  distinctUntilChanged,
-  exhaustMap,
-  filter,
-  first,
-  groupBy,
-  ignoreElements,
-  map,
-  mapTo,
-  mergeMap,
-  switchMap,
-  take,
-  tap,
-  timeout,
-  withLatestFrom,
-} from 'rxjs/operators';
+import { fromEvent, timer } from 'rxjs';
+import { delayWhen, filter, ignoreElements, mergeMap, withLatestFrom } from 'rxjs/operators';
 
 import type { RaidenAction } from '../../actions';
-import { channelMonitored } from '../../channels/actions';
-import type { RaidenConfig } from '../../config';
-import { intervalFromConfig } from '../../config';
-import { Capabilities } from '../../constants';
-import { messageReceived } from '../../messages/actions';
 import type { RaidenState } from '../../state';
-import { transferSigned } from '../../transfers/actions';
-import { Direction } from '../../transfers/state';
 import type { RaidenEpicDeps } from '../../types';
-import { isActionOf } from '../../utils/actions';
-import { matchError, networkErrors } from '../../utils/error';
 import { getServerName } from '../../utils/matrix';
-import { completeWith, pluckDistinct, retryWhile } from '../../utils/rx';
-import type { Address } from '../../utils/types';
-import { isntNil } from '../../utils/types';
-import { matrixPresence, matrixRoom, matrixRoomLeave } from '../actions';
-import { getCap, getSortedAddresses } from '../utils';
-import { getRoom$, globalRoomNames, roomMatch } from './helpers';
+import { completeWith, mergeWith } from '../../utils/rx';
+import { globalRoomNames, roomMatch } from './helpers';
 
 /**
- * Returns an observable which keeps inviting userId to roomId while user doesn't join
+ * Leave any (new or invited) room which is not global
  *
- * If user already joined, completes immediatelly.
- *
- * @param matrix - client instance
- * @param roomId - room to invite user to
- * @param userId - user to be invited
- * @param config - Config object
- * @param config.pollingInterval - wait this interval before first invite
- * @param config.httpTimeout - wait this interval between retries
- * @param opts - Options object
- * @param opts.log - Logger instance
- * @returns Cold observable which keep inviting user if needed and then completes.
- */
-function inviteLoop$(
-  matrix: MatrixClient,
-  roomId: string,
-  userId: string,
-  { pollingInterval, httpTimeout }: RaidenConfig,
-  { log }: Pick<RaidenEpicDeps, 'log'>,
-) {
-  return timer(pollingInterval, httpTimeout).pipe(
-    exhaustMap(() =>
-      defer(async () => {
-        const membership = matrix.getRoom(roomId)?.getMember(userId)?.membership;
-        if (membership === 'join' || membership === 'invite') return null;
-        return matrix.invite(roomId, userId);
-      }).pipe(
-        tap((e) => {
-          if (!e) return;
-          log.info('Invited to room', { roomId, userId });
-        }),
-        catchError((err) => {
-          if (!matchError('is already in the room', err))
-            // log and suppress to retry on next timer emit
-            log.warn('Error inviting', roomId, userId, err);
-          return EMPTY;
-        }),
-        ignoreElements(),
-      ),
-    ),
-  );
-}
-
-/**
- * Create room (if needed) for a transfer's target, channel's partner or, as a fallback, for any
- * recipient of a messageSend.request action
- *
- * @param action$ - Observable of transferSigned|channelMonitored|messageSend.request actions
+ * @param action$ - Observable of RaidenActions
  * @param state$ - Observable of RaidenStates
  * @param deps - RaidenEpicDeps members
- * @param deps.address - Our address
  * @param deps.log - Logger instance
  * @param deps.matrix$ - MatrixClient async subject
- * @param deps.latest$ - Latest values
  * @param deps.config$ - Config observable
- * @returns Observable of matrixRoom actions
- */
-export function matrixCreateRoomEpic(
-  action$: Observable<RaidenAction>,
-  {}: Observable<RaidenState>,
-  { address, log, matrix$, latest$, config$ }: RaidenEpicDeps,
-): Observable<matrixRoom> {
-  // actual output observable, selects addresses of interest from actions
-  return action$.pipe(
-    // ensure there's a room for address of interest for each of these actions
-    // matrixRoomLeave ensures a new room is created if all we had are forgotten/left
-    filter(isActionOf([transferSigned, channelMonitored, matrixRoomLeave])),
-    map((action) => {
-      let peer;
-      switch (action.type) {
-        case transferSigned.type:
-          if (
-            action.meta.direction === Direction.SENT &&
-            action.payload.message.initiator === address
-          )
-            peer = action.payload.message.target;
-          else if (
-            action.meta.direction === Direction.RECEIVED &&
-            action.payload.message.target === address
-          )
-            peer = action.payload.message.initiator;
-          break;
-        case channelMonitored.type:
-          peer = action.meta.partner;
-          break;
-        default:
-          peer = action.meta.address;
-          break;
-      }
-      // proceed to create room only if we're the room creator (lower address)
-      if (peer && getSortedAddresses(address, peer)[0] === address) return peer;
-    }),
-    filter(isntNil),
-    // groupby+mergeMap ensures different addresses are processed in parallel, and also
-    // prevents one stuck address observable (e.g. presence delayed) from holding whole queue
-    groupBy((peer) => peer),
-    mergeMap((grouped$) =>
-      grouped$.pipe(
-        // this mergeMap is like withLatestFrom, but waits until matrix$ emits its only value
-        mergeMap((peer) => matrix$.pipe(map((matrix) => ({ peer, matrix })))),
-        // exhaustMap is used to prevent bursts of actions for a given address (eg. on startup)
-        // of creating multiple rooms for same address, so we ignore new address items while
-        // previous is being processed. If user roams, matrixInviteEpic will re-invite
-        exhaustMap(({ peer, matrix }) =>
-          // presencesStateReplay$+take(1) acts like withLatestFrom with cached result
-          latest$.pipe(
-            // wait for user to be monitored
-            filter(({ presences }) => peer in presences),
-            completeWith(action$),
-            take(1),
-            // skip room creation/invite if both partner and us have ToDevice capability set
-            filter(
-              ({ presences, config }) =>
-                !getCap(config.caps, Capabilities.TO_DEVICE) ||
-                !getCap(presences[peer].payload.caps, Capabilities.TO_DEVICE),
-            ),
-            // if there's already a room in state for address, skip
-            filter(({ state }) => !state.transport.rooms?.[peer]?.[0]),
-            // else, create a room, invite known user and persist roomId in state
-            mergeMap(({ presences }) =>
-              matrix.createRoom({
-                visibility: 'private',
-                invite: [presences[peer].payload.userId],
-              }),
-            ),
-            map(({ room_id: roomId }) => matrixRoom({ roomId }, { address: peer })),
-            retryWhile(intervalFromConfig(config$), { onErrors: networkErrors }),
-            catchError((err) => (log.error('Error creating room, ignoring', err), EMPTY)),
-          ),
-        ),
-      ),
-    ),
-  );
-}
-
-/**
- * Invites users coming online to main room we may have with them
- *
- * This also keeps retrying inviting every config.httpTimeout (default=30s) while user doesn't
- * accept our invite or don't invite or write to us to/in another room.
- *
- * @param action$ - Observable of matrixPresence.success actions
- * @param state$ - Observable of RaidenStates
- * @param deps - RaidenEpicDeps
- * @param deps.matrix$ - MatrixClient AsyncSubject
- * @param deps.config$ - RaidenConfig BehaviorSubject
- * @param deps.latest$ - Latest values
- * @param deps.log - Logger instance
- * @returns Empty observable (whole side-effect on matrix instance)
- */
-export function matrixInviteEpic(
-  action$: Observable<RaidenAction>,
-  {}: Observable<RaidenState>,
-  { matrix$, config$, latest$, log }: RaidenEpicDeps,
-): Observable<never> {
-  return action$.pipe(
-    filter(isActionOf(matrixPresence.success)),
-    groupBy((a) => a.meta.address),
-    mergeMap((grouped$) =>
-      // grouped$ is one observable of presence actions per partners address
-      combineLatest([
-        grouped$,
-        latest$.pipe(
-          map(({ state }) => state.transport.rooms?.[grouped$.key]?.[0]),
-          distinctUntilChanged(),
-        ),
-      ]).pipe(
-        // action comes only after matrix$ is started, so it's safe to use withLatestFrom
-        withLatestFrom(matrix$, config$),
-        // switchMap on new presence action for address
-        switchMap(([[action, roomId], matrix, config]) => {
-          // if not available, do nothing (and unsubscribe from previous observable)
-          if (!action.payload.available || !roomId) return EMPTY;
-          return inviteLoop$(matrix, roomId, action.payload.userId, config, { log });
-        }),
-        completeWith(action$),
-      ),
-    ),
-  );
-}
-
-/**
- * Handle invites sent to us and accepts them iff sent by a monitored user
- *
- * @param action$ - Observable of RaidenActions
- * @param state$ - Observable of RaidenStates
- * @param deps - RaidenEpicDeps members
- * @param deps.log - Logger instance
- * @param deps.matrix$ - MatrixClient async subject
- * @param deps.config$ - Config ReplaySubject
- * @param deps.latest$ - Latest values
- * @returns Observable of matrixRoom actions
- */
-export function matrixHandleInvitesEpic(
-  action$: Observable<RaidenAction>,
-  {}: Observable<RaidenState>,
-  { log, matrix$, config$, latest$ }: RaidenEpicDeps,
-): Observable<matrixRoom> {
-  return matrix$.pipe(
-    // when matrix finishes initialization, register to matrix invite events
-    switchMap((matrix) =>
-      fromEvent<[MatrixEvent, RoomMember]>(matrix, 'RoomMember.membership').pipe(
-        map(([event, member]) => ({ event, member, matrix })),
-        completeWith(action$),
-      ),
-    ),
-    filter(
-      // filter for invite events to us
-      ({ member, matrix }) =>
-        member.userId === matrix.getUserId() && member.membership === 'invite',
-    ),
-    withLatestFrom(config$),
-    mergeMap(([{ event, member, matrix }, { httpTimeout }]) =>
-      latest$.pipe(
-        pluckDistinct('presences'),
-        map((presences) =>
-          Object.values(presences).find((p) => p.payload.userId === event.getSender()),
-        ),
-        filter(isntNil),
-        completeWith(action$),
-        take(1),
-        // Don't wait more than some arbitrary time for this sender presence update to show
-        // up; completes without emitting anything otherwise, ending this pipeline.
-        // This also works as a filter to continue processing invites only for monitored
-        // users, as it'll complete without emitting if no MatrixPresenceUpdateAction is
-        // found for sender in time
-        timeout(httpTimeout),
-        map((senderPresence) => ({ matrix, member, senderPresence })),
-        // on timeout error, leave invited room
-        catchError(() =>
-          defer(async () => {
-            log.info("Leaving invited room because we don't know the inviter", event);
-            return matrix.leave(member.roomId);
-          }).pipe(
-            retryWhile(intervalFromConfig(config$), { onErrors: networkErrors }),
-            catchError((err) => (log.warn('Error leaving invited room, ignoring', err), EMPTY)),
-            ignoreElements(),
-          ),
-        ),
-      ),
-    ),
-    mergeMap(({ matrix, member, senderPresence }) =>
-      // join room and emit MatrixRoomAction to make it default/first option for sender address
-      defer(async () => matrix.joinRoom(member.roomId, { syncRoom: true })).pipe(
-        mapTo(matrixRoom({ roomId: member.roomId }, { address: senderPresence.meta.address })),
-        retryWhile(intervalFromConfig(config$), { onErrors: networkErrors }),
-        catchError((err) => (log.warn('Error joining invited room, ignoring', err), EMPTY)),
-      ),
-    ),
-  );
-}
-
-/**
- * Leave any excess room for a partner when creating or joining a new one.
- * Excess rooms are LRU beyond a given threshold (configurable, default=3) in address's rooms
- * queue and are checked (only) when a new one is added to it.
- *
- * @param action$ - Observable of matrixRoom actions
- * @param state$ - Observable of RaidenStates
- * @param deps - RaidenEpicDeps members
- * @param deps.log - Logger instance
- * @param deps.matrix$ - MatrixClient async subject
- * @param deps.config$ - Config object
- * @returns Observable of matrixRoomLeave actions
- */
-export function matrixLeaveExcessRoomsEpic(
-  action$: Observable<RaidenAction>,
-  state$: Observable<RaidenState>,
-  { log, matrix$, config$ }: RaidenEpicDeps,
-): Observable<matrixRoomLeave> {
-  return action$.pipe(
-    // act whenever a new room is added to the address queue in state
-    filter(isActionOf(matrixRoom)),
-    // this mergeMap is like withLatestFrom, but waits until matrix$ emits its only value
-    mergeMap((action) => matrix$.pipe(map((matrix) => ({ action, matrix })))),
-    withLatestFrom(state$, config$),
-    mergeMap(([{ action, matrix }, state, { matrixExcessRooms }]) => {
-      const rooms = state.transport.rooms?.[action.meta.address] ?? [];
-      return from(rooms.filter(({}, i) => i >= matrixExcessRooms)).pipe(
-        mergeMap((roomId) =>
-          matrix
-            .leave(roomId)
-            .catch((err) => log.error('Error leaving excess room, ignoring', err))
-            .then(() => roomId),
-        ),
-        map((roomId) => matrixRoomLeave({ roomId }, action.meta)),
-      );
-    }),
-  );
-}
-
-/**
- * Leave any room which is neither global nor known as a room for some user of interest
- *
- * @param action$ - Observable of RaidenActions
- * @param state$ - Observable of RaidenStates
- * @param deps - RaidenEpicDeps members
- * @param deps.log - Logger instance
- * @param deps.matrix$ - MatrixClient async subject
- * @param deps.config$ - Config object
  * @returns Empty observable (whole side-effect on matrix instance)
  */
 export function matrixLeaveUnknownRoomsEpic(
@@ -352,148 +28,28 @@ export function matrixLeaveUnknownRoomsEpic(
 ): Observable<RaidenAction> {
   return matrix$.pipe(
     // when matrix finishes initialization, register to matrix Room events
-    switchMap((matrix) => fromEvent<Room>(matrix, 'Room').pipe(map((room) => ({ matrix, room })))),
+    mergeWith((matrix) => fromEvent<Room>(matrix, 'Room')),
+    withLatestFrom(config$),
     // this room may become known later for some reason, so wait a little
-    delayWhen(() =>
-      config$.pipe(
-        first(),
-        mergeMap(({ httpTimeout }) => timer(httpTimeout)),
-      ),
+    delayWhen(([, { httpTimeout }]) =>
+      timer(Math.round((0.5 + 0.5 * Math.random()) * httpTimeout)),
     ),
     completeWith(state$),
-    withLatestFrom(state$, config$),
     // filter for leave events to us
-    filter(([{ matrix, room }, { transport }, config]) => {
-      if (!room) return false; // room already gone while waiting
+    filter(([[matrix, room], config]) => {
+      const myMembership = room.getMyMembership();
+      if (!myMembership || myMembership === 'leave') return false; // room already gone while waiting
       const serverName = getServerName(matrix.getHomeserverUrl());
       if (globalRoomNames(config).some((g) => roomMatch(`#${g}:${serverName}`, room)))
         return false;
-      for (const rooms of Object.values(transport.rooms ?? {})) {
-        for (const roomId of rooms) {
-          if (roomId === room.roomId) return false;
-        }
-      }
       return true;
     }),
-    mergeMap(async ([{ matrix, room }]) => {
+    mergeMap(async ([[matrix, room]]) => {
       log.warn('Unknown room in matrix, leaving', room.roomId);
       return matrix
         .leave(room.roomId)
         .catch((err) => log.error('Error leaving unknown room, ignoring', err));
     }),
     ignoreElements(),
-  );
-}
-
-/**
- * If we leave a room for any reason (eg. a kick event), purge it from state
- * Notice excess rooms left by matrixLeaveExcessRoomsEpic are cleaned before the matrix event is
- * detected, and then no MatrixRoomLeaveAction is emitted for them by this epic.
- *
- * @param action$ - Observable of RaidenActions
- * @param state$ - Observable of RaidenStates
- * @param deps - RaidenEpicDeps members
- * @param deps.matrix$ - MatrixClient async subject
- * @param deps.log - Logger instance
- * @returns Observable of matrixRoomLeave actions
- */
-export function matrixCleanLeftRoomsEpic(
-  {}: Observable<RaidenAction>,
-  state$: Observable<RaidenState>,
-  { log, matrix$ }: RaidenEpicDeps,
-): Observable<matrixRoomLeave> {
-  return matrix$.pipe(
-    // when matrix finishes initialization, register to matrix invite events
-    switchMap((matrix) =>
-      fromEvent<[Room, string]>(matrix, 'Room.myMembership').pipe(
-        map(([room, membership]) => ({ room, membership, matrix })),
-        completeWith(state$),
-      ),
-    ),
-    // filter for leave events to us
-    filter(({ membership }) => membership === 'leave'),
-    withLatestFrom(state$),
-    mergeMap(function* ([{ room }, { transport }]) {
-      for (const [address, rooms] of Object.entries(transport.rooms ?? {})) {
-        for (const roomId of rooms) {
-          if (roomId === room.roomId) {
-            log.warn('Left event for peer room detected, forgetting', address, roomId);
-            yield matrixRoomLeave({ roomId }, { address: address as Address });
-          }
-        }
-      }
-    }),
-  );
-}
-
-/**
- * If some room we had with a peer doesn't show up in transport, forget it
- *
- * @param action$ - Observable of RaidenActions
- * @param state$ - Observable of RaidenStates
- * @param deps - RaidenEpicDeps members
- * @param deps.log - Logger instance
- * @param deps.matrix$ - MatrixClient async subject
- * @param deps.config$ - Config object
- * @returns Observable of matrixRoomLeave actions
- */
-export function matrixCleanMissingRoomsEpic(
-  {}: Observable<RaidenAction>,
-  state$: Observable<RaidenState>,
-  { log, matrix$, config$ }: RaidenEpicDeps,
-): Observable<matrixRoomLeave> {
-  return state$.pipe(
-    pluckDistinct('transport', 'rooms'),
-    filter(isntNil),
-    mergeMap(function* (rooms) {
-      for (const [address, peerRooms] of Object.entries(rooms)) {
-        for (const roomId of peerRooms) {
-          yield { roomId, address: address as Address };
-        }
-      }
-    }),
-    distinct(({ roomId }) => roomId),
-    mergeMap(({ roomId, address }) =>
-      matrix$.pipe(map((matrix) => ({ matrix, roomId, address }))),
-    ),
-    withLatestFrom(config$),
-    mergeMap(([{ roomId, address, matrix }, { httpTimeout }]) =>
-      getRoom$(matrix, roomId).pipe(
-        // wait for room to show up in MatrixClient; if it doesn't, clean up
-        timeout(httpTimeout),
-        ignoreElements(),
-        catchError(() => {
-          log.warn('Peer room in state not found in matrix, forgetting', address, roomId);
-          return of(matrixRoomLeave({ roomId }, { address }));
-        }),
-      ),
-    ),
-  );
-}
-
-/**
- * If matrix received a message from user in a room we have with them, but not the first on queue,
- * update queue so this room goes to the front and will be used as send message room from now on
- *
- * @param action$ - Observable of messageReceived actions
- * @param state$ - Observable of RaidenStates
- * @returns Observable of matrixRoom actions
- */
-export function matrixMessageReceivedUpdateRoomEpic(
-  action$: Observable<RaidenAction>,
-  state$: Observable<RaidenState>,
-): Observable<matrixRoom> {
-  return action$.pipe(
-    filter(messageReceived.is),
-    withLatestFrom(state$),
-    filter(([action, state]) => {
-      const rooms = state.transport.rooms?.[action.meta.address] ?? [];
-      return (
-        !!action.payload.roomId &&
-        rooms.includes(action.payload.roomId) &&
-        rooms[0] !== action.payload.roomId
-      );
-    }),
-    map(([action]) => matrixRoom({ roomId: action.payload.roomId! }, action.meta)),
   );
 }

--- a/raiden-ts/src/transport/reducer.ts
+++ b/raiden-ts/src/transport/reducer.ts
@@ -1,7 +1,9 @@
+import isEqual from 'lodash/isEqual';
+
 import { initialState } from '../state';
 import { createReducer } from '../utils/actions';
 import { partialCombineReducers } from '../utils/redux';
-import { matrixRoom, matrixRoomLeave, matrixSetup } from './actions';
+import { matrixSetup } from './actions';
 
 /**
  * state.transport reducer
@@ -12,36 +14,11 @@ import { matrixRoom, matrixRoomLeave, matrixSetup } from './actions';
  * @returns New RaidenState['transport'] slice
  */
 
-const transport = createReducer(initialState.transport)
-  .handle(matrixSetup, (state, action) => {
-    // immutably remove rooms from state.transport
-    const { rooms: _, ...noRooms } = state;
-    return {
-      ...(state.server !== action.payload.server ? noRooms : state),
-      ...action.payload,
-    };
-  })
-  .handle(matrixRoom, (state, action) => ({
-    ...state,
-    rooms: {
-      ...state.rooms,
-      [action.meta.address]: [
-        action.payload.roomId,
-        ...(state.rooms?.[action.meta.address] ?? []).filter(
-          (room) => room !== action.payload.roomId,
-        ),
-      ],
-    },
-  }))
-  .handle(matrixRoomLeave, (state, action) => ({
-    ...state,
-    rooms: {
-      ...state.rooms,
-      [action.meta.address]: (state.rooms?.[action.meta.address] ?? []).filter(
-        (room) => room !== action.payload.roomId,
-      ),
-    },
-  }));
+const transport = createReducer(initialState.transport).handle(matrixSetup, (state, action) => {
+  // immutably remove rooms from state.transport
+  if (!isEqual(state, action.payload)) state = action.payload;
+  return state;
+});
 
 /**
  * Nested/combined reducer for transport

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -305,6 +305,7 @@ const mockedRooms: {
     members: { [userId: string]: string };
     aliases: string[];
     getMember: (userId: string) => { membership: string; roomId: string; userId: string } | null;
+    getMyMembership: () => string | null;
     getCanonicalAlias: () => string | null | undefined;
     getAliases: () => string[];
     currentState: { setStateEvents: (state: any) => void };
@@ -323,6 +324,9 @@ function mockedGetOrMakeRoom(roomId: string) {
       getMember(userId) {
         if (!(userId in this.members)) return null;
         return { membership: this.members[userId], roomId, userId };
+      },
+      getMyMembership() {
+        return 'join';
       },
       getCanonicalAlias() {
         return null;
@@ -528,6 +532,7 @@ function mockedMatrixCreateClient({
     }),
     sendToDevice: jest.fn(
       async (type: string, contentMap: { [userId: string]: { [deviceID: string]: any } }) => {
+        if (stopped) return true;
         for (const [partnerId, map] of Object.entries(contentMap)) {
           for (const client of mockedClients) {
             const matrix = await client.deps.matrix$.toPromise();
@@ -869,7 +874,7 @@ export async function makeRaiden(
       caps: {
         [Capabilities.DELIVERY]: 0,
         [Capabilities.WEBRTC]: 0,
-        [Capabilities.TO_DEVICE]: 0,
+        [Capabilities.TO_DEVICE]: 1,
         [Capabilities.MEDIATE]: 1,
       },
     },

--- a/raiden-ts/tests/unit/reducers.spec.ts
+++ b/raiden-ts/tests/unit/reducers.spec.ts
@@ -20,7 +20,7 @@ import { ShutdownReason } from '@/constants';
 import { raidenReducer } from '@/reducer';
 import type { RaidenState } from '@/state';
 import { makeInitialState } from '@/state';
-import { matrixRoom, matrixRoomLeave, matrixSetup } from '@/transport/actions';
+import { matrixSetup } from '@/transport/actions';
 import { ErrorCodes, RaidenError } from '@/utils/error';
 import type { Address, Hash, UInt } from '@/utils/types';
 
@@ -824,34 +824,6 @@ describe('raidenReducer', () => {
       const newState = [matrixSetup({ server, setup })].reduce(raidenReducer, state);
       expect(newState.transport.server).toBe(server);
       expect(newState.transport.setup).toEqual(setup);
-    });
-
-    test('matrixRoom', () => {
-      const roomId = '!roomId:matrix.raiden.test',
-        newRoomId = '!newRoomId:matrix.raiden.test';
-
-      let newState = [matrixRoom({ roomId }, { address: partner })].reduce(raidenReducer, state);
-      expect(newState.transport.rooms?.[partner]).toEqual([roomId]);
-
-      // new room goes to the front
-      newState = [matrixRoom({ roomId: newRoomId }, { address: partner })].reduce(
-        raidenReducer,
-        newState,
-      );
-      expect(newState.transport.rooms?.[partner]).toEqual([newRoomId, roomId]);
-
-      // old room is brought back to the front
-      newState = [matrixRoom({ roomId }, { address: partner })].reduce(raidenReducer, newState);
-      expect(newState.transport.rooms?.[partner]).toEqual([roomId, newRoomId]);
-    });
-
-    test('matrixRoomLeave', () => {
-      const roomId = '!roomId:matrix.raiden.test';
-      const newState = [
-        matrixRoom({ roomId }, { address: partner }),
-        matrixRoomLeave({ roomId }, { address: partner }),
-      ].reduce(raidenReducer, state);
-      expect(newState.transport.rooms?.[partner]).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
Fixes #2567 
~~Currently based on top of #2575 due to `mergeWith` requirement~~

~~Without considering its base, this PR currently is `12 files changed, 312 insertions(+), 1126 deletions(-)`, the additions being mostly the optimization and an additional test for it.~~

**Short description**
Removes almost all rooms handling epics, actions and reducers and related tests.
Keep only trimmed down `matrixLeaveUnknownRoomsEpic` in order to leave rooms when invited and avoid syncing its state later.
Now that only `toDevice` and `webRTC` p2p communication is available, I've rewritten the `matrixMessageSendEpic` with an important optimization: have an unified queue for all peers, and send batched messages in a single serialized `sendToDevice` API call. The waiting which comes later (until partner is online) before emitting `success` is done in parallel to avoid holding the queue. `WebRTC` peers skip this queue entirely and is done even more efficiently in parallel.
This PR mostly does not touch the same code as its base, so should be more or less easily rebased even after that one gets changed.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
