### PR TITLE
Adds amount-based fee safety margin

### DIFF
--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- [#2581] CLI now defaults to `3% * fee + 0.05% * amount` for fee safety margin, same as PC
+
+[#2581]: https://github.com/raiden-network/light-client/pull/2581
 
 ## [0.15.0] - 2021-01-26
 ### Added

--- a/raiden-cli/src/config.json
+++ b/raiden-cli/src/config.json
@@ -1,5 +1,5 @@
 {
-  "pfsSafetyMargin": 1.1,
+  "pfsSafetyMargin": [0.03, 0.0005],
   "expiryFactor": 2.0,
   "autoSettle": true,
   "caps": {

--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -5,7 +5,7 @@ import inquirer from 'inquirer';
 import * as path from 'path';
 import yargs from 'yargs/yargs';
 
-import type { RaidenConfig, UInt } from 'raiden-ts';
+import type { Decodable, RaidenConfig, UInt } from 'raiden-ts';
 import { Address, assert, Capabilities, Raiden } from 'raiden-ts';
 
 import { makeCli } from './cli';
@@ -256,8 +256,11 @@ function registerShutdownHooks(this: Cli): void {
   });
 }
 
-function createRaidenConfig(argv: ReturnType<typeof parseArguments>): Partial<RaidenConfig> {
-  let config: Partial<RaidenConfig> = DEFAULT_RAIDEN_CONFIG;
+function createRaidenConfig(
+  argv: ReturnType<typeof parseArguments>,
+): Partial<Decodable<RaidenConfig>> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let config: Partial<Decodable<RaidenConfig>> = DEFAULT_RAIDEN_CONFIG as any;
 
   if (argv.configFile)
     config = { ...config, ...JSON.parse(fs.readFileSync(argv.configFile, 'utf-8')) };

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
 ## [Unreleased]
-### Changed
-- [#2250] **BREAKING** remove migration of legacy state at localStorage during creation
+### Added
+- [#2581] `config.pfsSafetyMargin` now also accepts a `[f, a]` pair, which will add `f*fee + a*amount` on top of PFS's estimated fee, if one wants finer-grain control on safety margin which is added on the transfer to be initiated.
 
-[#2550]: https://github.com/raiden-network/light-client/pull/2550
+### Changed
+- [#2550] **BREAKING** remove migration of legacy state at localStorage during creation
+
+[#2550]: https://github.com/raiden-network/light-client/issues/2550
+[#2581]: https://github.com/raiden-network/light-client/pull/2581
 
 ## [0.15.0] - 2021-01-26
 ### Added
@@ -18,7 +22,6 @@
 - [#2409] Lower default payment expiration to 1.1 × reveal timeout
 - [#2505] Properly shut down epics on stop and wait for teardown/cleanup tasks
 - [#2536] Wait for global messages before resolving deposits and channel open request
-- [#2550] **BREAKING** remove migration of legacy state at localStorage during creation
 
 ### Fixed
 - [#2352] Presence bug, transport fixes and performance improvements
@@ -32,7 +35,6 @@
 [#2446]: https://github.com/raiden-network/light-client/issues/2446
 [#2505]: https://github.com/raiden-network/light-client/pull/2505
 [#2536]: https://github.com/raiden-network/light-client/issues/2536
-[#2550]: https://github.com/raiden-network/light-client/issues/2550
 
 ## [0.14.0] - 2020-11-25
 ### Fixed

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -93,6 +93,7 @@
     "@ethersproject/units": "^5.0.10",
     "@ethersproject/wallet": "^5.0.11",
     "abort-controller": "^3.0.0",
+    "bignumber.js": "^9.0.1",
     "fp-ts": "^2.9.5",
     "io-ts": "^2.2.14",
     "isomorphic-fetch": "^3.0.0",

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -35,8 +35,9 @@ const RTCIceServer = t.type({ urls: t.union([t.string, t.array(t.string)]) });
  *    use null to disable
  * - pfs - Path Finding Service URL or Address. Set to null to disable, or empty string to enable
  *    automatic fetching from ServiceRegistry.
- * - pfsSafetyMargin - Safety margin to be added to fees received from PFS. Use `1.1` to add a 10%
- *    safety margin.
+ * - pfsSafetyMargin - Safety margin to be added to fees received from PFS. Either a fee
+ *    multiplier, or a [fee, amount] pair ofmultipliers. Use `1.1` to add a 10% over estimated fee
+ *    margin, or `[0.03, 0.0005]` to add a 3% over fee plus 0.05% over amount.
  * - pfsMaxPaths - Limit number of paths requested from PFS for a route.
  * - pfsMaxFee - Maximum fee we're willing to pay a PFS for a route (in SVT/RDN wei)
  * - pfsIouTimeout - Number of blocks to timeout an IOU to a PFS.
@@ -70,7 +71,7 @@ export const RaidenConfig = t.readonly(
       pfsRoom: t.union([t.string, t.null]),
       monitoringRoom: t.union([t.string, t.null]),
       pfs: t.union([Address, t.string, t.null]),
-      pfsSafetyMargin: t.number,
+      pfsSafetyMargin: t.union([t.number, t.tuple([t.number, t.number])]),
       pfsMaxPaths: t.number,
       pfsMaxFee: UInt(32),
       pfsIouTimeout: t.number,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5229,7 +5229,7 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
-bignumber.js@^9.0.0:
+bignumber.js@^9.0.0, bignumber.js@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
   integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==


### PR DESCRIPTION
Split from #2575 

**Short description**
Adds the ability to set a `[f, a]` tuple as safety margin, where the final fee is calculated as `ceil(estimated_fee + f * estimated_fee + a * amount)`. This is needed in order to reproduce PC's default safety margin of `+3% estiamated_fee + 0.05% amount`.

This also introduces the `mergeWith` Rx operator, which should help simplify some deep-mergeMap operators callback-hell which are used simply to allow previous and current value in a context.

A new dependency, `bignumber.js`, which was already pulled in by some dependency, is now explicitly required and imported as `BN`, in order to properly perform **floating/decimal big number arithmetics**, but it should be used only for the internal operations, interfaces should still expose the simpler bn.js-based `ethers` `BigNumber` and our custom derivative types (`UInt`, `Int`, etc). When rounding, an explicit rounding mode is expected instead of setting it globally. For reference, Python's default `round()` mode is `BN.ROUND_HALF_EVEN`.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
