### PR TITLE
Improve first and non-first initial sync times on testnet and mainnet, reduce number of ETH RPC requests

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -7,12 +7,14 @@
 ### Changed
 - [#2536] Wait for global messages before resolving deposits and channel open request
 - [#2550] **BREAKING** remove migration of legacy state at localStorage during creation
+- [#2566] Optimize initial sync and resume previous sync filters scans
 
 ### Removed
 - [#2567] **BREAKING** Remove support for peer-to-peer communication through Matrix rooms; now supports only `toDevice` and WebRTC channels.
 
 [#2536]: https://github.com/raiden-network/light-client/issues/2536
 [#2550]: https://github.com/raiden-network/light-client/issues/2550
+[#2566]: https://github.com/raiden-network/light-client/issues/2566
 [#2567]: https://github.com/raiden-network/light-client/issues/2567
 [#2581]: https://github.com/raiden-network/light-client/pull/2581
 

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -5,7 +5,7 @@ import * as t from 'io-ts';
 import type { Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 
-import { Capabilities } from './constants';
+import { Capabilities, DEFAULT_CONFIRMATIONS } from './constants';
 import { exponentialBackoff } from './transfers/epics/utils';
 import { Caps } from './transport/types';
 import { getNetworkName } from './utils/ethers';
@@ -148,7 +148,7 @@ export function makeDefaultConfig(
     pfsMaxPaths: 3,
     pfsMaxFee: parseEther('0.05') as UInt<32>, // in SVT/RDN, 18 decimals
     pfsIouTimeout: 200000, // in blocks
-    confirmationBlocks: 5,
+    confirmationBlocks: DEFAULT_CONFIRMATIONS,
     // SVT also uses 18 decimals, like Ether, so parseEther works
     monitoringReward: parseEther('5') as UInt<32>,
     logger: 'info',

--- a/raiden-ts/src/constants.ts
+++ b/raiden-ts/src/constants.ts
@@ -32,3 +32,4 @@ export const CapsFallback = {
 } as const;
 
 export const RAIDEN_DEVICE_ID = 'RAIDEN';
+export const DEFAULT_CONFIRMATIONS = 5;

--- a/raiden-ts/src/db/migrations.ts
+++ b/raiden-ts/src/db/migrations.ts
@@ -1,4 +1,9 @@
 import type { Migrations } from './types';
 
-const migrations: Migrations = {};
+const migrations: Migrations = {
+  1: async (doc) => {
+    if (doc._id === 'state.address') return [doc, { _id: 'state.services', value: {} }];
+    return [doc];
+  },
+};
 export default migrations;

--- a/raiden-ts/src/db/types.ts
+++ b/raiden-ts/src/db/types.ts
@@ -9,8 +9,10 @@ export interface TransferStateish extends Decodable<TransferState> {
 }
 
 export type Migrations = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly [version: number]: (doc: any, db: RaidenDatabase) => Promise<any[]>;
+  readonly [version: number]: (
+    doc: PouchDB.Core.IdMeta & PouchDB.Core.RevisionIdMeta,
+    db: RaidenDatabase,
+  ) => Promise<(PouchDB.Core.IdMeta & Partial<PouchDB.Core.RevisionIdMeta>)[]>;
 };
 
 export interface RaidenDatabaseMeta {

--- a/raiden-ts/src/db/utils.ts
+++ b/raiden-ts/src/db/utils.ts
@@ -303,8 +303,8 @@ export async function migrateDatabase(
             defer(() => migrations[newVersion](change.doc!, db!)).pipe(
               mergeMap((results) => from(results)),
               concatMap(async (result) => {
-                if ('_rev' in result) delete result['_rev'];
-                return newStorage.put(result);
+                const { _rev: _, ...doc } = result;
+                return newStorage.put(doc);
               }),
             ),
           ),

--- a/raiden-ts/src/epics.ts
+++ b/raiden-ts/src/epics.ts
@@ -31,7 +31,7 @@ import * as ChannelsEpics from './channels/epics';
 import type { RaidenConfig } from './config';
 import { Capabilities } from './constants';
 import * as DatabaseEpics from './db/epics';
-import { pfsListUpdated, udcDeposit } from './services/actions';
+import { udcDeposit } from './services/actions';
 import * as ServicesEpics from './services/epics';
 import type { RaidenState } from './state';
 import * as TransfersEpics from './transfers/epics';
@@ -41,7 +41,7 @@ import type { Caps } from './transport/types';
 import { getPresences$ } from './transport/utils';
 import type { Latest, RaidenEpicDeps } from './types';
 import { completeWith, pluckDistinct } from './utils/rx';
-import type { Address, UInt } from './utils/types';
+import type { UInt } from './utils/types';
 
 // default values for dynamic capabilities not specified on defaultConfig nor userConfig
 function dynamicCaps({
@@ -185,11 +185,6 @@ export function getLatest$(
     map(([userConfig, caps]) => ({ ...defaultConfig, ...userConfig, caps })),
   );
   const presences$ = getPresences$(action$);
-  const pfsList$ = action$.pipe(
-    filter(pfsListUpdated.is),
-    pluck('payload', 'pfsList'),
-    startWith([] as readonly Address[]),
-  );
   const rtc$ = action$.pipe(
     filter(rtcChannel.is),
     // scan: if v.payload is defined, set it; else, unset
@@ -202,15 +197,14 @@ export function getLatest$(
   );
 
   return combineLatest([
-    combineLatest([action$, state$, config$, presences$, pfsList$, rtc$]),
+    combineLatest([action$, state$, config$, presences$, rtc$]),
     combineLatest([udcBalance$, blockTime$, stale$]),
   ]).pipe(
-    map(([[action, state, config, presences, pfsList, rtc], [udcBalance, blockTime, stale]]) => ({
+    map(([[action, state, config, presences, rtc], [udcBalance, blockTime, stale]]) => ({
       action,
       state,
       config,
       presences,
-      pfsList,
       rtc,
       udcBalance,
       blockTime,

--- a/raiden-ts/src/persister.ts
+++ b/raiden-ts/src/persister.ts
@@ -81,7 +81,7 @@ export function createPersisterMiddleware(
           dirtyDocs[_id] = state[key][id];
         }
       } else if (key === 'transfers') {
-        // iterate over channels separately
+        // iterate over transfers separately
         for (const _id in state.transfers) {
           if (state.transfers[_id] === prevState.transfers[_id]) continue;
           db.storageKeys.add(_id);

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -1157,14 +1157,12 @@ export class Raiden {
    */
   public async findPFS(): Promise<PFS[]> {
     assert(this.config.pfs !== null, ErrorCodes.PFS_DISABLED, this.log.info);
+    await this.synced;
     return (this.config.pfs
       ? of<readonly (string | Address)[]>([this.config.pfs])
-      : this.deps.latest$.pipe(
-          pluckDistinct('pfsList'),
-          first((v) => v.length > 0),
-        )
+      : of<readonly Address[]>(Object.keys(this.state.services) as Address[])
     )
-      .pipe(mergeMap((pfsList) => pfsListInfo(pfsList, this.deps)))
+      .pipe(mergeMap((service) => pfsListInfo(service, this.deps)))
       .toPromise();
   }
 

--- a/raiden-ts/src/services/actions.ts
+++ b/raiden-ts/src/services/actions.ts
@@ -4,7 +4,7 @@ import * as t from 'io-ts';
 import type { ActionType } from '../utils/actions';
 import { createAction, createAsyncAction } from '../utils/actions';
 import { Address, Hash, Signed, UInt } from '../utils/types';
-import { IOU, Paths, PFS } from './types';
+import { IOU, Paths, PFS, ServicesValidityMap } from './types';
 
 const PathId = t.type({
   tokenNetwork: Address,
@@ -31,11 +31,8 @@ export namespace pathFind {
   export interface failure extends ActionType<typeof pathFind.failure> {}
 }
 
-export const pfsListUpdated = createAction(
-  'pfs/list/updated',
-  t.type({ pfsList: t.readonlyArray(Address) }),
-);
-export interface pfsListUpdated extends ActionType<typeof pfsListUpdated> {}
+export const servicesValid = createAction('services/valid', ServicesValidityMap);
+export interface servicesValid extends ActionType<typeof servicesValid> {}
 
 export const iouPersist = createAction('iou/persist', t.type({ iou: Signed(IOU) }), ServiceId);
 export interface iouPersist extends ActionType<typeof iouPersist> {}

--- a/raiden-ts/src/services/reducer.ts
+++ b/raiden-ts/src/services/reducer.ts
@@ -11,7 +11,7 @@ import unset from 'lodash/fp/unset';
 import { initialState } from '../state';
 import { createReducer } from '../utils/actions';
 import { partialCombineReducers } from '../utils/redux';
-import { iouClear, iouPersist } from './actions';
+import { iouClear, iouPersist, servicesValid } from './actions';
 
 const iou = createReducer(initialState.iou)
   .handle(iouPersist, (state, action) => ({
@@ -25,9 +25,14 @@ const iou = createReducer(initialState.iou)
     unset([action.meta.tokenNetwork, action.meta.serviceAddress], state),
   );
 
+const services = createReducer(initialState.services).handle(
+  servicesValid,
+  (_s, action) => action.payload,
+);
+
 /**
  * Nested combined reducer for iou
  * Handles the 'iou' substate.
  */
-const servicesReducer = partialCombineReducers({ iou }, initialState);
+const servicesReducer = partialCombineReducers({ iou, services }, initialState);
 export default servicesReducer;

--- a/raiden-ts/src/services/types.ts
+++ b/raiden-ts/src/services/types.ts
@@ -92,3 +92,6 @@ export const SuggestedPartner = t.readonly(
 );
 export interface SuggestedPartner extends t.TypeOf<typeof SuggestedPartner> {}
 export const SuggestedPartners = t.array(SuggestedPartner, 'SuggestedPartners');
+
+export const ServicesValidityMap = t.readonly(t.record(t.string, t.number), 'ServicesValidityMap');
+export type ServicesValidityMap = t.TypeOf<typeof ServicesValidityMap>;

--- a/raiden-ts/src/state.ts
+++ b/raiden-ts/src/state.ts
@@ -7,7 +7,7 @@ import { ConfirmableAction } from './actions';
 import { Channel } from './channels/state';
 import { ChannelKey } from './channels/types';
 import { PartialRaidenConfig } from './config';
-import { IOU } from './services/types';
+import { IOU, ServicesValidityMap } from './services/types';
 import { TransferState } from './transfers/state';
 import { RaidenMatrixSetup } from './transport/state';
 import type { ContractsInfo } from './types';
@@ -33,6 +33,7 @@ const _RaidenState = t.readonly(
       ),
     ),
     pendingTxs: t.readonlyArray(ConfirmableAction),
+    services: ServicesValidityMap,
   }),
   'RaidenState',
 );
@@ -77,6 +78,7 @@ export function makeInitialState(
     transfers: {},
     iou: {},
     pendingTxs: [],
+    services: {},
     config: {},
     ...overrides,
   };

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -40,7 +40,6 @@ export interface Latest {
   state: RaidenState;
   config: RaidenConfig;
   presences: Presences;
-  pfsList: readonly Address[];
   rtc: { [address: string]: RTCDataChannel };
   udcBalance: UInt<32>;
   blockTime: number;

--- a/raiden-ts/src/utils/ethers.ts
+++ b/raiden-ts/src/utils/ethers.ts
@@ -26,6 +26,7 @@ import {
   tap,
 } from 'rxjs/operators';
 
+import { DEFAULT_CONFIRMATIONS } from '../constants';
 import { mergeWith } from './rx';
 
 /**
@@ -151,7 +152,7 @@ export function fromEthersEvent<T>(
     ) as Observable<T>;
 
   const confirmations$ = !confirmations
-    ? of(5)
+    ? of(DEFAULT_CONFIRMATIONS)
     : typeof confirmations === 'number'
     ? of(confirmations)
     : confirmations;

--- a/raiden-ts/src/utils/rx.ts
+++ b/raiden-ts/src/utils/rx.ts
@@ -329,15 +329,17 @@ export function concatBuffer<T, R>(
  *   );
  *
  * @param project - Project function passed to mergeMap
+ * @param mapFunc - Funtion to merge result with, like mergeMap or switchMap
  * @returns Observable mirroring project's return, but prepending emitted values from this inner
  *    observable in a tuple with the value from the outter observable which generated the inner.
  */
 export function mergeWith<T, R>(
   project: (value: T, index: number) => ObservableInput<R>,
+  mapFunc = mergeMap,
 ): OperatorFunction<T, [T, R]> {
   return (input$) =>
     input$.pipe(
-      mergeMap((value, index) =>
+      mapFunc((value, index) =>
         from(project(value, index)).pipe(map((res) => [value, res] as [T, R])),
       ),
     );

--- a/raiden-ts/tests/integration/raiden.spec.ts
+++ b/raiden-ts/tests/integration/raiden.spec.ts
@@ -87,6 +87,7 @@ describe('Raiden', () => {
     revealTimeout: 5,
     confirmationBlocks,
     pollingInterval: 10,
+    httpTimeout: 5000,
   };
 
   let httpBackend: MockMatrixRequestFn;
@@ -733,7 +734,10 @@ describe('Raiden', () => {
       expect.assertions(4);
 
       const promise = raiden.events$
-        .pipe(first((value) => tokenMonitored.is(value) && !!value.payload.fromBlock))
+        .pipe(
+          filter(tokenMonitored.is),
+          first((action) => action.payload.token === token),
+        )
         .toPromise();
 
       // deploy a new token & tokenNetwork
@@ -768,7 +772,10 @@ describe('Raiden', () => {
       const raiden1 = await createRaiden(partner);
 
       const promise1 = raiden1.events$
-        .pipe(first((value) => tokenMonitored.is(value) && !!value.payload.fromBlock))
+        .pipe(
+          filter(tokenMonitored.is),
+          first((action) => action.payload.token === token),
+        )
         .toPromise();
 
       raiden1.start();

--- a/raiden-ts/tests/unit/epics/raiden.spec.ts
+++ b/raiden-ts/tests/unit/epics/raiden.spec.ts
@@ -41,6 +41,16 @@ describe('raiden init epics', () => {
     const otherToken = makeAddress();
     const otherTokenNetwork = makeAddress();
 
+    // first, register some random tokenNetworks, so the later can be scanned
+    for (let i = 0; i < 5; i++) {
+      raiden.deps.provider.emit(
+        {},
+        makeLog({
+          blockNumber: 65 + i,
+          filter: registryContract.filters.TokenNetworkCreated(makeAddress(), makeAddress()),
+        }),
+      );
+    }
     // on registryContract's getLogs, return 2 registered tokenNetworks
     raiden.deps.provider.emit(
       {},

--- a/raiden-ts/tests/unit/epics/transport.spec.ts
+++ b/raiden-ts/tests/unit/epics/transport.spec.ts
@@ -226,6 +226,7 @@ describe('initMatrixEpic', () => {
     raiden.store.dispatch(raidenConfigUpdate({ matrixServer: '' }));
 
     await raiden.start();
+    await raiden.action$.toPromise();
 
     expect(raiden.started).toBeFalsy();
     expect(raiden.output).toContainEqual(
@@ -260,7 +261,7 @@ describe('initMatrixEpic', () => {
     // set fetch list from matrixServerLookup
     raiden.store.dispatch(raidenConfigUpdate({ matrixServer: '' }));
     await raiden.start();
-    await sleep();
+    await raiden.action$.toPromise();
 
     expect(raiden.started).toBeFalsy();
     expect(raiden.output).toContainEqual(

--- a/raiden-ts/tests/unit/fixtures.ts
+++ b/raiden-ts/tests/unit/fixtures.ts
@@ -98,6 +98,7 @@ export async function getOrWaitTransfer(
  * @param raiden - Client instance
  */
 export async function ensureTokenIsMonitored(raiden: MockedRaiden): Promise<void> {
+  await raiden.synced;
   if (token in raiden.store.getState().tokens) return;
   raiden.store.dispatch(tokenMonitored({ token, tokenNetwork }));
 }


### PR DESCRIPTION
Fixes #2566
Fixes #2569 

**Short description**
This PR optimizes some filters for first, initial and on-block syncs/events monitoring.
- `getLogsByChunk$` now can fetch events from arrays of `address`es, allowing a single request to be used to monitor multiple contracts at the same time
- The above is used in order to remove a long standing workaround in code: now, all TokenNetworks are scanned in search of channels with us, to decide on TNs "of interest" to be monitored
  - Besides this, we also always monitors the first 2 TNs found, in order to avoid this re-scan in cases no channels are found, e.g. on mainnet, which did slow down the non-first initial syncs in case no TN got monitored for that client.
- `fromEthersEvent` can now properly report when its first/past event scanning phase is completed, so we can better report it at `synced` promise and `deps.init$` subject
  - Also, it can take a `blockNumber$` observable to use, instead of listening `provider.on('block')`, which does start the block polling. This was done in order to delay this polling until `synced` on `initNewBlockEpic` and passing the `block/new` action-based observable whenever this function is used.
- On TokenNetwork scanning, we now rely on `fromEthersEvent` working properly, and resume `fromBlock` since latest seen block, which reduces by a lot the range of blocks on non-first initial syncs.
- `pfsList` is replaced by `servicesValid`, which is persisted on `state.services` and resumed properly on next initial sync, instead of scanning the whole deployment range again, which was one of the other bottlenecks on initial sync times.
  - a db migration is included to include this property on already initialized states
- waiting for `messageGlobalSend` responses on `init$`/`synced`, waits for init-time `PFSFeeUpdate` global messages to be sent before considering node `synced`
- **TODO on a follow up PR**: monitors all TNs by default using a single filter with all TN's addresses, possibly also using this same filter/request (once per block) to perform all events fetching on the LC, not only TN's. This will reduce as much as possible the number of requests per time-unit on the LC, which will optimize on Infura usecases. Possibly, we can do with a single getLogs request per block!

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Initialize a CLI & dApp client on a clean state, on testnet and mainnet, and notice the `raiden/synced`'s `payload.tookMs` value;
2. Restart it, and see this time drop to < 5s if there're channels; <1s if there's no channel (due to the global messages)
