### PR TITLE
Correcting the names of variables syncedTarget, syncedAmount

### DIFF
--- a/raiden-dapp/src/components/transfer/TransferInputs.vue
+++ b/raiden-dapp/src/components/transfer/TransferInputs.vue
@@ -6,7 +6,9 @@
       class="transfer-inputs__form"
       autocomplete="off"
       novalidate
-      @submit.prevent="navigateToTransferSteps(token.address, syncedTarget, syncedAmount)"
+      @submit.prevent="
+        navigateToTransferSteps(token.address, syncedTargetAddress, syncedTransferAmount)
+      "
     >
       <v-row no-gutters class="transfer-inputs__form__heading">
         <span class="transfer-inputs__form__heading--title">


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2587  

**Short description**
The `syncedTargetAddress` and the `syncedTransferAmount` props were wrongly named hence correcting them though it still gives an error for querying the PFS. I am investigating why it does that. So please consider this as still a work in progress.

Edit:
We will create a new issue for the PFS.
**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. yarn install
2. yarn workspace raiden-ts run build
3. yarn workspace raiden-dapp run serve

Please test this PR thoroughly