### PR TITLE
Fix SDK getLogs on geth

### DIFF
--- a/raiden-ts/src/utils/ethers.ts
+++ b/raiden-ts/src/utils/ethers.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { hexlify } from '@ethersproject/bytes';
+import { hexValue } from '@ethersproject/bytes';
 import type { Contract, Event } from '@ethersproject/contracts';
 import type {
   EventType,
@@ -66,8 +66,8 @@ export function getLogsByChunk$(
       provider.send('eth_getLogs', [
         {
           ...filter,
-          fromBlock: hexlify(start),
-          toBlock: hexlify(Math.min(start + curChunk - 1, toBlock)),
+          fromBlock: hexValue(start),
+          toBlock: hexValue(Math.min(start + curChunk - 1, toBlock)),
         },
       ]),
     ).pipe(


### PR DESCRIPTION
Fixes # 

**Short description**
Fix a small issue which prevented the SDK from talking with `geth` nodes validating `getLogs`'s `[from,to]Block` parameters didn't contain leading zeroes. The dApp still require some changes in order to properly get the nightlies green again.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
