### PR TITLE
Fix unlocking when receiving is disabled

### DIFF
--- a/raiden-dapp/src/utils/logstore.ts
+++ b/raiden-dapp/src/utils/logstore.ts
@@ -136,9 +136,9 @@ export async function setupLogStore(additionalLoggers: string[] = ['matrix']): P
 }
 
 const redactions: readonly [RegExp, string][] = [
-  [/("?access_?token"?\s*[=:]\s*)("?)\w+("?)/gi, '$1$2<redacted>$3'],
-  [/("?secret"?\s*[=:]\s*)\[[^\]]+\]/gi, '$1["<redacted>"]'],
-  [/("?secret"?\s*[=:]\s*)("?)\w+("?)/gi, '$1$2<redacted>$3'],
+  [/(\\?"?access_?token\\?"?\s*[=:]\s*)(\\?"?)[\w-]+(\\?"?)/gi, '$1$2<redacted>$3'],
+  [/(\\?"?secret\\?"?\s*[=:]\s*)\[[^\]]+\]/gi, '$1["<redacted>"]'],
+  [/(\\?"?secret\\?"?\s*[=:]\s*)(\\?"?)\w+(\\?"?)/gi, '$1$2<redacted>$3'],
 ];
 function redactLogs(text: string): string {
   for (const [re, repl] of redactions) text = text.replace(re, repl);

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -7,11 +7,14 @@
 
 ### Changed
 - [#2536] Wait for global messages before resolving deposits and channel open request
-- [#2550] **BREAKING** remove migration of legacy state at localStorage during creation
 - [#2566] Optimize initial sync and resume previous sync filters scans
 
 ### Removed
+- [#2550] **BREAKING** Remove migration of legacy state at localStorage during creation
 - [#2567] **BREAKING** Remove support for peer-to-peer communication through Matrix rooms; now supports only `toDevice` and WebRTC channels.
+
+### Fixed
+- [#2596] Fix unlocking sent transfers even if receiving is disabled
 
 [#1342]: https://github.com/raiden-network/light-client/issues/1342
 [#2536]: https://github.com/raiden-network/light-client/issues/2536
@@ -19,6 +22,7 @@
 [#2566]: https://github.com/raiden-network/light-client/issues/2566
 [#2567]: https://github.com/raiden-network/light-client/issues/2567
 [#2581]: https://github.com/raiden-network/light-client/pull/2581
+[#2596]: https://github.com/raiden-network/light-client/issues/2596
 
 ## [0.15.0] - 2021-01-26
 ### Added


### PR DESCRIPTION
Fixes #2596

**Short description**
A small bug prevented sender from handling `RevealSecret` messages in order to unlock in case it had receiving disabled for any reason (in the issue, it was due to the sender not having deposited to UDC), which was an unintended side-effect of skipping handling those messages if receiving was disabled on the receiver side to avoid receiver being forced to receive and unlock a transfer it didn't want. This fixes it by moving the check to after sender/unlock is handled. A regression test is included.
Additionally, on the above issue, it was noticed some dApp's logs redactions weren't redacting `message/received`/escaped secrets, so a small fix to the regex was also included (even though secrets are not sensible information, specially after they already expired).

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Try to send a message from a sender who has receiving disabled
2. Check it still gets properly unlocked
