### PR TITLE
dApp: fixes NoTokens component not being displayed

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- [#2606] Fixes NoTokens screen not being displayed
 - [#2420] Fix withdraw and deposit button for channels on mobile
 - [#2421] Fix account menu on mobile devices by making it scrollable
 - [#2422] Fix broken layout on RaidenAccount screen for mobile virtual keyboard
@@ -13,6 +14,7 @@
 
 - [#1515] Button for disconnecting the dApp
 
+[#2606]: https://github.com/raiden-network/light-client/issues/2606
 [#1515]: https://github.com/raiden-network/light-client/issues/1515
 [#2420]: https://github.com/raiden-network/light-client/issues/2420
 [#2421]: https://github.com/raiden-network/light-client/issues/2421

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -479,7 +479,7 @@
       "title": "Transfer"
     },
     "no-channels-dialog": {
-      "title": "No connected tokens and open channels",
+      "title": "No open channels for the selected token",
       "button": "Connect new token"
     },
     "steps": {

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -179,6 +179,15 @@ const store: StoreOptions<CombinedStoreState> = {
   },
   actions: {},
   getters: {
+    tokensWithChannels: function (state: RootState): Tokens {
+      const tokensWithChannels: Tokens = {};
+
+      for (const [address, token] of Object.entries(state.tokens)) {
+        if (!!state.channels[address]) tokensWithChannels[address] = token;
+      }
+
+      return tokensWithChannels;
+    },
     tokens: function (state: RootState): TokenModel[] {
       const reducer = (acc: AccTokenModel, channel: RaidenChannel): AccTokenModel => {
         acc.address = channel.token;

--- a/raiden-dapp/src/views/TransferRoute.vue
+++ b/raiden-dapp/src/views/TransferRoute.vue
@@ -54,12 +54,12 @@ const ONE_DAY = new Date(0).setUTCHours(24);
     NoChannelsDialog,
   },
   computed: {
-    ...mapState(['tokens', 'stateBackupReminderDateMs']),
-    ...mapGetters(['channels', 'channelWithBiggestCapacity', 'openChannels']),
+    ...mapState(['stateBackupReminderDateMs']),
+    ...mapGetters(['tokensWithChannels', 'channels', 'channelWithBiggestCapacity']),
   },
 })
 export default class TransferRoute extends Vue {
-  tokens!: Tokens;
+  tokensWithChannels!: Tokens;
   stateBackupReminderDateMs!: number;
   channels!: (tokenAddress: string) => RaidenChannel[];
   channelWithBiggestCapacity!: (tokenAddress: string) => RaidenChannel | undefined;
@@ -69,7 +69,7 @@ export default class TransferRoute extends Vue {
   targetAddress = '';
 
   get noTokens(): boolean {
-    return Object.keys(this.tokens).length === 0;
+    return Object.keys(this.tokensWithChannels).length === 0;
   }
 
   get noChannels(): boolean {
@@ -136,18 +136,18 @@ export default class TransferRoute extends Vue {
   }
 
   async getTokenFromStore(tokenAddress: string): Promise<Token> {
-    if (!(tokenAddress in this.tokens)) {
+    if (!(tokenAddress in this.tokensWithChannels)) {
       await this.$raiden.fetchAndUpdateTokenData([tokenAddress]);
     }
 
     // From the SDK implementation it should not be possible undefined here as
     // it should have thrown earier on the fetch procedure.
-    return this.tokens[tokenAddress];
+    return this.tokensWithChannels[tokenAddress];
   }
 
   selectFirstAvailableTokenIfAny(): void {
     if (!this.noTokens) {
-      this.token = Object.values(this.tokens)[0];
+      this.token = Object.values(this.tokensWithChannels)[0];
     }
   }
 

--- a/raiden-dapp/src/views/TransferRoute.vue
+++ b/raiden-dapp/src/views/TransferRoute.vue
@@ -55,7 +55,12 @@ const ONE_DAY = new Date(0).setUTCHours(24);
   },
   computed: {
     ...mapState(['stateBackupReminderDateMs']),
-    ...mapGetters(['tokensWithChannels', 'channels', 'channelWithBiggestCapacity']),
+    ...mapGetters([
+      'tokensWithChannels',
+      'channels',
+      'channelWithBiggestCapacity',
+      'openChannels',
+    ]),
   },
 })
 export default class TransferRoute extends Vue {

--- a/raiden-dapp/tests/unit/views/transfer-route.spec.ts
+++ b/raiden-dapp/tests/unit/views/transfer-route.spec.ts
@@ -51,11 +51,12 @@ async function createWrapper({
   channels = channels ?? { [firstToken.address]: [channel] };
 
   const state = {
-    tokens: tokens ?? { [firstToken.address]: firstToken, [otherToken.address]: otherToken },
     stateBackupReminderDateMs: stateBackupReminderDateMs ?? 0,
   };
 
   const getters = {
+    tokensWithChannels: () =>
+      tokens ?? { [firstToken.address]: firstToken, [otherToken.address]: otherToken },
     channels: () => (tokenAddress: string) => channels![tokenAddress] ?? [],
     // This simplified version that expects one open channel per token none
     channelWithBiggestCapacity: () => (tokenAddress: string) =>


### PR DESCRIPTION
Fixes #2606 

**Short description**
Fixes the bug where a user with no tokens got redirected to the Transfer screen instead of the "No Tokens" screen when connecting.

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to the dApp with an account where there are no connected tokens.
2. After connecting the "No Tokens" screen should be displayed.
