### PR TITLE
dApp: fixing back arrow not showing on account screen

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixed
 
-- [#2606] Fixes NoTokens screen not being displayed
+- [#2590] Fix back arrow not visible on account screen when disconnected
+- [#2606] Fix NoTokens screen not being displayed
 - [#2420] Fix withdraw and deposit button for channels on mobile
 - [#2421] Fix account menu on mobile devices by making it scrollable
 - [#2422] Fix broken layout on RaidenAccount screen for mobile virtual keyboard
@@ -14,6 +15,7 @@
 
 - [#1515] Button for disconnecting the dApp
 
+[#2590]: https://github.com/raiden-network/light-client/issues/2590
 [#2606]: https://github.com/raiden-network/light-client/issues/2606
 [#1515]: https://github.com/raiden-network/light-client/issues/1515
 [#2420]: https://github.com/raiden-network/light-client/issues/2420

--- a/raiden-dapp/src/components/HeaderContent.vue
+++ b/raiden-dapp/src/components/HeaderContent.vue
@@ -74,7 +74,7 @@ export default class HeaderContent extends Vue {
   }
 
   get canNavigateBack(): boolean {
-    return this.isConnected && !this.disableBackButton && !this.$route.meta.cannotNavigateBack;
+    return !this.disableBackButton && !this.$route.meta.cannotNavigateBack;
   }
 }
 </script>

--- a/raiden-dapp/tests/unit/components/header-content.spec.ts
+++ b/raiden-dapp/tests/unit/components/header-content.spec.ts
@@ -49,11 +49,6 @@ const createWrapper = (
 };
 
 describe('HeaderContent.vue', () => {
-  test('cannot navigate back if not connected', () => {
-    const wrapper = createWrapper(RouteNames.CHANNELS, false);
-    expect((wrapper.vm as any).canNavigateBack).toBe(false);
-  });
-
   test('cannot navigate back if back button is disabled', () => {
     const wrapper = createWrapper(RouteNames.CHANNELS, true, true, true);
     expect((wrapper.vm as any).canNavigateBack).toBe(false);


### PR DESCRIPTION
Fixes #2590 

**Short description**
This PR fixes the bug where the back arrow was not showing on the account screen when disconnected.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Serve the dApp and click to open the account screen without connecting first.
2. Should be able to navigate back to the connect screen.
