### PR TITLE
Send service messages toDevice and don't join global service rooms

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -8,10 +8,12 @@
 ### Changed
 - [#2536] Wait for global messages before resolving deposits and channel open request
 - [#2566] Optimize initial sync and resume previous sync filters scans
+- [#2572] **BREAKING** Send services messages through `toDevice` instead of global rooms
 
 ### Removed
 - [#2550] **BREAKING** Remove migration of legacy state at localStorage during creation
 - [#2567] **BREAKING** Remove support for peer-to-peer communication through Matrix rooms; now supports only `toDevice` and WebRTC channels.
+- [#2571] **BREAKING** Remove ability to join and send messages to global service rooms
 
 ### Fixed
 - [#2596] Fix unlocking sent transfers even if receiving is disabled
@@ -21,6 +23,8 @@
 [#2550]: https://github.com/raiden-network/light-client/issues/2550
 [#2566]: https://github.com/raiden-network/light-client/issues/2566
 [#2567]: https://github.com/raiden-network/light-client/issues/2567
+[#2571]: https://github.com/raiden-network/light-client/issues/2571
+[#2572]: https://github.com/raiden-network/light-client/issues/2572
 [#2581]: https://github.com/raiden-network/light-client/pull/2581
 [#2596]: https://github.com/raiden-network/light-client/issues/2596
 

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -30,9 +30,6 @@ const RTCIceServer = t.type({ urls: t.union([t.string, t.array(t.string)]) });
  *    transfer expiration block should be
  * - httpTimeout - Used in http fetch requests
  * - discoveryRoom - Discovery Room to auto-join, use null to disable
- * - pfsRoom - PFS Room to auto-join and send PFSCapacityUpdate to, use null to disable
- * - monitoringRoom - MS global room to auto-join and send RequestMonitoring messages;
- *    use null to disable
  * - pfs - Path Finding Service URL or Address. Set to null to disable, or empty string to enable
  *    automatic fetching from ServiceRegistry.
  * - pfsSafetyMargin - Safety margin to be added to fees received from PFS. Either a fee
@@ -68,8 +65,6 @@ export const RaidenConfig = t.readonly(
       expiryFactor: t.number, // must be > 1.0
       httpTimeout: t.number,
       discoveryRoom: t.union([t.string, t.null]),
-      pfsRoom: t.union([t.string, t.null]),
-      monitoringRoom: t.union([t.string, t.null]),
       pfs: t.union([Address, t.string, t.null]),
       pfsSafetyMargin: t.union([t.number, t.tuple([t.number, t.number])]),
       pfsMaxPaths: t.number,
@@ -144,8 +139,6 @@ export function makeDefaultConfig(
     expiryFactor: 1.1, // must be > 1.0
     httpTimeout: 30e3,
     discoveryRoom: `raiden_${networkName}_discovery`,
-    pfsRoom: `raiden_${networkName}_path_finding`,
-    monitoringRoom: `raiden_${networkName}_monitoring`,
     pfs: '', // empty string = auto mode
     pfsSafetyMargin: 1.0, // multiplier
     pfsMaxPaths: 3,

--- a/raiden-ts/src/transport/epics/helpers.ts
+++ b/raiden-ts/src/transport/epics/helpers.ts
@@ -19,7 +19,7 @@ import { isntNil } from '../../utils/types';
  * @returns Array of room names
  */
 export function globalRoomNames(config: RaidenConfig) {
-  return [config.discoveryRoom, config.pfsRoom, config.monitoringRoom].filter(isntNil);
+  return [config.discoveryRoom].filter(isntNil);
 }
 
 /**

--- a/raiden-ts/src/transport/epics/messages.ts
+++ b/raiden-ts/src/transport/epics/messages.ts
@@ -1,4 +1,5 @@
-import type { MatrixClient, MatrixEvent } from 'matrix-js-sdk';
+import isEmpty from 'lodash/isEmpty';
+import type { MatrixEvent } from 'matrix-js-sdk';
 import type { Observable } from 'rxjs';
 import {
   asapScheduler,
@@ -15,9 +16,11 @@ import {
 import {
   catchError,
   concatMap,
+  delayWhen,
+  endWith,
   filter,
   first,
-  groupBy,
+  ignoreElements,
   map,
   mapTo,
   mergeMap,
@@ -30,25 +33,24 @@ import {
 } from 'rxjs/operators';
 
 import type { RaidenAction } from '../../actions';
-import type { RaidenConfig } from '../../config';
 import { intervalFromConfig } from '../../config';
 import { Capabilities, RAIDEN_DEVICE_ID } from '../../constants';
 import { messageReceived, messageSend, messageServiceSend } from '../../messages/actions';
 import type { Delivered, Message } from '../../messages/types';
 import { MessageType, Processed, SecretRequest, SecretReveal } from '../../messages/types';
 import { encodeJsonMessage, isMessageReceivedOfType, signMessage } from '../../messages/utils';
-import { Service } from '../../services/types';
+import { ServiceDeviceId } from '../../services/types';
 import type { RaidenState } from '../../state';
 import type { Latest, RaidenEpicDeps } from '../../types';
 import { isActionOf } from '../../utils/actions';
 import { assert, networkErrors } from '../../utils/error';
 import { LruCache } from '../../utils/lru';
 import { getServerName } from '../../utils/matrix';
-import { completeWith, concatBuffer, mergeWith, retryWhile } from '../../utils/rx';
+import { completeWith, mergeWith, retryWhile } from '../../utils/rx';
 import { Signed } from '../../utils/types';
 import type { Presences } from '../types';
 import { getCap, getPresenceByUserId } from '../utils';
-import { getRoom$, globalRoomNames, parseMessage } from './helpers';
+import { parseMessage } from './helpers';
 
 function getMessageBody(message: string | Signed<Message>): string {
   return typeof message === 'string' ? message : encodeJsonMessage(message);
@@ -231,76 +233,60 @@ export function matrixMessageSendEpic(
   return merge(sendToRtc$, sendToDevice$);
 }
 
-function sendGlobalMessages(
-  actions: readonly messageServiceSend.request[],
-  matrix: MatrixClient,
-  config: RaidenConfig,
-  { config$ }: Pick<RaidenEpicDeps, 'config$'>,
-): Observable<messageServiceSend.success['payload']> {
-  const servicesToRoomName = {
-    [Service.PFS]: config.pfsRoom,
-    [Service.MS]: config.monitoringRoom,
-  };
-  const roomName = servicesToRoomName[actions[0].meta.service];
-  const globalRooms = globalRoomNames(config);
-  assert(roomName && globalRooms.includes(roomName), [
-    'messageServiceSend for unknown global room',
-    { roomName, globalRooms: globalRooms.join(',') },
-  ]);
-  const serverName = getServerName(matrix.getHomeserverUrl());
-  const roomAlias = `#${roomName}:${serverName}`;
-  // batch action messages in a single text body
-  const body = actions.map((action) => getMessageBody(action.payload.message)).join('\n');
-  const start = Date.now();
-  let retries = -1;
-  return getRoom$(matrix, roomAlias).pipe(
-    // send message!
-    mergeMap(async (room) => {
-      retries++;
-      await matrix.sendEvent(room.roomId, 'm.room.message', { body, msgtype: textMsgType }, '');
-      return { via: room.roomId, tookMs: Date.now() - start, retries };
+function sendServiceMessage(
+  request: messageServiceSend.request,
+  { matrix$, config$, latest$ }: Pick<RaidenEpicDeps, 'matrix$' | 'config$' | 'latest$'>,
+) {
+  return matrix$.pipe(
+    withLatestFrom(latest$),
+    mergeMap(([matrix, { state }]) => {
+      assert(!isEmpty(state.services), 'no services to messageServiceSend to');
+      const serverName = getServerName(matrix.getHomeserverUrl());
+      const userIds = Object.keys(state.services).map(
+        (service) => `@${service.toLowerCase()}:${serverName}`,
+      );
+      // batch action messages in a single text body
+      const content = {
+        msgtype: 'm.text',
+        body: getMessageBody(request.payload.message),
+      };
+      const payload = Object.fromEntries(
+        userIds.map((uid) => [uid, { [ServiceDeviceId[request.meta.service]]: content }]),
+      );
+      const start = Date.now();
+      let retries = -1;
+      return defer(async () => {
+        retries++;
+        await matrix.sendToDevice('m.room.message', payload); // send message!
+        return messageServiceSend.success(
+          { via: userIds, tookMs: Date.now() - start, retries },
+          request.meta,
+        );
+      }).pipe(retryWhile(intervalFromConfig(config$), { maxRetries: 3, onErrors: networkErrors }));
     }),
-    retryWhile(intervalFromConfig(config$), { maxRetries: 3, onErrors: networkErrors }),
+    catchError((err) => of(messageServiceSend.failure(err, request.meta))),
   );
 }
 
 /**
- * Handles a [[messageServiceSend.request]] action and send one-shot message to a global room
+ * Handles a [[messageServiceSend.request]] action and send one-shot message to a service
  *
  * @param action$ - Observable of messageServiceSend actions
  * @param state$ - Observable of RaidenStates
- * @param deps - RaidenEpicDeps members
- * @param deps.log - Logger instance
- * @param deps.matrix$ - MatrixClient async subject
- * @param deps.config$ - Config observable
- * @returns Empty observable (whole side-effect on matrix instance)
+ * @param deps - Epics dependencies
+ * @returns Observable of messageServiceSend.success|failure actions
  */
-export function matrixMessageGlobalSendEpic(
+export function matrixMessageServiceSendEpic(
   action$: Observable<RaidenAction>,
   {}: Observable<RaidenState>,
   deps: RaidenEpicDeps,
 ): Observable<messageServiceSend.success | messageServiceSend.failure> {
-  const { matrix$, config$ } = deps;
   return action$.pipe(
     filter(isActionOf(messageServiceSend.request)),
-    groupBy((action) => action.meta.service),
-    mergeMap((grouped$) =>
-      grouped$.pipe(
-        concatBuffer((actions) => {
-          return matrix$.pipe(
-            withLatestFrom(config$),
-            mergeMap(([matrix, config]) => sendGlobalMessages(actions, matrix, config, deps)),
-            mergeMap((payload) =>
-              from(actions.map((action) => messageServiceSend.success(payload, action.meta))),
-            ),
-            catchError((err) =>
-              from(actions.map((action) => messageServiceSend.failure(err, action.meta))),
-            ),
-            completeWith(action$, 10),
-          );
-        }, 20),
-      ),
-    ),
+    // wait until init$ is completed before handling requests, so state.services is populated
+    delayWhen(() => deps.init$.pipe(ignoreElements(), endWith(true))),
+    mergeMap((request) => sendServiceMessage(request, deps), 5),
+    completeWith(action$, 10),
   );
 }
 

--- a/raiden-ts/tests/integration/mocks.ts
+++ b/raiden-ts/tests/integration/mocks.ts
@@ -86,6 +86,7 @@ export class MockMatrixRequestFn {
     this.endpoints['/send/m.room.message'] = ({}, callback) =>
       this.respond(callback, 200, { event_id: `$eventId_${Date.now()}` });
     this.endpoints['/invite'] = ({}, callback) => this.respond(callback, 200, {});
+    this.endpoints['/sendToDevice'] = ({}, callback) => this.respond(callback, 200, {});
   }
 
   public requestFn(opts: RequestOpts, callback: RequestCallback): any {

--- a/raiden-ts/tests/integration/raiden.spec.ts
+++ b/raiden-ts/tests/integration/raiden.spec.ts
@@ -396,7 +396,6 @@ describe('Raiden', () => {
     expect.assertions(3);
     expect(raiden.config).toMatchObject({
       discoveryRoom: 'raiden_1338_discovery',
-      pfsRoom: 'raiden_1338_path_finding',
       settleTimeout: 20,
       revealTimeout: 5,
     });


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2571 
Fixes #2572 

**Short description**
Sends service messages to service users in the same federated server (since they're expected to have clients listening on every transport server in the federation), instead of a global room. Therefore, joining such rooms isn't needed anymore.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. SP pass again
2.
