### PR TITLE
Support multiple custom services addresses

### DIFF
--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Changed
+- [#2570] Support list of additional services URLs to be passed to `--pathfindingServiceAddress`
 - [#2581] CLI now defaults to `3% * fee + 0.05% * amount` for fee safety margin, same as PC
 
 ### Added

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -7,7 +7,7 @@ import type Router from 'vue-router';
 import type { Store } from 'vuex';
 
 import type { ChangeEvent, RaidenPaths, RaidenPFS } from 'raiden-ts';
-import { Capabilities, ErrorCodes, EventTypes, Raiden, RaidenError } from 'raiden-ts';
+import { Capabilities, ErrorCodes, EventTypes, PfsMode, Raiden, RaidenError } from 'raiden-ts';
 
 import i18n from '@/i18n';
 import type { Progress, Token } from '@/model/types';
@@ -60,7 +60,9 @@ export default class RaidenService {
         contracts,
         {
           pfsSafetyMargin: 1.1,
-          pfs: process.env.VUE_APP_PFS,
+          ...(process.env.VUE_APP_PFS
+            ? { pfsMode: PfsMode.onlyAdditional, additionalServices: [process.env.VUE_APP_PFS] }
+            : {}),
           matrixServer: process.env.VUE_APP_MATRIX_SERVER,
           matrixServerLookup: process.env.VUE_APP_MATRIX_LIST_URL,
           ...(process.env.VUE_APP_REVEAL_TIMEOUT && +process.env.VUE_APP_REVEAL_TIMEOUT

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - [#2536] Wait for global messages before resolving deposits and channel open request
 - [#2566] Optimize initial sync and resume previous sync filters scans
+- [#2570] Support multiple custom services in config.pfs
 
 ### Removed
 - [#2550] **BREAKING** Remove migration of legacy state at localStorage during creation
@@ -21,6 +22,7 @@
 [#2550]: https://github.com/raiden-network/light-client/issues/2550
 [#2566]: https://github.com/raiden-network/light-client/issues/2566
 [#2567]: https://github.com/raiden-network/light-client/issues/2567
+[#2570]: https://github.com/raiden-network/light-client/issues/2570
 [#2581]: https://github.com/raiden-network/light-client/pull/2581
 [#2596]: https://github.com/raiden-network/light-client/issues/2596
 

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -33,8 +33,8 @@ const RTCIceServer = t.type({ urls: t.union([t.string, t.array(t.string)]) });
  * - pfsRoom - PFS Room to auto-join and send PFSCapacityUpdate to, use null to disable
  * - monitoringRoom - MS global room to auto-join and send RequestMonitoring messages;
  *    use null to disable
- * - pfs - Path Finding Service URL or Address. Set to null to disable, or empty string to enable
- *    automatic fetching from ServiceRegistry.
+ * - pfs - Array of Path Finding Service Addresses (require PFS to be registered) or URLs.
+ *    Set to false to disable, or true to enable automatic fetching from ServiceRegistry.
  * - pfsSafetyMargin - Safety margin to be added to fees received from PFS. Either a fee
  *    multiplier, or a [fee, amount] pair ofmultipliers. Use `1.1` to add a 10% over estimated fee
  *    margin, or `[0.03, 0.0005]` to add a 3% over fee plus 0.05% over amount.
@@ -70,7 +70,7 @@ export const RaidenConfig = t.readonly(
       discoveryRoom: t.union([t.string, t.null]),
       pfsRoom: t.union([t.string, t.null]),
       monitoringRoom: t.union([t.string, t.null]),
-      pfs: t.union([Address, t.string, t.null]),
+      pfs: t.union([t.readonlyArray(t.union([Address, t.string])), t.boolean]),
       pfsSafetyMargin: t.union([t.number, t.tuple([t.number, t.number])]),
       pfsMaxPaths: t.number,
       pfsMaxFee: UInt(32),
@@ -146,7 +146,7 @@ export function makeDefaultConfig(
     discoveryRoom: `raiden_${networkName}_discovery`,
     pfsRoom: `raiden_${networkName}_path_finding`,
     monitoringRoom: `raiden_${networkName}_monitoring`,
-    pfs: '', // empty string = auto mode
+    pfs: true, // true = auto mode
     pfsSafetyMargin: 1.0, // multiplier
     pfsMaxPaths: 3,
     pfsMaxFee: parseEther('0.05') as UInt<32>, // in SVT/RDN, 18 decimals

--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -571,7 +571,7 @@ export async function waitForPFSCapacityUpdate(
   state$: Observable<RaidenState>,
   { meta, config }: { meta: channelDeposit.request['meta']; config: RaidenConfig },
 ) {
-  if (config.pfs === null) return;
+  if (!config.pfs) return;
   const postMeta: messageServiceSend.request['meta'] = { service: Service.PFS, msgId: '' };
   let deposited = false;
   return asyncActionToPromise(

--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -50,7 +50,7 @@ import mainnetServicesDeploy from './deployment/deployment_services_mainnet.json
 import rinkebyServicesDeploy from './deployment/deployment_services_rinkeby.json';
 import ropstenServicesDeploy from './deployment/deployment_services_ropsten.json';
 import { messageServiceSend } from './messages/actions';
-import { Service } from './services/types';
+import { PfsMode, Service } from './services/types';
 import { makeInitialState, RaidenState } from './state';
 import type { RaidenTransfer } from './transfers/state';
 import { Direction, TransferState } from './transfers/state';
@@ -556,7 +556,7 @@ export async function waitForPFSCapacityUpdate(
   state$: Observable<RaidenState>,
   { meta, config }: { meta: channelDeposit.request['meta']; config: RaidenConfig },
 ) {
-  if (!config.pfs) return;
+  if (config.pfsMode === PfsMode.disabled) return;
   const postMeta: messageServiceSend.request['meta'] = { service: Service.PFS, msgId: '' };
   let deposited = false;
   return asyncActionToPromise(

--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -379,21 +379,6 @@ export async function waitConfirmation(
     .toPromise();
 }
 
-/*
- * Returns true if `url` is a valid URL or domain.
- * On production `https://` is required for URLs, otherwise `http://` matches as well.
- *
- * @param url - A URL or hostname
- * @returns true if valid URL or domain
- */
-export const isValidUrl = (url: string): boolean => {
-  const regex =
-    process.env.NODE_ENV === 'production'
-      ? /^(?:https:\/\/)?[^\s\/$.?#&"']+\.[^\s\/$?#&"']+$/
-      : /^(?:(http|https):\/\/)?([^\s\/$.?#&"']+\.)*[^\s\/$?#&"']+(?:(\d+))*$/;
-  return regex.test(url);
-};
-
 /**
  * Construct entire ContractsInfo using UserDeposit contract address as entrypoint
  *

--- a/raiden-ts/src/index.ts
+++ b/raiden-ts/src/index.ts
@@ -6,7 +6,7 @@ export { RaidenAction, RaidenEvent } from './actions';
 export { ChannelState, RaidenChannel, RaidenChannels } from './channels/state';
 export { RaidenConfig } from './config';
 export * from './constants';
-export { RaidenPaths, RaidenPFS } from './services/types';
+export { PfsMode, RaidenPaths, RaidenPFS } from './services/types';
 export { RaidenState } from './state';
 export { RaidenTransfer, RaidenTransferStatus } from './transfers/state';
 export * from './types';

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -1166,10 +1166,10 @@ export class Raiden {
    * @returns Promise to array of PFS, which is the interface which describes a PFS
    */
   public async findPFS(): Promise<PFS[]> {
-    assert(this.config.pfs !== null, ErrorCodes.PFS_DISABLED, this.log.info);
+    assert(this.config.pfs !== false, ErrorCodes.PFS_DISABLED, this.log.info);
     await this.synced;
-    return (this.config.pfs
-      ? of<readonly (string | Address)[]>([this.config.pfs])
+    return (this.config.pfs !== true
+      ? of(this.config.pfs)
       : of<readonly Address[]>(Object.keys(this.state.services) as Address[])
     )
       .pipe(mergeMap((service) => pfsListInfo(service, this.deps)))

--- a/raiden-ts/src/services/types.ts
+++ b/raiden-ts/src/services/types.ts
@@ -17,6 +17,14 @@ export const ServiceDeviceId: { readonly [K in Service]: string } = {
   [Service.MS]: 'MONITORING',
 };
 
+export const PfsMode = {
+  disabled: 'disabled',
+  auto: 'auto',
+  onlyAdditional: 'onlyAdditional',
+} as const;
+export type PfsMode = typeof PfsMode[keyof typeof PfsMode];
+export const PfsModeC = t.keyof(invert(PfsMode) as { [D in PfsMode]: string });
+
 /**
  * Codec for PFS API returned data
  */

--- a/raiden-ts/src/services/utils.ts
+++ b/raiden-ts/src/services/utils.ts
@@ -2,23 +2,23 @@ import type { Signer } from '@ethersproject/abstract-signer';
 import { concat as concatBytes } from '@ethersproject/bytes';
 import * as t from 'io-ts';
 import memoize from 'lodash/memoize';
+import uniqBy from 'lodash/uniqBy';
 import type { Observable } from 'rxjs';
-import { EMPTY, from, of } from 'rxjs';
-import { fromFetch } from 'rxjs/fetch';
-import { catchError, map, mergeMap, timeout, toArray, withLatestFrom } from 'rxjs/operators';
+import { defer, EMPTY, from } from 'rxjs';
+import { catchError, first, map, mergeMap, toArray } from 'rxjs/operators';
 
 import { ChannelState } from '../channels/state';
 import { channelAmounts, channelKey } from '../channels/utils';
 import { Capabilities } from '../constants';
 import type { ServiceRegistry } from '../contracts';
-import { isValidUrl } from '../helpers';
 import { MessageTypeId } from '../messages/utils';
 import type { RaidenState } from '../state';
 import type { Presences } from '../transport/types';
 import { getCap } from '../transport/utils';
 import type { RaidenEpicDeps } from '../types';
 import { encode, jsonParse } from '../utils/data';
-import { assert, ErrorCodes, networkErrors, RaidenError } from '../utils/error';
+import { assert, ErrorCodes, networkErrors } from '../utils/error';
+import { LruCache } from '../utils/lru';
 import { retryAsync$ } from '../utils/rx';
 import type { Signature, Signed } from '../utils/types';
 import { Address, decode, UInt } from '../utils/types';
@@ -64,8 +64,25 @@ const serviceRegistryToken = memoize(
     }).toPromise() as Promise<Address>,
 );
 
+const urlRegex =
+  process.env.NODE_ENV === 'production'
+    ? /^(?:https:\/\/)?[^\s\/$.?#&"']+\.[^\s\/$?#&"']+$/
+    : /^(?:(http|https):\/\/)?([^\s\/$.?#&"']+\.)*[^\s\/$?#&"']+(?:(\d+))*$/;
+
+function validatePfsUrl(url: string) {
+  assert(url, ErrorCodes.PFS_EMPTY_URL);
+  assert(urlRegex.test(url), [ErrorCodes.PFS_INVALID_URL, { url }]);
+  // default to https for schema-less urls
+  if (!url.match(/^https?:\/\//)) url = `https://${url}`;
+  return url;
+}
+
+const pfsAddressCache_ = new LruCache<string, Promise<Address>>(32);
+
 /**
  * Returns a cold observable which fetch PFS info & validate for a given server address or URL
+ *
+ * This is a memoized function which caches by url or address, network and registry used.
  *
  * @param pfsAddrOrUrl - PFS account/address or URL
  * @param deps - RaidenEpicDeps needed for various parameters
@@ -74,12 +91,13 @@ const serviceRegistryToken = memoize(
  * @param deps.contractsInfo - ContractsInfo mapping
  * @param deps.config$ - Config observable
  * @param deps.provider - Eth provider
- * @returns Observable containing PFS server info
+ * @returns Promise containing PFS server info
  */
-export function pfsInfo(
+export async function pfsInfo(
   pfsAddrOrUrl: Address | string,
   { serviceRegistryContract, network, contractsInfo, provider, config$ }: RaidenEpicDeps,
-): Observable<PFS> {
+): Promise<PFS> {
+  const { pfsMaxFee } = await config$.pipe(first()).toPromise();
   /**
    * Codec for PFS /api/v1/info result schema
    */
@@ -95,49 +113,55 @@ export function pfsInfo(
     price_info: UInt(32),
     version: t.string,
   });
-  // if it's an address, fetch url from ServiceRegistry, else it's already the URL
-  const url$ = Address.is(pfsAddrOrUrl)
-    ? retryAsync$(
-        () => serviceRegistryContract.callStatic.urls(pfsAddrOrUrl),
-        provider.pollingInterval,
-        { onErrors: networkErrors },
-      )
-    : of(pfsAddrOrUrl);
-  return url$.pipe(
-    withLatestFrom(config$),
-    mergeMap(([url, { httpTimeout, pfsMaxFee }]) => {
-      if (!url) throw new RaidenError(ErrorCodes.PFS_EMPTY_URL);
-      else if (!isValidUrl(url)) throw new RaidenError(ErrorCodes.PFS_INVALID_URL, { url });
-      // default to https for domain-only urls
-      else if (!url.startsWith('https://') && !url.startsWith('http://')) url = `https://${url}`;
 
-      const start = Date.now();
-      return fromFetch(url + '/api/v1/info').pipe(
-        timeout(httpTimeout),
-        mergeMap(
-          async (res) =>
-            [
-              decode(PathInfo, jsonParse(await res.text())),
-              await serviceRegistryToken(serviceRegistryContract, provider.pollingInterval),
-            ] as const,
-        ),
-        map(([info, token]) => {
-          assert(info.price_info.lte(pfsMaxFee), [
-            ErrorCodes.PFS_TOO_EXPENSIVE,
-            { price: info.price_info.toString() },
-          ]);
-          return {
-            address: info.payment_address,
-            url,
-            rtt: Date.now() - start,
-            price: info.price_info,
-            token,
-          };
-        }),
-      );
-    }),
-  );
+  // if it's an address, fetch url from ServiceRegistry, else it's already the URL
+  let url = pfsAddrOrUrl;
+  if (Address.is(pfsAddrOrUrl)) url = await serviceRegistryContract.callStatic.urls(pfsAddrOrUrl);
+
+  url = validatePfsUrl(url);
+  const start = Date.now();
+  const res = await fetch(url + '/api/v1/info', { mode: 'cors' });
+  const text = await res.text();
+  assert(res.ok, [ErrorCodes.PFS_ERROR_RESPONSE, { text }]);
+  const info = decode(PathInfo, jsonParse(text));
+
+  assert(info.price_info.lte(pfsMaxFee), [
+    ErrorCodes.PFS_TOO_EXPENSIVE,
+    { price: info.price_info.toString() },
+  ]);
+  pfsAddressCache_.set(url, Promise.resolve(info.payment_address));
+
+  return {
+    address: info.payment_address,
+    url,
+    rtt: Date.now() - start,
+    price: info.price_info,
+    token: await serviceRegistryToken(serviceRegistryContract, provider.pollingInterval),
+  };
 }
+
+/**
+ * Returns the address for the PFS/service with the given URL.
+ * Result is cached and this cache is shared with [[pfsInfo]] calls.
+ *
+ * @param url - Url of the PFS to retrieve address for
+ * @param deps - Epics dependencies (for pfsInfo)
+ * @returns Promise to Address of PFS on given URL
+ */
+export const pfsInfoAddress = Object.assign(
+  async function pfsInfoAddress(url: string, deps: RaidenEpicDeps): Promise<Address> {
+    url = validatePfsUrl(url);
+    let addrPromise = pfsAddressCache_.get(url);
+    if (!addrPromise) {
+      // since the url is already validated, this will always set the cache, even if to the promise
+      // which will be rejected on '/info' request/validation
+      addrPromise = pfsInfo(url, deps).then(({ address }) => address);
+      pfsAddressCache_.set(url, addrPromise);
+    }
+    return addrPromise;
+  },
+  { cache: pfsAddressCache_ },
+);
 
 /**
  * Retrieve pfsInfo for these servers & return sorted PFS info
@@ -156,20 +180,18 @@ export function pfsListInfo(
 ): Observable<PFS[]> {
   const { log } = deps;
   return from(pfsList).pipe(
-    mergeMap(
-      (addrOrUrl) =>
-        pfsInfo(addrOrUrl, deps).pipe(
-          catchError((err) => {
-            log.warn(`Error trying to fetch PFS info for "${addrOrUrl}" - ignoring:`, err);
-            return EMPTY;
-          }),
-        ),
-      5, // maximum concurrency
-    ),
+    mergeMap(function (addrOrUrl) {
+      return defer(async () => pfsInfo(addrOrUrl, deps)).pipe(
+        catchError((err) => {
+          log.warn(`Error trying to fetch PFS info for "${addrOrUrl}" - ignoring:`, err);
+          return EMPTY;
+        }),
+      );
+    }, 5),
     toArray(),
     map((list) => {
-      if (!list.length) throw new RaidenError(ErrorCodes.PFS_INVALID_INFO);
-      return list.sort((a, b) => {
+      assert(list.length || !pfsList.length, ErrorCodes.PFS_INVALID_INFO);
+      return uniqBy(list, 'url').sort((a, b) => {
         const dif = a.price.sub(b.price);
         // first, sort by price
         if (dif.lt(0)) return -1;

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -1048,7 +1048,7 @@ function receiveWithdrawExpired(
           message_identifier: expired.message_identifier,
         };
         processed$ = from(signMessage(signer, processed, { log })).pipe(
-          tap((signed) => cache.put(cacheKey, signed)),
+          tap((signed) => cache.set(cacheKey, signed)),
         );
       }
 

--- a/raiden-ts/src/transfers/epics/withdraw.ts
+++ b/raiden-ts/src/transfers/epics/withdraw.ts
@@ -273,7 +273,7 @@ export function withdrawMessageProcessedEpic(
               message_identifier: message.message_identifier,
             };
             processed$ = from(signMessage(signer, processed, { log })).pipe(
-              tap((signed) => cache.put(cacheKey, signed)),
+              tap((signed) => cache.set(cacheKey, signed)),
             );
           }
 

--- a/raiden-ts/src/transport/epics/init.ts
+++ b/raiden-ts/src/transport/epics/init.ts
@@ -48,7 +48,7 @@ import { globalRoomNames } from './helpers';
 /**
  * Joins the global broadcast rooms and returns the room ids.
  *
- * @param config - The {@link RaidenConfig} provides the broadcast room aliases for pfs and discovery.
+ * @param config - The {@link RaidenConfig} provides the global room aliases.
  * @param matrix - The {@link MatrixClient} instance used to create the filter.
  * @returns Observable of the list of room ids for the the broadcast rooms.
  */

--- a/raiden-ts/src/transport/epics/messages.ts
+++ b/raiden-ts/src/transport/epics/messages.ts
@@ -411,7 +411,7 @@ export function deliveredEpic(
         };
         log.info(`Signing "${delivered.type}" for "${message.type}" with id=${msgId.toString()}`);
         return from(signMessage(signer, delivered, { log })).pipe(
-          tap((signed) => cache.put(key, signed)),
+          tap((signed) => cache.set(key, signed)),
           map((signed) =>
             messageSend.request({ message: signed }, { address: action.meta.address, msgId: key }),
           ),

--- a/raiden-ts/src/utils/lru.ts
+++ b/raiden-ts/src/utils/lru.ts
@@ -3,30 +3,30 @@
  *
  * @param max - Maximum size of cache
  */
-export class LruCache<K, V> {
-  public values: Map<K, V> = new Map<K, V>();
-  public max: number;
-
-  public constructor(max: number) {
-    this.max = max;
+export class LruCache<K, V> extends Map<K, V> {
+  constructor(public max: number) {
+    super();
   }
 
-  public get(key: K): V | undefined {
-    const entry = this.values.get(key);
-    if (entry) {
+  get(key: K): V | undefined {
+    let value;
+    if (this.has(key)) {
       // peek the entry, re-insert for LRU strategy
-      this.values.delete(key);
-      this.values.set(key, entry);
+      value = super.get(key) as V;
+      this.delete(key);
+      super.set(key, value);
     }
-    return entry;
+    return value;
   }
 
-  public put(key: K, value: V) {
-    if (this.values.size >= this.max) {
+  set(key: K, value: V) {
+    this.get(key); // bump key on set if exists
+    super.set(key, value);
+    while (this.size > this.max) {
       // least-recently used cache eviction strategy
-      const keyToDelete = this.values.keys().next().value;
-      this.values.delete(keyToDelete);
+      const keyToDelete = this.keys().next().value;
+      this.delete(keyToDelete);
     }
-    this.values.set(key, value);
+    return this;
   }
 }

--- a/raiden-ts/tests/e2e/e2e.spec.ts
+++ b/raiden-ts/tests/e2e/e2e.spec.ts
@@ -6,6 +6,7 @@ import { promises as fs } from 'fs';
 
 import { Raiden } from '@/raiden';
 import type { RaidenPaths } from '@/services/types';
+import { PfsMode } from '@/services/types';
 import type { ContractsInfo } from '@/types';
 import { assert } from '@/utils';
 
@@ -46,7 +47,8 @@ async function createRaiden(account: number | string | Signer): Promise<Raiden> 
     { adapter: 'memory' },
     contractsInfo,
     {
-      pfs: 'http://localhost:5555',
+      additionalServices: ['http://localhost:5555'],
+      pfsMode: PfsMode.onlyAdditional,
       matrixServer: 'http://localhost',
       revealTimeout: 20,
       settleTimeout: 50,

--- a/raiden-ts/tests/unit/epics/path.spec.ts
+++ b/raiden-ts/tests/unit/epics/path.spec.ts
@@ -354,7 +354,7 @@ describe('PFS: pathFindServiceEpic', () => {
     // original test(old pattern) fails ;)
     expect.assertions(1);
 
-    const pfsUrl = raiden.config.pfs!;
+    const pfsUrl = (raiden.config.pfs as string[])[0]!;
     const pathFindMeta = {
       tokenNetwork,
       target: target.address,
@@ -430,7 +430,7 @@ describe('PFS: pathFindServiceEpic', () => {
 
     // put config.pfs into auto mode
     const pfsSafetyMargin = 2;
-    raiden.store.dispatch(raidenConfigUpdate({ pfs: '' }));
+    raiden.store.dispatch(raidenConfigUpdate({ pfs: true }));
 
     // pfsAddress1 will be accepted with default https:// schema
     raiden.deps.serviceRegistryContract.urls.mockResolvedValueOnce('domain.only.url');
@@ -532,7 +532,7 @@ describe('PFS: pathFindServiceEpic', () => {
     expect.assertions(1);
 
     // put config.pfs into auto mode
-    raiden.store.dispatch(raidenConfigUpdate({ pfs: '' }));
+    raiden.store.dispatch(raidenConfigUpdate({ pfs: true }));
 
     // invalid url
     raiden.deps.serviceRegistryContract.urls.mockResolvedValueOnce('""');
@@ -986,8 +986,8 @@ describe('PFS: pathFindServiceEpic', () => {
     expect.assertions(2);
 
     // disable pfs
-    raiden.store.dispatch(raidenConfigUpdate({ pfs: null }));
-    expect(raiden.config.pfs).toBeNull();
+    raiden.store.dispatch(raidenConfigUpdate({ pfs: false }));
+    expect(raiden.config.pfs).toBe(false);
 
     const pathFindMeta = {
       tokenNetwork,
@@ -1155,7 +1155,7 @@ describe('PFS: pfsServiceRegistryMonitorEpic', () => {
     const { serviceRegistryContract } = raiden.deps;
 
     // enable config.pfs auto ('')
-    raiden.store.dispatch(raidenConfigUpdate({ pfs: '' }));
+    raiden.store.dispatch(raidenConfigUpdate({ pfs: true }));
     await raiden.start();
 
     const validTill = BigNumber.from(Math.floor(Date.now() / 1000) + 86400), // tomorrow

--- a/raiden-ts/tests/unit/helpers.spec.ts
+++ b/raiden-ts/tests/unit/helpers.spec.ts
@@ -3,7 +3,7 @@ import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
 import { toUtf8String } from '@ethersproject/strings';
 import { Wallet } from '@ethersproject/wallet';
 
-import { getContracts, getSigner, isValidUrl } from '@/helpers';
+import { getContracts, getSigner } from '@/helpers';
 import Raiden from '@/raiden';
 import type { Address } from '@/utils/types';
 
@@ -127,13 +127,4 @@ describe('Raiden Versions', () => {
   test('Returns raiden contract version', () => {
     expect(Raiden.contractVersion).toMatch(someVersion);
   });
-});
-
-test('accept PFS http addresses on non-production environments', () => {
-  const nodeEnv = process.env.NODE_ENV;
-  const httpUrl = 'http://pfs.dev';
-  expect(isValidUrl(httpUrl)).toBe(true);
-  process.env.NODE_ENV = 'production';
-  expect(isValidUrl(httpUrl)).toBe(false);
-  process.env.NODE_ENV = nodeEnv;
 });

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -877,7 +877,7 @@ export async function makeRaiden(
       // matrixServerLookup: 'https://matrixLookup.raiden.test',
       matrixServer: 'https://matrix.raiden.test',
       pfsSafetyMargin: 1.1,
-      pfs: 'pfs.raiden.test',
+      pfs: ['pfs.raiden.test'],
       pollingInterval,
       httpTimeout: 300,
       settleTimeout: 60,

--- a/raiden-ts/tests/unit/mocks.ts
+++ b/raiden-ts/tests/unit/mocks.ts
@@ -877,7 +877,7 @@ export async function makeRaiden(
       // matrixServerLookup: 'https://matrixLookup.raiden.test',
       matrixServer: 'https://matrix.raiden.test',
       pfsSafetyMargin: 1.1,
-      pfs: ['pfs.raiden.test'],
+      additionalServices: ['pfs.raiden.test'],
       pollingInterval,
       httpTimeout: 300,
       settleTimeout: 60,

--- a/raiden-ts/tests/unit/utils.spec.ts
+++ b/raiden-ts/tests/unit/utils.spec.ts
@@ -235,24 +235,27 @@ describe('types', () => {
 
 test('LruCache', () => {
   const cache = new LruCache<string, { v: number }>(2);
-  expect(cache.values.size).toBe(0);
+  expect(cache.size).toBe(0);
   expect(cache.max).toBe(2);
 
   const v1 = { v: 1 },
     v2 = { v: 2 },
     v3 = { v: 3 };
-  cache.put('1', v1);
-  cache.put('2', v2);
+  cache.set('1', v1);
+  cache.set('2', v2);
 
   expect(cache.get('1')).toBe(v1);
   expect(cache.get('2')).toBe(v2);
   expect(cache.get('3')).toBeUndefined();
 
-  cache.put('3', v3);
+  cache.set('3', v3);
   expect(cache.get('3')).toBe(v3);
   expect(cache.get('2')).toBe(v2);
   expect(cache.get('1')).toBeUndefined();
-  expect(cache.values.size).toBe(2);
+  expect(cache.size).toBe(2);
+
+  cache.clear();
+  expect(cache.size).toBe(0);
 });
 
 describe('data', () => {


### PR DESCRIPTION
Fixes #2570

**Short description**
This changes the format of `config.pfs` to support receiving an array of addresses or urls as additional/custom services to be used. By default, the first working one will be chosen when not specifying one in `findRoutes` and `transfer`.
The main reason for allowing it is to use this list as complementary Services to be notified when channel state changes (this last part is only relevant on `next`, where `toDevice` messages to specific services are used instead of global room messages), but it also serves on `master` to allow multiple services to be tried when doing an auto PFS request, instead of rejecting when the first fails.
The interface on cli now allows multiple parameters be passed to `--pathfindingServiceAddress`, which already served the purpose of specifying a single url, so this change is backwards compatible.
Most of this PR is intended for `master`, but the `next:` commit is going to be removed when merging this to `master` and then that commit will be pushed to `next`.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
