### PR TITLE
dapp: fix navigation loop when adding new token

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [#2421] Fix account menu on mobile devices by making it scrollable
 - [#2422] Fix broken layout on RaidenAccount screen for mobile virtual keyboard
 - [#2383] Fix broken handling of path/query parameters of transfer route
+- [#2607] Fix endless navigation loop when canceling open channel route
 
 ### Added
 
@@ -22,6 +23,7 @@
 [#2421]: https://github.com/raiden-network/light-client/issues/2421
 [#2422]: https://github.com/raiden-network/light-client/issues/2422
 [#2383]: https://github.com/raiden-network/light-client/issues/2383
+[#2607]: https://github.com/raiden-network/light-client/issues/2607
 
 ## [0.15.0] - 2021-01-26
 

--- a/raiden-dapp/src/mixins/navigation-mixin.ts
+++ b/raiden-dapp/src/mixins/navigation-mixin.ts
@@ -130,13 +130,9 @@ export default class NavigationMixin extends Vue {
         this.navigateToTransfer(this.$route.params.token);
         break;
       case RouteNames.SELECT_TOKEN:
-        this.$router.go(-1); // Preserve current token without knowing it.
-        break;
       case RouteNames.SELECT_HUB:
-        this.navigateToTokenSelect();
-        break;
       case RouteNames.OPEN_CHANNEL:
-        this.navigateToSelectHub(this.$route.params.token);
+        this.$router.go(-1); // Preserve current token without knowing it.
         break;
       default:
         break;

--- a/raiden-dapp/tests/unit/components/mixins/navigation-mixin.spec.ts
+++ b/raiden-dapp/tests/unit/components/mixins/navigation-mixin.spec.ts
@@ -170,12 +170,8 @@ describe('NavigationMixin', () => {
       wrapper.vm.$route.name = RouteNames.SELECT_HUB;
       wrapper.vm.onBackClicked();
 
-      expect(router.push).toHaveBeenCalledTimes(1);
-      expect(router.push).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: RouteNames.SELECT_TOKEN,
-        }),
-      );
+      expect(router.go).toHaveBeenCalledTimes(1);
+      expect(router.go).toHaveBeenCalledWith(-1);
     });
 
     test('from channels', async () => {
@@ -203,15 +199,8 @@ describe('NavigationMixin', () => {
       };
       wrapper.vm.onBackClicked();
 
-      expect(router.push).toHaveBeenCalledTimes(1);
-      expect(router.push).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: RouteNames.SELECT_HUB,
-          params: {
-            token: '0xtoken',
-          },
-        }),
-      );
+      expect(router.go).toHaveBeenCalledTimes(1);
+      expect(router.go).toHaveBeenCalledWith(-1);
     });
 
     test('from transfer steps', async () => {


### PR DESCRIPTION
Fixes #2607 

**Short description**
See the commit message

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

0. If possible change the token first if multiple are connected (i.e. don't use the per default selected token)
1. Attempt to connect a new token
2. Continue the navigation until selecting a hub
3. Click back twice
4. Verify that you are back on the transfer route (home screen) and the last selected token is still active
5. Do the same again from 1. on, but continue the navigation up to the amount to insert for the new channel and then go back three times
