### PR TITLE
Bugfix/dapp auto select token on external channel opening

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [#2422] Fix broken layout on RaidenAccount screen for mobile virtual keyboard
 - [#2383] Fix broken handling of path/query parameters of transfer route
 - [#2607] Fix endless navigation loop when canceling open channel route
+- [#2617] Fix automatic token selection on external open channel event for new accounts
 
 ### Added
 
@@ -24,6 +25,7 @@
 [#2422]: https://github.com/raiden-network/light-client/issues/2422
 [#2383]: https://github.com/raiden-network/light-client/issues/2383
 [#2607]: https://github.com/raiden-network/light-client/issues/2607
+[#2617]: https://github.com/raiden-network/light-client/issues/2617
 
 ## [0.15.0] - 2021-01-26
 

--- a/raiden-dapp/src/views/TransferRoute.vue
+++ b/raiden-dapp/src/views/TransferRoute.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container class="transfer" fluid>
-    <no-tokens v-if="noTokens" />
+    <no-tokens v-if="noTokenWithOpenChannel" />
     <template v-else>
       <transfer-headers
         class="transfer__menus"
@@ -73,7 +73,7 @@ export default class TransferRoute extends Vue {
   transferAmount = '';
   targetAddress = '';
 
-  get noTokens(): boolean {
+  get noTokenWithOpenChannel(): boolean {
     return Object.keys(this.tokensWithChannels).length === 0;
   }
 
@@ -151,7 +151,7 @@ export default class TransferRoute extends Vue {
   }
 
   selectFirstAvailableTokenIfAny(): void {
-    if (!this.noTokens) {
+    if (!this.noTokenWithOpenChannel) {
       this.token = Object.values(this.tokensWithChannels)[0];
     }
   }

--- a/raiden-dapp/src/views/TransferRoute.vue
+++ b/raiden-dapp/src/views/TransferRoute.vue
@@ -130,6 +130,15 @@ export default class TransferRoute extends Vue {
     }
   }
 
+  @Watch('noTokenWithOpenChannel')
+  onNoTokenWithOpenChannelChange(now: boolean, before: boolean): void {
+    const switchFromNoTokenWithOpenChannelToSome = before && !now;
+
+    if (switchFromNoTokenWithOpenChannelToSome) {
+      this.selectFirstAvailableTokenIfAny();
+    }
+  }
+
   @Watch('$route.query.amount', { immediate: true })
   async onAmountQueryParameterChanged(transferAmount: string | undefined) {
     this.transferAmount = transferAmount ?? '';


### PR DESCRIPTION
Fixes #2617 

**Short description**
Details as always in the commit messages.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Create a new account in MetaMask or take one that has guaranteed no channels in Raiden
2. Connect the dApp with this account and make sure you see the "no tokens" screen with the big plus in the middle
3. Use another Raiden node instance (dApp?) and open a new channel for any token with the fresh account of 1.
4. Observe the dApp of the fresh account (open channel notification should pop up) and wait until the channel opening got confirmed
5. Make sure the "no tokens" view automatically switches to the "regular" view with the tokens selected with has now an open channel. Though the balance must be `0`.
