### PR TITLE
Adding proportional fees to the mediation fees in the SDK along with adding options for it in the raiden CLI

### DIFF
--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -168,7 +168,7 @@ function parseArguments() {
         type: 'string',
         nargs: 2,
         desc:
-          'Sets the proportional fee required for every mediation in wei of the mediated token for a certain token address: [address value] pair',
+          'Sets the proportional fee required for every mediation, in micros (parts per million, 1% = 10000) of the mediated token for a certain token address: [address value] pair',
         coerce: parseFeeOption,
       },
     })
@@ -329,8 +329,8 @@ function createRaidenConfig(
       },
     };
 
-  type Feetype = 'flat' | 'proportional';
-  let mediationFees: { [token: string]: { [K in Feetype]?: BigNumberish } } = {};
+  type FeeType = 'flat' | 'proportional';
+  let mediationFees: { [token: string]: { [K in FeeType]?: BigNumberish } } = {};
   for (const [addr, flat] of Object.entries(argv.flatFee ?? {})) {
     mediationFees = { ...mediationFees, [addr]: { ...mediationFees[addr], flat } };
   }

--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -164,6 +164,13 @@ function parseArguments() {
           'Sets the flat fee required for every mediation in wei of the mediated token for a certain token address: [address value] pair',
         coerce: parseFeeOption,
       },
+      proportionalFee: {
+        type: 'string',
+        nargs: 2,
+        desc:
+          'Sets the proportional fee required for every mediation in wei of the mediated token for a certain token address: [address value] pair',
+        coerce: parseFeeOption,
+      },
     })
     .help()
     .alias('h', 'help')
@@ -322,9 +329,13 @@ function createRaidenConfig(
       },
     };
 
-  let mediationFees: { [token: string]: { flat: BigNumberish } } = {};
+  type Feetype = 'flat' | 'proportional';
+  let mediationFees: { [token: string]: { [K in Feetype]?: BigNumberish } } = {};
   for (const [addr, flat] of Object.entries(argv.flatFee ?? {})) {
     mediationFees = { ...mediationFees, [addr]: { ...mediationFees[addr], flat } };
+  }
+  for (const [addr, proportional] of Object.entries(argv.proportionalFee ?? {})) {
+    mediationFees = { ...mediationFees, [addr]: { ...mediationFees[addr], proportional } };
   }
   if (Object.keys(mediationFees).length) config = { ...config, mediationFees };
 

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - [#1342] Flat (fixed) mediation fees for mediator nodes
+- [#1343] Proportional (per transfer amount) mediation fees for mediator nodes
 - [#2581] `config.pfsSafetyMargin` now also accepts a `[f, a]` pair, which will add `f*fee + a*amount` on top of PFS's estimated fee, if one wants finer-grain control on safety margin which is added on the transfer to be initiated.
 - [#2629] `config.autoUDCWithdraw` (default=true) to allow disabling automatically completing a planned UDC withdraw, and new `Raiden.getUDCWithdrawPlan` and `Raiden.withdrawFromUDC` to check and perform UDC withdraw when not in auto mode.
 
@@ -21,6 +22,7 @@
 - [#2596] Fix unlocking sent transfers even if receiving is disabled
 
 [#1342]: https://github.com/raiden-network/light-client/issues/1342
+[#1343]: https://github.com/raiden-network/light-client/issues/1343
 [#2536]: https://github.com/raiden-network/light-client/issues/2536
 [#2550]: https://github.com/raiden-network/light-client/issues/2550
 [#2566]: https://github.com/raiden-network/light-client/issues/2566

--- a/raiden-ts/src/transfers/mediate/types.ts
+++ b/raiden-ts/src/transfers/mediate/types.ts
@@ -72,15 +72,13 @@ export const proportionalFee: FeeModel<Int<32>, { proportional: Int<32> }> = {
   name: 'proportional',
   emptySchedule: { proportional: Zero as Int<32> },
   decodeConfig(config, defaultConfig) {
-    // flat config uses 'half' the per-token config, one half for each channel [in, out]
-    return decode(Int(32), config ?? defaultConfig).div(2) as Int<32>;
+    return decode(Int(32), config ?? defaultConfig) as Int<32>;
   },
   fee(proportional) {
     return (amountIn) =>
       decode(
         Int(32),
         new BN(proportional.toHexString())
-          .times(2)
           .div(1e6)
           .times(amountIn.toHexString())
           .toFixed(0, BN.ROUND_HALF_EVEN),

--- a/raiden-ts/tests/integration/epics/mediate.spec.ts
+++ b/raiden-ts/tests/integration/epics/mediate.spec.ts
@@ -21,7 +21,7 @@ import { Capabilities } from '@/constants';
 import { MessageType } from '@/messages/types';
 import { transfer, transferSigned } from '@/transfers/actions';
 import type { FeeModel } from '@/transfers/mediate/types';
-import { flatFee, getStandardFeeCalculator } from '@/transfers/mediate/types';
+import { flatFee, getStandardFeeCalculator, proportionalFee } from '@/transfers/mediate/types';
 import { Direction } from '@/transfers/state';
 import { makePaymentId } from '@/transfers/utils';
 import { assert } from '@/utils';
@@ -291,4 +291,27 @@ test('flatFee', () => {
   );
 
   expect(flatFee.schedule(config, null as any)).toEqual({ flat: config });
+});
+
+test('proportionalFee', () => {
+  expect(proportionalFee.name).toEqual('proportional');
+  expect(proportionalFee.emptySchedule).toEqual({ proportional: Zero });
+  let config = proportionalFee.decodeConfig('99');
+  expect(config).toEqual(BigNumber.from(49));
+  // For sufficiently small amounts of proportional we get zero for the given input
+  expect(proportionalFee.fee(config, null as any, null as any)(decode(UInt(32), 1337))).toEqual(
+    Zero,
+  );
+
+  config = proportionalFee.decodeConfig('999');
+  expect(config).toEqual(BigNumber.from(499));
+  expect(proportionalFee.fee(config, null as any, null as any)(decode(UInt(32), 1337))).toEqual(
+    BigNumber.from(1),
+  );
+
+  config = proportionalFee.decodeConfig('9999');
+  expect(config).toEqual(BigNumber.from(4999));
+  expect(proportionalFee.fee(config, null as any, null as any)(decode(UInt(32), 1337))).toEqual(
+    BigNumber.from(13),
+  );
 });

--- a/raiden-ts/tests/integration/epics/mediate.spec.ts
+++ b/raiden-ts/tests/integration/epics/mediate.spec.ts
@@ -296,22 +296,33 @@ test('flatFee', () => {
 test('proportionalFee', () => {
   expect(proportionalFee.name).toEqual('proportional');
   expect(proportionalFee.emptySchedule).toEqual({ proportional: Zero });
-  let config = proportionalFee.decodeConfig('99');
-  expect(config).toEqual(BigNumber.from(49));
-  // For sufficiently small amounts of proportional we get zero for the given input
-  expect(proportionalFee.fee(config, null as any, null as any)(decode(UInt(32), 1337))).toEqual(
-    Zero,
+  let config = proportionalFee.decodeConfig('1000000');
+  expect(config).toEqual(BigNumber.from(1000000));
+  expect(proportionalFee.fee(config, null as any, null as any)(decode(UInt(32), 1000))).toEqual(
+    BigNumber.from(1000),
   );
 
-  config = proportionalFee.decodeConfig('999');
-  expect(config).toEqual(BigNumber.from(499));
-  expect(proportionalFee.fee(config, null as any, null as any)(decode(UInt(32), 1337))).toEqual(
-    BigNumber.from(1),
+  config = proportionalFee.decodeConfig('50000');
+  expect(config).toEqual(BigNumber.from(50000));
+  expect(proportionalFee.fee(config, null as any, null as any)(decode(UInt(32), 1000))).toEqual(
+    BigNumber.from(50),
   );
 
-  config = proportionalFee.decodeConfig('9999');
-  expect(config).toEqual(BigNumber.from(4999));
-  expect(proportionalFee.fee(config, null as any, null as any)(decode(UInt(32), 1337))).toEqual(
-    BigNumber.from(13),
+  config = proportionalFee.decodeConfig('4990');
+  expect(config).toEqual(BigNumber.from(4990));
+  expect(proportionalFee.fee(config, null as any, null as any)(decode(UInt(32), 100))).toEqual(
+    BigNumber.from(0),
+  );
+
+  config = proportionalFee.decodeConfig('10000');
+  expect(config).toEqual(BigNumber.from(10000));
+  expect(proportionalFee.fee(config, null as any, null as any)(decode(UInt(32), 10000))).toEqual(
+    BigNumber.from(100),
+  );
+
+  config = proportionalFee.decodeConfig('10000');
+  expect(config).toEqual(BigNumber.from(10000));
+  expect(proportionalFee.fee(config, null as any, null as any)(decode(UInt(32), 10100))).toEqual(
+    BigNumber.from(101),
   );
 });


### PR DESCRIPTION
Fixes #1343 
Fixes #1996 

**Short description**
The PC uses [a weird formula to calculate the proportional fee](https://raiden-network-specification.readthedocs.io/en/latest/mediation_fees.html#converting-per-hop-proportional-fees-in-per-channel-proportional-fees), and we needed [to adjust to exactly that](https://github.com/raiden-network/raiden/blob/6f36e3c57eb81d5355af03d1928c41da8ea02ffd/raiden/utils/mediation_fees.py#L8-L19) to get the correct values.

MFEE2 passing on top of this PR:

![Screenshot_20210327_163704](https://user-images.githubusercontent.com/587021/112732769-ac71e880-8f1a-11eb-9e36-50a31f4ff92f.png)


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Run MFEE2 with `next` merged on this PR
