### PR TITLE
Allow SDK to detect and work without WebRTC API

### DIFF
--- a/raiden-cli/package.json
+++ b/raiden-cli/package.json
@@ -41,6 +41,7 @@
     "node-localstorage": "^2.1.6",
     "raiden-ts": "*",
     "rxjs": "^6.6.6",
+    "wrtc": "^0.4.7",
     "yargs": "^16.2.0"
   }
 }

--- a/raiden-cli/src/global.d.ts
+++ b/raiden-cli/src/global.d.ts
@@ -1,9 +1,0 @@
-import type { RaidenChannel } from 'raiden-ts';
-
-declare global {
-  namespace Express {
-    export interface Request {
-      channels: RaidenChannel[];
-    }
-  }
-}

--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -15,6 +15,11 @@ import DISCLAIMER from './disclaimer.json';
 import type { Cli } from './types';
 import { setupLoglevel } from './utils/logging';
 
+if (!('RTCPeerConnection' in globalThis)) {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  Object.assign(globalThis, require('wrtc'));
+}
+
 function parseFeeOption(args: readonly string[]) {
   assert(args.length && args.length % 2 === 0, 'fees must have the format [address, number]');
   const res: { [addr: string]: string } = {};

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Removed
 - [#2550] **BREAKING** Remove migration of legacy state at localStorage during creation
 - [#2567] **BREAKING** Remove support for peer-to-peer communication through Matrix rooms; now supports only `toDevice` and WebRTC channels.
+- [#2600] `wrtc` auto-polyfill; now, if you're using `raiden-ts` in a NodeJS project, you're expected to polyfill `wrtc` or some WebRTC-compatible API to your global object; in exchange, the SDK doesn't require WebRTC, and therefore should work fine on environments without it (through matrix' toDevice messages).
 
 ### Fixed
 - [#2596] Fix unlocking sent transfers even if receiving is disabled
@@ -25,6 +26,7 @@
 [#2570]: https://github.com/raiden-network/light-client/issues/2570
 [#2581]: https://github.com/raiden-network/light-client/pull/2581
 [#2596]: https://github.com/raiden-network/light-client/issues/2596
+[#2600]: https://github.com/raiden-network/light-client/issues/2600
 
 ## [0.15.0] - 2021-01-26
 ### Added

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -107,12 +107,12 @@
     "redux-devtools-extension": "^2.13.9",
     "redux-logger": "^3.0.6",
     "redux-observable": "^1.2.0",
-    "rxjs": "^6.6.6",
-    "wrtc": "^0.4.7"
+    "rxjs": "^6.6.6"
   },
   "optionalDependencies": {
     "pouchdb-adapter-indexeddb": "^7.2.2",
-    "pouchdb-adapter-leveldb": "^7.2.2"
+    "pouchdb-adapter-leveldb": "^7.2.2",
+    "wrtc": "^0.4.7"
   },
   "files": [
     "/dist",

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -139,7 +139,6 @@ export function makeDefaultConfig(
       : {
           [Capabilities.DELIVERY]: 0,
           [Capabilities.MEDIATE]: 0,
-          [Capabilities.WEBRTC]: 1,
           [Capabilities.TO_DEVICE]: 1,
           ...overwrites?.caps,
         };

--- a/raiden-ts/src/epics.ts
+++ b/raiden-ts/src/epics.ts
@@ -54,6 +54,7 @@ function dynamicCaps({
   return {
     [Capabilities.RECEIVE]:
       !stale && monitoringReward?.gt(0) && monitoringReward.lte(udcBalance) ? 1 : 0,
+    [Capabilities.WEBRTC]: 'RTCPeerConnection' in globalThis ? 1 : 0,
   };
 }
 

--- a/raiden-ts/src/global.d.ts
+++ b/raiden-ts/src/global.d.ts
@@ -11,7 +11,6 @@ declare module 'matrix-js-sdk/lib/logger' {
 }
 
 declare module 'abort-controller/polyfill';
-declare module 'wrtc'; // types provided by @types/webrtc
 
 declare module 'pouchdb-adapter-indexeddb';
 declare module 'pouchdb-debug';

--- a/raiden-ts/src/polyfills.ts
+++ b/raiden-ts/src/polyfills.ts
@@ -18,7 +18,3 @@ request((opts: Record<string, unknown>, cb: (err?: Error, res?: any, body?: any)
     },
   });
 });
-
-if (!('RTCPeerConnection' in globalThis)) {
-  Object.assign(globalThis, require('wrtc')); // eslint-disable-line @typescript-eslint/no-var-requires
-}

--- a/raiden-ts/src/transport/actions.ts
+++ b/raiden-ts/src/transport/actions.ts
@@ -38,7 +38,7 @@ export namespace matrixPresence {
 
 export const rtcChannel = createAction(
   'rtc/channel',
-  t.union([t.undefined, instanceOf(RTCDataChannel)]),
+  t.union([t.undefined, instanceOf<RTCDataChannel>('RTCDataChannel')]),
   NodeId,
 );
 export interface rtcChannel extends ActionType<typeof rtcChannel> {}

--- a/raiden-ts/src/utils/types.ts
+++ b/raiden-ts/src/utils/types.ts
@@ -271,22 +271,18 @@ export const Signed: <C extends t.Mixed>(
   t.intersection([codec, t.readonly(t.type({ signature: Signature }))]),
 );
 
-export interface Newable {
-  new (...args: any[]): any;
-}
-
 /**
  * Memoized factory to create codecs validating an arbitrary class C
  *
  * @param C - Class to create a codec for
  * @returns Codec validating class C
  */
-export const instanceOf: <C extends Newable>(C: C) => t.Type<InstanceType<C>> = memoize(
-  <C extends Newable>(C: C): t.Type<InstanceType<C>> =>
-    new t.Type<InstanceType<C>>(
-      `instanceOf(${C.name})`,
-      (v): v is InstanceType<C> => (v as any)?.constructor?.name === C.name,
-      (i, c) => (i instanceof C ? t.success<InstanceType<C>>(i) : t.failure(i, c)),
+export const instanceOf: <C>(name: string) => t.Type<C> = memoize(
+  <C>(name: string): t.Type<C> =>
+    new t.Type<C>(
+      `instanceOf(${name})`,
+      (v): v is C => (v as any)?.constructor?.name === name,
+      (i, c) => ((i as any)?.constructor?.name === name ? t.success(i as C) : t.failure(i, c)),
       t.identity,
     ),
 );

--- a/raiden-ts/tests/setup.ts
+++ b/raiden-ts/tests/setup.ts
@@ -12,3 +12,8 @@ PouchDB.plugin(MemAdapter);
 PouchDB.plugin(PouchDebug);
 
 logging.setLevel(logging.levels.DEBUG);
+
+if (!('RTCPeerConnection' in globalThis)) {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  Object.assign(globalThis, require('wrtc'));
+}


### PR DESCRIPTION
Fixes #2600

**Short description**
The SDK now doesn't auto-polyfill `wrtc` for RTC support, since it doesn't wor on all environments.
Projects running the SDK on environments without native WebRTC support (e.g. NodeJS) now are expected to provide a compatible API, e.g. by dropping this line early in some script:
```js
Object.assign(globalThis, require('wrtc'));
```
In exchange, the SDK should work fine on environments which don't support this framework.
Nothing changes for environments natively supporting RTC, e.g. modern browsers.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Comment out CLI's polyfill expression in the beginning of `index.ts` and re-build it
2. Run the CLI and check `webRTC` capability is turned off and CLI still can perform payments over `toDevice` messages only