### PR TITLE
Fix picking UDC withdraw plan on connect

### DIFF
--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -1301,7 +1301,7 @@ export function channelAutoSettleEpic(
         ),
       ),
     ),
-    takeIf(config$.pipe(pluck('autoSettle'))),
+    takeIf(config$.pipe(pluck('autoSettle'), completeWith(state$))),
   );
 }
 

--- a/raiden-ts/src/transfers/epics/secret.ts
+++ b/raiden-ts/src/transfers/epics/secret.ts
@@ -436,6 +436,7 @@ export function transferAutoRegisterEpic(
       config$.pipe(
         pluck('caps'),
         map((caps) => getCap(caps, Capabilities.RECEIVE)),
+        completeWith(action$),
       ),
     ),
   );

--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -588,6 +588,6 @@ export function rtcConnectEpic(
         completeWith(action$),
       ),
     ),
-    takeIf(config$.pipe(pluck('caps', Capabilities.WEBRTC))),
+    takeIf(config$.pipe(pluck('caps', Capabilities.WEBRTC), completeWith(action$))),
   );
 }


### PR DESCRIPTION
Follow up of #2635 

**Short description**
`dApp` registers an pending udcWithdraw plan on `udcWithdrawPlan.success`, usually emitted on interactive `Raiden.planUDCWithdraw` call, but when restarting while a plan is ongoing, this action wasn't emitted, so we fix it by emitting it as a `confirmed` action when starting Raiden if there's a registered plan (`ready` or not).
While debugging it, some edge cases were found on `takeIf` custom Rx operator, and a simplified version of it was added, together with unit tests for all cases.
No changelog entry is needed since this didn't get released and is just a follow up of the previous PR.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. `yarn workspace raiden-ts clean && yarn workspace raiden-ts build`
2. On the served dApp, plan a UDC withdraw, see the block counter and amount on the UDC management screen
3. Reload the dApp, connect, go to that screen and check the same withdraw plan is picked up again on startup.