### PR TITLE
Add Raiden.getUDCTotalDeposit method

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#1343] Proportional (per transfer amount) mediation fees for mediator nodes
 - [#2581] `config.pfsSafetyMargin` now also accepts a `[f, a]` pair, which will add `f*fee + a*amount` on top of PFS's estimated fee, if one wants finer-grain control on safety margin which is added on the transfer to be initiated.
 - [#2629] `config.autoUDCWithdraw` (default=true) to allow disabling automatically completing a planned UDC withdraw, and new `Raiden.getUDCWithdrawPlan` and `Raiden.withdrawFromUDC` to check and perform UDC withdraw when not in auto mode.
+- [#2644] `Raiden.getUDCTotalDeposit` method to fetch UDC total_deposit, base of `depositToUDC` amounts
 
 ### Changed
 - [#2536] Wait for global messages before resolving deposits and channel open request
@@ -33,6 +34,7 @@
 [#2600]: https://github.com/raiden-network/light-client/issues/2600
 [#2629]: https://github.com/raiden-network/light-client/issues/2629
 [#2635]: https://github.com/raiden-network/light-client/pull/2635
+[#2644]: https://github.com/raiden-network/light-client/pull/2644
 
 ## [0.15.0] - 2021-01-26
 ### Added

--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -438,7 +438,7 @@ export async function fetchContractsInfo(
 export async function getUdcBalance(latest$: Observable<Latest>): Promise<UInt<32>> {
   return latest$
     .pipe(
-      pluck('udcBalance'),
+      pluck('udcDeposit', 'balance'),
       first((balance) => !!balance && balance.lt(MaxUint256)),
     )
     .toPromise();

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -1250,6 +1250,23 @@ export class Raiden {
   }
 
   /**
+   * Fetches total_deposit of UserDeposit Contract for SDK's account
+   *
+   * The usable part of the deposit should be fetched with [[getUDCCapacity]], but this function
+   * is useful when trying to deposit based on the absolute value of totalDeposit.
+   *
+   * @returns Promise to UDC total deposit
+   */
+  public async getUDCTotalDeposit(): Promise<BigNumber> {
+    return this.deps.latest$
+      .pipe(
+        pluck('udcDeposit', 'totalDeposit'),
+        first((deposit) => !!deposit && deposit.lt(MaxUint256)),
+      )
+      .toPromise();
+  }
+
+  /**
    * Deposits the amount to the UserDeposit contract with the target/signer as a beneficiary.
    * The deposited amount can be used as a collateral in order to sign valid IOUs that will
    * be accepted by the Services.

--- a/raiden-ts/src/services/epics/monitor.ts
+++ b/raiden-ts/src/services/epics/monitor.ts
@@ -67,11 +67,11 @@ function makeMonitoringRequest$({
     return combineLatest([latest$, config$]).pipe(
       // combineLatest + filter ensures it'll pass if anything here changes
       filter(
-        ([{ udcBalance }, { monitoringReward, rateToSvt }]) =>
+        ([{ udcDeposit }, { monitoringReward, rateToSvt }]) =>
           // ignore actions while/if config.monitoringReward isn't enabled
           !!monitoringReward?.gt(Zero) &&
-          // wait for udcBalance >= monitoringReward, fires immediately if already
-          udcBalance.gte(monitoringReward) &&
+          // wait for udcDepost.balance >= monitoringReward, fires immediately if already
+          udcDeposit.balance.gte(monitoringReward) &&
           // use partner's total off & on-chain unlocked, total we'd lose if don't update BP
           partnerUnlocked
             // use rateToSvt to convert to equivalent SVT, and pass only if > monitoringReward;
@@ -167,7 +167,7 @@ export function msMonitorRequestEpic(
           // otherwise transfer completed, emits immediately
           cur.partner.locks.length > prev.partner.locks.length ? timer(httpTimeout) : of(1),
         ),
-        // switchMap may unsubscribe from previous udcBalance wait/signature prompts if partner's
+        // switchMap may unsubscribe from previous udcDeposit wait/signature prompts if partner's
         // balanceProof balance changes in the meantime
         switchMap(makeMonitoringRequest$(deps)),
       ),

--- a/raiden-ts/src/services/epics/udc.ts
+++ b/raiden-ts/src/services/epics/udc.ts
@@ -41,7 +41,7 @@ import type { Address, UInt } from '../../utils/types';
 import { udcDeposit, udcWithdraw, udcWithdrawPlan } from '../actions';
 
 /**
- * Monitors the balance of UDC and emits udcDeposited, made available in Latest['udcBalance']
+ * Monitors the balance of UDC and emits udcDeposited, made available in Latest['udcDeposit']
  *
  * @param action$ - Observable of newBlock actions
  * @param state$ - Observable of RaidenStates
@@ -78,7 +78,7 @@ export function monitorUdcBalanceEpic(
       ).pipe(catchError(constant(EMPTY))),
     ),
     withLatestFrom(latest$),
-    filter(([[balance], { udcBalance }]) => !udcBalance.eq(balance)),
+    filter(([[balance], { udcDeposit }]) => !udcDeposit.balance.eq(balance)),
     map(([[balance, totalDeposit]]) => udcDeposit.success({ balance }, { totalDeposit })),
   );
 }

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -43,7 +43,7 @@ export interface Latest {
   config: RaidenConfig;
   presences: Presences;
   rtc: { [address: string]: RTCDataChannel };
-  udcBalance: UInt<32>;
+  udcDeposit: { balance: UInt<32>; totalDeposit: UInt<32> };
   blockTime: number;
   stale: boolean;
 }

--- a/raiden-ts/tests/integration/epics/monitor.spec.ts
+++ b/raiden-ts/tests/integration/epics/monitor.spec.ts
@@ -93,7 +93,7 @@ describe('msMonitorRequestEpic', () => {
     const [raiden, partner] = await makeRaidens(2);
     raiden.store.dispatch(raidenConfigUpdate({ rateToSvt: {} }));
     expect(
-      (await raiden.deps.latest$.pipe(pluck('udcBalance'), first()).toPromise()).gte(
+      (await raiden.deps.latest$.pipe(pluck('udcDeposit', 'balance'), first()).toPromise()).gte(
         raiden.config.monitoringReward!,
       ),
     ).toBe(true);
@@ -130,7 +130,7 @@ describe('msMonitorRequestEpic', () => {
     );
   });
 
-  test('ignore: not enough udcBalance', async () => {
+  test('ignore: not enough udcDeposit.balance', async () => {
     expect.assertions(2);
 
     const [raiden, partner] = await makeRaidens(2);

--- a/raiden-ts/tests/integration/epics/udc.spec.ts
+++ b/raiden-ts/tests/integration/epics/udc.spec.ts
@@ -25,7 +25,7 @@ test('monitorUdcBalanceEpic', async () => {
     udcDeposit.success({ balance: Zero as UInt<32> }, { totalDeposit: Zero as UInt<32> }),
   );
   await expect(
-    raiden.deps.latest$.pipe(pluck('udcBalance'), first()).toPromise(),
+    raiden.deps.latest$.pipe(pluck('udcDeposit', 'balance'), first()).toPromise(),
   ).resolves.toEqual(Zero);
 
   const balance = BigNumber.from(23) as UInt<32>;
@@ -35,7 +35,7 @@ test('monitorUdcBalanceEpic', async () => {
 
   expect(raiden.output).toContainEqual(udcDeposit.success({ balance }, { totalDeposit: balance }));
   await expect(
-    raiden.deps.latest$.pipe(pluck('udcBalance'), first()).toPromise(),
+    raiden.deps.latest$.pipe(pluck('udcDeposit', 'balance'), first()).toPromise(),
   ).resolves.toEqual(balance);
   expect(userDepositContract.effectiveBalance).toHaveBeenCalledTimes(2);
 });


### PR DESCRIPTION
Follow up of #2635
Needed for https://github.com/raiden-network/light-client/pull/2642#discussion_r603651570

**Short description**
`totalDeposit` was already available on udcDepost.success actions, but was not persisted on `latest$`, therefore we also changed `Latest['udcBalance']` to `Latest['udcDeposit']` containing an object with both `balance` and `totalDeposit` properties and adjusted epics.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
