### PR TITLE
Wait for condition to be ready on settleChannel and withdrawFromUDC

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [#2566] Optimize initial sync and resume previous sync filters scans
 - [#2570] Support multiple custom services in config.pfs
 - [#2635] **BREAKING** Renamed `Raiden.planUdcWithdraw` to `Raiden.planUDCWithdraw` for consistency
+- [#2645] Wait for condition to be ready on `settleChannel` and `withdrawFromUDC` in case it's called early instead of erroring
 
 ### Removed
 - [#2550] **BREAKING** Remove migration of legacy state at localStorage during creation
@@ -33,6 +34,7 @@
 [#2600]: https://github.com/raiden-network/light-client/issues/2600
 [#2629]: https://github.com/raiden-network/light-client/issues/2629
 [#2635]: https://github.com/raiden-network/light-client/pull/2635
+[#2645]: https://github.com/raiden-network/light-client/issues/2645
 
 ## [0.15.0] - 2021-01-26
 ### Added

--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -1375,7 +1375,7 @@ export function channelSettleEpic(
             ).pipe(
               catchError(() =>
                 throwError(
-                  new RaidenError(ErrorCodes.CNL_SETTLECHANNEL_INVALID_BALANCEHASH, {
+                  new RaidenError(ErrorCodes.CNL_SETTLE_INVALID_BALANCEHASH, {
                     address,
                     ownBalanceHash: ownBH,
                   }),
@@ -1397,7 +1397,7 @@ export function channelSettleEpic(
             ).pipe(
               catchError(() =>
                 throwError(
-                  new RaidenError(ErrorCodes.CNL_SETTLECHANNEL_INVALID_BALANCEHASH, {
+                  new RaidenError(ErrorCodes.CNL_SETTLE_INVALID_BALANCEHASH, {
                     address,
                     partnerBalanceHash: partnerBH,
                   }),
@@ -1439,7 +1439,7 @@ export function channelSettleEpic(
                   part2[1].locksroot,
                 ),
               ).pipe(
-                assertTx('settleChannel', ErrorCodes.CNL_SETTLECHANNEL_FAILED, { log, provider }),
+                assertTx('settleChannel', ErrorCodes.CNL_SETTLE_FAILED, { log, provider }),
                 retryWhile(intervalFromConfig(config$), {
                   onErrors: commonAndFailTxErrors,
                   log: log.info,

--- a/raiden-ts/src/errors.json
+++ b/raiden-ts/src/errors.json
@@ -21,8 +21,9 @@
   "CNL_OPENCHANNEL_FAILED": "TokenNetwork.openChannel transaction reverted.",
   "CNL_SETTOTALDEPOSIT_FAILED": "TokenNetwork.setTotalDeposit transaction reverted.",
   "CNL_CLOSECHANNEL_FAILED": "TokenNetwork.closeChannel transaction reverted.",
-  "CNL_SETTLECHANNEL_INVALID_BALANCEHASH": "Could not find BalanceProof matching on-chain closing data. This client may have had its state cleared and can't settle.",
-  "CNL_SETTLECHANNEL_FAILED": "TokenNetwork.settleChannel transaction reverted.",
+  "CNL_SETTLE_INVALID_BALANCEHASH": "Could not find BalanceProof matching on-chain closing data. This client may have had its state cleared and can't settle.",
+  "CNL_SETTLE_FAILED": "TokenNetwork.settleChannel transaction reverted.",
+  "CNL_SETTLE_AUTO_ENABLED": "Interactive channel settlement disabled when config.autoSettle is enabled; request will be made automatically",
   "CNL_UPDATE_NONCLOSING_BP_FAILED": "updateNonClosingBalanceProof transaction reverted.",
   "CNL_ONCHAIN_UNLOCK_FAILED": "on-chain unlock transaction reverted.",
 
@@ -94,7 +95,6 @@
   "UDC_WITHDRAW_FAILED" : "An error occurred while withdrawing from the UDC.",
   "UDC_WITHDRAW_AUTO_ENABLED": "Interactive UDC withdraw disabled when config.autoUDCWithdraw is enabled; request will be made automatically",
   "UDC_WITHDRAW_NO_PLAN": "No plan currently registered; you must call Raiden.planUDCWithdraw first",
-  "UDC_WITHDRAW_TOO_EARLY": "The current UDC withdraw plan is not yet ready to be withdrawn",
   "UDC_WITHDRAW_TOO_LARGE": "Your current plan is not enough to withdraw the requested amount"
 }
 

--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -600,7 +600,7 @@ const preSettleableStates = [ChannelState.closed, ...settleableStates] as const;
 /**
  * Waits for channel to become settleable
  *
- * Errors if channel doesn't exist or isn't closed, settleable ot settling (states which precede
+ * Errors if channel doesn't exist or isn't closed, settleable or settling (states which precede
  * or are considered settleable)
  *
  * @param state$ - Observable of RaidenStates

--- a/raiden-ts/tests/unit/reducers.spec.ts
+++ b/raiden-ts/tests/unit/reducers.spec.ts
@@ -663,7 +663,7 @@ describe('raidenReducer', () => {
         channelSettleable({ settleableBlock: settleBlock }, { tokenNetwork, partner }),
         channelSettle.request(undefined, { tokenNetwork, partner }),
       ].reduce(raidenReducer, state);
-      const error = new RaidenError(ErrorCodes.CNL_SETTLECHANNEL_FAILED);
+      const error = new RaidenError(ErrorCodes.CNL_SETTLE_FAILED);
       const newState2 = raidenReducer(
         newState,
         channelSettle.failure(error, { tokenNetwork, partner }),


### PR DESCRIPTION
Fixes #2645 

**Short description**
These methods are only available if the `autoSettle` and `autoUDCWithdraw` configs aren't set. In these cases, calling it before it's ready (timeout blocks have passed) would error. This PR makes an early call wait until ready instead of erroring.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
