### PR TITLE
Simplify constructing Raiden from state machine parameters and improve tests logs

### DIFF
--- a/raiden-cli/src/utils/logging.ts
+++ b/raiden-cli/src/utils/logging.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from 'ethers';
 import fs from 'fs';
 import logging from 'loglevel';
 import util from 'util';
@@ -43,3 +44,11 @@ export function setupLoglevel(output?: string): void {
   };
   logging.setLevel(process.env.NODE_ENV === 'production' ? 'INFO' : 'DEBUG');
 }
+
+// better BigNumber inspect representation for logs
+Object.defineProperty(BigNumber.prototype, util.inspect.custom, {
+  enumerable: false,
+  value(this: BigNumber, _: number, opts: util.InspectOptionsStylized) {
+    return `${opts.stylize('BN', 'special')}(${opts.stylize(this.toString(), 'number')})`;
+  },
+});

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -44,6 +44,8 @@
   },
   "homepage": "https://github.com/raiden-network/light-client#readme",
   "devDependencies": {
+    "@jest/console": "^26.6.2",
+    "@jest/reporters": "^26.6.2",
     "@sastan/typedoc-plugin-pages": "^0.0.1",
     "@typechain/ethers-v5": "^6.0.5",
     "@types/isomorphic-fetch": "^0.0.35",
@@ -131,7 +133,8 @@
       "<rootDir>/tests/setup.ts"
     ],
     "setupFilesAfterEnv": [
-      "jest-extended"
+      "jest-extended",
+      "<rootDir>/tests/setupAfter.ts"
     ],
     "verbose": true,
     "collectCoverageFrom": [

--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -579,11 +579,11 @@ export async function getState(
   ].join('_');
 
   let db;
-  let { state: dump } = storage;
-  const { adapter, prefix } = storage;
+  const { state: stateDump, ...opts } = storage;
+  let dump = stateDump;
 
   // PouchDB configs are passed as custom database constructor using PouchDB.defaults
-  const dbCtor = await getDatabaseConstructorFromOptions({ log, adapter, prefix });
+  const dbCtor = await getDatabaseConstructorFromOptions({ ...opts, log });
 
   if (dump) {
     if (typeof dump === 'string') dump = jsonParse(dump);

--- a/raiden-ts/tests/global.d.ts
+++ b/raiden-ts/tests/global.d.ts
@@ -1,3 +1,32 @@
-import 'jest-extended';
-
 declare module 'pouchdb-debug';
+
+declare namespace jasmine {
+  interface TestResult {
+    id: string;
+    description: string;
+    fullName: string;
+    failedExpectations: {
+      actual: string;
+      error: Error;
+      expected: string;
+      matcherName: string;
+      message: string;
+      passed: boolean;
+      stack: string;
+    }[];
+    passedExpectations: unknown[];
+    pendingReason: string;
+    testPath: string;
+  }
+  let currentTest: TestResult | null;
+
+  interface Reporter {
+    specStarted(result: TestResult): void;
+  }
+
+  interface Env {
+    addReporter: (reporter: Reporter) => void;
+  }
+
+  function getEnv(): Env;
+}

--- a/raiden-ts/tests/integration/mocks.ts
+++ b/raiden-ts/tests/integration/mocks.ts
@@ -528,7 +528,6 @@ function mockedMatrixCreateClient({
           matrix.getRoom(roomId),
         );
       }
-      logging.info('__sendEvent', address, roomId, type, content);
       return true;
     }),
     sendToDevice: jest.fn(
@@ -545,7 +544,6 @@ function mockedMatrixCreateClient({
                 getContent: jest.fn(() => content),
                 event: { type, sender: userId, content },
               });
-              logging.info('__sendToDevice', address, type, content);
             }
           }
         }

--- a/raiden-ts/tests/setup.ts
+++ b/raiden-ts/tests/setup.ts
@@ -1,14 +1,19 @@
 import '@/polyfills';
 
-// import util from 'util';
-import logging from 'loglevel';
+import { BigNumber } from '@ethersproject/bignumber';
 import PouchDB from 'pouchdb';
 import MemAdapter from 'pouchdb-adapter-memory';
 import PouchDebug from 'pouchdb-debug';
+import util from 'util';
 
-// util.inspect.defaultOptions.depth = null;
 // PouchDB.debug.enable('*');
 PouchDB.plugin(MemAdapter);
 PouchDB.plugin(PouchDebug);
 
-logging.setLevel(logging.levels.DEBUG);
+// better BigNumber inspect representation for logs
+Object.defineProperty(BigNumber.prototype, util.inspect.custom, {
+  enumerable: false,
+  value(this: BigNumber, _: number, opts: util.InspectOptionsStylized) {
+    return `${opts.stylize('BN', 'special')}(${opts.stylize(this.toString(), 'number')})`;
+  },
+});

--- a/raiden-ts/tests/setupAfter.ts
+++ b/raiden-ts/tests/setupAfter.ts
@@ -1,0 +1,90 @@
+import 'jest-extended';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { LogMessage, LogType } from '@jest/console';
+import { CustomConsole } from '@jest/console';
+import util from 'util';
+
+type Level = 'log' | 'error' | 'warn' | 'info' | 'debug';
+
+class FailBufferedConsole extends CustomConsole {
+  private queue: { level: Level; stack?: string; message: string }[] = [];
+
+  constructor() {
+    super(process.stdout, process.stderr, FailBufferedConsole.formatter);
+
+    this.log = this.enqueue.bind(this, 'log');
+    this.error = this.enqueue.bind(this, 'error');
+    this.warn = this.enqueue.bind(this, 'warn');
+    this.info = this.enqueue.bind(this, 'info');
+    this.debug = this.enqueue.bind(this, 'debug');
+  }
+
+  private static formatter(_type: LogType, message: LogMessage): string {
+    const TITLE = `  [${_type}]`.padEnd(10);
+    const INDENT = ''.padStart(12);
+
+    return message
+      .split(/\n/)
+      .map((line, i) => (i ? INDENT : TITLE) + line)
+      .join('\n');
+  }
+
+  private enqueue(level: Level, ...args: [any, ...any[]]) {
+    const trace = new Error().stack!.split('\n');
+    trace.shift(); // removes Error: stacktrace
+    trace.shift(); // removes enqueue()
+    this.queue.push({
+      level,
+      stack: trace.join('\n'),
+      message: util.formatWithOptions({ colors: true, depth: 6 }, ...args),
+    });
+  }
+
+  raw(level: Level, ...args: [any, ...any[]]) {
+    super[level].call(this, ...args);
+  }
+
+  clear() {
+    return this.queue.splice(0, this.queue.length);
+  }
+
+  flush() {
+    for (const { level, stack, message } of this.clear()) {
+      this.raw(
+        level,
+        message,
+        ...(stack && ['warn', 'error'].includes(level) ? ['\n' + stack] : []),
+        '\n',
+      );
+    }
+  }
+}
+
+const testConsole = new FailBufferedConsole();
+
+jasmine.getEnv().addReporter({
+  specStarted(result) {
+    jasmine.currentTest = result;
+  },
+});
+
+beforeAll(() => {
+  globalThis.console = testConsole;
+});
+
+afterEach(() => {
+  // this includes tests that got aborted, ran into errors etc.
+  const failed =
+    jasmine.currentTest && Array.isArray(jasmine.currentTest.failedExpectations)
+      ? jasmine.currentTest.failedExpectations.length > 0
+      : true;
+  if (failed) {
+    testConsole.raw('info', `====== LOGS [${jasmine.currentTest!.fullName}] ======\n`);
+    testConsole.info(`====== LOGS [${jasmine.currentTest!.fullName}] END ======`);
+    testConsole.flush();
+  } else {
+    testConsole.clear();
+  }
+  jasmine.currentTest = null;
+});

--- a/raiden-ts/tests/unit/raiden.spec.ts
+++ b/raiden-ts/tests/unit/raiden.spec.ts
@@ -1,0 +1,126 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { getAddress } from '@ethersproject/address';
+import { hexlify } from '@ethersproject/bytes';
+import type { Network } from '@ethersproject/providers';
+import { JsonRpcProvider } from '@ethersproject/providers';
+import { randomBytes } from '@ethersproject/random';
+import { Wallet } from '@ethersproject/wallet';
+import memoize from 'lodash/memoize';
+import logging from 'loglevel';
+import type { MatrixClient } from 'matrix-js-sdk';
+import type { Observable } from 'rxjs';
+import { AsyncSubject, ReplaySubject } from 'rxjs';
+import { ignoreElements } from 'rxjs/operators';
+
+import type { RaidenAction } from '@/actions';
+import { makeDefaultConfig } from '@/config';
+import {
+  HumanStandardToken__factory,
+  MonitoringService__factory,
+  SecretRegistry__factory,
+  ServiceRegistry__factory,
+  TokenNetwork__factory,
+  TokenNetworkRegistry__factory,
+  UserDeposit__factory,
+} from '@/contracts';
+import { Raiden } from '@/raiden';
+import type { RaidenState } from '@/state';
+import { makeInitialState } from '@/state';
+import { standardCalculator } from '@/transfers/mediate/types';
+import type { ContractsInfo, Latest, RaidenEpicDeps } from '@/types';
+import { pluckDistinct } from '@/utils/rx';
+import type { Address } from '@/utils/types';
+
+jest.mock('@ethersproject/providers');
+
+// TODO: dedupe this from integrations/mocks.ts in a higher utility file
+// don't import from there to avoid pulling in all the patches there
+function makeAddress() {
+  return getAddress(hexlify(randomBytes(20))) as Address;
+}
+
+const wallet = new Wallet(hexlify(randomBytes(32)));
+const address = wallet.address as Address;
+const network: Network = { name: 'test', chainId: 1337 };
+const contractsInfo: ContractsInfo = {
+  TokenNetworkRegistry: { address: makeAddress(), block_number: 1 },
+  ServiceRegistry: { address: makeAddress(), block_number: 1 },
+  UserDeposit: { address: makeAddress(), block_number: 1 },
+  SecretRegistry: { address: makeAddress(), block_number: 1 },
+  MonitoringService: { address: makeAddress(), block_number: 1 },
+  OneToN: { address: makeAddress(), block_number: 1 },
+};
+
+const dummyState = makeInitialState({
+  address,
+  network,
+  contractsInfo,
+});
+
+function dummyEpic(action$: Observable<RaidenAction>) {
+  return action$.pipe(ignoreElements());
+}
+
+function dummyReducer(state: RaidenState = dummyState) {
+  return state;
+}
+
+function makeDummyDependencies(): RaidenEpicDeps {
+  const provider = new JsonRpcProvider();
+  Object.assign(provider, { _isProvider: true });
+  const signer = wallet.connect(provider);
+  const latest$ = new ReplaySubject<Latest>(1);
+  const config$ = latest$.pipe(pluckDistinct('config'));
+  const matrix$ = new AsyncSubject<MatrixClient>();
+  const db = {} as any;
+
+  const defaultConfig = makeDefaultConfig({ network });
+  const log = logging.getLogger(`raiden:${address}`);
+
+  return {
+    latest$,
+    config$,
+    matrix$,
+    provider,
+    network,
+    signer,
+    address,
+    log,
+    defaultConfig,
+    contractsInfo,
+    registryContract: TokenNetworkRegistry__factory.connect(
+      contractsInfo.TokenNetworkRegistry.address,
+      signer,
+    ),
+    getTokenNetworkContract: memoize((address: Address) =>
+      TokenNetwork__factory.connect(address, signer),
+    ),
+    getTokenContract: memoize((address: Address) =>
+      HumanStandardToken__factory.connect(address, signer),
+    ),
+    serviceRegistryContract: ServiceRegistry__factory.connect(
+      contractsInfo.ServiceRegistry.address,
+      signer,
+    ),
+    userDepositContract: UserDeposit__factory.connect(contractsInfo.UserDeposit.address, signer),
+    secretRegistryContract: SecretRegistry__factory.connect(
+      contractsInfo.SecretRegistry.address,
+      signer,
+    ),
+    monitoringServiceContract: MonitoringService__factory.connect(
+      contractsInfo.MonitoringService.address,
+      signer,
+    ),
+    db,
+    init$: new ReplaySubject(),
+    mediationFeeCalculator: standardCalculator,
+  };
+}
+
+describe('Raiden', () => {
+  test('address', () => {
+    const deps = makeDummyDependencies();
+    const raiden = new Raiden(dummyState, deps, dummyEpic, dummyReducer);
+    expect(raiden.address).toBe(dummyState.address);
+  });
+});


### PR DESCRIPTION
Fixes #2638

**Short description**
This adds yet another `raiden.spec.ts`, now in `tests/unit`, with some mocks and dummies which are able to instantiate the `Raiden` class. Not everything is mocked, but just enough to quickly initialize the instance and allow unit-testing the individual public members. The `deps` mocked parameter can be initialized separately (as demonstrated) and its members tweaked per-test in order to satisfy conditions for each member function.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Tests pass
