### PR TITLE
Add native sqlite backend for mobile

### DIFF
--- a/raiden-dapp/.env.capacitor
+++ b/raiden-dapp/.env.capacitor
@@ -2,3 +2,4 @@ VUE_APP_PUBLIC_PATH=./
 VUE_APP_HUB=hub.raiden.eth
 VUE_APP_ALLOW_MAINNET=true
 VUE_APP_CONFIGURATION_URL=./config.capacitor.json
+VUE_APP_DB_ADAPTER=cordova-sqlite

--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "compare-versions": "^3.6.0",
+    "cordova-sqlite-storage": "^6.0.0",
     "core-js": "^3.8.3",
     "ethereum-blockies-base64": "^1.0.2",
     "ethers": "^5.0.31",
@@ -31,6 +32,8 @@
     "idb": "^6.0.0",
     "lodash": "^4.17.20",
     "loglevel": "^1.7.1",
+    "pouchdb": "^7.2.2",
+    "pouchdb-adapter-cordova-sqlite": "^2.0.8",
     "raiden-ts": "*",
     "rxjs": "^6.6.3",
     "tiny-async-pool": "^1.2.0",

--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -23,6 +23,7 @@
     "serve:no-logging": "export NODE_ENV=nologging && vue-cli-service serve"
   },
   "dependencies": {
+    "@capacitor/core": "^3.0.0-rc.0",
     "compare-versions": "^3.6.0",
     "cordova-sqlite-storage": "^6.0.0",
     "core-js": "^3.8.3",
@@ -57,7 +58,6 @@
     "@babel/preset-typescript": "^7.12.16",
     "@capacitor/android": "^3.0.0-rc.0",
     "@capacitor/cli": "^3.0.0-rc.0",
-    "@capacitor/core": "^3.0.0-rc.0",
     "@capacitor/ios": "^3.0.0-rc.0",
     "@cypress/code-coverage": "^3.9.2",
     "@cypress/webpack-preprocessor": "^5.6.0",

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -50,14 +50,22 @@ export default class RaidenService {
     stateBackup?: string,
     subkey?: true,
   ): Promise<Raiden> {
-    const { default: adapterPlugin } = await import('pouchdb-adapter-cordova-sqlite');
-    PouchDB.plugin(adapterPlugin);
-
-    const storageOpts = {
+    let storageOpts:
+      | { state: string | undefined }
+      | { state: string | undefined; adapter: string; iosDatabaseLocation: string } = {
       state: stateBackup,
-      adapter: 'cordova-sqlite',
-      iosDatabaseLocation: 'Library',
     };
+    // When running in capacitor, enable native sqlite plugin
+    if (process.env.VUE_APP_DB_ADAPTER === 'cordova-sqlite') {
+      const { default: adapterPlugin } = await import('pouchdb-adapter-cordova-sqlite');
+      PouchDB.plugin(adapterPlugin);
+
+      storageOpts = {
+        state: stateBackup,
+        adapter: 'cordova-sqlite',
+        iosDatabaseLocation: 'Library',
+      };
+    }
 
     try {
       const contracts = await ConfigProvider.contracts();

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -1,3 +1,4 @@
+import { Capacitor } from '@capacitor/core';
 import type { BigNumber, BigNumberish, providers } from 'ethers';
 import { constants, utils } from 'ethers';
 import PouchDB from 'pouchdb';
@@ -52,7 +53,12 @@ export default class RaidenService {
   ): Promise<Raiden> {
     let storageOpts:
       | { state: string | undefined }
-      | { state: string | undefined; adapter: string; iosDatabaseLocation: string } = {
+      | {
+          state: string | undefined;
+          adapter: string;
+          location: string;
+          iosDatabaseLocation: string;
+        } = {
       state: stateBackup,
     };
     // When running in capacitor, enable native sqlite plugin
@@ -60,11 +66,20 @@ export default class RaidenService {
       const { default: adapterPlugin } = await import('pouchdb-adapter-cordova-sqlite');
       PouchDB.plugin(adapterPlugin);
 
-      storageOpts = {
-        state: stateBackup,
-        adapter: 'cordova-sqlite',
-        iosDatabaseLocation: 'Library',
-      };
+      const platform = Capacitor.getPlatform();
+      if (platform === 'android') {
+        storageOpts = {
+          ...storageOpts,
+          adapter: 'cordova-sqlite',
+          location: 'default',
+        };
+      } else if (platform === 'ios') {
+        storageOpts = {
+          ...storageOpts,
+          adapter: 'cordova-sqlite',
+          iosDatabaseLocation: 'Library',
+        };
+      }
     }
 
     try {

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -56,8 +56,8 @@ export default class RaidenService {
       | {
           state: string | undefined;
           adapter: string;
-          location: string;
-          iosDatabaseLocation: string;
+          location?: string;
+          iosDatabaseLocation?: string;
         } = {
       state: stateBackup,
     };

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -1,5 +1,6 @@
 import type { BigNumber, BigNumberish, providers } from 'ethers';
 import { constants, utils } from 'ethers';
+import PouchDB from 'pouchdb';
 import type { ObservedValueOf } from 'rxjs';
 import { exhaustMap, filter } from 'rxjs/operators';
 import asyncPool from 'tiny-async-pool';
@@ -49,14 +50,21 @@ export default class RaidenService {
     stateBackup?: string,
     subkey?: true,
   ): Promise<Raiden> {
+    const { default: adapterPlugin } = await import('pouchdb-adapter-cordova-sqlite');
+    PouchDB.plugin(adapterPlugin);
+
+    const storageOpts = {
+      state: stateBackup,
+      adapter: 'cordova-sqlite',
+      iosDatabaseLocation: 'Library',
+    };
+
     try {
       const contracts = await ConfigProvider.contracts();
       return await Raiden.create(
         provider,
         account,
-        {
-          state: stateBackup,
-        },
+        storageOpts,
         contracts,
         {
           pfsSafetyMargin: 1.1,

--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -525,11 +525,11 @@ export async function getState(
   ].join('_');
 
   let db;
-  let { state: dump } = storage;
-  const { adapter, prefix } = storage;
+  const { state: stateDump, ...opts } = storage;
+  let dump = stateDump;
 
   // PouchDB configs are passed as custom database constructor using PouchDB.defaults
-  const dbCtor = await getDatabaseConstructorFromOptions({ log, adapter, prefix });
+  const dbCtor = await getDatabaseConstructorFromOptions({ ...opts, log });
 
   if (dump) {
     if (typeof dump === 'string') dump = jsonParse(dump);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5792,6 +5792,11 @@ buffer-fill@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
   integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
 
+buffer-from@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
+  integrity sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==
+
 buffer-from@1.1.1, buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -6964,6 +6969,18 @@ copy-webpack-plugin@^6.4.1:
     schema-utils "^3.0.0"
     serialize-javascript "^5.0.1"
     webpack-sources "^1.4.3"
+
+cordova-sqlite-storage-dependencies@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cordova-sqlite-storage-dependencies/-/cordova-sqlite-storage-dependencies-4.0.0.tgz#2ffa2d1f2fb3bae868f489b6e174fb58d2926b8f"
+  integrity sha512-dTBxYaX/RGzH6+pp49o4sb3FuHCvhrssaKn1XMJ4LL3f9dnvz3rhFK2LdcWrdFkhOLOndnW/azUkbzZd+WWhRA==
+
+cordova-sqlite-storage@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cordova-sqlite-storage/-/cordova-sqlite-storage-6.0.0.tgz#25eba8eb4657d2b526c4b753747e6d1533fcb73b"
+  integrity sha512-njRloA3AICaUFztKHXoFfVcwlL7zbvyFxtdZIkK7P+MA3umILXtSKhYAQkSe2GtHr0LBNzJI5xUUqAlZl/Js0A==
+  dependencies:
+    cordova-sqlite-storage-dependencies "4.0.0"
 
 core-js-compat@^3.1.1, core-js-compat@^3.6.5, core-js-compat@^3.8.0:
   version "3.8.3"
@@ -10723,6 +10740,11 @@ ignore@^5.0.5, ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+
+immediate@3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=
 
 immediate@3.3.0, immediate@^3.2.3:
   version "3.3.0"
@@ -15786,6 +15808,13 @@ pouchdb-abstract-mapreduce@7.2.2:
     pouchdb-md5 "7.2.2"
     pouchdb-utils "7.2.2"
 
+pouchdb-adapter-cordova-sqlite@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/pouchdb-adapter-cordova-sqlite/-/pouchdb-adapter-cordova-sqlite-2.0.8.tgz#c9dce809385a16d35199afb17fdd380dac38f100"
+  integrity sha512-7mGeloXHtpR0QEe+Q0XCombKx5BPfy+kk3Y9C2uX60WYf6cwygS+LsQWFnSgHJ/3PQCdHCNJ2n4QC4KneyZZXw==
+  dependencies:
+    pouchdb-adapter-websql-core "^7.0.0"
+
 pouchdb-adapter-indexeddb@^7.2.2:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/pouchdb-adapter-indexeddb/-/pouchdb-adapter-indexeddb-7.2.2.tgz#ffcee0435bb5a9599c8d45de09a5758103e31c61"
@@ -15840,6 +15869,18 @@ pouchdb-adapter-memory@^7.2.2:
     pouchdb-adapter-leveldb-core "7.2.2"
     pouchdb-utils "7.2.2"
 
+pouchdb-adapter-utils@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pouchdb-adapter-utils/-/pouchdb-adapter-utils-7.0.0.tgz#1ac8d34481911e0e9a9bf51024610a2e7351dc80"
+  integrity sha512-UWKPC6jkz6mHUzZefrU7P5X8ZGvBC8LSNZ7BIp0hWvJE6c20cnpDwedTVDpZORcCbVJpDmFOHBYnOqEIblPtbA==
+  dependencies:
+    pouchdb-binary-utils "7.0.0"
+    pouchdb-collections "7.0.0"
+    pouchdb-errors "7.0.0"
+    pouchdb-md5 "7.0.0"
+    pouchdb-merge "7.0.0"
+    pouchdb-utils "7.0.0"
+
 pouchdb-adapter-utils@7.2.2:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/pouchdb-adapter-utils/-/pouchdb-adapter-utils-7.2.2.tgz#c64426447d9044ba31517a18500d6d2d28abd47d"
@@ -15851,6 +15892,26 @@ pouchdb-adapter-utils@7.2.2:
     pouchdb-md5 "7.2.2"
     pouchdb-merge "7.2.2"
     pouchdb-utils "7.2.2"
+
+pouchdb-adapter-websql-core@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pouchdb-adapter-websql-core/-/pouchdb-adapter-websql-core-7.0.0.tgz#27b3e404159538e515b2567baa7869f90caac16c"
+  integrity sha512-NyMaH0bl20SdJdOCzd+fwXo8JZ15a48/MAwMcIbXzsRHE4DjFNlRcWAcjUP6uN4Ezc+Gx+r2tkBBMf71mIz1Aw==
+  dependencies:
+    pouchdb-adapter-utils "7.0.0"
+    pouchdb-binary-utils "7.0.0"
+    pouchdb-collections "7.0.0"
+    pouchdb-errors "7.0.0"
+    pouchdb-json "7.0.0"
+    pouchdb-merge "7.0.0"
+    pouchdb-utils "7.0.0"
+
+pouchdb-binary-utils@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pouchdb-binary-utils/-/pouchdb-binary-utils-7.0.0.tgz#cb71a288b09572a231f6bab1b4aed201c4d219a7"
+  integrity sha512-yUktdOPIPvOVouCjJN3uop+bCcpdPwePrLm9eUAZNgEYnUFu0njdx7Q0WRsZ7UJ6l75HinL5ZHk4bnvEt86FLw==
+  dependencies:
+    buffer-from "1.1.0"
 
 pouchdb-binary-utils@7.2.2:
   version "7.2.2"
@@ -15864,6 +15925,11 @@ pouchdb-collate@7.2.2:
   resolved "https://registry.yarnpkg.com/pouchdb-collate/-/pouchdb-collate-7.2.2.tgz#fc261f5ef837c437e3445fb0abc3f125d982c37c"
   integrity sha512-/SMY9GGasslknivWlCVwXMRMnQ8myKHs4WryQ5535nq1Wj/ehpqWloMwxEQGvZE1Sda3LOm7/5HwLTcB8Our+w==
 
+pouchdb-collections@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pouchdb-collections/-/pouchdb-collections-7.0.0.tgz#fd1f632337dc6301b0ff8649732ca79204e41780"
+  integrity sha512-DaoUr/vU24Q3gM6ghj0va9j/oBanPwkbhkvnqSyC3Dm5dgf5pculNxueLF9PKMo3ycApoWzHMh6N2N8KJbDU2Q==
+
 pouchdb-collections@7.2.2:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/pouchdb-collections/-/pouchdb-collections-7.2.2.tgz#aeed77f33322429e3f59d59ea233b48ff0e68572"
@@ -15875,6 +15941,13 @@ pouchdb-debug@^7.2.1:
   integrity sha512-eP3ht/AKavLF2RjTzBM6S9gaI2/apcW6xvaKRQhEdOfiANqerFuksFqHCal3aikVQuDO+cB/cw+a4RyJn/glBw==
   dependencies:
     debug "3.1.0"
+
+pouchdb-errors@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pouchdb-errors/-/pouchdb-errors-7.0.0.tgz#4e2a5a8b82af20cbe5f9970ca90b7ec74563caa0"
+  integrity sha512-dTusY8nnTw4HIztCrNl7AoGgwvS1bVf/3/97hDaGc4ytn72V9/4dK8kTqlimi3UpaurohYRnqac0SGXYP8vgXA==
+  dependencies:
+    inherits "2.0.3"
 
 pouchdb-errors@7.2.2:
   version "7.2.2"
@@ -15905,6 +15978,13 @@ pouchdb-find@^7.2.2:
     pouchdb-selector-core "7.2.2"
     pouchdb-utils "7.2.2"
 
+pouchdb-json@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pouchdb-json/-/pouchdb-json-7.0.0.tgz#d9860f66f27a359ac6e4b24da4f89b6909f37530"
+  integrity sha512-w0bNRu/7VmmCrFWMYAm62n30wvJJUT2SokyzeTyj3hRohj4GFwTRg1mSZ+iAmxgRKOFE8nzZstLG/WAB4Ymjew==
+  dependencies:
+    vuvuzela "1.0.3"
+
 pouchdb-json@7.2.2:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/pouchdb-json/-/pouchdb-json-7.2.2.tgz#b939be24b91a7322e9a24b8880a6e21514ec5e1f"
@@ -15922,6 +16002,14 @@ pouchdb-mapreduce-utils@7.2.2:
     pouchdb-collections "7.2.2"
     pouchdb-utils "7.2.2"
 
+pouchdb-md5@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pouchdb-md5/-/pouchdb-md5-7.0.0.tgz#935dc6bb507a5f3978fb653ca5790331bae67c96"
+  integrity sha512-yaSJKhLA3QlgloKUQeb2hLdT3KmUmPfoYdryfwHZuPTpXIRKTnMQTR9qCIRUszc0ruBpDe53DRslCgNUhAyTNQ==
+  dependencies:
+    pouchdb-binary-utils "7.0.0"
+    spark-md5 "3.0.0"
+
 pouchdb-md5@7.2.2:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/pouchdb-md5/-/pouchdb-md5-7.2.2.tgz#415401acc5a844112d765bd1fb4e5d9f38fb0838"
@@ -15929,6 +16017,11 @@ pouchdb-md5@7.2.2:
   dependencies:
     pouchdb-binary-utils "7.2.2"
     spark-md5 "3.0.1"
+
+pouchdb-merge@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pouchdb-merge/-/pouchdb-merge-7.0.0.tgz#9f476ce7e32aae56904ad770ae8a1dfe14b57547"
+  integrity sha512-tci5u6NpznQhGcPv4ho1h0miky9rs+ds/T9zQ9meQeDZbUojXNaX1Jxsb0uYEQQ+HMqdcQs3Akdl0/u0mgwPGg==
 
 pouchdb-merge@7.2.2:
   version "7.2.2"
@@ -15942,6 +16035,20 @@ pouchdb-selector-core@7.2.2:
   dependencies:
     pouchdb-collate "7.2.2"
     pouchdb-utils "7.2.2"
+
+pouchdb-utils@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pouchdb-utils/-/pouchdb-utils-7.0.0.tgz#48bfced6665b8f5a2b2d2317e2aa57635ed1e88e"
+  integrity sha512-1bnoX1KdZYHv9wicDIFdO0PLiVIMzNDUBUZ/yOJZ+6LW6niQCB8aCv09ZztmKfSQcU5nnN3fe656tScBgP6dOQ==
+  dependencies:
+    argsarray "0.0.1"
+    clone-buffer "1.0.0"
+    immediate "3.0.6"
+    inherits "2.0.3"
+    pouchdb-collections "7.0.0"
+    pouchdb-errors "7.0.0"
+    pouchdb-md5 "7.0.0"
+    uuid "3.2.1"
 
 pouchdb-utils@7.2.2:
   version "7.2.2"
@@ -17669,6 +17776,11 @@ sourcemap-codec@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+
+spark-md5@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.0.tgz#3722227c54e2faf24b1dc6d933cc144e6f71bfef"
+  integrity sha1-NyIifFTi+vJLHcbZM8wUTm9xv+8=
 
 spark-md5@3.0.1:
   version "3.0.1"
@@ -19526,6 +19638,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+  integrity sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==
 
 uuid@8.1.0:
   version "8.1.0"


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2601

**Short description**

Adds the `cordova-sqlite-storage` plugin to be able to use native sqlite storage on mobile.

**TODOs**
- [x] Only tested on iOS emulator so far
- [ ] Only enable this on mobile builds


**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
