### PR TITLE
Replace raidenRootEpic with combineRaidenEpics

### DIFF
--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -50,7 +50,7 @@ import { PartialRaidenConfig } from './config';
 import { ShutdownReason } from './constants';
 import { CustomToken__factory } from './contracts';
 import { dumpDatabaseToArray } from './db/utils';
-import { getLatest$, raidenRootEpic } from './epics';
+import { combineRaidenEpics, getLatest$ } from './epics';
 import {
   callAndWaitMined,
   chooseOnchainAccount,
@@ -199,7 +199,7 @@ export class Raiden {
   public constructor(
     state: RaidenState,
     private readonly deps: RaidenEpicDeps,
-    private readonly epic = raidenRootEpic,
+    private readonly epic = combineRaidenEpics(),
     reducer = raidenReducer,
   ) {
     // use next from latest known blockNumber as start block when polling

--- a/raiden-ts/tests/integration/mocks.ts
+++ b/raiden-ts/tests/integration/mocks.ts
@@ -57,7 +57,7 @@ import {
 } from '@/contracts';
 import type { RaidenDatabaseConstructor } from '@/db/types';
 import { getRaidenState, migrateDatabase, putRaidenState } from '@/db/utils';
-import { raidenRootEpic } from '@/epics';
+import { combineRaidenEpics } from '@/epics';
 import { signMessage } from '@/messages/utils';
 import { createPersisterMiddleware } from '@/persister';
 import { raidenReducer } from '@/reducer';
@@ -979,7 +979,7 @@ export async function makeRaiden(
       raiden.deps.config$
         .pipe(finalize(() => (raiden.started = false)))
         .subscribe((config) => (raiden.config = config));
-      epicMiddleware.run(raidenRootEpic);
+      epicMiddleware.run(combineRaidenEpics());
       raiden.store.dispatch(raidenStarted());
       await raiden.synced;
     },


### PR DESCRIPTION
Part of #2588 

**Short description**

combineRaidenEpics is an utility which composes a root epic from an observable of RaidenEpics, doing the wiring of action$, state$ and latest$ and ensuring db teardown upon epics completion. This allows using this utility to have this latest$ wiring for dummy epics in unit/raiden.spec.ts, for example.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Tests pass
2.