### PR TITLE
dApp: Fixing broken info overlays on mobile

### DIFF
--- a/raiden-dapp/src/components/overlays/InfoOverlay.vue
+++ b/raiden-dapp/src/components/overlays/InfoOverlay.vue
@@ -1,18 +1,20 @@
 <template>
   <div class="info-overlay">
-    <div class="info-overlay__header">
-      <header-content disable-back-button disable-info-button />
-    </div>
-    <div class="info-overlay__close-icon">
-      <v-icon icon @click="closeOverlay()"> mdi-close </v-icon>
-    </div>
-    <div class="info-overlay__image">
-      <img :src="require(`@/assets/info-overlay/${$route.meta.infoOverlay.headerImage}`)" />
-    </div>
-    <span class="info-overlay__title">{{ $t($route.meta.infoOverlay.header) }}</span>
-    <span class="info-overlay__body">{{ $t($route.meta.infoOverlay.body) }}</span>
-    <div class="info-overlay__button">
-      <action-button enabled :text="$t('info-overlay.done')" @click="closeOverlay()" />
+    <div class="info-overlay__content">
+      <div class="info-overlay__content__header">
+        <header-content disable-back-button disable-info-button />
+      </div>
+      <div class="info-overlay__content__close-icon">
+        <v-icon icon @click="closeOverlay()">mdi-close</v-icon>
+      </div>
+      <div class="info-overlay__content__image">
+        <img :src="require(`@/assets/info-overlay/${$route.meta.infoOverlay.headerImage}`)" />
+      </div>
+      <span class="info-overlay__content__title">{{ $t($route.meta.infoOverlay.header) }}</span>
+      <span class="info-overlay__content__body">{{ $t($route.meta.infoOverlay.body) }}</span>
+      <div class="info-overlay__content__button">
+        <action-button enabled :text="$t('info-overlay.done')" @click="closeOverlay()" />
+      </div>
     </div>
   </div>
 </template>
@@ -38,60 +40,77 @@ export default class InfoOverlay extends Vue {
 </script>
 
 <style lang="scss" scoped>
+@import '@/scss/dimensions';
 @import '@/scss/mixins';
 @import '@/scss/colors';
 
 .info-overlay {
-  align-items: center;
   background-color: $transfer-screen-bg-color;
   border-radius: 10px;
-  display: flex;
-  flex-direction: column;
-  height: calc(844px);
-  padding: 0 46px;
+  height: 844px;
   position: absolute;
   width: 100%;
   z-index: 102;
+
   @include respond-to(handhelds) {
     border-radius: 0;
     height: 100vh;
+    overflow-y: auto;
   }
 
-  &__header {
+  &__content {
+    align-items: center;
     display: flex;
-    height: 80px;
-    width: 100%;
-  }
+    flex-direction: column;
+    height: 100%;
+    @include respond-to(handhelds) {
+      margin-top: $ios-safe-area;
+    }
 
-  &__close-icon {
-    width: 100%;
-    display: flex;
-    justify-content: flex-end;
-  }
+    &__header {
+      display: flex;
+      height: 80px;
+      width: 100%;
+      @include respond-to(handhelds) {
+        height: 60px;
+      }
+    }
 
-  &__image {
-    margin-top: 46px;
-    height: auto;
-    width: 300px;
-  }
+    &__close-icon {
+      display: flex;
+      justify-content: flex-end;
+      padding-right: 36px;
+      width: 100%;
+    }
 
-  &__title {
-    color: $color-gray;
-    font-size: 24px;
-    margin: 36px 0;
-  }
+    &__image {
+      padding-top: 46px;
+      height: auto;
+      width: 300px;
+    }
 
-  &__body {
-    font-size: 19px;
-    text-align: center;
-  }
+    &__title {
+      font-size: 24px;
+      margin: 36px 0;
+      text-align: center;
+    }
 
-  &__button {
-    align-items: flex-end;
-    display: flex;
-    flex: 1;
-    margin-bottom: 98px;
-    width: 100%;
+    &__body {
+      font-size: 19px;
+      text-align: center;
+      margin: 0 36px;
+    }
+
+    &__button {
+      align-items: flex-end;
+      display: flex;
+      flex: 1;
+      margin-bottom: 98px;
+      width: 100%;
+      @include respond-to(handhelds) {
+        padding: 36px 0;
+      }
+    }
   }
 }
 </style>

--- a/raiden-dapp/src/components/overlays/InfoOverlay.vue
+++ b/raiden-dapp/src/components/overlays/InfoOverlay.vue
@@ -48,6 +48,7 @@ export default class InfoOverlay extends Vue {
   background-color: $transfer-screen-bg-color;
   border-radius: 10px;
   height: 844px;
+  overflow-y: auto;
   position: absolute;
   width: 100%;
   z-index: 102;
@@ -55,7 +56,6 @@ export default class InfoOverlay extends Vue {
   @include respond-to(handhelds) {
     border-radius: 0;
     height: 100vh;
-    overflow-y: auto;
   }
 
   &__content {
@@ -63,9 +63,7 @@ export default class InfoOverlay extends Vue {
     display: flex;
     flex-direction: column;
     height: 100%;
-    @include respond-to(handhelds) {
-      margin-top: $ios-safe-area;
-    }
+    margin: 0 36px;
 
     &__header {
       display: flex;
@@ -79,7 +77,6 @@ export default class InfoOverlay extends Vue {
     &__close-icon {
       display: flex;
       justify-content: flex-end;
-      padding-right: 36px;
       width: 100%;
     }
 
@@ -98,7 +95,6 @@ export default class InfoOverlay extends Vue {
     &__body {
       font-size: 19px;
       text-align: center;
-      margin: 0 36px;
     }
 
     &__button {

--- a/raiden-dapp/src/scss/dimensions.scss
+++ b/raiden-dapp/src/scss/dimensions.scss
@@ -1,3 +1,4 @@
 $first-child-padding: 80px;
 $list-header-padding-top: 30px;
 $dialog-button-height: 35px;
+$ios-safe-area: 44px;

--- a/raiden-dapp/src/scss/dimensions.scss
+++ b/raiden-dapp/src/scss/dimensions.scss
@@ -1,4 +1,3 @@
 $first-child-padding: 80px;
 $list-header-padding-top: 30px;
 $dialog-button-height: 35px;
-$ios-safe-area: 44px;

--- a/raiden-dapp/tests/unit/components/overlays/info-overlay.spec.ts
+++ b/raiden-dapp/tests/unit/components/overlays/info-overlay.spec.ts
@@ -35,14 +35,14 @@ const createWrapper = (): Wrapper<InfoOverlay> => {
 describe('InfoOverlay.vue', () => {
   test('displays info overlay title text', () => {
     const wrapper = createWrapper();
-    const infoOverlayTitle = wrapper.find('.info-overlay__title');
+    const infoOverlayTitle = wrapper.find('.info-overlay__content__title');
 
     expect(infoOverlayTitle.text()).toBe(header);
   });
 
   test('displays info overlay body text', () => {
     const wrapper = createWrapper();
-    const infoOverlayBody = wrapper.find('.info-overlay__body');
+    const infoOverlayBody = wrapper.find('.info-overlay__content__body');
 
     expect(infoOverlayBody.text()).toBe(body);
   });


### PR DESCRIPTION
**Short description**

This PR takes care of all broken info overlays on mobile. See issue #2604. The changes has been made based on a mobile device with screen size 320x568 in mind and have also been tested on screen size 414x736 (iPhone Plus).


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Open the various info overlays on mobile and desktop and check that they look fine.
