### PR TITLE
Remove dependency on reactive notifications of peer's presences changes and update WebRTC signaling algorithm

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
 ## [Unreleased]
-
 ### Changed
 - [#2669] Update to Raiden contracts `v0.37.5`
+- [#2677] Removed the dependency on reactive notifications of peer's presences changes and updated WebRTC signaling algorithm
 
 [#2669]: https://github.com/raiden-network/light-client/issues/2669
+[#2677]: https://github.com/raiden-network/light-client/issues/2677
 
 ## [0.16.0] - 2021-04-01
 ### Added

--- a/raiden-ts/src/errors.json
+++ b/raiden-ts/src/errors.json
@@ -28,7 +28,6 @@
   "CNL_ONCHAIN_UNLOCK_FAILED": "on-chain unlock transaction reverted.",
 
   "CNL_WITHDRAW_TRANSACTION_FAILED": "Withdraw transaction has failed.",
-  "CNL_WITHDRAW_PARTNER_OFFLINE": "Channel partner isn't online.",
   "CNL_WITHDRAW_EXPIRES_SOON": "Withdraw request expired or expires too soon.",
   "CNL_WITHDRAW_EXPIRED": "Withdraw request expired.",
   "CNL_WITHDRAW_AMOUNT_TOO_LOW": "Withdraw request contains an amount smaller than already withdrawn.",

--- a/raiden-ts/src/messages/actions.ts
+++ b/raiden-ts/src/messages/actions.ts
@@ -7,7 +7,9 @@ import { createAction, createAsyncAction } from '../utils/actions';
 import { Address, Signed } from '../utils/types';
 import { Message } from './types';
 
-/** One-shot send payload.message to meta.address user in transport */
+/**
+ * One-shot send payload.message to meta.address user in transport
+ */
 export const messageSend = createAsyncAction(
   t.type({ address: Address, msgId: t.string }),
   'message/send/request',
@@ -15,7 +17,7 @@ export const messageSend = createAsyncAction(
   'message/send/failure',
   t.intersection([
     t.type({ message: t.union([t.string, Signed(Message)]) }),
-    t.partial({ msgtype: t.string }),
+    t.partial({ msgtype: t.string, userId: t.string }),
   ]),
   t.union([t.undefined, t.type({ via: t.string, tookMs: t.number, retries: t.number })]),
 );

--- a/raiden-ts/src/reducer.ts
+++ b/raiden-ts/src/reducer.ts
@@ -1,7 +1,7 @@
 import unset from 'lodash/fp/unset';
 
 import type { RaidenAction } from './actions';
-import { raidenConfigUpdate } from './actions';
+import { raidenConfigUpdate, raidenStarted } from './actions';
 import channelsReducer from './channels/reducer';
 import type { PartialRaidenConfig } from './config';
 import servicesReducer from './services/reducer';
@@ -13,9 +13,8 @@ import { createReducer } from './utils/actions';
 
 // update state.config on raidenConfigUpdate action
 // resets key to default value if value is undefined, otherwise overwrites it
-const configReducer = createReducer(initialState).handle(
-  raidenConfigUpdate,
-  (state, { payload }) => {
+const configReducer = createReducer(initialState)
+  .handle(raidenConfigUpdate, (state, { payload }) => {
     let config: PartialRaidenConfig = state.config;
     for (const [k, v] of Object.entries(payload)) {
       if (v !== undefined) config = { ...config, [k]: v };
@@ -23,8 +22,9 @@ const configReducer = createReducer(initialState).handle(
     }
     if (config === state.config) return state;
     return { ...state, config };
-  },
-);
+  })
+  // raidenStarted changes reference to ensure state$ emits when starting
+  .handle(raidenStarted, (state) => ({ ...state }));
 
 const raidenReducers = {
   configReducer,

--- a/raiden-ts/src/services/utils.ts
+++ b/raiden-ts/src/services/utils.ts
@@ -40,6 +40,18 @@ function validatePfsUrl(url: string) {
 
 const pfsAddressCache_ = new LruCache<string, Promise<Address>>(32);
 
+/** Codec for PFS API returned error */
+export const ServiceError = t.readonly(
+  t.intersection([
+    t.type({
+      error_code: t.number,
+      errors: t.string,
+    }),
+    t.partial({ error_details: t.record(t.string, t.unknown) }),
+  ]),
+);
+export type ServiceError = t.TypeOf<typeof ServiceError>;
+
 /**
  * Returns a cold observable which fetch PFS info & validate for a given server address or URL
  *

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -746,27 +746,22 @@ function receiveTransferExpired(
  * @param deps.signer - Signer instance
  * @param deps.network - Current Network
  * @param deps.config$ - Config observable
- * @param deps.latest$ - Latest observable
  * @returns Observable of withdrawMessage.request|withdraw.failure actions
  */
 function sendWithdrawRequest(
   state$: Observable<RaidenState>,
   action: withdraw.request,
-  { log, address, signer, network, config$, latest$ }: RaidenEpicDeps,
+  { log, address, signer, network, config$ }: RaidenEpicDeps,
 ): Observable<withdrawMessage.request | withdraw.failure> {
   if (action.meta.direction !== Direction.SENT) return EMPTY;
-  return combineLatest([state$, config$, latest$]).pipe(
+  return combineLatest([state$, config$]).pipe(
     first(),
-    mergeMap(([state, { revealTimeout }, { presences }]) => {
+    mergeMap(([state, { revealTimeout }]) => {
       const channel = getOpenChannel(state, action.meta);
       if (
         channel.own.pendingWithdraws.some(matchWithdraw(MessageType.WITHDRAW_REQUEST, action.meta))
       )
         return EMPTY; // already requested, skip without failing
-      assert(
-        presences[action.meta.partner]?.payload.available,
-        ErrorCodes.CNL_WITHDRAW_PARTNER_OFFLINE,
-      );
       assert(
         action.meta.expiration >= state.blockNumber + revealTimeout,
         ErrorCodes.CNL_WITHDRAW_EXPIRES_SOON,

--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -1,7 +1,7 @@
 import * as t from 'io-ts';
 import constant from 'lodash/constant';
 import type { MatrixClient } from 'matrix-js-sdk';
-import type { Observable, OperatorFunction } from 'rxjs';
+import type { Observable, ObservedValueOf, OperatorFunction } from 'rxjs';
 import {
   asapScheduler,
   AsyncSubject,
@@ -11,6 +11,8 @@ import {
   fromEvent,
   merge,
   of,
+  pipe,
+  Subject,
   throwError,
   timer,
 } from 'rxjs';
@@ -18,19 +20,18 @@ import {
   bufferTime,
   catchError,
   delayWhen,
-  distinct,
   endWith,
+  exhaustMap,
   filter,
   finalize,
+  groupBy,
   ignoreElements,
   map,
-  mapTo,
   mergeMap,
   mergeMapTo,
   observeOn,
   pluck,
-  repeatWhen,
-  share,
+  retryWhen,
   startWith,
   switchMap,
   take,
@@ -40,25 +41,32 @@ import {
   withLatestFrom,
 } from 'rxjs/operators';
 
+import type { RaidenConfig } from '../..';
 import type { RaidenAction } from '../../actions';
 import { channelMonitored } from '../../channels/actions';
-import type { RaidenConfig } from '../../config';
 import { Capabilities } from '../../constants';
 import { messageReceived, messageSend } from '../../messages/actions';
 import type { RaidenState } from '../../state';
 import { transferSigned } from '../../transfers/actions';
-import { dispatchAndWait$, exponentialBackoff } from '../../transfers/epics/utils';
+import { dispatchAndWait$ } from '../../transfers/epics/utils';
 import { Direction } from '../../transfers/state';
 import { makeMessageId } from '../../transfers/utils';
 import type { RaidenEpicDeps } from '../../types';
-import { isActionOf, isResponseOf } from '../../utils/actions';
+import { isResponseOf } from '../../utils/actions';
 import { jsonParse, jsonStringify } from '../../utils/data';
-import { matchError } from '../../utils/error';
-import { completeWith, dispatchRequestAndGetResponse, takeIf, timeoutFirst } from '../../utils/rx';
+import { assert, matchError } from '../../utils/error';
+import {
+  completeWith,
+  dispatchRequestAndGetResponse,
+  mergeWith,
+  partitionMap,
+  takeIf,
+  timeoutFirst,
+} from '../../utils/rx';
 import type { Address } from '../../utils/types';
-import { decode, isntNil } from '../../utils/types';
+import { decode, isntNil, last } from '../../utils/types';
 import { matrixPresence, rtcChannel } from '../actions';
-import { getCap, getSortedAddresses } from '../utils';
+import { getCap } from '../utils';
 import { parseMessage } from './helpers';
 
 interface CallInfo {
@@ -110,6 +118,31 @@ const rtcCodecs = {
   [RtcEventType.hangup]: RtcHangup,
 } as const;
 
+type ConnectionInfo = readonly [RTCPeerConnection, RTCDataChannel, CallInfo];
+function isConnectionInfo(value: unknown): value is ConnectionInfo {
+  return Array.isArray(value) && value.length === 3 && value[1]?.readyState;
+}
+
+const hangUpError = 'peer hung up';
+const closedError = 'channel closed';
+const pingMsg = 'ping';
+const failedConnectionStates = ['failed', 'closed', 'disconnected'];
+
+const enum Role {
+  caller = 'caller',
+  callee = 'callee',
+}
+type ChannelRequest = readonly [
+  peer: Address,
+  role: Role,
+  channel$: ReturnType<typeof rtcConnectionManagerEpic>,
+];
+type ChannelUpdate = readonly [put: boolean, channel: RTCDataChannel, error?: Error];
+
+type RtcMessage = messageReceived & {
+  payload: { userId: string; msgtype: typeof rtcMatrixMsgType };
+};
+
 // fetches and caches matrix set turnServer
 const _matrixIceServersCache = new WeakMap<MatrixClient, [number, RTCIceServer[]]>();
 async function getMatrixIceServers(matrix: MatrixClient): Promise<RTCIceServer[]> {
@@ -139,18 +172,18 @@ async function getMatrixIceServers(matrix: MatrixClient): Promise<RTCIceServer[]
   return servers;
 }
 
-// returns a stream of filtered, valid MatrixEvents
+// returns a stream of filtered, valid Rtc events coming on matrix messages
 function matrixWebrtcEvents$<T extends RtcEventType>(
   action$: Observable<RaidenAction>,
   type: T,
-  sender: Address,
-  callId: string | undefined,
+  info: Pick<CallInfo, 'peerAddress'> & Partial<Pick<CallInfo, 'callId'>>,
   { log }: Partial<Pick<RaidenEpicDeps, 'log'>> = {},
 ) {
   return action$.pipe(
     filter(messageReceived.is),
     filter(
-      (action) => action.meta.address === sender && action.payload.msgtype === rtcMatrixMsgType,
+      ({ meta, payload }) =>
+        meta.address === info.peerAddress && payload.msgtype === rtcMatrixMsgType,
     ),
     mergeMap(function* (action) {
       try {
@@ -165,27 +198,20 @@ function matrixWebrtcEvents$<T extends RtcEventType>(
         });
       }
     }),
-    filter((e) => !callId || e.call_id === callId),
+    filter((e) => !info.callId || e.call_id === info.callId),
   );
 }
 
-type RtcConnPair = readonly [RTCPeerConnection, RTCDataChannel];
-function isRtcConnPair(value: unknown): value is RtcConnPair {
-  return Array.isArray(value) && value.length === 2 && value[1]?.readyState;
-}
-
-// setup candidates$ handlers
+// setup candidates$ handlers: receives & sets candidates from peer, sends ours to them
 function handleCandidates$(
   connection: RTCPeerConnection,
   action$: Observable<RaidenAction>,
-  info: CallInfo,
+  info: Readonly<CallInfo>,
   { log }: Pick<RaidenEpicDeps, 'log'>,
 ) {
   return merge(
     // when receiving candidates from peer, add it locally
-    matrixWebrtcEvents$(action$, RtcEventType.candidates, info.peerAddress, info.callId, {
-      log,
-    }).pipe(
+    matrixWebrtcEvents$(action$, RtcEventType.candidates, info, { log }).pipe(
       tap((e) => log.debug('RTC: received candidates', info.callId, e.candidates)),
       mergeMap((event) => from((event.candidates ?? []) as RTCIceCandidateInit[])),
       mergeMap(async (candidate) => {
@@ -217,7 +243,7 @@ function handleCandidates$(
           call_id: info.callId,
         };
         return messageSend.request(
-          { message: jsonStringify(body), msgtype: rtcMatrixMsgType },
+          { message: jsonStringify(body), msgtype: rtcMatrixMsgType, userId: info.peerId },
           { address: info.peerAddress, msgId: makeMessageId().toString() },
         );
       }),
@@ -225,126 +251,130 @@ function handleCandidates$(
   );
 }
 
-// setup RTC data channel for caller
-function setupCallerDataChannel$(
-  action$: Observable<RaidenAction>,
-  info: CallInfo,
-  deps: Pick<RaidenEpicDeps, 'matrix$' | 'log' | 'latest$' | 'config$'>,
-): Observable<RtcConnPair | messageSend.request> {
-  const { peerAddress } = info;
-  return deps.matrix$.pipe(
-    mergeMap((matrix) => getMatrixIceServers(matrix)),
-    withLatestFrom(deps.config$),
-    mergeMap(([matrixTurnServers, { fallbackIceServers }]) => {
-      const connection = new RTCPeerConnection({
-        iceServers: [...matrixTurnServers, ...fallbackIceServers],
-      });
-      // start$ indicates invite/offer/answer cycle completed, and candidates can be exchanged
-      const start$ = new AsyncSubject<true>();
-      // we relay on retries, no need to enforce ordered
-      const dataChannel = connection.createDataChannel(info.callId, { ordered: false });
-      return merge(
-        handleCandidates$(connection, action$, info, deps).pipe(delayWhen(constant(start$))),
-        defer(async () => connection.createOffer()).pipe(
-          mergeMap(async (offer) => {
-            await connection.setLocalDescription(offer);
-            return offer;
-          }),
-          mergeMap((offer) => {
-            const body: t.TypeOf<typeof RtcOffer> = {
-              type: offer.type as RtcEventType.offer,
-              sdp: offer.sdp!,
-              call_id: info.callId,
-            };
-            const meta = { address: peerAddress, msgId: makeMessageId().toString() };
-            const request = messageSend.request(
-              { message: jsonStringify(body), msgtype: rtcMatrixMsgType },
-              meta,
-            );
-            let emitted = 0;
-            return merge(
-              // wait for answer
-              matrixWebrtcEvents$(
-                action$,
-                RtcEventType.answer,
-                peerAddress,
-                info.callId,
-                deps,
-              ).pipe(
-                take(1),
-                mergeMap(async (event) => {
-                  deps.log.info('RTC: got answer', event.call_id);
-                  await connection.setRemoteDescription(event);
-                  // output created channel when the offer has been sent
-                  return [connection, dataChannel] as const;
-                }),
-                finalize(() => {
-                  start$.next(true);
-                  start$.complete();
-                }),
-              ),
-              // send invite with offer, complete when response goes through
-              dispatchAndWait$(action$, request, isResponseOf(messageSend, meta)).pipe(
-                endWith([connection, dataChannel] as const),
-              ),
-              // merge emits connection pair on either (or both) request sent or answer received;
-              // this filter ensures connection pair is emitted only once, while keeping observable
-              // from completing until all merged observables complete
-            ).pipe(
-              filter((value) => (isRtcConnPair(value) ? !emitted++ : true)),
-              finalize(() => (!emitted ? connection.close() : null)),
-            );
-          }),
-        ),
-      );
-    }),
-  );
-}
-
-// setup RTC data channel for callee
-function setupCalleeDataChannel$(
-  action$: Observable<RaidenAction>,
-  info: CallInfo,
-  deps: Pick<RaidenEpicDeps, 'matrix$' | 'log' | 'latest$' | 'config$'>,
-): Observable<RtcConnPair | messageSend.request> {
-  const { peerAddress } = info;
-  return matrixWebrtcEvents$(action$, RtcEventType.offer, peerAddress, undefined, deps).pipe(
-    tap((event) => deps.log.info('RTC: got invite', event.call_id)),
-    mergeMap((event) =>
-      deps.matrix$.pipe(
-        mergeMap((matrix) => getMatrixIceServers(matrix).then((serv) => [event, serv] as const)),
+// extracted helper of [listenDataChannel]
+function makeDataChannelObservable(
+  [connection, dataChannel, info]: ConnectionInfo,
+  [action$, open$]: [Observable<RaidenAction>, Subject<true>],
+  { httpTimeout }: Pick<RaidenConfig, 'httpTimeout'>,
+  deps: RaidenEpicDeps,
+) {
+  return merge(
+    fromEvent<Event>(connection, 'connectionstatechange').pipe(
+      startWith(null),
+      mergeMap(() =>
+        failedConnectionStates.includes(connection.connectionState)
+          ? throwError(new Error('RTC: connection failed'))
+          : EMPTY,
       ),
     ),
-    withLatestFrom(deps.config$),
-    switchMap(([[event, matrixTurnServers], { fallbackIceServers }]) => {
-      if (event.call_id !== info.callId) {
-        deps.log.info('RTC: setting callId from caller', { info, event });
-        if (event.call_id) info.callId = event.call_id; // set callId as per caller's
-      }
-      // start$ indicates invite/offer/answer cycle completed, and candidates can be exchanged
-      const start$ = new AsyncSubject<true>();
-      // create connection only upon invite/offer
-      const connection = new RTCPeerConnection({
-        iceServers: [...matrixTurnServers, ...fallbackIceServers],
-      });
-      let close = true;
+    fromEvent<Event>(dataChannel, 'close').pipe(mergeMapTo(throwError(new Error(closedError)))),
+    fromEvent<RTCErrorEvent>(dataChannel, 'error').pipe(mergeMap((ev) => throwError(ev.error))),
+    matrixWebrtcEvents$(action$, RtcEventType.hangup, info, deps).pipe(
+      mergeMapTo(throwError(new Error(hangUpError))),
+    ),
+    fromEvent<Event>(dataChannel, 'open').pipe(
+      take(1),
+      timeoutFirst(httpTimeout),
+      map(() => {
+        deps.log.info('RTC: dataChannel open', dataChannel.label);
+        info.callId = dataChannel.label;
+        // when connected, sends a first message
+        dataChannel.send(pingMsg);
+        open$.next(true);
+        open$.complete();
+        return rtcChannel(dataChannel, { address: info.peerAddress });
+      }),
+    ),
+    fromEvent<MessageEvent>(dataChannel, 'message').pipe(
+      tap((e) => deps.log.debug('RTC: dataChannel message', dataChannel.label, e)),
+      pluck('data'),
+      filter((d: unknown): d is string => typeof d === 'string'),
+      // ignore pingMsg, used only to succeed rtcChannel
+      filter((line) => line !== pingMsg),
+      mergeMap((lines) => from(lines.split('\n'))),
+      observeOn(asapScheduler),
+      map((line) =>
+        messageReceived(
+          {
+            text: line,
+            message: parseMessage(line, info.peerAddress, deps),
+            ts: Date.now(),
+            userId: info.peerId,
+          },
+          { address: info.peerAddress },
+        ),
+      ),
+    ),
+  ).pipe(finalize(() => connection.close()));
+}
+
+// setup listeners & events for a data channel, when it gets opened, and teardown when closed
+function listenDataChannel<T>(
+  action$: Observable<RaidenAction>,
+  deps: RaidenEpicDeps,
+): OperatorFunction<T | ConnectionInfo, T | rtcChannel | messageReceived> {
+  const { config$ } = deps;
+  return (source$) => {
+    let open$: AsyncSubject<true>;
+    return defer(() => {
+      open$ = new AsyncSubject<true>();
+      return source$.pipe(takeUntil(open$));
+    }).pipe(
+      // partitionMap will send only ConnectionInfo tuples to pipe below, and passthrough the rest
+      partitionMap(
+        isConnectionInfo,
+        pipe(
+          withLatestFrom(config$),
+          switchMap(([connection, config]) =>
+            makeDataChannelObservable(connection, [action$, open$], config, deps),
+          ),
+        ),
+      ),
+    );
+  };
+}
+
+// make an observable which answers an incoming call when subscribed
+function makeCalleeAnswer$(
+  action$: Observable<RaidenAction>,
+  [received, offer]: [RtcMessage, t.TypeOf<typeof RtcOffer>],
+  deps: RaidenEpicDeps,
+): Observable<rtcChannel | messageReceived | messageSend.request> {
+  const { matrix$, config$, log } = deps;
+  const info: CallInfo = {
+    callId: offer.call_id!,
+    peerId: received.payload.userId,
+    peerAddress: received.meta.address,
+  };
+  log.info('RTC: callee answering', info);
+  const start$ = new AsyncSubject<true>();
+
+  return matrix$.pipe(
+    mergeMap(async (matrix) => getMatrixIceServers(matrix)),
+    withLatestFrom(config$),
+    mergeMap(([matrixIce, { fallbackIceServers: fallback }]) => {
+      const connection = new RTCPeerConnection({ iceServers: matrixIce.concat(fallback) });
+      let emitted = 0;
       return merge(
         handleCandidates$(connection, action$, info, deps).pipe(delayWhen(constant(start$))),
-        defer(async () => connection.setRemoteDescription(event)).pipe(
+        defer(async () => connection.setRemoteDescription(offer)).pipe(
           mergeMap(async () => connection.createAnswer()),
-          mergeMap(async (answer) => {
-            await connection.setLocalDescription(answer);
-            return answer;
-          }),
-          mergeMap((answer) => {
+          mergeWith(async (answer) => connection.setLocalDescription(answer)),
+          mergeMap(([answer]) => {
             const body: t.TypeOf<typeof RtcAnswer> = {
               type: answer.type as RtcEventType.answer,
               sdp: answer.sdp!,
               call_id: info.callId,
             };
+            // send answer, complete when response goes through; no need to forward
+            // the success
             const request = messageSend.request(
-              { message: jsonStringify(body), msgtype: rtcMatrixMsgType },
-              { address: peerAddress, msgId: makeMessageId().toString() },
+              {
+                message: jsonStringify(body),
+                msgtype: rtcMatrixMsgType,
+                userId: received.payload.userId,
+              },
+              { address: info.peerAddress, msgId: makeMessageId().toString() },
             );
             // send answer, complete when response goes through
             return dispatchAndWait$(action$, request, isResponseOf(messageSend, request.meta));
@@ -352,242 +382,338 @@ function setupCalleeDataChannel$(
           finalize(() => (start$.next(true), start$.complete())),
         ),
         fromEvent<RTCDataChannelEvent>(connection, 'datachannel').pipe(
-          map(({ channel }) => [connection, channel] as const),
+          map(({ channel }) => (++emitted, [connection, channel, info] as const)),
           take(1),
-          tap(() => (close = false)),
-          // if switchMap unsubscribes before datachannel got emitted, release connection
-          finalize(() => (close ? connection.close() : null)),
+          // if switchMap unsubscribes before datachannel got emitted, release
+          // connection
+          finalize(() => (!emitted ? connection.close() : null)),
         ),
+      );
+    }),
+    listenDataChannel(action$, deps),
+  );
+}
+
+// extracted helper of [makeCallerObservable]
+function makeOfferWaitAnswer(
+  request: messageSend.request,
+  connInfo: ConnectionInfo,
+  [action$, start$]: readonly [Observable<RaidenAction>, Subject<true>],
+  deps: RaidenEpicDeps,
+) {
+  return merge(
+    // wait for answer
+    matrixWebrtcEvents$(action$, RtcEventType.answer, connInfo[2], deps).pipe(
+      take(1),
+      mergeMap(async (event) => {
+        deps.log.info('RTC: got answer', event.call_id);
+        await connInfo[0].setRemoteDescription(event);
+        // output created channel when the offer has been sent
+        return connInfo;
+      }),
+      finalize(() => (start$.next(true), start$.complete())),
+    ),
+    // send invite with offer, complete when success goes through
+    dispatchAndWait$(action$, request, isResponseOf(messageSend, request.meta)).pipe(
+      endWith(connInfo),
+    ),
+  );
+}
+
+// extracted helper of [makeCallerCall$]
+function makeCallerObservable(
+  [peer, peerId]: readonly [Address, string],
+  action$: Observable<RaidenAction>,
+  deps: RaidenEpicDeps,
+) {
+  const { matrix$, config$, log, address } = deps;
+  return matrix$.pipe(
+    mergeMap(async (matrix) => getMatrixIceServers(matrix)),
+    withLatestFrom(config$),
+    mergeMap(([matrixIce, { fallbackIceServers: fallback }]) => {
+      const info: CallInfo = {
+        callId: `${address}|${peer}|${Date.now()}`,
+        peerId,
+        peerAddress: peer,
+      };
+      log.info('RTC: caller calling', info);
+      const connection = new RTCPeerConnection({ iceServers: matrixIce.concat(fallback) });
+      const dataChannel = connection.createDataChannel(info.callId, { ordered: false });
+      // start$ indicates invite/answer cycle completed, and candidates can be exchanged
+      const start$ = new AsyncSubject<true>();
+      let emitted = 0;
+
+      return merge(
+        handleCandidates$(connection, action$, info, deps).pipe(delayWhen(constant(start$))),
+        defer(async () => connection.createOffer()).pipe(
+          mergeMap(async (offer) => (await connection.setLocalDescription(offer), offer)),
+          mergeMap((offer) => {
+            const body: t.TypeOf<typeof RtcOffer> = {
+              type: offer.type as RtcEventType.offer,
+              sdp: offer.sdp!,
+              call_id: info.callId,
+            };
+            const request = messageSend.request(
+              { message: jsonStringify(body), msgtype: rtcMatrixMsgType, userId: info.peerId },
+              { address: peer, msgId: makeMessageId().toString() },
+            );
+            return makeOfferWaitAnswer(
+              request,
+              [connection, dataChannel, info],
+              [action$, start$],
+              deps,
+            );
+          }),
+        ),
+      ).pipe(
+        filter((value) => (isConnectionInfo(value) ? !emitted++ : true)),
+        finalize(() => (!emitted ? connection.close() : null)),
+      );
+    }),
+    listenDataChannel(action$, deps),
+  );
+}
+
+// make an observable which calls peer when subscribed
+function makeCallerCall$(
+  action$: Observable<RaidenAction>,
+  [peer, peerId]: readonly [peer: Address, peerId?: string],
+  deps: RaidenEpicDeps,
+): Observable<rtcChannel | messageReceived | messageSend.request | matrixPresence.request> {
+  if (peerId) return makeCallerObservable([peer, peerId], action$, deps);
+  return action$.pipe(
+    dispatchRequestAndGetResponse(matrixPresence, (dispatch) =>
+      dispatch(matrixPresence.request(undefined, { address: peer })).pipe(
+        mergeMap((presence) => {
+          assert(getCap(presence.payload.caps, Capabilities.WEBRTC), "peer doesn't support RTC");
+          return makeCallerObservable([peer, presence.payload.userId], action$, deps);
+        }),
+      ),
+    ),
+  );
+}
+
+// manage stream of callee observables and subscribe to them when needed
+function manageCalleeChannel(
+  peer: Address,
+  setChannel: Subject<ChannelUpdate>,
+  { log }: Pick<RaidenEpicDeps, 'log'>,
+): OperatorFunction<ChannelRequest, ObservedValueOf<ChannelRequest[2]>> {
+  return pipe(
+    // switchMap *unsubscribes* previous incoming call
+    switchMap(([, , channel$]) => {
+      let channel: RTCDataChannel | undefined;
+      let error: Error | undefined;
+      return channel$.pipe(
+        tap((action) => {
+          if (!channel && rtcChannel.is(action) && action.payload)
+            setChannel.next([true, (channel = action.payload)]);
+        }),
+        catchError((err) => {
+          log.info('RTC: callee channel error', peer, err.message);
+          error = err;
+          return EMPTY;
+        }),
+        finalize(() => {
+          log.info('RTC: callee disconnecting', peer);
+          if (channel) setChannel.next([false, channel, error]);
+        }),
+        // give up if annother channel (caller) gets established
+        takeUntil(setChannel.pipe(filter(([put, channel_]) => put && channel_ !== channel))),
       );
     }),
   );
 }
 
-const hangUpError = 'peer hung up';
-const closedError = 'channel closed';
-const pingMsg = 'ping';
-const failedConnectionStates = ['failed', 'closed', 'disconnected'];
-
-// setup listeners & events for a data channel, when it gets opened, and teardown when closed
-function listenDataChannel(
-  openTimeout: number,
-  { peerId, peerAddress }: CallInfo,
-  { log }: Pick<RaidenEpicDeps, 'log'>,
-): OperatorFunction<
-  messageSend.request | RtcConnPair,
-  messageSend.request | rtcChannel | messageReceived
-> {
-  return (source$) => {
-    const open$ = new AsyncSubject<true>();
-    // input$ mirrors source$, but completes when a dataChannel gets opened
-    const input$ = source$.pipe(takeUntil(open$), share());
-
-    const sendReq$ = input$.pipe(filter(messageSend.request.is));
-    const handleChannel$ = input$.pipe(filter(isRtcConnPair)).pipe(
-      switchMap(([connection, dataChannel]) =>
-        merge(
-          fromEvent<Event>(connection, 'connectionstatechange').pipe(
-            startWith(null),
-            mergeMap(() =>
-              failedConnectionStates.includes(connection.connectionState)
-                ? throwError(new Error('RTC: connection failed'))
-                : EMPTY,
-            ),
-          ),
-          fromEvent<Event>(dataChannel, 'close').pipe(
-            mergeMapTo(throwError(new Error(closedError))),
-          ),
-          fromEvent<RTCErrorEvent>(dataChannel, 'error').pipe(
-            mergeMap((ev) => throwError(ev.error)),
-          ),
-          fromEvent<Event>(dataChannel, 'open').pipe(
-            tap(() => {
-              log.info('RTC: dataChannel open', dataChannel.label);
-              // when connected, sends a first message
-              dataChannel.send(pingMsg);
+// manage stream of caller observables and subscribe to them when needed
+function manageCallerChannel(
+  peer: Address,
+  setChannel: Subject<ChannelUpdate>,
+  { log, config$ }: Pick<RaidenEpicDeps, 'log' | 'config$'>,
+): OperatorFunction<ChannelRequest, ObservedValueOf<ChannelRequest[2]>> {
+  return pipe(
+    // exhaustMap *ignores* new call requests if one is already running
+    exhaustMap(([, , channel$]) => {
+      let channel: RTCDataChannel | undefined;
+      let error: Error | undefined;
+      return defer(() => {
+        // upon retrying/re-subscribing, reset channel & error;
+        channel = undefined;
+        error = undefined;
+        return channel$.pipe(
+          tap({
+            next(action) {
+              if (!channel && rtcChannel.is(action) && action.payload)
+                setChannel.next([true, (channel = action.payload)]);
+            },
+            error(err) {
+              log.info('RTC: caller channel error', peer, err.message);
+              error = err;
+            },
+          }),
+          finalize(() => {
+            if (channel) setChannel.next([false, channel, error]);
+          }),
+        );
+      }).pipe(
+        retryWhen((err$) =>
+          err$.pipe(
+            withLatestFrom(config$),
+            mergeMap(([, { pollingInterval, httpTimeout }], retryCount) => {
+              if (retryCount >= 5) return of(true);
+              const delay = Math.min(pollingInterval * Math.pow(2, retryCount), httpTimeout * 2);
+              log.info('RTC: caller retrying in', delay, peer, retryCount);
+              return timer(delay);
             }),
-            timeoutFirst(openTimeout),
-            // output rtcChannel action with defined channel instance to have it set in latest$
-            // on (and only on) first received message; if no message is received, it'll
-            // timeout and retry channel
-            tap(() => {
-              open$.next(true);
-              open$.complete();
-            }),
-            mapTo(rtcChannel(dataChannel, { address: peerAddress })),
+            takeWhile((val) => val !== true),
+            finalize(() => log.info('RTC: caller giving up', peer)),
           ),
-          // 'race+throwError' is like timeout operator, but applies only once
-          // i.e. times out to retry whole connection if no first message is received on time;
-          // emits rtcChannel action on first message, instead of on 'open' event
-          fromEvent<MessageEvent>(dataChannel, 'message').pipe(
-            observeOn(asapScheduler),
-            tap((e) => log.debug('RTC: dataChannel message', dataChannel.label, e)),
-            pluck('data'),
-            filter((d: unknown): d is string => typeof d === 'string'),
-            filter((line) => line !== pingMsg), // ignore pingMsg, used only to succeed rtcChannel
-            mergeMap((lines) => from(lines.split('\n'))),
-            map((line) =>
-              messageReceived(
-                {
-                  text: line,
-                  message: parseMessage(line, peerAddress, { log }),
-                  ts: Date.now(),
-                  userId: peerId,
-                },
-                { address: peerAddress },
-              ),
-            ),
-          ),
-        ).pipe(finalize(() => connection.close())),
-      ),
-    );
-    return merge(sendReq$, handleChannel$);
-  };
-}
-
-function makeCallId(our: Address, partner: Address) {
-  const addresses = getSortedAddresses(our, partner);
-  const isCaller = addresses[0] === our;
-  let callId = addresses.join('|');
-  if (isCaller) callId += `|${Date.now()}`;
-  return callId;
-}
-
-// handles presence changes for a single peer address (grouped)
-function handlePresenceChange$(
-  action: matrixPresence.success,
-  action$: Observable<RaidenAction>,
-  { httpTimeout, pollingInterval }: RaidenConfig,
-  deps: RaidenEpicDeps,
-): Observable<rtcChannel | messageSend.request | messageReceived> {
-  // if peer goes offline in Matrix, reset dataChannel & unsubscribe defer to close dataChannel
-  if (!getCap(action.payload.caps, Capabilities.WEBRTC))
-    return of(rtcChannel(undefined, action.meta));
-
-  const { log, address } = deps;
-  const isCaller = getSortedAddresses(address, action.meta.address)[0] === address;
-  // since the lower and upper limits for timeouts are relatively closer, we reduce the
-  // multiplier to give more iterations before topping
-  const timeoutGen = exponentialBackoff(httpTimeout, 2 * httpTimeout, 1.2);
-
-  return defer(() => {
-    const callId = makeCallId(address, action.meta.address);
-    const info: CallInfo = {
-      callId, // callee is expected to update its callId when receiving from caller
-      peerId: action.payload.userId,
-      peerAddress: action.meta.address,
-    };
-
-    // stop$ indicates dataChannel closed (maybe by peer), and teardown should take place
-    const stop$ = new AsyncSubject<boolean>();
-
-    let dataChannel$;
-    if (isCaller) dataChannel$ = setupCallerDataChannel$(action$, info, deps);
-    else dataChannel$ = setupCalleeDataChannel$(action$, info, deps);
-
-    const { value: timeoutValue } = timeoutGen.next();
-    if (!timeoutValue) return EMPTY; // shouldn't happen with exponentialBackoff
-
-    // listenDataChannel$ needs channel$:Observable<[RTCDataChannel]>, but we must include/
-    // merge setup and monitoring Observable<never>'s to get things moving on subscription
-    return merge(
-      merge(
-        dataChannel$,
-        // throws and restart if peer hangs up
-        matrixWebrtcEvents$(action$, RtcEventType.hangup, info.peerAddress, info.callId, {
-          log,
-        }).pipe(
-          // no need for specific error since this is just logged and ignored
-          mergeMapTo(throwError(new Error(hangUpError))),
         ),
-      ).pipe(
-        listenDataChannel(timeoutValue, info, deps),
-        takeUntil(stop$),
-        catchError((err) => {
-          // emit false for these errors, to prevent delayed hangup event to be sent
-          stop$.next(!matchError([hangUpError, closedError], err));
-          stop$.complete();
-          log.info(
-            "Couldn't set up WebRTC dataChannel, retrying",
-            info.callId,
-            err?.message ?? err,
-          );
-          return EMPTY;
-        }),
-        // if it ends by takeUntil or catchError, output rtcChannel to reset latest$ mapping
-        endWith(rtcChannel(undefined, { address: action.meta.address })),
-      ),
-      // merge possible hangup on stop$
-      stop$.pipe(
-        filter((errored) => errored),
-        map(() => {
-          const body: t.TypeOf<typeof RtcHangup> = {
-            type: RtcEventType.hangup,
-            call_id: info.callId,
-          };
-          return messageSend.request(
-            { message: jsonStringify(body), msgtype: rtcMatrixMsgType },
-            { address: info.peerAddress, msgId: makeMessageId().toString() },
-          );
-        }),
-      ),
-    );
-  }).pipe(
-    // if it disconnects for any reason, try to reconnect by repeating from 'defer';
-    // caller waits some time before retrying, caller starts listening immediately
-    repeatWhen((completed$) =>
-      completed$.pipe(mergeMap(() => (isCaller ? timer(pollingInterval) : of(null)))),
+        // give up if another channel (callee) gets established
+        takeUntil(setChannel.pipe(filter(([put, channel_]) => put && channel_ !== channel))),
+      );
+    }),
+  );
+}
+
+// operator to map stream of RaidenActions to incoming calls (received message and decoded offer)
+function mapRtcMessage(): OperatorFunction<
+  RaidenAction,
+  readonly [RtcMessage, t.TypeOf<typeof RtcOffer>]
+> {
+  return pipe(
+    filter(messageReceived.is),
+    filter(
+      (action): action is RtcMessage =>
+        action.payload.msgtype === rtcMatrixMsgType && !!action.payload.userId,
     ),
+    mergeWith(function* (action) {
+      try {
+        const json = jsonParse(action.payload.text);
+        if (json['type'] === RtcEventType.offer) yield decode(rtcCodecs[RtcEventType.offer], json);
+      } catch (error) {}
+    }),
+  );
+}
+
+// from actions, choose peers which whom we should attempt to [re]establish RTC channels
+function getAddressOfInterest(action: RaidenAction, { address }: Pick<RaidenEpicDeps, 'address'>) {
+  let peer: Address | undefined;
+  if (channelMonitored.is(action)) peer = action.meta.partner;
+  else if (transferSigned.is(action)) {
+    if (action.meta.direction === Direction.SENT && action.payload.message.initiator === address)
+      peer = action.payload.message.target;
+    else if (
+      action.meta.direction === Direction.RECEIVED &&
+      action.payload.message.target === address
+    )
+      peer = action.payload.message.initiator;
+  } else if (messageSend.request.is(action) && action.payload.msgtype !== rtcMatrixMsgType) {
+    peer = action.meta.address;
+  } else if (rtcChannel.is(action) && !action.payload) {
+    // payload=undefined is only emitted when the last valid RTC connection with this peer got
+    // closed, so let's attempt to call them
+    peer = action.meta.address;
+  }
+  return peer;
+}
+
+// adds channel to peer's channel queue when open/put; pops, reset & send hangup when closed
+function mapChannelUpdateReset(
+  peer: Address,
+  channels: RTCDataChannel[],
+): OperatorFunction<ChannelUpdate, rtcChannel | messageSend.request> {
+  return pipe(
+    mergeMap(function* ([put, channel, err]) {
+      if (put) {
+        channels.push(channel);
+        return;
+      }
+      if (last(channels) === channel) {
+        channels.pop();
+        yield rtcChannel(last(channels), { address: peer });
+      } else {
+        const idx = channels.indexOf(channel);
+        if (idx >= 0) channels.splice(idx, 1); // else should never happen
+      }
+      if (!matchError([hangUpError, closedError], err)) {
+        const body: t.TypeOf<typeof RtcHangup> = {
+          type: RtcEventType.hangup,
+          call_id: channel.label,
+        };
+        yield messageSend.request(
+          { message: jsonStringify(body), msgtype: rtcMatrixMsgType },
+          { address: peer, msgId: makeMessageId().toString() },
+        );
+      }
+    }),
   );
 }
 
 /**
- * Epic to handle presence updates and try to connect a webRTC channel with compatible peers
+ * Creates and manages WebRTC connection requests
+ *
+ * For whitelisted peers, it'll always listen for 'offer' messages and answer to try to establish
+ * the RTC channel. If a new one comes while the previous is waiting, it'll teardown the previous
+ * request and answer the new.
+ * For Raiden channel partners (on startup/channelOpen), targets, initiators and also upon new
+ * messageSend.requests, it's checked if the peer is online, and in parallel with any callee
+ * handling, a call is initiated, times out after a few seconds and is retried a few times (to be
+ * retried again in any of the above events). The winner channel of the callee/caller race is used.
  *
  * @param action$ - Observable of RaidenActions
  * @param deps - Epics dependencies
- * @returns Observable of rtcChannel | messageReceived actions
+ * @returns Observable of rtcChannel|messageSend.request|messageReceived|matrixPresence.request
+ *      actions
  */
-export function rtcConnectEpic(
+export function rtcConnectionManagerEpic(
   action$: Observable<RaidenAction>,
   {}: Observable<RaidenState>,
   deps: RaidenEpicDeps,
 ): Observable<rtcChannel | messageSend.request | messageReceived | matrixPresence.request> {
-  const { config$, address } = deps;
-  return action$.pipe(
+  // observable of observables, created when *receiving* a call
+  const asCallee$: Observable<ChannelRequest> = action$.pipe(
+    mapRtcMessage(),
+    map(([action, offer]) => [
+      action.meta.address,
+      Role.callee,
+      makeCalleeAnswer$(action$, [action, offer], deps),
+    ]),
+  );
+  // observable of observables, created upon certain events which triggers us to try to call peer
+  const asCaller$: Observable<ChannelRequest> = action$.pipe(
     // allow RTC connect to neighbors, initiators for received and targets for sent transfers
-    filter(isActionOf([transferSigned, channelMonitored])),
-    mergeMap(function* (action) {
-      if (channelMonitored.is(action)) yield action.meta.partner;
-      else if (
-        action.meta.direction === Direction.SENT &&
-        action.payload.message.initiator === address
-      )
-        yield action.payload.message.target;
-      else if (
-        action.meta.direction === Direction.RECEIVED &&
-        action.payload.message.target === address
-      )
-        yield action.payload.message.initiator;
+    mergeMap(function* (action): Iterable<readonly [peerAddress: Address, peerId?: string]> {
+      const peerAddress = getAddressOfInterest(action, deps);
+      if (peerAddress) yield [peerAddress];
     }),
-    distinct(),
-    mergeMap((peer) =>
-      action$.pipe(
-        dispatchRequestAndGetResponse(matrixPresence, (dispatch) =>
-          dispatch(matrixPresence.request(undefined, { address: peer })).pipe(
-            withLatestFrom(config$),
-            switchMap(([presence, config]) =>
-              handlePresenceChange$(presence, action$, config, deps),
-            ),
-            completeWith(action$),
-            catchError((err) => {
-              deps.log.warn('Error fetching presence for WebRTC', peer, err);
-              return EMPTY;
-            }),
+    map((peer) => [peer[0], Role.caller, makeCallerCall$(action$, peer, deps)]),
+  );
+
+  return merge(asCallee$, asCaller$).pipe(
+    groupBy(([peer]) => peer),
+    mergeMap((perPeer$) => {
+      const peer = perPeer$.key;
+      const channels: RTCDataChannel[] = []; // peer's channels
+      const setChannel = new Subject<ChannelUpdate>();
+
+      return merge(
+        perPeer$.pipe(
+          groupBy(([, role]) => role),
+          mergeMap((perRole$) =>
+            perRole$.key === Role.callee
+              ? perRole$.pipe(manageCalleeChannel(peer, setChannel, deps))
+              : perRole$.pipe(
+                  filter(() => !channels.length), // don't call if there's already an open channel
+                  manageCallerChannel(peer, setChannel, deps),
+                ),
           ),
+          completeWith(action$),
+          finalize(() => setTimeout(() => setChannel.complete(), 10)),
         ),
-      ),
-    ),
-    takeIf(config$.pipe(pluck('caps', Capabilities.WEBRTC), completeWith(action$))),
+        setChannel.pipe(mapChannelUpdateReset(peer, channels)),
+      );
+    }),
+    takeIf(deps.config$.pipe(pluck('caps', Capabilities.WEBRTC), completeWith(action$))),
   );
 }

--- a/raiden-ts/src/transport/utils.ts
+++ b/raiden-ts/src/transport/utils.ts
@@ -1,51 +1,26 @@
-import memoize from 'lodash/memoize';
-import type { Observable } from 'rxjs';
-import { filter, scan, share, startWith } from 'rxjs/operators';
+import { getAddress } from '@ethersproject/address';
 
-import type { RaidenAction } from '../actions';
 import type { Capabilities } from '../constants';
 import { CapsFallback } from '../constants';
 import { jsonParse } from '../utils/data';
 import type { Address } from '../utils/types';
-import { matrixPresence } from './actions';
-import type { Caps, CapsPrimitive, Presences } from './types';
+import type { Caps, CapsPrimitive } from './types';
+
+const userRe = /^@(0x[0-9a-f]{40})[.:]/i;
 
 /**
- * Helper to map/get an aggregated Presences observable from action$ bus
- * Known presences as { address: <last seen MatrixPresenceUpdateAction> } mapping
- * It's memoized and shared, so all subscriptions share the same mapped/output object, but the type
- * is explicitly set to avoid requiring the exported MemoizedFunction type
+ * Extract the address in a matrix userId and returns it, or undefined it none
  *
- * @param action$ - Observable
- * @returns Observable of aggregated Presences from subscription to now
+ * @param userId - matrix user identifier
+ * @returns address contained in userId
  */
-export const getPresences$: (action$: Observable<RaidenAction>) => Observable<Presences> = memoize(
-  (action$: Observable<RaidenAction>): Observable<Presences> =>
-    action$.pipe(
-      filter(matrixPresence.success.is),
-      scan(
-        // scan all presence update actions and populate/output a per-address mapping
-        (presences, update) => ({
-          ...presences,
-          [update.meta.address]: update,
-        }),
-        {} as Presences,
-      ),
-      share(),
-      startWith({}),
-    ),
-);
-
-/**
- * @param presences - Presences mapping
- * @param userId - Peer userId
- * @returns Presence of peer with userId
- */
-export function getPresenceByUserId(
-  presences: Presences,
-  userId: string,
-): matrixPresence.success | undefined {
-  return Object.values(presences).find((presence) => presence.payload.userId === userId);
+export function getAddressFromUserId(userId: string): Address | undefined {
+  let address: Address | undefined;
+  try {
+    const match = userRe.exec(userId);
+    if (match) address = getAddress(match[1]) as Address;
+  } catch (e) {}
+  return address;
 }
 
 /**

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -20,7 +20,6 @@ import type { RaidenDatabase } from './db/types';
 import type { PFSFeeUpdate } from './messages/types';
 import type { RaidenState } from './state';
 import type { FeeModel } from './transfers/mediate/types';
-import type { Presences } from './transport/types';
 import type { Address, UInt } from './utils/types';
 
 interface Info {
@@ -41,7 +40,7 @@ export interface Latest {
   action: RaidenAction;
   state: RaidenState;
   config: RaidenConfig;
-  presences: Presences;
+  whitelisted: readonly Address[];
   rtc: { [address: string]: RTCDataChannel };
   udcDeposit: { balance: UInt<32>; totalDeposit: UInt<32> };
   blockTime: number;

--- a/raiden-ts/src/utils/error.ts
+++ b/raiden-ts/src/utils/error.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { map } from 'fp-ts/lib/Either';
-import { pipe } from 'fp-ts/lib/pipeable';
+import { pipe } from 'fp-ts/lib/function';
 import * as t from 'io-ts';
 import findKey from 'lodash/findKey';
 

--- a/raiden-ts/src/utils/error.ts
+++ b/raiden-ts/src/utils/error.ts
@@ -9,9 +9,6 @@ import errorCodes from '../errors.json';
 export const ErrorCodes = errorCodes;
 export type ErrorCodes = keyof typeof ErrorCodes;
 
-export const ErrorDetails = t.record(t.string, t.union([t.string, t.number, t.boolean, t.null]));
-export interface ErrorDetails extends t.TypeOf<typeof ErrorDetails> {}
-
 export type ErrorMatch = string | number | { [k: string]: string | number };
 export type ErrorMatches = readonly ErrorMatch[];
 
@@ -127,7 +124,7 @@ export const commonAndFailTxErrors: ErrorMatches = [...commonTxErrors, ...txFail
 export class RaidenError extends Error {
   public name = 'RaidenError';
 
-  public constructor(message?: string, public details: ErrorDetails = {}) {
+  public constructor(message?: string, public details?: unknown) {
     super(message);
     Object.setPrototypeOf(this, RaidenError.prototype);
   }
@@ -169,7 +166,7 @@ export function assert<E extends Error = RaidenError>(
 
 const serializedErr = t.intersection([
   t.type({ name: t.string }),
-  t.partial({ message: t.string, stack: t.string, details: ErrorDetails }),
+  t.partial({ message: t.string, stack: t.string, details: t.unknown }),
 ]);
 
 /**
@@ -181,7 +178,7 @@ const serializedErr = t.intersection([
  */
 export const ErrorCodec = new t.Type<
   Error,
-  { name: string; message?: string; stack?: string; details?: ErrorDetails }
+  { name: string; message?: string; stack?: string; details?: unknown }
 >(
   'Error',
   // if it quacks like a duck... without relying on instanceof

--- a/raiden-ts/src/utils/rx.ts
+++ b/raiden-ts/src/utils/rx.ts
@@ -1,10 +1,24 @@
+import type * as t from 'io-ts';
 import type {
   MonoTypeOperatorFunction,
   Observable,
   ObservableInput,
   OperatorFunction,
 } from 'rxjs';
-import { defer, EMPTY, from, pairs, race, Subject, throwError, timer } from 'rxjs';
+import {
+  defer,
+  EMPTY,
+  from,
+  merge,
+  pairs,
+  partition,
+  pipe,
+  race,
+  ReplaySubject,
+  Subject,
+  throwError,
+  timer,
+} from 'rxjs';
 import {
   catchError,
   concatMap,
@@ -12,6 +26,7 @@ import {
   distinctUntilChanged,
   endWith,
   filter,
+  finalize,
   ignoreElements,
   last,
   map,
@@ -21,12 +36,15 @@ import {
   repeatWhen,
   retryWhen,
   scan,
+  share,
   switchMap,
   takeUntil,
   takeWhile,
   tap,
 } from 'rxjs/operators';
 
+import type { ActionType, AsyncActionCreator } from './actions';
+import { isResponseOf } from './actions';
 import { shouldRetryError } from './error';
 import { isntNil } from './types';
 
@@ -39,9 +57,8 @@ import { isntNil } from './types';
  * @param properties - The nested properties to pluck from each source value (an object).
  * @returns A new Observable of property values from the source values.
  */
-export const pluckDistinct: typeof pluck = <T, R>(...properties: string[]) => (
-  source: Observable<T>,
-) => source.pipe(pluck<T, R>(...properties), distinctUntilChanged());
+export const pluckDistinct: typeof pluck = <T, R>(...properties: string[]) =>
+  pipe(pluck<T, R>(...properties), distinctUntilChanged());
 
 /**
  * Creates an operator to output changed values unique by key ([key, value] tuples)
@@ -53,24 +70,23 @@ export const pluckDistinct: typeof pluck = <T, R>(...properties: string[]) => (
 export function distinctRecordValues<R>(
   compareFn: (x: R, y: R) => boolean = (x, y) => x === y,
 ): OperatorFunction<{ [k: string]: R }, [string, R]> {
-  return (input: Observable<Record<string, R>>): Observable<[string, R]> =>
-    input.pipe(
-      distinctUntilChanged(),
-      mergeMap((map) => pairs<R>(map)),
-      /* this scan stores a reference to each [key,value] in 'acc', and emit as 'changed' iff it
-       * changes from last time seen. It relies on value references changing only if needed */
-      scan<[string, R], { acc: { [k: string]: R }; changed?: [string, R] }>(
-        ({ acc }, [key, value]) =>
-          // if ref didn't change, emit previous accumulator, without 'changed' value
-          compareFn(acc[key], value)
-            ? { acc }
-            : // else, update ref in 'acc' and emit value in 'changed' prop
-              { acc: { ...acc, [key]: value }, changed: [key, value] },
-        { acc: {} as { [k: string]: R } },
-      ),
-      pluck('changed'),
-      filter(isntNil), // filter out if reference didn't change from last emit
-    );
+  return pipe(
+    distinctUntilChanged(),
+    mergeMap((map) => pairs<R>(map)),
+    /* this scan stores a reference to each [key,value] in 'acc', and emit as 'changed' iff it
+     * changes from last time seen. It relies on value references changing only if needed */
+    scan<[string, R], { acc: { [k: string]: R }; changed?: [string, R] }>(
+      ({ acc }, [key, value]) =>
+        // if ref didn't change, emit previous accumulator, without 'changed' value
+        compareFn(acc[key], value)
+          ? { acc }
+          : // else, update ref in 'acc' and emit value in 'changed' prop
+            { acc: { ...acc, [key]: value }, changed: [key, value] },
+      { acc: {} as { [k: string]: R } },
+    ),
+    pluck('changed'),
+    filter(isntNil), // filter out if reference didn't change from last emit
+  );
 }
 
 /**
@@ -89,21 +105,20 @@ export function repeatUntil<T>(
   // waits for address's user in transport to be online and joined room before actually
   // sending the message. That's why repeatWhen emits/resubscribe only some time after
   // sendOnceAndWaitSent$ completes, instead of a plain 'interval'
-  return (input$) =>
-    input$.pipe(
-      repeatWhen((completed$) =>
-        completed$.pipe(
-          map(() => {
-            if (typeof delayMs === 'number') return delayMs;
-            const next = delayMs.next();
-            return !next.done ? next.value : -1;
-          }),
-          takeWhile((value) => value >= 0), // stop repeatWhen when done
-          switchMap((value) => timer(value)),
-        ),
+  return pipe(
+    repeatWhen((completed$) =>
+      completed$.pipe(
+        map(() => {
+          if (typeof delayMs === 'number') return delayMs;
+          const next = delayMs.next();
+          return !next.done ? next.value : -1;
+        }),
+        takeWhile((value) => value >= 0), // stop repeatWhen when done
+        switchMap((value) => timer(value)),
       ),
-      takeUntil(notifier),
-    );
+    ),
+    takeUntil(notifier),
+  );
 }
 
 // guard an Iterable between an iterable and iterator union
@@ -237,9 +252,7 @@ export function completeWith<T>(
 export function lastMap<T, R>(
   project: (lastValue: T | null) => ObservableInput<R>,
 ): OperatorFunction<T, R> {
-  return (input$) => {
-    return input$.pipe(last(undefined, null), mergeMap(project));
-  };
+  return pipe(last(undefined, null), mergeMap(project));
 }
 
 /**
@@ -318,12 +331,11 @@ export function mergeWith<T, R>(
   project: (value: T, index: number) => ObservableInput<R>,
   mapFunc = mergeMap,
 ): OperatorFunction<T, [T, R]> {
-  return (input$) =>
-    input$.pipe(
-      mapFunc((value, index) =>
-        from(project(value, index)).pipe(map((res) => [value, res] as [T, R])),
-      ),
-    );
+  return pipe(
+    mapFunc((value, index) =>
+      from(project(value, index)).pipe(map((res) => [value, res] as [T, R])),
+    ),
+  );
 }
 
 /**
@@ -340,11 +352,121 @@ export function catchAndLog<T>(
 ): MonoTypeOperatorFunction<T> {
   if (opts.log && logParams.length) opts = { ...opts, log: opts.log.bind(null, ...logParams) };
   const shouldSuppress = shouldRetryError(opts);
+  return pipe(
+    catchError((err) => {
+      if (!shouldSuppress(err)) return throwError(err);
+      else return EMPTY;
+    }),
+  );
+}
+
+/**
+ * Custom operator providing a project function which is mirrored in the output, but provides a
+ * parameter function which allows submitting requests directly to the output as well, and returns
+ * with an observable which filters input$ for success|failures, errors on failures and completes
+ * on successes. In case 'confirmed' is true, this observable also emits intermediate unconfirmed
+ * successes and only completes upon the confirmed one is seen.
+ * Example:
+ * output$: Observable<anotherAction.success | messageSend.request> = action$.pipe(
+ *   dispatchRequestAndGetResponse(messageSend, (dispatchRequest) =>
+ *     // this observable will be mirrored to output, plus requests sent to dispatchRequest
+ *     action$.pipe(
+ *       filter(anotherAction.request.is),
+ *       mergeMap((action) =>
+ *         dispatchRequest(messageSend.request('test')).pipe(
+ *           map((sentAction) => anotherAction.success({ sent: msgSendSucAction })),
+ *         ),
+ *       ),
+ *     ),
+ *   ),
+ * )
+ *
+ * @param aac - AsyncActionCreator type to wait for response
+ * @param project - Function to be merged to output; called with a function which allows to
+ *      dispatch requests directly to output and returns an observable which will emit the success
+ *      coming in input and complete, or error if a failure goes through
+ * @param confirmed - Keep emitting success to dispatchRequest's returned observable while it isn't
+ *      confirmed yet
+ * @param dedupKey - Function to calculate keys to deduplicate requests (returns the same
+        observable as result if a request with similar key is performed while one is still pending)
+ * @returns Custom operator which mirrors projected observable plus requests called in the
+ *      project's function parameter
+ */
+export function dispatchRequestAndGetResponse<
+  T,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  AAC extends AsyncActionCreator<t.Mixed, any, any, any, any, t.Mixed, t.Mixed>,
+  R
+>(
+  aac: AAC,
+  project: (
+    dispatchRequest: (
+      request: ActionType<AAC['request']>,
+    ) => Observable<ActionType<AAC['success']>>,
+  ) => ObservableInput<R>,
+  confirmed = false,
+  dedupKey = (value: ActionType<AAC['request']>): unknown => value,
+): OperatorFunction<T, R | ActionType<AAC['request']>> {
   return (input$) =>
-    input$.pipe(
-      catchError((err) => {
-        if (!shouldSuppress(err)) return throwError(err);
-        else return EMPTY;
-      }),
-    );
+    defer(() => {
+      const requestOutput$ = new Subject<ActionType<AAC['request']>>();
+      const pending = new Map<unknown, Observable<ActionType<AAC['success']>>>();
+      const projectOutput$ = defer(() =>
+        project((request) => {
+          const key = dedupKey(request);
+          const pending$ = pending.get(key);
+          if (pending$) return pending$;
+          const result$ = new ReplaySubject<ActionType<AAC['success']>>(1);
+          const sub = input$
+            .pipe(
+              filter(isResponseOf<AAC>(aac, request.meta)),
+              map((response) => {
+                if (aac.failure.is(response)) throw response.payload;
+                return response;
+              }),
+              takeWhile(
+                (response) =>
+                  confirmed &&
+                  'confirmed' in response.payload &&
+                  response.payload.confirmed === undefined,
+                true,
+              ),
+            )
+            .subscribe(result$);
+          requestOutput$.next(request);
+          const res = result$.pipe(
+            finalize(() => {
+              sub.unsubscribe();
+              pending.delete(key);
+            }),
+          );
+          pending.set(key, res);
+          return res;
+        }),
+      ).pipe(finalize(() => requestOutput$.complete()));
+      return merge(requestOutput$, projectOutput$);
+    });
+}
+
+/**
+ * A custom operator to apply an inner operator only to a partitioned (filtered) view of the input,
+ * matching a given predicate, and merging the output with the values which doesn't match it
+ *
+ * @param predicate - Test input values if they should be projected
+ * @param operator - Receives observable of input values which matches predicate and return an
+ *      observable input to be merged in the output together with values which don't
+ * @returns Observable of values which doesn't pass the predicate merged with the projected
+ *      observables returned on the values which pass
+ */
+export function partitionMap<T, U, R>(
+  predicate: (value: unknown) => value is T,
+  operator: (input$: Observable<T>) => ObservableInput<R>,
+): OperatorFunction<T | U, Exclude<T | U, T> | R> {
+  return (source$) => {
+    const [true$, false$] = partition(source$.pipe(share<T | U>()), predicate) as [
+      Observable<T>,
+      Observable<Exclude<T | U, T>>,
+    ];
+    return merge(operator(true$), false$);
+  };
 }

--- a/raiden-ts/tests/unit/utils.spec.ts
+++ b/raiden-ts/tests/unit/utils.spec.ts
@@ -4,7 +4,7 @@ import { keccak256 } from '@ethersproject/keccak256';
 import type { JsonRpcProvider } from '@ethersproject/providers';
 import { Web3Provider } from '@ethersproject/providers';
 import { fold, isRight } from 'fp-ts/lib/Either';
-import { pipe } from 'fp-ts/lib/pipeable';
+import { pipe } from 'fp-ts/lib/function';
 import * as t from 'io-ts';
 import { concat, defer, from, of, timer } from 'rxjs';
 import { delay, first, ignoreElements, map, mapTo, take, tap, toArray } from 'rxjs/operators';
@@ -219,11 +219,10 @@ describe('types', () => {
     }
     expect(ErrorCodec.is(err)).toBe(true);
     const encoded = ErrorCodec.encode(err);
-    expect(encoded).toStrictEqual({
+    expect(encoded).toEqual({
       name: 'RaidenError',
       message: ErrorCodes.RDN_GENERAL_ERROR,
       stack: expect.any(String),
-      details: expect.anything(),
     });
     expect(decode(ErrorCodec, encoded)).toStrictEqual(err);
     const decoded = decode(ErrorCodec, encoded);


### PR DESCRIPTION
Fixes #2677 

**Short description**
This doesn't actually remove the presence completely, but instead removes `latest.presences` _cache_ usage, replacing it by explicitly requesting presence and waiting for the success. The epic handling it then can decide if it'll use a cached presence (e.g. latest seen, as previously) or actively re-request the current user presence, e.g. from matrix (to not be supported on `next` transport) or from PFS (through a new endpoint).

Also, WebRTC now has a new signaling protocol, backwards compatible with past protocol:
- All nodes now acts as both caller and callee: i.e. removed the fixed ordering based on sorted addresses
- Callee starts listening peer's messages as soon as peer is whitelisted, and will try to answer as soon as offer is received; it uses/respects `callId` (`channel.label`) sent by caller, and don't mind caller's `webRTC` capability
- Caller start to try to call peer upon certain events of interest
  - Currently:
    - `channelMonitored` (startup partners, new channel opened partners)
    - `transferSigned` (transfer's initiator, target; can be removed/narrowed later if we can exchange secrets without a direct RTC channel)
    - `messageSend.request` (to retry when trying to message a peer which we don't have an RTC channel with yet)
    - `rtcChannel` with `payload=undefined` (previous/last RTC channel closed)
  - Caller always retrieve presence from PFS, errors if peer don't have `webRTC` capability set
  - Caller retries a *limited* number of times, expo backoff 5s-60s delays, ~6 retries, then give up and retry again iff a new event from above is emitted
- At all times, for each peer, `callee` and `caller` channels race, the winner cancels the other's attempt to establish the channel.
- Since callee is always listening, peer's caller could retry and would still be able to get a new channel through
- If a node is online for some time, its caller should have given up; a partner coming online will then get their caller handler calling, so it always get almost instantly (except for matrix's `toDevice` message delays) connected
- If both nodes are coming online at the same time, and they get each other's presence as offline at first, caller's retry loop will get them connected after ~5s at most, so races are always gracefully handled
- This protocol also work for a matrixless transport, where one side can't receive calls (maybe a web dApp which can't expose a REST endpoint for such) but also is always expected to connect to full node's partners which are always online and  have such open endpoints
- This is backwards compatible with previous WebRTC algorithm, because since it acts as both caller & callee, the previous transport requiring/assuming a fixed role will always succeed.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
