### PR TITLE
dapp: fix header line break on mobile screens

### DIFF
--- a/raiden-dapp/src/components/AppHeader.vue
+++ b/raiden-dapp/src/components/AppHeader.vue
@@ -112,6 +112,12 @@ export default class AppHeader extends Mixins(NavigationMixin) {
       display: flex;
       justify-content: flex-end;
 
+      &__notifications-button {
+        @include respond-to(handhelds) {
+          margin-right: -10px;
+        }
+      }
+
       &__identicon {
         cursor: pointer;
         margin-left: 15px;

--- a/raiden-dapp/src/components/HeaderContent.vue
+++ b/raiden-dapp/src/components/HeaderContent.vue
@@ -1,40 +1,42 @@
 <template>
-  <div class="header-content">
-    <div class="header-content__back-button">
-      <v-btn
-        v-if="canNavigateBack"
-        data-cy="header-content_back-button"
-        height="40px"
-        width="40px"
-        icon
-        @click="navigateBack()"
-      >
-        <v-img :src="require('@/assets/app-header/back_arrow.svg')" />
-      </v-btn>
-    </div>
-    <div class="header-content__title">
-      <div class="header-content__title__route">
-        <span class="header-content__title__route__name">{{ $route.meta.title }}</span>
+  <v-container class="header-content pa-0" fluid>
+    <v-row align="center" no-gutters>
+      <v-col cols="2">
         <v-btn
-          v-if="availableInfoOverlay && !disableInfoButton"
-          class="header-content__title__route__info"
+          v-if="canNavigateBack"
+          data-cy="header-content_back-button"
+          height="36px"
+          width="36px"
           icon
-          height="20px"
-          width="20px"
+          @click="navigateBack()"
         >
-          <v-img
-            class="header-content__title__route__info__icon"
-            :src="require('@/assets/app-header/info.svg')"
-            @click="showInfo()"
-          />
+          <v-img :src="require('@/assets/app-header/back_arrow.svg')" />
         </v-btn>
-      </div>
-      <span v-if="showNetwork" class="header-content__title__network">{{ network }}</span>
-    </div>
-    <div class="header-content__items">
-      <slot />
-    </div>
-  </div>
+      </v-col>
+      <v-col cols="auto" class="header-content__title">
+        <div class="header-content__title__route">
+          <span class="header-content__title__route__name">{{ $route.meta.title }}</span>
+          <v-btn
+            v-if="availableInfoOverlay && !disableInfoButton"
+            class="header-content__title__route__info"
+            icon
+            x-small
+          >
+            <v-img
+              class="header-content__title__route__info__icon"
+              :src="require('@/assets/app-header/info.svg')"
+              width="10px"
+              @click="showInfo()"
+            />
+          </v-btn>
+        </div>
+        <span v-if="showNetwork" class="header-content__title__network">{{ network }}</span>
+      </v-col>
+      <v-col cols="2">
+        <slot />
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script lang="ts">
@@ -81,16 +83,13 @@ export default class HeaderContent extends Vue {
 
 <style lang="scss" scoped>
 @import '@/scss/colors';
+@import '@/scss/mixins';
 
 .header-content {
-  align-items: center;
-  display: flex;
-  flex: 1;
-  justify-content: center;
+  margin: 20px 20px;
 
-  &__back-button {
-    flex: 1;
-    margin-left: 20px;
+  @include respond-to(handhelds) {
+    margin: 10px 10px;
   }
 
   &__title {
@@ -105,12 +104,20 @@ export default class HeaderContent extends Vue {
       &__name {
         color: $color-white;
         font-size: 24px;
+
+        @include respond-to(handhelds) {
+          font-size: 20px;
+        }
       }
 
       &__info {
         align-self: center;
         cursor: pointer;
         margin-left: 10px;
+
+        @include respond-to(handhelds) {
+          margin-left: 3px;
+        }
       }
     }
 
@@ -118,12 +125,8 @@ export default class HeaderContent extends Vue {
       color: $secondary-text-color;
       font-size: 12px;
       font-weight: 500;
+      margin-top: -7px;
     }
-  }
-
-  &__items {
-    flex: 1;
-    margin-right: 20px;
   }
 }
 </style>


### PR DESCRIPTION
Partially solves #2604

**Short description**
See [this comment](https://github.com/raiden-network/light-client/issues/2604#issuecomment-822315851)
I'm not proud of the solution. 😑 

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Use the browser dev-tools to go into the mobile view and shrink the width to 320px
2. Visit all routes of the dApp and verify that the header title never breaks
