### PR TITLE
dapp: add connection pending dialog

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -9,9 +9,11 @@
 ### Added
 
 - [#2599] Add WalletConnect as another wallet/provider
+- [#2685] Add a hint dialog when the connection process takes very long
 
 [#2671]: https://github.com/raiden-network/light-client/issues/2671
 [#2599]: https://github.com/raiden-network/light-client/issues/2599
+[#2685]: https://github.com/raiden-network/light-client/issues/2685
 
 ## [0.16.0] - 2021-04-01
 

--- a/raiden-dapp/src/components/dialogs/ConnectionPendingDialog.vue
+++ b/raiden-dapp/src/components/dialogs/ConnectionPendingDialog.vue
@@ -1,0 +1,44 @@
+<template>
+  <raiden-dialog :visible="dialogVisible" :hide-close="true">
+    <v-card-title>
+      {{ $t('home.connection-pending-dialog.title') }}
+    </v-card-title>
+
+    <v-card-text>
+      <spinner :size="60" class="my-4" />
+      {{ $t('home.connection-pending-dialog.text') }}
+    </v-card-text>
+  </raiden-dialog>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+
+import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
+import Spinner from '@/components/icons/Spinner.vue';
+
+const SHOW_DIALOG_TIMEOUT = 7000;
+
+/*
+  Please note that because the underlying dialog component by Vuetify, it is not
+  possible to implement the delayed rendering with a Vue transition or pure CSS
+  effect. Therefore this alternative approach of using the life-cycle hook and
+  a timer is necessary.
+*/
+@Component({ components: { RaidenDialog, Spinner } })
+export default class ConnectionPendingDialog extends Vue {
+  dialogVisible = false;
+
+  mounted() {
+    this.delayVisibilityOfDialog();
+  }
+
+  delayVisibilityOfDialog(): void {
+    setTimeout(this.showDialog, SHOW_DIALOG_TIMEOUT);
+  }
+
+  showDialog(): void {
+    this.dialogVisible = true;
+  }
+}
+</script>

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -97,6 +97,10 @@
       "description-raiden-account": "A Raiden Account will be generated.",
       "description-web3-account": "You can use your Web3 account directly by enabling it in the settings menu.",
       "no-provider": "No Web3 provider detected, please install e.g. MetaMask."
+    },
+    "connection-pending-dialog": {
+      "title": "Connecting",
+      "text": "Please check if any actions are required in your wallet."
     }
   },
   "notifications": {

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -27,7 +27,7 @@ import type { NotificationsState } from './notifications/types';
 Vue.use(Vuex);
 
 const _defaultState: RootState = {
-  loading: true,
+  loading: false,
   blockNumber: 0,
   defaultAccount: '',
   accountBalance: '0.0',
@@ -108,6 +108,9 @@ const store: StoreOptions<CombinedStoreState> = {
     },
     account(state: RootState, account: string) {
       state.defaultAccount = account;
+    },
+    loadStart(state: RootState) {
+      state.loading = true;
     },
     loadComplete(state: RootState) {
       state.loading = false;

--- a/raiden-dapp/src/views/Home.vue
+++ b/raiden-dapp/src/views/Home.vue
@@ -53,6 +53,7 @@
       @connect="connect"
       @close="connectDialog = false"
     />
+    <connection-pending-dialog v-if="loading" />
   </v-container>
 </template>
 
@@ -63,6 +64,7 @@ import { mapGetters, mapState } from 'vuex';
 
 import ActionButton from '@/components/ActionButton.vue';
 import ConnectDialog from '@/components/dialogs/ConnectDialog.vue';
+import ConnectionPendingDialog from '@/components/dialogs/ConnectionPendingDialog.vue';
 import NoAccessMessage from '@/components/NoAccessMessage.vue';
 import type { TokenModel } from '@/model/types';
 import { DeniedReason } from '@/model/types';
@@ -79,6 +81,7 @@ import type { Settings } from '@/types';
   components: {
     ActionButton,
     ConnectDialog,
+    ConnectionPendingDialog,
     NoAccessMessage,
   },
 })
@@ -127,6 +130,7 @@ export default class Home extends Vue {
     this.$store.commit('reset');
     // Have to reset this explicitly, for some reason
     this.$store.commit('accessDenied', DeniedReason.UNDEFINED);
+    this.$store.commit('loadStart');
 
     await this.$raiden.connect(stateBackup, useRaidenAccount ? true : undefined);
     this.connecting = false;

--- a/raiden-dapp/tests/unit/store.spec.ts
+++ b/raiden-dapp/tests/unit/store.spec.ts
@@ -44,7 +44,9 @@ describe('store', () => {
     expect(store.getters.isConnected).toBe(false);
   });
 
-  test('loadComplete mutation changes the loading state', () => {
+  test('loadStart and loadComplete control the loading state', () => {
+    expect(store.state.loading).toBe(false);
+    store.commit('loadStart');
     expect(store.state.loading).toBe(true);
     store.commit('loadComplete');
     expect(store.state.loading).toBe(false);
@@ -225,10 +227,10 @@ describe('store', () => {
   });
 
   test('the reset mutation resets the state', () => {
-    store.commit('loadComplete', false);
-    expect(store.state.loading).toBe(false);
+    store.commit('updateBlock', 1);
+    expect(store.state.blockNumber).toBe(1);
     store.commit('reset');
-    expect(store.state.loading).toBe(true);
+    expect(store.state.blockNumber).toBe(defaultState().blockNumber);
   });
 
   test('the set available version mutation updates the version info', () => {
@@ -349,6 +351,7 @@ describe('store', () => {
   });
 
   test('isConnected should be false if loading', () => {
+    store.commit('loadStart');
     store.commit('account', '0x0000000000000000000000000000000000020001');
     expect(store.getters.isConnected).toBe(false);
   });


### PR DESCRIPTION
Fixes #2685

**Short description**
This is just very first issue and this feature will get improved over time (e.g. #2690)
I'm open to change the time value to anything. 

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Run the dApp
2. Click on the connect button and wait for >7s without taking any action in the wallet
3. Make sure a new dialog pops up which informs you that you need to take action in the wallet.
