### PR TITLE
sdk: Clean up helper imports in integration tests

### DIFF
--- a/raiden-ts/tests/integration/epics/channels.spec.ts
+++ b/raiden-ts/tests/integration/epics/channels.spec.ts
@@ -23,8 +23,6 @@ import {
   txHash,
 } from '../fixtures';
 import {
-  makeAddress,
-  makeHash,
   makeLog,
   makeRaiden,
   makeRaidens,
@@ -59,6 +57,8 @@ import { Direction } from '@/transfers/state';
 import { getLocksroot, transferKey } from '@/transfers/utils';
 import { ErrorCodes } from '@/utils/error';
 import type { UInt } from '@/utils/types';
+
+import { makeAddress, makeHash } from '../../utils';
 
 test('channelSettleableEpic', async () => {
   expect.assertions(3);

--- a/raiden-ts/tests/integration/epics/mediate.spec.ts
+++ b/raiden-ts/tests/integration/epics/mediate.spec.ts
@@ -10,7 +10,7 @@ import {
   token,
   tokenNetwork,
 } from '../fixtures';
-import { makeAddress, makeRaidens, sleep } from '../mocks';
+import { makeRaidens, sleep } from '../mocks';
 
 import { BigNumber } from '@ethersproject/bignumber';
 import { AddressZero, MaxUint256, Zero } from '@ethersproject/constants';
@@ -26,6 +26,8 @@ import { Direction } from '@/transfers/state';
 import { makePaymentId } from '@/transfers/utils';
 import { assert } from '@/utils';
 import { decode, Int, UInt } from '@/utils/types';
+
+import { makeAddress } from '../../utils';
 
 describe('mediate transfers', () => {
   test('success with flat fees', async () => {

--- a/raiden-ts/tests/integration/epics/monitor.spec.ts
+++ b/raiden-ts/tests/integration/epics/monitor.spec.ts
@@ -11,8 +11,6 @@ import {
   tokenNetwork,
 } from '../fixtures';
 import {
-  makeAddress,
-  makeHash,
   makeLog,
   makeRaidens,
   mockedSignMessage,
@@ -34,6 +32,8 @@ import { createBalanceHash } from '@/messages/utils';
 import { msBalanceProofSent, udcDeposit } from '@/services/actions';
 import { Service } from '@/services/types';
 import type { UInt } from '@/utils/types';
+
+import { makeAddress, makeHash } from '../../utils';
 
 describe('msMonitorRequestEpic', () => {
   test('success: receiving a transfer triggers monitoring', async () => {

--- a/raiden-ts/tests/integration/epics/path.spec.ts
+++ b/raiden-ts/tests/integration/epics/path.spec.ts
@@ -12,7 +12,6 @@ import {
 } from '../fixtures';
 import {
   fetch,
-  makeAddress,
   makeLog,
   makeRaiden,
   makeRaidens,
@@ -39,6 +38,7 @@ import { ErrorCodes } from '@/utils/error';
 import type { Address, Int, Signature, UInt } from '@/utils/types';
 import { Signed } from '@/utils/types';
 
+import { makeAddress } from '../../utils';
 import type { MockedRaiden } from '../mocks';
 
 const pfsAddress = makeAddress();

--- a/raiden-ts/tests/integration/epics/raiden.spec.ts
+++ b/raiden-ts/tests/integration/epics/raiden.spec.ts
@@ -9,7 +9,7 @@ import {
   tokenNetwork,
   txHash,
 } from '../fixtures';
-import { makeAddress, makeLog, makeRaiden, sleep, waitBlock } from '../mocks';
+import { makeLog, makeRaiden, sleep, waitBlock } from '../mocks';
 
 import { defaultAbiCoder } from '@ethersproject/abi';
 import { HashZero, One } from '@ethersproject/constants';
@@ -20,6 +20,8 @@ import { channelMonitored, channelOpen, newBlock, tokenMonitored } from '@/chann
 import { ShutdownReason } from '@/constants';
 import { ErrorCodes, RaidenError } from '@/utils/error';
 import { last } from '@/utils/types';
+
+import { makeAddress } from '../../utils';
 
 const partner = makeAddress();
 

--- a/raiden-ts/tests/integration/epics/receive.spec.ts
+++ b/raiden-ts/tests/integration/epics/receive.spec.ts
@@ -9,7 +9,6 @@ import {
 } from '../fixtures';
 import {
   flushPromises,
-  makeHash,
   makeLog,
   makeRaiden,
   makeRaidens,
@@ -51,6 +50,8 @@ import { Direction } from '@/transfers/state';
 import { getSecrethash, makeMessageId, makePaymentId, makeSecret } from '@/transfers/utils';
 import type { Int, UInt } from '@/utils/types';
 import { Signed, untime } from '@/utils/types';
+
+import { makeHash } from '../../utils';
 
 const direction = Direction.RECEIVED;
 const paymentId = makePaymentId();

--- a/raiden-ts/tests/integration/epics/send.spec.ts
+++ b/raiden-ts/tests/integration/epics/send.spec.ts
@@ -9,15 +9,7 @@ import {
   secrethash,
   tokenNetwork,
 } from '../fixtures';
-import {
-  makeHash,
-  makeLog,
-  makeRaiden,
-  makeRaidens,
-  providersEmit,
-  sleep,
-  waitBlock,
-} from '../mocks';
+import { makeLog, makeRaiden, makeRaidens, providersEmit, sleep, waitBlock } from '../mocks';
 
 import { BigNumber } from '@ethersproject/bignumber';
 import { Two, Zero } from '@ethersproject/constants';
@@ -45,6 +37,7 @@ import { getSecrethash, makePaymentId, makeSecret, transferKey } from '@/transfe
 import { isResponseOf } from '@/utils/actions';
 import type { Int, UInt } from '@/utils/types';
 
+import { makeHash } from '../../utils';
 import type { MockedRaiden } from '../mocks';
 
 const direction = Direction.SENT;

--- a/raiden-ts/tests/integration/fixtures.ts
+++ b/raiden-ts/tests/integration/fixtures.ts
@@ -1,4 +1,4 @@
-import { makeAddress, makeHash, makeLog, providersEmit, sleep, waitBlock } from './mocks';
+import { makeLog, providersEmit, sleep, waitBlock } from './mocks';
 
 import { defaultAbiCoder } from '@ethersproject/abi';
 import { BigNumber } from '@ethersproject/bignumber';
@@ -24,6 +24,7 @@ import { assert } from '@/utils';
 import { isResponseOf } from '@/utils/actions';
 import type { Address, Hash, Int, Secret, UInt } from '@/utils/types';
 
+import { makeAddress, makeHash } from '../utils';
 import type { MockedRaiden } from './mocks';
 
 // fixture constants

--- a/raiden-ts/tests/integration/mocks.ts
+++ b/raiden-ts/tests/integration/mocks.ts
@@ -72,8 +72,6 @@ import { Address, decode, Secret } from '@/utils/types';
 
 import { makeAddress, makeHash } from '../utils';
 
-export { makeAddress, makeHash } from '../utils';
-
 jest.mock('@/messages/utils', () => ({
   ...jest.requireActual<any>('@/messages/utils'),
   signMessage: jest.fn(jest.requireActual<any>('@/messages/utils').signMessage),


### PR DESCRIPTION
The new utils module was introduced in 857952e67d1d177426f0f60b53c39e72c3775601
but some imports were not adjusted right away.


