### PR TITLE
dapp: add availability field to connections

### DIFF
--- a/raiden-dapp/src/services/ethereum-connection/direct-rpc-provider.ts
+++ b/raiden-dapp/src/services/ethereum-connection/direct-rpc-provider.ts
@@ -4,6 +4,7 @@ import { EthereumConnection } from './types';
 
 export class DirectRpcProvider extends EthereumConnection {
   public static readonly connection_name = 'direct_rpc_provider';
+  public static readonly isAvailable = true;
   public readonly provider: providers.JsonRpcProvider;
   public readonly account: string;
 

--- a/raiden-dapp/src/services/ethereum-connection/injected-provider.ts
+++ b/raiden-dapp/src/services/ethereum-connection/injected-provider.ts
@@ -7,13 +7,18 @@ export class InjectedProvider extends EthereumConnection {
   public readonly provider: providers.JsonRpcProvider;
   public readonly account = 0; // Refers to the currently selected account in the wallet.
 
+  public static get isAvailable(): boolean {
+    return !!window.ethereum || !!window.web3;
+  }
+
   private constructor(injetedProvider: providers.ExternalProvider) {
     super();
     this.provider = new providers.Web3Provider(injetedProvider);
   }
 
   public static async connect(): Promise<InjectedProvider> {
-    if (!window.ethereum && !window.web3) {
+    // We can't use the check of the super constructor here, else this function does not work.
+    if (!InjectedProvider.isAvailable) {
       throw new Error('No injected provider is available.');
     }
 

--- a/raiden-dapp/src/services/ethereum-connection/types.ts
+++ b/raiden-dapp/src/services/ethereum-connection/types.ts
@@ -2,7 +2,16 @@ import type { providers } from 'ethers';
 
 export abstract class EthereumConnection {
   static connection_name: string;
+  static isAvailable = false;
   static connect: (options?: any) => Promise<EthereumConnection>; // eslint-disable-line @typescript-eslint/no-explicit-any
   abstract provider: providers.JsonRpcProvider;
   abstract account: string | number;
+
+  constructor() {
+    const isAvailable = (this.constructor as typeof EthereumConnection).isAvailable;
+
+    if (!isAvailable) {
+      throw new Error('The connection is not available.');
+    }
+  }
 }

--- a/raiden-dapp/src/services/ethereum-connection/wallet-connect.ts
+++ b/raiden-dapp/src/services/ethereum-connection/wallet-connect.ts
@@ -5,6 +5,7 @@ import { EthereumConnection } from './types';
 
 export class WalletConnect extends EthereumConnection {
   public static readonly connection_name = 'wallet_connect';
+  public static readonly isAvailable = true;
   public readonly provider: providers.JsonRpcProvider;
   public readonly account = 0; // Refers to the currently selected account in the wallet.
 

--- a/raiden-dapp/tests/unit/services/ethereum-connection/direct-rpc-provider.spec.ts
+++ b/raiden-dapp/tests/unit/services/ethereum-connection/direct-rpc-provider.spec.ts
@@ -1,6 +1,10 @@
 import { DirectRpcProvider } from '@/services/ethereum-connection/direct-rpc-provider';
 
 describe('DirectRpcProvider', () => {
+  test('is always available', () => {
+    expect(DirectRpcProvider.isAvailable).toBe(true);
+  });
+
   test('it can connect', async () => {
     const options = { rpcUrl: 'https://some.rpc.provider', privateKey: 'privateKey' };
     const connection = await DirectRpcProvider.connect(options);

--- a/raiden-dapp/tests/unit/services/ethereum-connection/injected-provider.spec.ts
+++ b/raiden-dapp/tests/unit/services/ethereum-connection/injected-provider.spec.ts
@@ -14,19 +14,31 @@ jest.mock('ethers', () => {
   };
 });
 
-const originalWindow = window;
-
 describe('InjectedProvider', () => {
   beforeEach(() => {
-    window = originalWindow;
+    window.ethereum = undefined;
+    window.web3 = undefined;
     jest.clearAllMocks();
     jest.resetAllMocks();
   });
 
-  test('connect throws error if no injected provider is available', () => {
-    expect(window.ethereum).toBeUndefined();
-    expect(window.web3).toBeUndefined();
+  test('is not available when no injected provider is available', () => {
+    expect(InjectedProvider.isAvailable).toBe(false);
+  });
 
+  test('is available when ethereum provider is available', () => {
+    window.ethereum = new MockedJsonRpcProviderWithRequestHandler();
+
+    expect(InjectedProvider.isAvailable).toBe(true);
+  });
+
+  test('is available when web3 provider is available', () => {
+    window.web3 = { currentProvider: new MockedJsonRpcProvider() };
+
+    expect(InjectedProvider.isAvailable).toBe(true);
+  });
+
+  test('connect throws error if no injected provider is available', () => {
     expect(InjectedProvider.connect()).rejects.toThrow('No injected provider is available.');
   });
 

--- a/raiden-dapp/tests/unit/services/ethereum-connection/wallet-connect.spec.ts
+++ b/raiden-dapp/tests/unit/services/ethereum-connection/wallet-connect.spec.ts
@@ -19,6 +19,10 @@ jest.mock('ethers', () => {
 });
 
 describe('WalletConnect', () => {
+  test('is always available', () => {
+    expect(WalletConnect.isAvailable).toBe(true);
+  });
+
   test('fail to connect when none of the options is provided', () => {
     expect(WalletConnect.connect({})).rejects.toThrow(
       'One of the options RPC URL or Infura Id are required to connect.',


### PR DESCRIPTION
**Short description**
"Restores" the (unused) evaluation if a connection is available or not. In first place this is necessary for the injected provider. Though requires all connections to explicitly define if they are available or not (might be static), else the construction will fail.

**Definition of Done**

- ~~ [x] Steps to manually test the change have been documented~~
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 
