### PR TITLE
Feature/dapp ethereum connection persistence

### DIFF
--- a/raiden-dapp/src/components/account/backup-state/UploadStateDialog.vue
+++ b/raiden-dapp/src/components/account/backup-state/UploadStateDialog.vue
@@ -54,13 +54,11 @@
 
 <script lang="ts">
 import { Component, Emit, Mixins, Prop } from 'vue-property-decorator';
-import { mapState } from 'vuex';
 
 import ActionButton from '@/components/ActionButton.vue';
 import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
 import Spinner from '@/components/icons/Spinner.vue';
 import NavigationMixin from '@/mixins/navigation-mixin';
-import type { Settings } from '@/types';
 
 @Component({
   components: {
@@ -68,16 +66,12 @@ import type { Settings } from '@/types';
     ActionButton,
     Spinner,
   },
-  computed: {
-    ...mapState(['settings']),
-  },
 })
 export default class UploadStateDialog extends Mixins(NavigationMixin) {
   dragCount = 0;
   activeDropzone = false;
   dropzoneErrorMessage = false;
   uploadingStateProgress = false;
-  settings!: Settings;
 
   @Prop({ required: true, type: Boolean, default: false })
   visible!: boolean;

--- a/raiden-dapp/src/services/ethereum-connection/direct-rpc-provider.ts
+++ b/raiden-dapp/src/services/ethereum-connection/direct-rpc-provider.ts
@@ -3,7 +3,7 @@ import { providers } from 'ethers';
 import { EthereumConnection } from './types';
 
 export class DirectRpcProvider extends EthereumConnection {
-  public static readonly connection_name = 'direct_rpc_provider';
+  public static readonly connectionName = 'direct_rpc_provider';
   public static readonly isAvailable = true;
   public readonly provider: providers.JsonRpcProvider;
   public readonly account: string;

--- a/raiden-dapp/src/services/ethereum-connection/injected-provider.ts
+++ b/raiden-dapp/src/services/ethereum-connection/injected-provider.ts
@@ -3,7 +3,7 @@ import { providers } from 'ethers';
 import { EthereumConnection } from './types';
 
 export class InjectedProvider extends EthereumConnection {
-  public static readonly connection_name = 'injected_provider';
+  public static readonly connectionName = 'injected_provider';
   public readonly provider: providers.JsonRpcProvider;
   public readonly account = 0; // Refers to the currently selected account in the wallet.
 

--- a/raiden-dapp/src/services/ethereum-connection/types.ts
+++ b/raiden-dapp/src/services/ethereum-connection/types.ts
@@ -1,9 +1,16 @@
 import type { providers } from 'ethers';
 
+// The type evaluation for static class members works slightly different for
+// the moment. Thereby it is not possible to have any better type restrictions
+// here. Though having the named type here in place will allows us to adopt it
+// later and being explicit about it at all places.
+export type EthereumConnectionOptions = any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+// TOOD: watch-out when `static abstract` becomes possible in TypeScript
 export abstract class EthereumConnection {
-  static connection_name: string;
+  static connectionName: string;
   static isAvailable = false;
-  static connect: (options?: any) => Promise<EthereumConnection>; // eslint-disable-line @typescript-eslint/no-explicit-any
+  static connect: (options: EthereumConnectionOptions) => Promise<EthereumConnection>;
   abstract provider: providers.JsonRpcProvider;
   abstract account: string | number;
 

--- a/raiden-dapp/src/services/ethereum-connection/wallet-connect.ts
+++ b/raiden-dapp/src/services/ethereum-connection/wallet-connect.ts
@@ -4,7 +4,7 @@ import { providers } from 'ethers';
 import { EthereumConnection } from './types';
 
 export class WalletConnect extends EthereumConnection {
-  public static readonly connection_name = 'wallet_connect';
+  public static readonly connectionName = 'wallet_connect';
   public static readonly isAvailable = true;
   public readonly provider: providers.JsonRpcProvider;
   public readonly account = 0; // Refers to the currently selected account in the wallet.

--- a/raiden-dapp/src/store/user-settings/getters.ts
+++ b/raiden-dapp/src/store/user-settings/getters.ts
@@ -1,0 +1,20 @@
+import type { GetterTree } from 'vuex';
+
+import type { EthereumConnectionOptions } from '@/services/ethereum-connection';
+import type { RootState } from '@/types';
+
+import type { UserSettingsState } from './types';
+
+type Getters = {
+  getEthereumConnectionOptions(
+    state: UserSettingsState,
+  ): (connectionName: string) => EthereumConnectionOptions;
+};
+
+export const getters: GetterTree<UserSettingsState, RootState> & Getters = {
+  // This getter is relevant to have a standardized default value that works for
+  // all component which interact with such connection options.
+  getEthereumConnectionOptions: (state) => (connectionName) => {
+    return state.ethereumConnectionOptions[connectionName] ?? {};
+  },
+};

--- a/raiden-dapp/src/store/user-settings/index.ts
+++ b/raiden-dapp/src/store/user-settings/index.ts
@@ -1,0 +1,21 @@
+import type { Module } from 'vuex';
+import { VuexPersistence } from 'vuex-persist';
+
+import type { RootState } from '@/types';
+
+import { mutations } from './mutations';
+import state from './state';
+import type { UserSettingsState } from './types';
+
+export const userSettings: Module<UserSettingsState, RootState> = {
+  namespaced: true,
+  state,
+  mutations,
+};
+
+export const userSettingsLocalStorage = new VuexPersistence<RootState>({
+  key: 'raiden_dapp_settings',
+  modules: ['userSettings'],
+});
+
+export * from './types';

--- a/raiden-dapp/src/store/user-settings/mutations.ts
+++ b/raiden-dapp/src/store/user-settings/mutations.ts
@@ -1,5 +1,7 @@
 import type { MutationTree } from 'vuex';
 
+import type { EthereumConnectionOptions } from '@/services/ethereum-connection';
+
 import type { UserSettingsState } from './types';
 
 export const mutations: MutationTree<UserSettingsState> = {
@@ -8,5 +10,14 @@ export const mutations: MutationTree<UserSettingsState> = {
   },
   disableRaidenAccount(state) {
     state.useRaidenAccount = false;
+  },
+  saveEthereumConnectionOptions(
+    state,
+    payload: {
+      connectionName: string;
+      connectionOptions: EthereumConnectionOptions;
+    },
+  ) {
+    state.ethereumConnectionOptions[payload.connectionName] = payload.connectionOptions;
   },
 };

--- a/raiden-dapp/src/store/user-settings/mutations.ts
+++ b/raiden-dapp/src/store/user-settings/mutations.ts
@@ -1,0 +1,12 @@
+import type { MutationTree } from 'vuex';
+
+import type { UserSettingsState } from './types';
+
+export const mutations: MutationTree<UserSettingsState> = {
+  enableRaidenAccount(state) {
+    state.useRaidenAccount = true;
+  },
+  disableRaidenAccount(state) {
+    state.useRaidenAccount = false;
+  },
+};

--- a/raiden-dapp/src/store/user-settings/state.ts
+++ b/raiden-dapp/src/store/user-settings/state.ts
@@ -1,0 +1,9 @@
+import type { UserSettingsState } from './types';
+
+export const defaultState = (): UserSettingsState => ({
+  useRaidenAccount: true,
+});
+
+const state: UserSettingsState = defaultState();
+
+export default state;

--- a/raiden-dapp/src/store/user-settings/state.ts
+++ b/raiden-dapp/src/store/user-settings/state.ts
@@ -2,6 +2,7 @@ import type { UserSettingsState } from './types';
 
 export const defaultState = (): UserSettingsState => ({
   useRaidenAccount: true,
+  ethereumConnectionOptions: {},
 });
 
 const state: UserSettingsState = defaultState();

--- a/raiden-dapp/src/store/user-settings/types.ts
+++ b/raiden-dapp/src/store/user-settings/types.ts
@@ -1,3 +1,6 @@
+import type { EthereumConnectionOptions } from '@/services/ethereum-connection';
+
 export interface UserSettingsState {
   useRaidenAccount: boolean;
+  ethereumConnectionOptions: { [connectionName: string]: EthereumConnectionOptions };
 }

--- a/raiden-dapp/src/store/user-settings/types.ts
+++ b/raiden-dapp/src/store/user-settings/types.ts
@@ -1,0 +1,3 @@
+export interface UserSettingsState {
+  useRaidenAccount: boolean;
+}

--- a/raiden-dapp/src/types.d.ts
+++ b/raiden-dapp/src/types.d.ts
@@ -11,7 +11,6 @@ import type RaidenService from '@/services/raiden-service';
 export type Tokens = { [token: string]: Token };
 export type Transfers = { [key: string]: RaidenTransfer };
 export type ChannelAction = 'close' | 'deposit' | 'withdraw' | 'settle';
-export type Settings = { [setting: string]: boolean | number | string };
 
 export interface VersionInfo {
   activeVersion: string;
@@ -31,7 +30,6 @@ export interface RootState {
   presences: Presences;
   transfers: Transfers;
   stateBackup: string;
-  settings: Settings;
   config: Partial<RaidenConfig>;
   disclaimerAccepted: boolean;
   stateBackupReminderDateMs: number;

--- a/raiden-dapp/src/views/Home.vue
+++ b/raiden-dapp/src/views/Home.vue
@@ -60,7 +60,7 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import type { Location } from 'vue-router';
-import { mapGetters, mapState } from 'vuex';
+import { createNamespacedHelpers, mapGetters, mapState } from 'vuex';
 
 import ActionButton from '@/components/ActionButton.vue';
 import ConnectionPendingDialog from '@/components/dialogs/ConnectionPendingDialog.vue';
@@ -75,7 +75,8 @@ import {
   InjectedProvider,
   WalletConnect,
 } from '@/services/ethereum-connection';
-import type { Settings } from '@/types';
+
+const { mapState: mapStateUserSettings } = createNamespacedHelpers('userSettings');
 
 function mapRaidenServiceErrorToErrorCode(error: Error): ErrorCode {
   if (error.message && error.message.includes('No deploy info provided')) {
@@ -90,6 +91,7 @@ function mapRaidenServiceErrorToErrorCode(error: Error): ErrorCode {
 @Component({
   computed: {
     ...mapState(['isConnected', 'stateBackup', 'settings']),
+    ...mapStateUserSettings(['useRaidenAccount']),
     ...mapGetters(['tokens']),
   },
   components: {
@@ -103,7 +105,7 @@ export default class Home extends Vue {
   connecting = false;
   connectionError: ErrorCode | null = null;
   stateBackup!: string;
-  settings!: Settings;
+  useRaidenAccount!: boolean;
 
   get navigationTarget(): Location {
     const redirectTo = this.$route.query.redirectTo as string;
@@ -131,7 +133,7 @@ export default class Home extends Vue {
 
     const stateBackup = this.stateBackup;
     const configuration = await ConfigProvider.configuration();
-    const useRaidenAccount = this.settings.useRaidenAccount ? true : undefined;
+    const useRaidenAccount = this.useRaidenAccount ? true : undefined;
     const ethereumConnection = await this.getEthereumConnection(configuration);
 
     // TODO: This will become removed when we have the connection manager.

--- a/raiden-dapp/src/views/account/Settings.vue
+++ b/raiden-dapp/src/views/account/Settings.vue
@@ -11,7 +11,7 @@
           </v-list-item-subtitle>
         </v-list-item-content>
         <v-list-item-action>
-          <v-switch v-model="settings.useRaidenAccount" @change="toggleMainAccount" />
+          <v-switch v-model="useRaidenAccount" @change="toggleRaidenAccountUsage" />
         </v-list-item-action>
       </v-list-item>
     </v-list>
@@ -20,18 +20,24 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import { mapState } from 'vuex';
+import { createNamespacedHelpers } from 'vuex';
 
-import type { Settings } from '@/types';
+const { mapState, mapMutations } = createNamespacedHelpers('userSettings');
 
 @Component({
-  computed: { ...mapState(['settings']) },
+  computed: {
+    ...mapState(['useRaidenAccount']),
+    ...mapMutations(['enableRaidenAccount', 'disableRaidenAccount']),
+  },
 })
 export default class RaidenSettings extends Vue {
-  settings!: Settings;
+  useRaidenAccount!: boolean;
 
-  toggleMainAccount() {
-    this.$store.commit('updateSettings', this.settings);
+  enableRaidenAccount!: () => void;
+  disableRaidenAccount!: () => void;
+
+  toggleRaidenAccountUsage(value: boolean): void {
+    value ? this.enableRaidenAccount() : this.disableRaidenAccount();
   }
 }
 </script>

--- a/raiden-dapp/tests/unit/store.spec.ts
+++ b/raiden-dapp/tests/unit/store.spec.ts
@@ -349,13 +349,6 @@ describe('store', () => {
     });
   });
 
-  test('usingRaidenAccount getter reflect settings state property', () => {
-    [true, false].forEach((useRaidenAccount) => {
-      store.commit('updateSettings', { useRaidenAccount });
-      expect(store.getters.usingRaidenAccount).toEqual(useRaidenAccount);
-    });
-  });
-
   test('version update is available if available version is higher than active one', () => {
     expect(store.getters.versionUpdateAvailable).toBe(false);
 

--- a/raiden-dapp/tests/unit/store/user-settings/getters.spec.ts
+++ b/raiden-dapp/tests/unit/store/user-settings/getters.spec.ts
@@ -1,0 +1,19 @@
+import { getters } from '@/store/user-settings/getters';
+import { defaultState } from '@/store/user-settings/state';
+
+describe('user settings store getters', () => {
+  test('get empty options for etherum connections per default', () => {
+    const state = defaultState();
+
+    expect(getters.getEthereumConnectionOptions(state)('test_connection')).toMatchObject({});
+  });
+
+  test('get saved options for etherum connections', () => {
+    const state = defaultState();
+    state.ethereumConnectionOptions['test_connection'] = { option: 'test' };
+
+    expect(getters.getEthereumConnectionOptions(state)('test_connection')).toMatchObject({
+      option: 'test',
+    });
+  });
+});

--- a/raiden-dapp/tests/unit/store/user-settings/mutations.spec.ts
+++ b/raiden-dapp/tests/unit/store/user-settings/mutations.spec.ts
@@ -1,0 +1,22 @@
+import { mutations } from '@/store/user-settings/mutations';
+import { defaultState } from '@/store/user-settings/state';
+
+describe('user setttings store mutations', () => {
+  test('can enable raiden account usage', () => {
+    const state = defaultState();
+    state.useRaidenAccount = false;
+
+    mutations.enableRaidenAccount(state);
+
+    expect(state.useRaidenAccount).toBe(true);
+  });
+
+  test('can disable raiden account usage', () => {
+    const state = defaultState();
+    expect(state.useRaidenAccount).toBe(true);
+
+    mutations.disableRaidenAccount(state);
+
+    expect(state.useRaidenAccount).toBe(false);
+  });
+});

--- a/raiden-dapp/tests/unit/store/user-settings/mutations.spec.ts
+++ b/raiden-dapp/tests/unit/store/user-settings/mutations.spec.ts
@@ -19,4 +19,14 @@ describe('user setttings store mutations', () => {
 
     expect(state.useRaidenAccount).toBe(false);
   });
+
+  test('can save ethereum connection options', () => {
+    const state = defaultState();
+    expect(state.ethereumConnectionOptions['test_connection']).toBeUndefined();
+
+    const payload = { connectionName: 'test_connection', connectionOptions: 'test_options' };
+    mutations.saveEthereumConnectionOptions(state, payload);
+
+    expect(state.ethereumConnectionOptions['test_connection']).toBe('test_options');
+  });
 });

--- a/raiden-dapp/tests/unit/views/home.spec.ts
+++ b/raiden-dapp/tests/unit/views/home.spec.ts
@@ -55,10 +55,11 @@ describe('Home.vue', () => {
   });
 
   async function connect(settings?: { useRaidenAccount?: boolean }): Promise<void> {
-    store.commit('updateSettings', {
-      useRaidenAccount: true,
-      ...settings,
-    });
+    const useRaidenAccount = settings?.useRaidenAccount ?? true;
+    const mutation = useRaidenAccount
+      ? 'userSettings/enableRaidenAccount'
+      : 'userSettings/disableRaidenAccount';
+    store.commit(mutation);
 
     await (wrapper.vm as any).connect();
     await flushPromises();
@@ -77,6 +78,7 @@ describe('Home.vue', () => {
   test('successful connect navigates to redirect target if given in query', async () => {
     const redirectTo = 'connect/0x5Fc523e13fBAc2140F056AD7A96De2cC0C4Cc63A';
     wrapper.vm.$route.query = { redirectTo };
+    await wrapper.vm.$nextTick();
 
     await connect();
 
@@ -85,7 +87,10 @@ describe('Home.vue', () => {
 
   test('connect can be called without displaying error after failing initially', async () => {
     (wrapper.vm as any).connectionError = ErrorCode.UNSUPPORTED_NETWORK;
+    await wrapper.vm.$nextTick();
+
     await connect();
+
     expect((wrapper.vm as any).connectionError).toBe(null);
   });
 


### PR DESCRIPTION
Related to #2689

**Short description**
Move user settings into a new store module. Extend user settings to include Ethereum connection options.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [x] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Make sure that the "use raiden account" setting still works as expected and gets preserved over a reset (during connection)
2. Make sure old settings from the localStorage get still parsed
3. Make sure that your localStorage shows that there are no saved options yet.
