### PR TITLE
Add instruction to update SDK submodule before building the dApp

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,7 @@ Go to the [CLI README](https://github.com/raiden-network/light-client/tree/maste
 3. **Update the sdk submodules**
 
    ```bash
-   cd raiden-ts
-   git submodule sync && git submodule update --init
-   cd ..
+   yarn workspace raiden-ts update-submodules
    ```
 
 4. **Build the Raiden SDK**

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <h2 align="center">
   <br/>
-  <a href='https://raiden.network/'><img 
-      width='400px' 
-      alt='Raiden Logo' 
+  <a href='https://raiden.network/'><img
+      width='400px'
+      alt='Raiden Logo'
       src="https://user-images.githubusercontent.com/35398162/54018436-ee3f6300-4188-11e9-9b4e-0666c44cda53.png" /></a>
   <br/>
   Raiden Light Client SDK, CLI and dApp
@@ -32,7 +32,7 @@
     <img src="https://codecov.io/gh/raiden-network/light-client/branch/master/graph/badge.svg?token=QzmREKozOH" alt="Codecov Badge">
   </a>
   <a href="https://codeclimate.com/github/raiden-network/light-client/maintainability">
-    <img src="https://api.codeclimate.com/v1/badges/d59cce05c229296c848d/maintainability" 
+    <img src="https://api.codeclimate.com/v1/badges/d59cce05c229296c848d/maintainability"
     alt="Code Climate Badge"/>
   </a>
   <a href="https://github.com/prettier/prettier">
@@ -81,9 +81,9 @@ The [Raiden Network](https://raiden.network/) is an off-chain scaling solution, 
 The Raiden client code is available [here](https://github.com/raiden-network/raiden) and has been [released for mainnet](https://medium.com/raiden-network/alderaan-mainnet-release-announcement-7f701e58c236).
 
 <center>
-<img 
-      width='750px' 
-      alt='Raiden Diagram' 
+<img
+      width='750px'
+      alt='Raiden Diagram'
       src="https://user-images.githubusercontent.com/43838780/85526750-8ecdc680-b60a-11ea-8a42-07da6b0f8296.png" />
 </center>
 
@@ -161,20 +161,20 @@ Fot a more in depth user guide, see the [Light Client documentation](https://lig
 ### Prerequisites
 
 - MetaMask needs to be installed in your browser and can be [downloaded from their website](https://metamask.io/).
-- An ETH balance. for mainnet you'll have to purchase ETH, for the Goerli testnet you can acquire some test ETH by:  
+- An ETH balance. for mainnet you'll have to purchase ETH, for the Goerli testnet you can acquire some test ETH by:
 
   1. By visiting a Goerli faucet either at [https://faucet.goerli.mudit.blog](https://faucet.goerli.mudit.blog) or [https://goerli-faucet.slock.it/](https://goerli-faucet.slock.it/).
   2. Follow the instructions on respective faucet on how to acquire the ETH.
 
 ### Making a First Transfer on Testnet
 
-1. **Connect to the dApp**  
+1. **Connect to the dApp**
 
    1. Visit the [Raiden Hub page](https://hub.raiden.network).
    2. Click on the **Open Channel with Hub** button.
    3. When redirected to the Light Client make sure **Goerli Test Network** is selected in MetaMask and click connect.
 
-2. **Select a Hub and Open a Channel**  
+2. **Select a Hub and Open a Channel**
 
    1. If you don't have any **SVT** (utility tokens), you can click the icon to mint and deposit **SVT**.
    2. Click on the icon at the very bottom to the right of the **TTT** symbol to mint **TTT** tokens.
@@ -182,19 +182,19 @@ Fot a more in depth user guide, see the [Light Client documentation](https://lig
    4. Enter the amount of tokens you want to deposit when opening the channel.
    5. Click **Open Channel** and sign with MetaMask.
 
-3. **Make a Transfer**  
+3. **Make a Transfer**
 
    1. Enter the address of the node receiving your transfer.
    2. Enter the amount you want to transfer.
    3. Click the **Transfer** button.
 
-### Receiving Transfers  
+### Receiving Transfers
 
 Receiving of transfers will be disabled if the utility token (SVT) balance is too low.
 
 To enable receiving again, make sure to add a utility token balance by minting and depositing if using the Light Client.
 
-### **Backup the State to Keep Your Tokens**  
+### **Backup the State to Keep Your Tokens**
 
    You should store a backup of your state to **avoid losing tokens** in case:
 
@@ -243,26 +243,34 @@ Go to the [CLI README](https://github.com/raiden-network/light-client/tree/maste
 
 ### Install and Run the dApp
 
-1. **Clone repository**  
+1. **Clone repository**
 
    ```bash
    git clone --recurse-submodules https://github.com/raiden-network/light-client.git
    cd light-client
    ```
 
-2. **Install dependencies**  
+2. **Install dependencies**
 
    ```bash
    yarn install
    ```
 
-3. **Build the Raiden SDK**  
+3. **Update the sdk submodules**
+
+   ```bash
+   cd raiden-ts
+   git submodule sync && git submodule update --init
+   cd ..
+   ```
+
+4. **Build the Raiden SDK**
 
    ```bash
    yarn workspace raiden-ts build
    ```
 
-4. **Run the dApp locally**  
+5. **Run the dApp locally**
 
    ```
    yarn workspace raiden-dapp serve

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -21,7 +21,8 @@
     "contracts": "yarn run contracts:pre && yarn run contracts:build",
     "versions": "node ./scripts/versions.js",
     "docs": "typedoc",
-    "prepack": "yarn clean && yarn build && yarn run docs"
+    "prepack": "yarn clean && yarn build && yarn run docs",
+    "update-submodules": "git submodule sync && git submodule update --init"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes # 

**Short description**
I've found that it's important to update the SDK submodule first before installing the SDK.
Otherwise, it'll throw some errors

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
