### PR TITLE
Feature/dapp add connection manager

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -11,11 +11,13 @@
 - [#2599] Add WalletConnect as another wallet/provider
 - [#2685] Add a hint dialog when the connection process takes very long
 - [#2690] Allow user to reset connections while in progress
+- [#2630] Allow user to customize WalletConnection options
 
 [#2671]: https://github.com/raiden-network/light-client/issues/2671
 [#2599]: https://github.com/raiden-network/light-client/issues/2599
 [#2685]: https://github.com/raiden-network/light-client/issues/2685
 [#2690]: https://github.com/raiden-network/light-client/issues/2690
+[#2630]: https://github.com/raiden-network/light-client/issues/2630
 
 ## [0.16.0] - 2021-04-01
 

--- a/raiden-dapp/__mocks__/@walletconnect/web3-provider.ts
+++ b/raiden-dapp/__mocks__/@walletconnect/web3-provider.ts
@@ -1,4 +1,6 @@
-export default class WalletConnectProvider {
-  enable = jest.fn().mockResolvedValue(true);
-  on = jest.fn();
-}
+// In lack of being reliably able to spy on a class constructor, use more low
+// level features to implement the mocking of the class.
+export default jest.fn().mockImplementation(() => ({
+  enable: jest.fn().mockResolvedValue(true),
+  on: jest.fn(),
+}));

--- a/raiden-dapp/public/config.json.example
+++ b/raiden-dapp/public/config.json.example
@@ -1,6 +1,5 @@
 {
   "rpc_endpoint": "goerli.infura.io/v3/6d333faba41b4c3d8ae979417e281832",
-  "rpc_endpoint_wallet_connect": "goerli.infura.io/v3/6d333faba41b4c3d8ae979417e281832",
   "private_key": "0x6d333faba41b4c3d8ae979417e2818326d333faba41b4c3d8ae979417e281832",
   "per_network": {
     "5": {

--- a/raiden-dapp/src/components/ActionButton.vue
+++ b/raiden-dapp/src/components/ActionButton.vue
@@ -24,10 +24,10 @@
       >
         {{ text }}
         <v-icon v-if="arrow" right>keyboard_arrow_right</v-icon>
-        <template v-if="syncing" #loader>
-          <div class="action-button__syncing">
-            <span>{{ $t('home.connect-button-syncing') }}</span>
-            <v-progress-linear class="action-button__syncing__indicator" indeterminate rounded />
+        <template v-if="loadingText" #loader>
+          <div class="action-button__loading">
+            <span>{{ loadingText }}</span>
+            <v-progress-linear class="action-button__loading__indicator" indeterminate rounded />
           </div>
         </template>
       </v-btn>
@@ -46,10 +46,10 @@ export default class ActionButton extends Vue {
   text!: string;
 
   @Prop({ type: Boolean, default: false })
-  syncing!: boolean;
-
-  @Prop({ type: Boolean, default: false })
   loading!: boolean;
+
+  @Prop({ type: String })
+  loadingText!: string;
 
   @Prop({ type: Boolean, default: false })
   sticky?: boolean;
@@ -154,7 +154,7 @@ export default class ActionButton extends Vue {
     width: 100%;
   }
 
-  &__syncing {
+  &__loading {
     display: flex;
     flex-direction: column;
     font-size: 14px;

--- a/raiden-dapp/src/components/ActionButton.vue
+++ b/raiden-dapp/src/components/ActionButton.vue
@@ -20,6 +20,7 @@
         }"
         depressed
         large
+        :style="{ width }"
         @click="click()"
       >
         {{ text }}
@@ -60,6 +61,9 @@ export default class ActionButton extends Vue {
   @Prop({ type: Boolean, default: false })
   ghost?: boolean;
 
+  @Prop({ type: String, default: '250px' })
+  width?: string;
+
   @Prop({ type: Boolean, default: false })
   fullWidth?: boolean;
 
@@ -86,7 +90,6 @@ export default class ActionButton extends Vue {
 .action-button {
   &__button {
     max-height: 40px;
-    width: 250px;
     border-radius: 29px;
     background-color: $primary-color !important;
 
@@ -110,7 +113,7 @@ export default class ActionButton extends Vue {
     }
 
     &--full-width {
-      width: 100%;
+      width: 100% !important;
     }
 
     &--ghost {

--- a/raiden-dapp/src/components/ConnectionManager.vue
+++ b/raiden-dapp/src/components/ConnectionManager.vue
@@ -39,6 +39,7 @@ import WalletConnectProviderDialog from '@/components/dialogs/WalletConnectProvi
 import { ErrorCode } from '@/model/types';
 import { ConfigProvider } from '@/services/config-provider';
 import type { EthereumProvider } from '@/services/ethereum-provider';
+import { DirectRpcProvider } from '@/services/ethereum-provider';
 
 function mapRaidenServiceErrorToErrorCode(error: Error): ErrorCode {
   if (error.message && error.message.includes('No deploy info provided')) {
@@ -82,6 +83,19 @@ export default class ConnectionManager extends Vue {
     } else {
       const translationKey = `error-codes.${this.errorCode.toString()}`;
       return this.$t(translationKey) as string;
+    }
+  }
+
+  /**
+   * This is a workaround to make the end-to-end tests working while the
+   * connection manager does not support user configured direct RPC provider
+   * connections.
+   */
+  async created(): Promise<void> {
+    const { rpc_endpoint: rpcUrl, private_key: privateKey } = await ConfigProvider.configuration();
+    if (rpcUrl && privateKey) {
+      const provider = await DirectRpcProvider.link({ rpcUrl, privateKey });
+      this.connect(provider);
     }
   }
 

--- a/raiden-dapp/src/components/ConnectionManager.vue
+++ b/raiden-dapp/src/components/ConnectionManager.vue
@@ -1,0 +1,159 @@
+<template>
+  <div class="connection-manager">
+    <v-alert
+      v-if="errorCode"
+      id="connection-manager__error-message"
+      class="font-weight-light"
+      color="error"
+      icon="warning"
+    >
+      {{ translatedErrorCode }}
+    </v-alert>
+
+    <action-button
+      :enabled="connectButtonEnabled"
+      :text="$t('connection-manager.connect-button')"
+      :loading="inProgress"
+      :loading-text="$t('connection-manager.connect-button-loading')"
+      sticky
+      @click="connect"
+    />
+
+    <connection-pending-dialog v-if="inProgress" @reset-connection="resetConnection" />
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+import { createNamespacedHelpers, mapState } from 'vuex';
+
+import ActionButton from '@/components/ActionButton.vue';
+import ConnectionPendingDialog from '@/components/dialogs/ConnectionPendingDialog.vue';
+import { ErrorCode } from '@/model/types';
+import type { Configuration } from '@/services/config-provider';
+import { ConfigProvider } from '@/services/config-provider';
+import type { EthereumProvider } from '@/services/ethereum-provider';
+import {
+  DirectRpcProvider,
+  InjectedProvider,
+  WalletConnectProvider,
+} from '@/services/ethereum-provider';
+
+function mapRaidenServiceErrorToErrorCode(error: Error): ErrorCode {
+  if (error.message && error.message.includes('No deploy info provided')) {
+    return ErrorCode.UNSUPPORTED_NETWORK;
+  } else if (error.message && error.message.includes('Could not replace stored state')) {
+    return ErrorCode.STATE_MIGRATION_FAILED;
+  } else {
+    return ErrorCode.SDK_INITIALIZATION_FAILED;
+  }
+}
+
+const { mapState: mapUserSettingsState } = createNamespacedHelpers('userSettings');
+
+@Component({
+  computed: {
+    ...mapState(['isConnected', 'stateBackup']),
+    ...mapUserSettingsState(['useRaidenAccount']),
+  },
+  components: {
+    ActionButton,
+    ConnectionPendingDialog,
+  },
+})
+export default class ConnectionManager extends Vue {
+  isConnected!: boolean;
+  stateBackup!: string;
+  useRaidenAccount!: boolean;
+
+  inProgress = false;
+  errorCode: ErrorCode | null = null;
+
+  get connectButtonEnabled(): boolean {
+    return !this.isConnected && !this.inProgress;
+  }
+
+  get translatedErrorCode(): string {
+    if (!this.errorCode) {
+      return '';
+    } else {
+      const translationKey = `error-codes.${this.errorCode.toString()}`;
+      return this.$t(translationKey) as string;
+    }
+  }
+
+  async connect() {
+    this.inProgress = true;
+    this.$store.commit('reset');
+    this.errorCode = null;
+
+    const stateBackup = this.stateBackup;
+    const configuration = await ConfigProvider.configuration();
+    const useRaidenAccount = this.useRaidenAccount ? true : undefined;
+    const provider = await this.getProvider(configuration);
+
+    // TODO: This will become removed when the provider options are controlled by the user.
+    if (provider === undefined) {
+      this.errorCode = ErrorCode.NO_ETHEREUM_PROVIDER;
+      this.inProgress = false;
+      return;
+    }
+
+    const network = await provider.provider.getNetwork();
+
+    if (network.chainId === 1 && process.env.VUE_APP_ALLOW_MAINNET !== 'true') {
+      this.errorCode = ErrorCode.UNSUPPORTED_NETWORK;
+      this.inProgress = false;
+      return;
+    }
+
+    try {
+      await this.$raiden.connect(
+        provider.provider,
+        provider.account,
+        stateBackup,
+        configuration.per_network,
+        useRaidenAccount,
+      );
+    } catch (error) {
+      this.errorCode = mapRaidenServiceErrorToErrorCode(error);
+      this.inProgress = false;
+      return;
+    }
+
+    this.$store.commit('setConnected');
+    this.$store.commit('clearBackupState');
+  }
+
+  async getProvider(configuration: Configuration): Promise<EthereumProvider | undefined> {
+    const {
+      rpc_endpoint: rpcUrl,
+      private_key: privateKey,
+      rpc_endpoint_wallet_connect: rpcUrlWalletConnect,
+    } = configuration;
+
+    if (rpcUrl && privateKey) {
+      return await DirectRpcProvider.link({ rpcUrl, privateKey });
+    } else if (!!window.ethereum || !!window.web3) {
+      return await InjectedProvider.link();
+    } else if (rpcUrlWalletConnect) {
+      return await WalletConnectProvider.link({ rpcUrl: rpcUrlWalletConnect });
+    } else {
+      return undefined;
+    }
+  }
+
+  resetConnection(): void {
+    localStorage.removeItem('walletconnect');
+    // There is no clean way to cancel the asynchronous connection function, therefore reload page.
+    window.location.replace(window.location.origin);
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.connection-manager {
+  font-size: 16px;
+  line-height: 20px;
+}
+</style>

--- a/raiden-dapp/src/components/ConnectionManager.vue
+++ b/raiden-dapp/src/components/ConnectionManager.vue
@@ -85,8 +85,8 @@ export default class ConnectionManager extends Vue {
     }
   }
 
-  onProviderLinkEstablished(linkedProvider: EthereumProvider): void {
-    this.connect(linkedProvider);
+  async onProviderLinkEstablished(linkedProvider: EthereumProvider): Promise<void> {
+    await this.connect(linkedProvider);
   }
 
   openWalletConnectDialog(): void {
@@ -98,6 +98,12 @@ export default class ConnectionManager extends Vue {
   }
 
   async connect(provider: EthereumProvider): Promise<void> {
+    if (this.isConnected || this.inProgress) {
+      // Nobody catches this error. But if this case occurs, this is an
+      // implementation error that should show up in the console and tests.
+      throw new Error('Can only connect once!');
+    }
+
     this.inProgress = true;
     this.$store.commit('reset');
     this.errorCode = null;

--- a/raiden-dapp/src/components/dialogs/ConnectionPendingDialog.vue
+++ b/raiden-dapp/src/components/dialogs/ConnectionPendingDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <raiden-dialog :visible="dialogVisible" :hide-close="true">
+  <raiden-dialog :visible="true" :hide-close="true">
     <v-card-title>
       {{ $t('connection-manager.dialogs.connection-pending.title') }}
     </v-card-title>
@@ -26,33 +26,11 @@ import ActionButton from '@/components/ActionButton.vue';
 import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
 import Spinner from '@/components/icons/Spinner.vue';
 
-const SHOW_DIALOG_TIMEOUT = 7000;
-
-/*
-  Please note that because the underlying dialog component by Vuetify, it is not
-  possible to implement the delayed rendering with a Vue transition or pure CSS
-  effect. Therefore this alternative approach of using the life-cycle hook and
-  a timer is necessary.
-*/
 @Component({ components: { ActionButton, RaidenDialog, Spinner } })
 export default class ConnectionPendingDialog extends Vue {
-  dialogVisible = false;
-
   @Emit('reset-connection')
   resetConnection(): void {
     // pass
-  }
-
-  mounted() {
-    this.delayVisibilityOfDialog();
-  }
-
-  delayVisibilityOfDialog(): void {
-    setTimeout(this.showDialog, SHOW_DIALOG_TIMEOUT);
-  }
-
-  showDialog(): void {
-    this.dialogVisible = true;
   }
 }
 </script>

--- a/raiden-dapp/src/components/dialogs/ConnectionPendingDialog.vue
+++ b/raiden-dapp/src/components/dialogs/ConnectionPendingDialog.vue
@@ -1,17 +1,17 @@
 <template>
   <raiden-dialog :visible="dialogVisible" :hide-close="true">
     <v-card-title>
-      {{ $t('home.connection-pending-dialog.title') }}
+      {{ $t('connection-manager.dialogs.connection-pending.title') }}
     </v-card-title>
 
     <v-card-text>
       <spinner :size="60" class="my-4" />
-      {{ $t('home.connection-pending-dialog.text') }}
+      {{ $t('connection-manager.dialogs.connection-pending.text') }}
     </v-card-text>
 
     <v-card-actions>
       <action-button
-        :text="$t('home.connection-pending-dialog.button')"
+        :text="$t('connection-manager.dialogs.connection-pending.button')"
         :enabled="true"
         @click="resetConnection"
       />

--- a/raiden-dapp/src/components/dialogs/RaidenDialog.vue
+++ b/raiden-dapp/src/components/dialogs/RaidenDialog.vue
@@ -42,6 +42,7 @@ export default class RaidenDialog extends Vue {
 <style scoped lang="scss">
 @import '@/scss/colors';
 @import '@/scss/fonts';
+@import '@/scss/mixins';
 
 ::v-deep {
   .v-dialog {
@@ -55,6 +56,10 @@ export default class RaidenDialog extends Vue {
   flex-direction: column;
   justify-content: center;
   padding: 25px;
+
+  @include respond-to(handhelds) {
+    padding: 10px;
+  }
 
   ::v-deep {
     .v-card {

--- a/raiden-dapp/src/components/dialogs/WalletConnectProviderDialog.vue
+++ b/raiden-dapp/src/components/dialogs/WalletConnectProviderDialog.vue
@@ -22,12 +22,12 @@
       <input
         class="wallet-connect-provider__input"
         type="text"
-        :value="bridgeServerUrl"
+        :value="bridgeUrl"
         :placeholder="
           $t('connection-manager.dialogs.wallet-connect-provider.placeholder.bridge-server')
         "
         :disabled="bridgeServerUrlInputDisabled"
-        @input="bridgeServerUrl = $event.target.value"
+        @input="bridgeUrl = $event.target.value"
       />
     </div>
 
@@ -99,7 +99,7 @@ enum InfuraOrRpcToggleState {
   },
 })
 export default class WalletConnectProviderDialog extends Vue {
-  bridgeServerUrl = '';
+  bridgeUrl = '';
   bridgeServerUrlInputDisabled = true;
   infuraIdOrRpcUrl = '';
   infuraOrRpcToggleState = InfuraOrRpcToggleState.INFURA;
@@ -135,10 +135,12 @@ export default class WalletConnectProviderDialog extends Vue {
   }
 
   get providerOptions(): Parameters<typeof WalletConnectProvider.link>[0] {
+    const bridgeUrl = this.bridgeUrl || undefined;
+
     if (this.infuraOrRpcToggleState === InfuraOrRpcToggleState.INFURA) {
-      return { infuraId: this.infuraIdOrRpcUrl };
+      return { infuraId: this.infuraIdOrRpcUrl, bridgeUrl };
     } else {
-      return { rpcUrl: this.infuraIdOrRpcUrl };
+      return { rpcUrl: this.infuraIdOrRpcUrl, bridgeUrl };
     }
   }
 

--- a/raiden-dapp/src/components/dialogs/WalletConnectProviderDialog.vue
+++ b/raiden-dapp/src/components/dialogs/WalletConnectProviderDialog.vue
@@ -1,82 +1,94 @@
 <template>
-  <raiden-dialog width="472" class="wallet-connect-provider" :visible="true" @close="cancel">
-    <span class="wallet-connect-provider__header">
+  <raiden-dialog width="472" class="wallet-connect-provider" :visible="true" @close="emitCancel">
+    <v-card-title>
       {{ $t('connection-manager.dialogs.wallet-connect-provider.header') }}
-    </span>
+    </v-card-title>
 
-    <div class="wallet-connect-provider__bridge-server">
-      <div class="wallet-connect-provider__bridge-server__details">
-        <div class="wallet-connect-provider__bridge-server__details__info">
-          <h3>
-            {{ $t('connection-manager.dialogs.wallet-connect-provider.bridge-server-header') }}
-          </h3>
-          <span>
-            {{ $t('connection-manager.dialogs.wallet-connect-provider.bridge-server-body') }}
-          </span>
-        </div>
+    <v-card-text>
+      <div class="wallet-connect-provider__options__bridge-url">
+        <h3>
+          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.bridge-url.header') }}
+        </h3>
+        <span>
+          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.bridge-url.details') }}
+        </span>
         <v-switch
-          class="wallet-connect-provider__bridge-server__details__toggle"
-          @change="toggleBridgeServerInputVisibility"
+          class="wallet-connect-provider__options__bridge-url__toggle"
+          @change="toggleBridgeUrlOption"
+        />
+        <input
+          v-model.trim="bridgeUrlOption"
+          class="wallet-connect-provider__input wallet-connect-provider__options__bridge-url__input"
+          :disabled="bridgeUrlOptionDisabled"
+          :placeholder="
+            $t('connection-manager.dialogs.wallet-connect-provider.options.bridge-url.placeholder')
+          "
+          @input="hideErrorMessage"
         />
       </div>
-      <input
-        class="wallet-connect-provider__input"
-        type="text"
-        :value="bridgeUrl"
-        :placeholder="
-          $t('connection-manager.dialogs.wallet-connect-provider.placeholder.bridge-server')
-        "
-        :disabled="bridgeServerUrlInputDisabled"
-        @input="bridgeUrl = $event.target.value"
-      />
-    </div>
 
-    <div class="wallet-connect-provider__infura-or-rpc">
       <v-btn-toggle mandatory>
-        <v-btn class="wallet-connect-provider__infura-or-rpc__button" @click="showInfura">
-          {{ $t('connection-manager.dialogs.wallet-connect-provider.infura-button') }}
+        <v-btn class="wallet-connect-provider__option-toggle-button" @click="showInfuraIdOption">
+          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.header') }}
         </v-btn>
-        <v-btn class="wallet-connect-provider__infura-or-rpc__button" @click="showRpc">
-          {{ $t('connection-manager.dialogs.wallet-connect-provider.rpc-button') }}
+        <v-btn class="wallet-connect-provider__option-toggle-button" @click="showRpcUrlOption">
+          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.header') }}
         </v-btn>
       </v-btn-toggle>
 
-      <div class="wallet-connect-provider__infura-or-rpc__details">
-        <div v-if="infuraVisible" class="wallet-connect-provider__infura-or-rpc__details--infura">
-          <h3>{{ $t('connection-manager.dialogs.wallet-connect-provider.infura-header') }}</h3>
-          <span>{{ $t('connection-manager.dialogs.wallet-connect-provider.infura-body') }}</span>
-        </div>
-        <div v-if="rpcVisible" class="wallet-connect-provider__infura-or-rpc__details--rpc">
-          <h3>{{ $t('connection-manager.dialogs.wallet-connect-provider.rpc-header') }}</h3>
-          <span>{{ $t('connection-manager.dialogs.wallet-connect-provider.rpc-body') }}</span>
-        </div>
-
+      <div v-if="infuraIdOptionVisible" class="wallet-connect-provider__options__infura-id">
+        <h3>
+          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.header') }}
+        </h3>
+        <span>
+          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.details') }}
+        </span>
         <input
-          class="wallet-connect-provider__input"
-          type="text"
-          :value="infuraIdOrRpcUrl"
-          :placeholder="infuraIdOrRpcUrlInputPlaceholder"
-          @input="infuraIdOrRpcUrl = $event.target.value"
+          v-model.trim="infuraIdOption"
+          class="wallet-connect-provider__input wallet-connect-provider__options__infura-id__input"
+          :placeholder="
+            $t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.placeholder')
+          "
+          @input="hideErrorMessage"
+        />
+      </div>
+
+      <div v-if="rpcUrlOptionVisible" class="wallet-connect-provider__options__rpc-url">
+        <h3>
+          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.header') }}
+        </h3>
+        <span>
+          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.details') }}
+        </span>
+        <input
+          v-model.trim="rpcUrlOption"
+          class="wallet-connect-provider__input wallet-connect-provider__options__rpc-url__input"
+          :placeholder="
+            $t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.placeholder')
+          "
+          @input="hideErrorMessage"
         />
       </div>
 
       <v-alert
         v-if="linkFailed"
-        class="wallet-connect-provider__error-message"
+        class="wallet-connect-provider__error-message text-left font-weight-light"
         color="error"
         icon="warning"
       >
         {{ $t('connection-manager.dialogs.wallet-connect-provider.error-message') }}
       </v-alert>
+    </v-card-text>
 
+    <v-card-actions>
       <action-button
         :enabled="canLink"
-        class="wallet-connect-provider__button"
+        class="wallet-connect-provider__link-button"
         :text="$t('connection-manager.dialogs.wallet-connect-provider.button')"
         width="200px"
         @click="link"
       />
-    </div>
+    </v-card-actions>
   </raiden-dialog>
 </template>
 
@@ -87,10 +99,12 @@ import ActionButton from '@/components/ActionButton.vue';
 import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
 import { WalletConnectProvider } from '@/services/ethereum-provider';
 
-enum InfuraOrRpcToggleState {
-  INFURA = 'infura',
-  RPC = 'rpc',
+enum OptionToggle {
+  INFURA_ID,
+  RPC_URL,
 }
+
+type WalletConnectProviderOptions = Parameters<typeof WalletConnectProvider.link>[0];
 
 @Component({
   components: {
@@ -99,61 +113,54 @@ enum InfuraOrRpcToggleState {
   },
 })
 export default class WalletConnectProviderDialog extends Vue {
-  bridgeUrl = '';
-  bridgeServerUrlInputDisabled = true;
-  infuraIdOrRpcUrl = '';
-  infuraOrRpcToggleState = InfuraOrRpcToggleState.INFURA;
+  bridgeUrlOptionDisabled = true;
+  optionToggleState = OptionToggle.INFURA_ID;
   linkFailed = false;
 
-  @Emit('linkEstablished')
-  emitLinkEstablished(linkedProvider: WalletConnectProvider): WalletConnectProvider {
-    return linkedProvider;
+  bridgeUrlOption = '';
+  infuraIdOption = '';
+  rpcUrlOption = '';
+
+  get infuraIdOptionVisible(): boolean {
+    return this.optionToggleState === OptionToggle.INFURA_ID;
   }
 
-  @Emit()
-  cancel(): void {
-    // pass
-  }
-
-  get infuraVisible(): boolean {
-    return this.infuraOrRpcToggleState === InfuraOrRpcToggleState.INFURA;
-  }
-
-  get rpcVisible(): boolean {
-    return this.infuraOrRpcToggleState === InfuraOrRpcToggleState.RPC;
-  }
-
-  get infuraIdOrRpcUrlInputPlaceholder(): string {
-    const kind = this.infuraOrRpcToggleState.toString();
-    return this.$t(
-      `connection-manager.dialogs.wallet-connect-provider.placeholder.${kind}`,
-    ) as string;
+  get rpcUrlOptionVisible(): boolean {
+    return this.optionToggleState === OptionToggle.RPC_URL;
   }
 
   get canLink(): boolean {
-    return this.infuraIdOrRpcUrl.length > 0;
+    return !!this.infuraIdOption || !!this.rpcUrlOption;
   }
 
-  get providerOptions(): Parameters<typeof WalletConnectProvider.link>[0] {
-    const bridgeUrl = this.bridgeUrl || undefined;
+  get providerOptions(): WalletConnectProviderOptions {
+    const bridgeUrl = this.bridgeUrlOption || undefined;
 
-    if (this.infuraOrRpcToggleState === InfuraOrRpcToggleState.INFURA) {
-      return { infuraId: this.infuraIdOrRpcUrl, bridgeUrl };
-    } else {
-      return { rpcUrl: this.infuraIdOrRpcUrl, bridgeUrl };
+    // We can't simply pass all options to the provider. In case the user
+    // specified an Infura ID **and** a RPC URL, the linking would fail.
+    switch (this.optionToggleState) {
+      case OptionToggle.INFURA_ID:
+        return { infuraId: this.infuraIdOption, bridgeUrl };
+
+      case OptionToggle.RPC_URL:
+        return { rpcUrl: this.rpcUrlOption, bridgeUrl };
     }
   }
 
-  showInfura(): void {
-    this.infuraOrRpcToggleState = InfuraOrRpcToggleState.INFURA;
+  showInfuraIdOption(): void {
+    this.optionToggleState = OptionToggle.INFURA_ID;
   }
 
-  showRpc(): void {
-    this.infuraOrRpcToggleState = InfuraOrRpcToggleState.RPC;
+  showRpcUrlOption(): void {
+    this.optionToggleState = OptionToggle.RPC_URL;
   }
 
-  toggleBridgeServerInputVisibility(): void {
-    this.bridgeServerUrlInputDisabled = !this.bridgeServerUrlInputDisabled;
+  toggleBridgeUrlOption(): void {
+    this.bridgeUrlOptionDisabled = !this.bridgeUrlOptionDisabled;
+  }
+
+  hideErrorMessage(): void {
+    this.linkFailed = false;
   }
 
   async link(): Promise<void> {
@@ -166,6 +173,16 @@ export default class WalletConnectProviderDialog extends Vue {
       this.linkFailed = true;
     }
   }
+
+  @Emit('linkEstablished')
+  emitLinkEstablished(linkedProvider: WalletConnectProvider): WalletConnectProvider {
+    return linkedProvider;
+  }
+
+  @Emit('cancel')
+  emitCancel(): void {
+    // pass
+  }
 }
 </script>
 
@@ -174,14 +191,7 @@ export default class WalletConnectProviderDialog extends Vue {
 @import '@/scss/colors';
 
 .wallet-connect-provider {
-  display: flex;
-
-  &__header {
-    font-size: 26px;
-    margin-top: 10px;
-    text-align: center;
-  }
-
+  // TODO: This is not nice. We need to get rid of it.
   &__input {
     background-color: $input-background;
     border-radius: 8px;
@@ -196,69 +206,40 @@ export default class WalletConnectProviderDialog extends Vue {
     }
   }
 
-  &__bridge-server {
-    background-color: $input-background;
-    border-radius: 8px !important;
-    margin: 20px 0;
-    padding: 16px;
-    width: 422px;
+  &__options {
+    &__bridge-url,
+    &__infura-id,
+    &__rpc-url {
+      display: flex;
+      flex-direction: column;
+      align-items: start;
+      color: $color-gray;
+      background-color: $input-background;
+      border-radius: 8px !important;
+      font-size: 14px;
+      text-align: left;
+      margin: 20px 0;
+      padding: 16px;
 
-    @include respond-to(handhelds) {
-      width: 100%;
-      margin: 10px 0;
+      @include respond-to(handhelds) {
+        margin: 10px 0;
+      }
     }
 
-    &__details {
-      color: $color-gray;
-      display: flex;
-
-      &__info {
-        display: flex;
-        flex: 1;
-        flex-direction: column;
-        font-size: 14px;
-        margin-right: 82px;
-        @include respond-to(handhelds) {
-          margin-right: 22px;
-        }
-      }
+    &__bridge-url {
+      position: relative;
 
       &__toggle {
+        position: absolute;
+        top: 0;
+        right: 10px;
         height: 32px;
       }
     }
   }
 
-  &__infura-or-rpc {
-    align-items: center;
-    display: flex;
-    flex-direction: column;
-
-    &__button {
-      width: 92px;
-    }
-
-    &__details {
-      background-color: $input-background;
-      border-radius: 8px !important;
-      color: $color-gray;
-      display: flex;
-      flex-direction: column;
-      font-size: 14px;
-      margin: 20px 0;
-      padding: 16px;
-      width: 422px;
-
-      @include respond-to(handhelds) {
-        width: 100%;
-        margin: 10px 0;
-      }
-    }
-  }
-
-  &__button {
-    margin-top: 10px;
-    margin-left: -38px; // Something is off with the ActionButton component - ugly quickfix
+  &__option-toggle-button {
+    width: 92px;
   }
 }
 </style>

--- a/raiden-dapp/src/components/dialogs/WalletConnectProviderDialog.vue
+++ b/raiden-dapp/src/components/dialogs/WalletConnectProviderDialog.vue
@@ -1,52 +1,58 @@
 <template>
-  <raiden-dialog width="472" class="wallet-connect" :visible="true" @close="cancel">
-    <span class="wallet-connect__header">
-      {{ $t('home.wallet-connect-dialog.wallet-connect-header') }}
+  <raiden-dialog width="472" class="wallet-connect-provider" :visible="true" @close="cancel">
+    <span class="wallet-connect-provider__header">
+      {{ $t('connection-manager.dialogs.wallet-connect-provider.header') }}
     </span>
 
-    <div class="wallet-connect__bridge-server">
-      <div class="wallet-connect__bridge-server__details">
-        <div class="wallet-connect__bridge-server__details__info">
-          <h3>{{ $t('home.wallet-connect-dialog.bridge-server-header') }}</h3>
-          <span>{{ $t('home.wallet-connect-dialog.bridge-server-body') }}</span>
+    <div class="wallet-connect-provider__bridge-server">
+      <div class="wallet-connect-provider__bridge-server__details">
+        <div class="wallet-connect-provider__bridge-server__details__info">
+          <h3>
+            {{ $t('connection-manager.dialogs.wallet-connect-provider.bridge-server-header') }}
+          </h3>
+          <span>
+            {{ $t('connection-manager.dialogs.wallet-connect-provider.bridge-server-body') }}
+          </span>
         </div>
         <v-switch
-          class="wallet-connect__bridge-server__details__toggle"
+          class="wallet-connect-provider__bridge-server__details__toggle"
           @change="toggleBridgeServerInputVisibility"
         />
       </div>
       <input
-        class="wallet-connect__input"
+        class="wallet-connect-provider__input"
         type="text"
         :value="bridgeServerUrl"
-        :placeholder="$t('home.wallet-connect-dialog.placeholder.bridge-server')"
+        :placeholder="
+          $t('connection-manager.dialogs.wallet-connect-provider.placeholder.bridge-server')
+        "
         :disabled="bridgeServerUrlInputDisabled"
         @input="bridgeServerUrl = $event.target.value"
       />
     </div>
 
-    <div class="wallet-connect__infura-or-rpc">
+    <div class="wallet-connect-provider__infura-or-rpc">
       <v-btn-toggle mandatory>
-        <v-btn class="wallet-connect__infura-or-rpc__button" @click="showInfura">
-          {{ $t('home.wallet-connect-dialog.infura-button') }}
+        <v-btn class="wallet-connect-provider__infura-or-rpc__button" @click="showInfura">
+          {{ $t('connection-manager.dialogs.wallet-connect-provider.infura-button') }}
         </v-btn>
-        <v-btn class="wallet-connect__infura-or-rpc__button" @click="showRpc">
-          {{ $t('home.wallet-connect-dialog.rpc-button') }}
+        <v-btn class="wallet-connect-provider__infura-or-rpc__button" @click="showRpc">
+          {{ $t('connection-manager.dialogs.wallet-connect-provider.rpc-button') }}
         </v-btn>
       </v-btn-toggle>
 
-      <div class="wallet-connect__infura-or-rpc__details">
-        <div v-if="infuraVisible" class="wallet-connect__infura-or-rpc__details--infura">
-          <h3>{{ $t('home.wallet-connect-dialog.infura-header') }}</h3>
-          <span>{{ $t('home.wallet-connect-dialog.infura-body') }}</span>
+      <div class="wallet-connect-provider__infura-or-rpc__details">
+        <div v-if="infuraVisible" class="wallet-connect-provider__infura-or-rpc__details--infura">
+          <h3>{{ $t('connection-manager.dialogs.wallet-connect-provider.infura-header') }}</h3>
+          <span>{{ $t('connection-manager.dialogs.wallet-connect-provider.infura-body') }}</span>
         </div>
-        <div v-if="rpcVisible" class="wallet-connect__infura-or-rpc__details--rpc">
-          <h3>{{ $t('home.wallet-connect-dialog.rpc-header') }}</h3>
-          <span>{{ $t('home.wallet-connect-dialog.rpc-body') }}</span>
+        <div v-if="rpcVisible" class="wallet-connect-provider__infura-or-rpc__details--rpc">
+          <h3>{{ $t('connection-manager.dialogs.wallet-connect-provider.rpc-header') }}</h3>
+          <span>{{ $t('connection-manager.dialogs.wallet-connect-provider.rpc-body') }}</span>
         </div>
 
         <input
-          class="wallet-connect__input"
+          class="wallet-connect-provider__input"
           type="text"
           :value="infuraIdOrRpcUrl"
           :placeholder="infuraIdOrRpcUrlInputPlaceholder"
@@ -56,8 +62,8 @@
 
       <action-button
         :enabled="canConnect"
-        class="wallet-connect__button"
-        :text="$t('home.connect-button')"
+        class="wallet-connect-provider__button"
+        :text="$t('connection-manager.dialogs.wallet-connect-provider.connect-button')"
         @click="connect"
       />
     </div>
@@ -81,7 +87,7 @@ enum InfuraOrRpcToggleState {
     ActionButton,
   },
 })
-export default class WalletConnectDialog extends Vue {
+export default class WalletConnectProviderDialog extends Vue {
   bridgeServerUrl = '';
   bridgeServerUrlInputDisabled = true;
   infuraIdOrRpcUrl = '';
@@ -107,7 +113,9 @@ export default class WalletConnectDialog extends Vue {
 
   get infuraIdOrRpcUrlInputPlaceholder(): string {
     const kind = this.infuraOrRpcToggleState.toString();
-    return this.$t(`home.wallet-connect-dialog.placeholder.${kind}`) as string;
+    return this.$t(
+      `connection-manager.dialogs.wallet-connect-provider.placeholder.${kind}`,
+    ) as string;
   }
 
   showInfura(): void {
@@ -132,7 +140,7 @@ export default class WalletConnectDialog extends Vue {
 @import '@/scss/mixins';
 @import '@/scss/colors';
 
-.wallet-connect {
+.wallet-connect-provider {
   display: flex;
 
   &__header {

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -84,8 +84,6 @@
   },
   "home": {
     "welcome": "Welcome to the Raiden dApp",
-    "connect-button": "Connect",
-    "connect-button-syncing": "Syncing",
     "disclaimer": "The Raiden dApp is a reference implementation of the Raiden Light Client SDK. It is work in progress and can only be used on Ethereum testnets.",
     "getting-started": {
       "description": "Read the {0} for detailed information on how to use the Raiden dApp.",
@@ -799,5 +797,9 @@
     "dismiss": "Dismiss",
     "message-mobile": "Add the Raiden dApp to your Home screen",
     "message-desktop": "Install the Raiden dApp on your desktop"
+  },
+  "connection-manager": {
+    "connect-button": "Connect",
+    "connect-button-loading": "Syncing"
   }
 }

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -88,34 +88,6 @@
     "getting-started": {
       "description": "Read the {0} for detailed information on how to use the Raiden dApp.",
       "link-name": "getting started guide"
-    },
-    "connect-dialog": {
-      "title": "Connect",
-      "raiden-account": "Generate Account & Key",
-      "description-raiden-account": "A Raiden Account will be generated.",
-      "description-web3-account": "You can use your Web3 account directly by enabling it in the settings menu.",
-      "no-provider": "No Web3 provider detected, please install e.g. MetaMask."
-    },
-    "wallet-connect-dialog": {
-      "wallet-connect-header": "WalletConnect",
-      "bridge-server-header": "Bridge Server",
-      "bridge-server-body": "Provide a bridge server URL",
-      "infura-button": "Infura",
-      "rpc-button": "RPC",
-      "infura-header": "Infura URL",
-      "infura-body": "Provide the URL for an Infura endpoint",
-      "rpc-header": "RPC URL",
-      "rpc-body": "Provide the URL for an RPC endpoint",
-      "placeholder": {
-        "bridge-server": "https://",
-        "infura": "Project ID",
-        "rpc": "https://"
-      }
-    },
-    "connection-pending-dialog": {
-      "title": "Connecting",
-      "text": "Please check if any actions are required in your wallet.",
-      "button": "Reset connection"
     }
   },
   "notifications": {
@@ -800,6 +772,30 @@
   },
   "connection-manager": {
     "connect-button": "Connect",
-    "connect-button-loading": "Syncing"
+    "connect-button-loading": "Syncing",
+    "dialogs": {
+      "wallet-connect-provider": {
+        "header": "WalletConnect",
+        "bridge-server-header": "Bridge Server",
+        "bridge-server-body": "Provide a bridge server URL",
+        "infura-button": "Infura",
+        "rpc-button": "RPC",
+        "infura-header": "Infura URL",
+        "infura-body": "Provide the URL for an Infura endpoint",
+        "rpc-header": "RPC URL",
+        "rpc-body": "Provide the URL for an RPC endpoint",
+        "connect-button": "Connect",
+        "placeholder": {
+          "bridge-server": "https://",
+          "infura": "Project ID",
+          "rpc": "https://"
+        }
+      },
+      "connection-pending": {
+        "title": "Connecting",
+        "text": "Please check if any actions are required in your wallet.",
+        "button": "Cancel"
+      }
+    }
   }
 }

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -773,20 +773,24 @@
     "dialogs": {
       "wallet-connect-provider": {
         "header": "WalletConnect",
-        "bridge-server-header": "Bridge Server",
-        "bridge-server-body": "Provide a bridge server URL",
-        "infura-button": "Infura",
-        "rpc-button": "RPC",
-        "infura-header": "Infura URL",
-        "infura-body": "Provide the URL for an Infura endpoint",
-        "rpc-header": "RPC URL",
-        "rpc-body": "Provide the URL for an RPC endpoint",
         "button": "Link Wallet",
         "error-message": "Failed to link via WalletConnect. Please make sure the given parmaters are correct and confirm the connection in the wallet.",
-        "placeholder": {
-          "bridge-server": "https://",
-          "infura": "Project ID",
-          "rpc": "https://"
+        "options": {
+          "bridge-url": {
+            "header": "Bridge Server",
+            "details": "Provide the URL for an alternative bridge server",
+            "placeholder": "https://"
+          },
+          "infura-id": {
+            "header": "Infura",
+            "details": "Provide the ID for an Infura project",
+            "placeholder": "Project ID"
+          },
+          "rpc-url": {
+            "header": "RPC",
+            "details": "Provide the URL for an RPC endpoint",
+            "placeholder": "https://"
+          }
         }
       },
       "connection-pending": {

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -406,7 +406,6 @@
     "title": "Error"
   },
   "error-codes": {
-    "no-ethereum-provider": "No Ethereum provider configured or available.",
     "unsupported-network": "The current network is unsupported. Please choose a different network.",
     "sdk-initialization-failed": "SDK initialization failed. Please check the console for more information.",
     "state-migration-failed": "Cannot replace state with older uploaded state."
@@ -771,8 +770,6 @@
     "message-desktop": "Install the Raiden dApp on your desktop"
   },
   "connection-manager": {
-    "connect-button": "Connect",
-    "connect-button-loading": "Syncing",
     "dialogs": {
       "wallet-connect-provider": {
         "header": "WalletConnect",
@@ -784,7 +781,8 @@
         "infura-body": "Provide the URL for an Infura endpoint",
         "rpc-header": "RPC URL",
         "rpc-body": "Provide the URL for an RPC endpoint",
-        "connect-button": "Connect",
+        "button": "Link Wallet",
+        "error-message": "Failed to link via WalletConnect. Please make sure the given parmaters are correct and confirm the connection in the wallet.",
         "placeholder": {
           "bridge-server": "https://",
           "infura": "Project ID",

--- a/raiden-dapp/src/model/types.ts
+++ b/raiden-dapp/src/model/types.ts
@@ -93,7 +93,6 @@ export const PlaceHolderNetwork: providers.Network = {
 };
 
 export enum ErrorCode {
-  NO_ETHEREUM_PROVIDER = 'no-ethereum-provider',
   UNSUPPORTED_NETWORK = 'unsupported-network',
   SDK_INITIALIZATION_FAILED = 'sdk-initialization-failed',
   STATE_MIGRATION_FAILED = 'state-migration-failed',

--- a/raiden-dapp/src/services/__mocks__/config-provider.ts
+++ b/raiden-dapp/src/services/__mocks__/config-provider.ts
@@ -1,0 +1,9 @@
+export class ConfigProvider {
+  static contracts = jest.fn().mockResolvedValue(undefined);
+
+  static configuration = jest.fn().mockResolvedValue({
+    rpc_endpoint: 'https://some.rpc.endpoint',
+    private_key: '0xprivateKey',
+    per_network: {},
+  });
+}

--- a/raiden-dapp/src/services/__mocks__/config-provider.ts
+++ b/raiden-dapp/src/services/__mocks__/config-provider.ts
@@ -2,8 +2,6 @@ export class ConfigProvider {
   static contracts = jest.fn().mockResolvedValue(undefined);
 
   static configuration = jest.fn().mockResolvedValue({
-    rpc_endpoint: 'https://some.rpc.endpoint',
-    private_key: '0xprivateKey',
     per_network: {},
   });
 }

--- a/raiden-dapp/src/services/__mocks__/raiden-service.ts
+++ b/raiden-dapp/src/services/__mocks__/raiden-service.ts
@@ -1,0 +1,13 @@
+export const raidenServiceConnectMock = jest.fn();
+
+export default class RaidenService {
+  closeChannel = jest.fn().mockResolvedValue(undefined);
+  connect = raidenServiceConnectMock;
+  deposit = jest.fn().mockResolvedValue(undefined);
+  fetchAndUpdateTokenData = jest.fn().mockResolvedValue(undefined);
+  monitorToken = jest.fn().mockResolvedValue(undefined);
+  openChannel = jest.fn().mockResolvedValue(undefined);
+  planUDCWithdraw = jest.fn().mockResolvedValue(undefined);
+  settleChannel = jest.fn().mockResolvedValue(undefined);
+  withdraw = jest.fn().mockResolvedValue(undefined);
+}

--- a/raiden-dapp/src/services/__mocks__/raiden-service.ts
+++ b/raiden-dapp/src/services/__mocks__/raiden-service.ts
@@ -1,8 +1,6 @@
-export const raidenServiceConnectMock = jest.fn();
-
 export default class RaidenService {
   closeChannel = jest.fn().mockResolvedValue(undefined);
-  connect = raidenServiceConnectMock;
+  connect = jest.fn();
   deposit = jest.fn().mockResolvedValue(undefined);
   fetchAndUpdateTokenData = jest.fn().mockResolvedValue(undefined);
   monitorToken = jest.fn().mockResolvedValue(undefined);

--- a/raiden-dapp/src/services/config-provider.ts
+++ b/raiden-dapp/src/services/config-provider.ts
@@ -34,7 +34,6 @@ export class ConfigProvider {
 
 export interface Configuration {
   readonly rpc_endpoint?: string;
-  readonly rpc_endpoint_wallet_connect?: string;
   readonly private_key?: string;
   readonly per_network: { [key: string]: NetworkConfiguration };
 }

--- a/raiden-dapp/src/services/ethereum-provider/__mocks__/direct-rpc-provider.ts
+++ b/raiden-dapp/src/services/ethereum-provider/__mocks__/direct-rpc-provider.ts
@@ -1,13 +1,18 @@
 export class DirectRpcProvider {
   public readonly account = 0;
+  private chainId: number;
 
-  public static link() {
-    return new this();
+  private constructor(chainId = 5) {
+    this.chainId = chainId;
+  }
+
+  public static async link(options?: { chainId?: number }) {
+    return new this(options?.chainId);
   }
 
   get provider() {
     return {
-      getNetwork: jest.fn().mockResolvedValue({ chainId: 5 }),
+      getNetwork: jest.fn().mockResolvedValue({ chainId: this.chainId }),
     };
   }
 }

--- a/raiden-dapp/src/services/ethereum-provider/__mocks__/wallet-connect-provider.ts
+++ b/raiden-dapp/src/services/ethereum-provider/__mocks__/wallet-connect-provider.ts
@@ -1,4 +1,5 @@
 export class WalletConnectProvider {
+  public static readonly providerName = 'wallet_connect_mock';
   public readonly account = 0;
 
   public static link = jest.fn().mockResolvedValue(undefined);

--- a/raiden-dapp/src/services/ethereum-provider/__mocks__/wallet-connect-provider.ts
+++ b/raiden-dapp/src/services/ethereum-provider/__mocks__/wallet-connect-provider.ts
@@ -1,0 +1,5 @@
+export class WalletConnectProvider {
+  public readonly account = 0;
+
+  public static link = jest.fn().mockResolvedValue(undefined);
+}

--- a/raiden-dapp/src/services/ethereum-provider/wallet-connect-provider.ts
+++ b/raiden-dapp/src/services/ethereum-provider/wallet-connect-provider.ts
@@ -17,7 +17,9 @@ export class WalletConnectProvider extends EthereumProvider {
   public static async link(options: {
     rpcUrl?: string;
     infuraId?: string;
+    bridgeUrl?: string;
   }): Promise<WalletConnectProvider> {
+    const bridgeUrl = options?.bridgeUrl || undefined;
     let walletConnect: WalletConnect;
 
     if (options.rpcUrl === undefined && options.infuraId === undefined) {
@@ -25,9 +27,9 @@ export class WalletConnectProvider extends EthereumProvider {
     } else if (options.rpcUrl !== undefined && options.infuraId !== undefined) {
       throw new Error('Only one link option allowed. Either a RPC URL or a Infura Id.');
     } else if (options.rpcUrl !== undefined) {
-      walletConnect = await getWalletConnectWithRpcUrl(options.rpcUrl);
+      walletConnect = await getWalletConnectWithRpcUrl(options.rpcUrl, bridgeUrl);
     } else if (options.infuraId) {
-      walletConnect = getWalletConnectWithInfuraId(options.infuraId);
+      walletConnect = getWalletConnectWithInfuraId(options.infuraId, bridgeUrl);
     }
 
     // The provider instance must be available here, though TypeScript can't see it.
@@ -39,10 +41,14 @@ export class WalletConnectProvider extends EthereumProvider {
   }
 }
 
-async function getWalletConnectWithRpcUrl(rpcUrl: string): Promise<WalletConnect> {
+async function getWalletConnectWithRpcUrl(
+  rpcUrl: string,
+  bridgeUrl?: string,
+): Promise<WalletConnect> {
   const temporaryJsonRpcProvider = new providers.JsonRpcProvider(rpcUrl);
   const networkOfProvider = await temporaryJsonRpcProvider.getNetwork();
   const options = {
+    bride: bridgeUrl,
     rpc: {
       [networkOfProvider.chainId]: rpcUrl,
     },
@@ -50,8 +56,8 @@ async function getWalletConnectWithRpcUrl(rpcUrl: string): Promise<WalletConnect
   return new WalletConnect(options);
 }
 
-function getWalletConnectWithInfuraId(infuraId: string): WalletConnect {
-  return new WalletConnect({ infuraId });
+function getWalletConnectWithInfuraId(infuraId: string, bridgeUrl?: string): WalletConnect {
+  return new WalletConnect({ bridge: bridgeUrl, infuraId });
 }
 
 function resetHandler() {

--- a/raiden-dapp/src/services/ethereum-provider/wallet-connect-provider.ts
+++ b/raiden-dapp/src/services/ethereum-provider/wallet-connect-provider.ts
@@ -35,7 +35,7 @@ export class WalletConnectProvider extends EthereumProvider {
     walletConnect!.on('chainChanged', resetHandler);
     walletConnect!.on('disconnect', resetHandler);
 
-    return new this(walletConnect!);
+    return new WalletConnectProvider(walletConnect!);
   }
 }
 

--- a/raiden-dapp/src/store/user-settings/getters.ts
+++ b/raiden-dapp/src/store/user-settings/getters.ts
@@ -1,17 +1,10 @@
 import type { GetterTree } from 'vuex';
 
-import type { EthereumProviderOptions } from '@/services/ethereum-provider';
 import type { RootState } from '@/types';
 
-import type { UserSettingsState } from './types';
+import type { UserSettingsGetters, UserSettingsState } from './types';
 
-type Getters = {
-  getEthereumProviderOptions(
-    state: UserSettingsState,
-  ): (providerName: string) => EthereumProviderOptions;
-};
-
-export const getters: GetterTree<UserSettingsState, RootState> & Getters = {
+export const getters: GetterTree<UserSettingsState, RootState> & UserSettingsGetters = {
   // This getter is relevant to have a standardized default value that works for
   // all component which interact with such provider options.
   getEthereumProviderOptions: (state) => (providerName) => {

--- a/raiden-dapp/src/store/user-settings/index.ts
+++ b/raiden-dapp/src/store/user-settings/index.ts
@@ -3,6 +3,7 @@ import { VuexPersistence } from 'vuex-persist';
 
 import type { RootState } from '@/types';
 
+import { getters } from './getters';
 import { mutations } from './mutations';
 import state from './state';
 import type { UserSettingsState } from './types';
@@ -10,6 +11,7 @@ import type { UserSettingsState } from './types';
 export const userSettings: Module<UserSettingsState, RootState> = {
   namespaced: true,
   state,
+  getters,
   mutations,
 };
 

--- a/raiden-dapp/src/store/user-settings/mutations.ts
+++ b/raiden-dapp/src/store/user-settings/mutations.ts
@@ -1,23 +1,15 @@
 import type { MutationTree } from 'vuex';
 
-import type { EthereumProviderOptions } from '@/services/ethereum-provider';
+import type { UserSettingsMutations, UserSettingsState } from './types';
 
-import type { UserSettingsState } from './types';
-
-export const mutations: MutationTree<UserSettingsState> = {
+export const mutations: MutationTree<UserSettingsState> & UserSettingsMutations = {
   enableRaidenAccount(state) {
     state.useRaidenAccount = true;
   },
   disableRaidenAccount(state) {
     state.useRaidenAccount = false;
   },
-  saveEthereumProviderOptions(
-    state,
-    payload: {
-      providerName: string;
-      providerOptions: EthereumProviderOptions;
-    },
-  ) {
+  saveEthereumProviderOptions(state, payload) {
     state.ethereumProviderOptions[payload.providerName] = payload.providerOptions;
   },
 };

--- a/raiden-dapp/src/store/user-settings/types.ts
+++ b/raiden-dapp/src/store/user-settings/types.ts
@@ -4,3 +4,16 @@ export interface UserSettingsState {
   useRaidenAccount: boolean;
   ethereumProviderOptions: { [providerName: string]: EthereumProviderOptions };
 }
+
+export type UserSettingsGetters<S = UserSettingsState> = {
+  getEthereumProviderOptions(state: S): (providerName: string) => EthereumProviderOptions;
+};
+
+export type UserSettingsMutations<S = UserSettingsState> = {
+  enableRaidenAccount(state: S): void;
+  disableRaidenAccount(state: S): void;
+  saveEthereumProviderOptions(
+    state: S,
+    payload: { providerName: string; providerOptions: EthereumProviderOptions },
+  ): void;
+};

--- a/raiden-dapp/src/views/DisclaimerRoute.vue
+++ b/raiden-dapp/src/views/DisclaimerRoute.vue
@@ -76,6 +76,7 @@
       data-cy="disclaimer_accept_button"
       class="disclaimer__accept-button"
       :enabled="checkedAccept"
+      full-width
       sticky
       @click="accept"
     />

--- a/raiden-dapp/src/views/Home.vue
+++ b/raiden-dapp/src/views/Home.vue
@@ -38,8 +38,8 @@
       </v-col>
     </v-row>
 
-    <v-row>
-      <v-col cols="8" offset="2" class="mt-10">
+    <v-row no-gutters>
+      <v-col cols="12" class="mt-10">
         <connection-manager />
       </v-col>
     </v-row>
@@ -86,10 +86,15 @@ export default class Home extends Vue {
 
 <style lang="scss" scoped>
 @import '@/scss/mixins';
+@import '@/scss/scroll';
 
 .home {
-  height: 100%;
   width: 100%;
+  height: 100% !important;
+
+  @include respond-to(handhelds) {
+    overflow-y: auto !important;
+  }
 
   ::v-deep {
     a {

--- a/raiden-dapp/src/views/OpenChannelRoute.vue
+++ b/raiden-dapp/src/views/OpenChannelRoute.vue
@@ -109,7 +109,7 @@ export default class OpenChannelRoute extends Mixins(NavigationMixin) {
     return this.getToken(address) || ({ address } as Token);
   }
 
-  beforeRouteLeave(to: Route, from: Route, next: NavigationGuardNext) {
+  beforeRouteLeave(_to: Route, _from: Route, next: NavigationGuardNext) {
     if (!this.loading) {
       next();
     } else {

--- a/raiden-dapp/src/views/TransferStepsRoute.vue
+++ b/raiden-dapp/src/views/TransferStepsRoute.vue
@@ -169,6 +169,7 @@
       class="transfer__button"
       :enabled="continueBtnEnabled"
       :text="callToActionText"
+      full-width
       sticky
       arrow
       @click="handleStep()"

--- a/raiden-dapp/tests/e2e/specs/scenario.spec.ts
+++ b/raiden-dapp/tests/e2e/specs/scenario.spec.ts
@@ -30,7 +30,7 @@ import {
 import {
   acceptDisclaimer,
   closeNotificationPanel,
-  connectToDApp,
+  // connectToDApp,
   deleteTopNotification,
   downloadState,
   enterAndSelectHub,
@@ -61,7 +61,7 @@ describe('dApp e2e tests', () => {
     cy.viewport('macbook-13');
     navigateToDisclaimer();
     acceptDisclaimer();
-    connectToDApp();
+    // connectToDApp();
     navigateToSelectHub();
     mintAndDepositUtilityTokenFromSelectHubScreen();
     mintConnectedTokenFromSelectHubScreen();
@@ -80,7 +80,7 @@ describe('dApp e2e tests', () => {
     navigateToAccountMenu();
     navigateToBackupState();
     downloadState();
-    connectToDApp();
+    // connectToDApp();
     navigateToTokenSelect();
     navigateToConnectNewTokenFromTokenOverlay();
     navigateBackToTransferScreenFromOverlay();

--- a/raiden-dapp/tests/unit/components/connection-manager.spec.ts
+++ b/raiden-dapp/tests/unit/components/connection-manager.spec.ts
@@ -1,0 +1,142 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { $t } from '../utils/mocks';
+
+import type { Wrapper } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import Vue from 'vue';
+import Vuetify from 'vuetify';
+import Vuex, { Store } from 'vuex';
+
+import ActionButton from '@/components/ActionButton.vue';
+import ConnectionManager from '@/components/ConnectionManager.vue';
+import RaidenService, { raidenServiceConnectMock } from '@/services/__mocks__/raiden-service';
+import { DirectRpcProvider } from '@/services/ethereum-provider/__mocks__/direct-rpc-provider';
+
+jest.mock('@/services/ethereum-provider/direct-rpc-provider');
+jest.mock('@/services/config-provider');
+
+Vue.use(Vuetify);
+Vue.use(Vuex);
+
+const vuetify = new Vuetify();
+const storeCommitMock = jest.fn();
+
+function createWrapper(): Wrapper<ConnectionManager> {
+  const state = {
+    isConnected: false,
+    stateBackup: '',
+  };
+
+  const userSettingsModule = {
+    namespaced: true,
+    state: { useRaidenAccount: true },
+  };
+
+  const store = new Store({ state, modules: { userSettings: userSettingsModule } });
+  const $raiden = new RaidenService();
+
+  store.commit = storeCommitMock;
+
+  return shallowMount(ConnectionManager, {
+    vuetify,
+    store,
+    mocks: {
+      $raiden,
+      $t,
+    },
+    stubs: {
+      'action-button': ActionButton,
+    },
+  });
+}
+
+async function clickConnectButton(wrapper: Wrapper<ConnectionManager>): Promise<void> {
+  const button = wrapper.findComponent(ActionButton).find('button');
+  button.trigger('click');
+  await flushPromises();
+}
+
+describe('ConnectionManager.vue', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.VUE_APP_ALLOW_MAINNET;
+  });
+
+  test('clicking on the connect button calls the raiden service to connect', async () => {
+    const wrapper = createWrapper();
+    await clickConnectButton(wrapper);
+    expect(raidenServiceConnectMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('clicking on the connect button resets the store its state', async () => {
+    const wrapper = createWrapper();
+    await clickConnectButton(wrapper);
+    expect(storeCommitMock).toHaveBeenCalledWith('reset');
+  });
+
+  test('clicking on the connect button sets the store to being connected', async () => {
+    const wrapper = createWrapper();
+    await clickConnectButton(wrapper);
+    expect(storeCommitMock).toHaveBeenCalledWith('setConnected');
+  });
+
+  test('clicking on the connect button clears the state backup in the store', async () => {
+    const wrapper = createWrapper();
+    await clickConnectButton(wrapper);
+    expect(storeCommitMock).toHaveBeenCalledWith('clearBackupState');
+  });
+
+  test('show error when no provider got configured', async () => {
+    const wrapper = createWrapper();
+    (wrapper.vm as any).getProvider = jest.fn().mockResolvedValue(undefined);
+
+    await clickConnectButton(wrapper);
+
+    const errorMessage = wrapper.find('#connection-manager__error-message');
+    expect(errorMessage.exists()).toBeTruthy();
+    expect(errorMessage.text()).toBe('error-codes.no-ethereum-provider');
+    expect(raidenServiceConnectMock).not.toHaveBeenCalled();
+  });
+
+  test('show error when provider of connection links to mainnet but it is not allowed', async () => {
+    process.env.VUE_APP_ALLOW_MAINNET = 'false';
+    const wrapper = createWrapper();
+    (wrapper.vm as any).getProvider = jest
+      .fn()
+      .mockResolvedValue(await DirectRpcProvider.link({ chainId: 1 }));
+
+    await clickConnectButton(wrapper);
+
+    const errorMessage = wrapper.find('#connection-manager__error-message');
+    expect(errorMessage.exists()).toBeTruthy();
+    expect(errorMessage.text()).toBe('error-codes.unsupported-network');
+    expect(raidenServiceConnectMock).not.toHaveBeenCalled();
+  });
+
+  test('accept that provider of connection links to mainnet if it is allowed', async () => {
+    process.env.VUE_APP_ALLOW_MAINNET = 'true';
+    const wrapper = createWrapper();
+    (wrapper.vm as any).getConnection = jest
+      .fn()
+      .mockResolvedValue(await DirectRpcProvider.link({ chainId: 1 }));
+
+    await clickConnectButton(wrapper);
+
+    const errorMessage = wrapper.find('#connection-manager__error-message');
+    expect(errorMessage.exists()).toBeFalsy();
+    expect(raidenServiceConnectMock).toHaveBeenCalled();
+  });
+
+  test('show error when raiden service connection throws', async () => {
+    const wrapper = createWrapper();
+    (wrapper.vm as any).$raiden.connect = jest
+      .fn()
+      .mockRejectedValue(new Error('No deploy info provided'));
+
+    await clickConnectButton(wrapper);
+
+    const errorMessage = wrapper.find('#connection-manager__error-message');
+    expect(errorMessage.exists()).toBeTruthy();
+  });
+});

--- a/raiden-dapp/tests/unit/components/dialogs/wallet-connect-provider-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/dialogs/wallet-connect-provider-dialog.spec.ts
@@ -4,14 +4,14 @@ import Vue from 'vue';
 import Vuetify from 'vuetify';
 
 import ActionButton from '@/components/ActionButton.vue';
-import WalletConnectDialog from '@/components/dialogs/WalletConnectDialog.vue';
+import WalletConnectProviderDialog from '@/components/dialogs/WalletConnectProviderDialog.vue';
 
 Vue.use(Vuetify);
 
-const createWrapper = (): Wrapper<WalletConnectDialog> => {
+const createWrapper = (): Wrapper<WalletConnectProviderDialog> => {
   const vuetify = new Vuetify();
 
-  return mount(WalletConnectDialog, {
+  return mount(WalletConnectProviderDialog, {
     vuetify,
     stubs: { 'v-dialog': true, 'action-button': ActionButton },
     mocks: {
@@ -24,33 +24,35 @@ const createWrapper = (): Wrapper<WalletConnectDialog> => {
 };
 
 async function clickInfuraRpcToggle(
-  wrapper: Wrapper<WalletConnectDialog>,
+  wrapper: Wrapper<WalletConnectProviderDialog>,
   buttonIndex: number,
 ): Promise<void> {
-  const rpcToggle = wrapper.findAll('.wallet-connect__infura-or-rpc__button').at(buttonIndex);
+  const rpcToggle = wrapper
+    .findAll('.wallet-connect-provider__infura-or-rpc__button')
+    .at(buttonIndex);
   rpcToggle.trigger('click');
   await wrapper.vm.$nextTick();
 }
 
-describe('WalletConnectDialog.vue', () => {
+describe('WalletConnectProviderDialog.vue', () => {
   test('can toggle between Infura and RPC input', async () => {
     const wrapper = createWrapper();
 
-    wrapper.get('.wallet-connect__infura-or-rpc__details--infura');
+    wrapper.get('.wallet-connect-provider__infura-or-rpc__details--infura');
     await clickInfuraRpcToggle(wrapper, 1);
-    wrapper.get('.wallet-connect__infura-or-rpc__details--rpc');
+    wrapper.get('.wallet-connect-provider__infura-or-rpc__details--rpc');
     await clickInfuraRpcToggle(wrapper, 0);
-    wrapper.get('.wallet-connect__infura-or-rpc__details--infura');
+    wrapper.get('.wallet-connect-provider__infura-or-rpc__details--infura');
   });
 
   test('can enable bridge server input field', async () => {
     const wrapper = createWrapper();
-    const bridgeServerURLInput = wrapper.findAll('.wallet-connect__input').at(0);
+    const bridgeServerURLInput = wrapper.findAll('.wallet-connect-provider__input').at(0);
 
     expect(bridgeServerURLInput.attributes('disabled')).toBeTruthy();
 
     const bridgeServerInputToggle = wrapper
-      .find('.wallet-connect__bridge-server__details__toggle')
+      .find('.wallet-connect-provider__bridge-server__details__toggle')
       .find('input');
     bridgeServerInputToggle.trigger('click');
     await wrapper.vm.$nextTick();

--- a/raiden-dapp/tests/unit/services/ethereum-provider/wallet-connect-provider.spec.ts
+++ b/raiden-dapp/tests/unit/services/ethereum-provider/wallet-connect-provider.spec.ts
@@ -1,3 +1,5 @@
+import WalletConnect from '@walletconnect/web3-provider';
+
 import { WalletConnectProvider } from '@/services/ethereum-provider/wallet-connect-provider';
 
 jest.mock('@walletconnect/web3-provider');
@@ -19,6 +21,10 @@ jest.mock('ethers', () => {
 });
 
 describe('WalletConnectProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   test('is always available', () => {
     expect(WalletConnectProvider.isAvailable).toBe(true);
   });
@@ -31,10 +37,20 @@ describe('WalletConnectProvider', () => {
 
   test('can link with a RPC URL', async () => {
     await WalletConnectProvider.link({ rpcUrl: 'https://some.rpc.url' });
+    expect(WalletConnect).toHaveBeenCalledWith({ rpc: { 5: 'https://some.rpc.url' } });
   });
 
   test('can link with an Infura ID', async () => {
-    await WalletConnectProvider.link({ infuraId: '6d333faba41b4c3d8ae979417e281832' });
+    await WalletConnectProvider.link({ infuraId: 'testId' });
+    expect(WalletConnect).toHaveBeenCalledWith({ infuraId: 'testId' });
+  });
+
+  test('can link with a custom bridge URL', async () => {
+    await WalletConnectProvider.link({ bridgeUrl: 'https://some.bridge.url', infuraId: 'testId' });
+    expect(WalletConnect).toHaveBeenCalledWith({
+      bridge: 'https://some.bridge.url',
+      infuraId: 'testId',
+    });
   });
 
   test('fail to link when multiple options are provided', () => {

--- a/raiden-dapp/tests/unit/utils/mocks.ts
+++ b/raiden-dapp/tests/unit/utils/mocks.ts
@@ -4,8 +4,7 @@ export const $identicon = () => ({
   getIdenticon: jest.fn().mockReturnValue(''),
 });
 
-export const $t = (key: VueI18n.Path, values?: VueI18n.Values): VueI18n.TranslateResult =>
-  `${key} values: ${JSON.stringify(values)}`;
+export const $t = (key: VueI18n.Path): VueI18n.TranslateResult => `${key}`;
 
 export class MockedJsonRpcProvider {
   getNetwork = jest.fn().mockResolvedValue({ chainId: 5 });

--- a/raiden-dapp/tests/unit/views/home.spec.ts
+++ b/raiden-dapp/tests/unit/views/home.spec.ts
@@ -1,114 +1,77 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import { $t } from '../utils/mocks';
+
 import type { Wrapper } from '@vue/test-utils';
-import { mount } from '@vue/test-utils';
-import flushPromises from 'flush-promises';
+import { shallowMount } from '@vue/test-utils';
 import Vue from 'vue';
 import VueRouter from 'vue-router';
-import Vuetify from 'vuetify';
 import Vuex from 'vuex';
 
-import { ErrorCode } from '@/model/types';
 import { RouteNames } from '@/router/route-names';
-import { ConfigProvider } from '@/services/config-provider';
-import RaidenService from '@/services/raiden-service';
-import store from '@/store/index';
 import Home from '@/views/Home.vue';
 
-jest.mock('@/services/raiden-service');
-jest.mock('@/services/config-provider');
-jest.mock('@/i18n', () => jest.fn());
-jest.mock('@/services/ethereum-provider/direct-rpc-provider');
-
-import Mocked = jest.Mocked;
-
 Vue.use(Vuex);
-Vue.use(Vuetify);
+
+const $router = new VueRouter() as jest.Mocked<VueRouter>;
+$router.push = jest.fn();
+
+function createWrapper(options?: { isConnected?: boolean; redirectTo?: string }): Wrapper<Home> {
+  const state = { isConnected: options?.isConnected ?? false };
+  const store = new Vuex.Store({ state });
+  const $route = { query: { redirectTo: options?.redirectTo } };
+
+  return shallowMount(Home, {
+    store,
+    mocks: {
+      $router,
+      $route,
+      $t,
+    },
+  });
+}
 
 describe('Home.vue', () => {
-  let wrapper: Wrapper<Home>;
-  let vuetify: Vuetify;
-  let router: Mocked<VueRouter>;
-  let $raiden: RaidenService;
-
   beforeEach(() => {
-    (ConfigProvider as jest.Mocked<typeof ConfigProvider>).configuration.mockResolvedValue({
-      rpc_endpoint: 'https://some.rpc.endpoint',
-      private_key: '0xprivateKey',
-      per_network: {},
-    });
-    vuetify = new Vuetify();
-    router = new VueRouter() as Mocked<VueRouter>;
-    router.push = jest.fn().mockResolvedValue(null);
-    $raiden = new RaidenService(store, router);
-    $raiden.connect = jest.fn();
-    wrapper = mount(Home, {
-      vuetify,
-      store,
-      stubs: ['i18n', 'v-dialog'],
-      mocks: {
-        $router: router,
-        $route: { query: {} },
-        $raiden: $raiden,
-        $t: (msg: string) => msg,
-      },
-    });
-  });
-
-  async function connect(settings?: { useRaidenAccount?: boolean }): Promise<void> {
-    const useRaidenAccount = settings?.useRaidenAccount ?? true;
-    const mutation = useRaidenAccount
-      ? 'userSettings/enableRaidenAccount'
-      : 'userSettings/disableRaidenAccount';
-    store.commit(mutation);
-
-    await (wrapper.vm as any).connect();
-    await flushPromises();
-  }
-
-  test('connects with sub key by default', async () => {
-    await connect();
-    expect($raiden.connect).toHaveBeenCalledTimes(1);
-  });
-
-  test('successful connect navigates to transfer route per default', async () => {
-    await connect();
-    expect(router.push).toHaveBeenCalledWith({ name: RouteNames.TRANSFER });
-  });
-
-  test('successful connect navigates to redirect target if given in query', async () => {
-    const redirectTo = 'connect/0x5Fc523e13fBAc2140F056AD7A96De2cC0C4Cc63A';
-    wrapper.vm.$route.query = { redirectTo };
-    await wrapper.vm.$nextTick();
-
-    await connect();
-
-    expect(router.push).toHaveBeenCalledWith({ path: redirectTo });
-  });
-
-  test('connect can be called without displaying error after failing initially', async () => {
-    (wrapper.vm as any).connectionError = ErrorCode.UNSUPPORTED_NETWORK;
-    await wrapper.vm.$nextTick();
-
-    await connect();
-
-    expect((wrapper.vm as any).connectionError).toBe(null);
+    jest.clearAllMocks();
   });
 
   test('displays welcome title', () => {
+    const wrapper = createWrapper();
     const welcomeTitle = wrapper.find('.home__app-welcome');
 
+    expect(welcomeTitle.exists()).toBeTruthy();
     expect(welcomeTitle.text()).toBe('home.welcome');
   });
 
   test('displays disclaimer', () => {
+    const wrapper = createWrapper();
     const disclaimer = wrapper.find('.home__disclaimer');
 
+    expect(disclaimer.exists()).toBeTruthy();
     expect(disclaimer.text()).toBe('home.disclaimer');
   });
 
   test('displays getting started link', () => {
+    const wrapper = createWrapper();
     const gettingStartedText = wrapper.find('.home__getting-started');
 
+    expect(gettingStartedText.exists()).toBeTruthy();
     expect(gettingStartedText.text()).toContain('home.getting-started.link-name');
+  });
+
+  test('navigates automatically to transfer route when connection got established', async () => {
+    createWrapper({ isConnected: true });
+
+    expect($router.push).toHaveBeenCalledWith({ name: RouteNames.TRANSFER });
+  });
+
+  test('successful connect navigates to redirect target if given in query', async () => {
+    createWrapper({
+      isConnected: true,
+      redirectTo: 'connect/0x5Fc523e13fBAc2140F056AD7A96De2cC0C4Cc63A',
+    });
+
+    expect($router.push).toHaveBeenCalledWith({
+      path: 'connect/0x5Fc523e13fBAc2140F056AD7A96De2cC0C4Cc63A',
+    });
   });
 });


### PR DESCRIPTION
Fixes #2630

**Short description**
This finally adds the connection manager. For the moment it supports only the WalletConnect provider. More will be added in follow up PRs. This enables the user to use WalletConnect on our public deployment and in a mobile app as the user can configure the required linking options.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [x] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Run the dApp
2. Connect via WalletConnect
3. Try different options
4. Make sure that when you connect the next time, the inserted options are available and you can connect instantly
