### PR TITLE
Feature/dapp add injected provider to connetion manager

### DIFF
--- a/raiden-dapp/src/components/ConnectionManager.vue
+++ b/raiden-dapp/src/components/ConnectionManager.vue
@@ -12,14 +12,14 @@
     <template v-if="showProviderButtons">
       <action-button
         class="connection-manager__provider-dialog-button"
-        :enabled="true"
+        :enabled="walletConnectProviderAvailable"
         :text="$t('connection-manager.dialogs.wallet-connect-provider.header')"
         width="280px"
         @click="openWalletConnectProviderDialog"
       />
       <action-button
         class="connection-manager__provider-dialog-button"
-        :enabled="true"
+        :enabled="injectedProviderAvailable"
         :text="$t('connection-manager.dialogs.injected-provider.header')"
         width="280px"
         @click="openInjectedProviderDialog"
@@ -54,7 +54,11 @@ import WalletConnectProviderDialog from '@/components/dialogs/WalletConnectProvi
 import { ErrorCode } from '@/model/types';
 import { ConfigProvider } from '@/services/config-provider';
 import type { EthereumProvider } from '@/services/ethereum-provider';
-import { DirectRpcProvider } from '@/services/ethereum-provider';
+import {
+  DirectRpcProvider,
+  InjectedProvider,
+  WalletConnectProvider,
+} from '@/services/ethereum-provider';
 
 function mapRaidenServiceErrorToErrorCode(error: Error): ErrorCode {
   if (error.message && error.message.includes('No deploy info provided')) {
@@ -101,6 +105,14 @@ export default class ConnectionManager extends Vue {
       const translationKey = `error-codes.${this.errorCode.toString()}`;
       return this.$t(translationKey) as string;
     }
+  }
+
+  get walletConnectProviderAvailable(): boolean {
+    return WalletConnectProvider.isAvailable;
+  }
+
+  get injectedProviderAvailable(): boolean {
+    return InjectedProvider.isAvailable;
   }
 
   /**

--- a/raiden-dapp/src/components/dialogs/InjectedProviderDialog.vue
+++ b/raiden-dapp/src/components/dialogs/InjectedProviderDialog.vue
@@ -1,0 +1,74 @@
+<template>
+  <raiden-dialog width="472" class="injected-provider" :visible="true" @close="emitCancel">
+    <v-card-title>
+      {{ $t('connection-manager.dialogs.wallet-connect-provider.header') }}
+    </v-card-title>
+
+    <v-card-text>
+      <spinner v-if="inProgress" />
+
+      <v-alert
+        v-if="linkFailed"
+        class="injected-provider__error-message text-left font-weight-light"
+        color="error"
+        icon="warning"
+      >
+        {{ $t('connection-manager.dialogs.injected-provider.error-message') }}
+      </v-alert>
+    </v-card-text>
+
+    <v-card-actions>
+      <action-button
+        :enabled="!inProgress"
+        class="injected-provider__link-button"
+        :text="$t('connection-manager.dialogs.injected-provider.link-button')"
+        width="200px"
+        @click="link"
+      />
+    </v-card-actions>
+  </raiden-dialog>
+</template>
+
+<script lang="ts">
+import { Component, Emit, Vue } from 'vue-property-decorator';
+
+import ActionButton from '@/components/ActionButton.vue';
+import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
+import Spinner from '@/components/icons/Spinner.vue';
+import { InjectedProvider } from '@/services/ethereum-provider';
+
+@Component({
+  components: {
+    ActionButton,
+    RaidenDialog,
+    Spinner,
+  },
+})
+export default class WalletConnectProviderDialog extends Vue {
+  linkFailed = false;
+  inProgress = false;
+
+  async link(): Promise<void> {
+    this.linkFailed = false;
+    this.inProgress = true;
+
+    try {
+      const provider = await InjectedProvider.link();
+      this.emitLinkEstablished(provider);
+    } catch {
+      this.linkFailed = true;
+      this.inProgress = false;
+    }
+  }
+
+  @Emit('linkEstablished')
+  emitLinkEstablished(linkedProvider: InjectedProvider): InjectedProvider {
+    return linkedProvider;
+  }
+
+  @Emit('cancel')
+  emitCancel(): void {
+    // pass
+  }
+}
+</script>

--- a/raiden-dapp/src/components/dialogs/WalletConnectProviderDialog.vue
+++ b/raiden-dapp/src/components/dialogs/WalletConnectProviderDialog.vue
@@ -84,7 +84,7 @@
       <action-button
         :enabled="canLink"
         class="wallet-connect-provider__link-button"
-        :text="$t('connection-manager.dialogs.wallet-connect-provider.button')"
+        :text="$t('connection-manager.dialogs.wallet-connect-provider.link-button')"
         width="200px"
         @click="link"
       />

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -771,9 +771,14 @@
   },
   "connection-manager": {
     "dialogs": {
+      "injected-provider": {
+        "header": "Injected Provider",
+        "link-button": "Link Provider",
+        "error-message": "Failed to link to provider. Please make sure to grant the requested permissions."
+      },
       "wallet-connect-provider": {
         "header": "WalletConnect",
-        "button": "Link Wallet",
+        "link-button": "Link Wallet",
         "error-message": "Failed to link via WalletConnect. Please make sure the given parmaters are correct and confirm the connection in the wallet.",
         "options": {
           "bridge-url": {

--- a/raiden-dapp/src/services/ethereum-provider/__mocks__/injected-provider.ts
+++ b/raiden-dapp/src/services/ethereum-provider/__mocks__/injected-provider.ts
@@ -1,0 +1,6 @@
+export class InjectedProvider {
+  public static readonly providerName = 'injected_provider_mock';
+  public readonly account = 0;
+
+  public static link = jest.fn().mockResolvedValue(undefined);
+}

--- a/raiden-dapp/src/services/ethereum-provider/__mocks__/injected-provider.ts
+++ b/raiden-dapp/src/services/ethereum-provider/__mocks__/injected-provider.ts
@@ -2,5 +2,9 @@ export class InjectedProvider {
   public static readonly providerName = 'injected_provider_mock';
   public readonly account = 0;
 
+  public static get isAvailable() {
+    return true;
+  }
+
   public static link = jest.fn().mockResolvedValue(undefined);
 }

--- a/raiden-dapp/tests/unit/components/connection-manager.spec.ts
+++ b/raiden-dapp/tests/unit/components/connection-manager.spec.ts
@@ -10,10 +10,11 @@ import Vuex, { Store } from 'vuex';
 
 import ActionButton from '@/components/ActionButton.vue';
 import ConnectionManager from '@/components/ConnectionManager.vue';
-import { DirectRpcProvider } from '@/services/ethereum-provider/direct-rpc-provider';
+import { DirectRpcProvider, InjectedProvider } from '@/services/ethereum-provider';
 import RaidenService from '@/services/raiden-service';
 
 jest.mock('@/services/ethereum-provider/direct-rpc-provider');
+jest.mock('@/services/ethereum-provider/injected-provider');
 jest.mock('@/services/raiden-service');
 jest.mock('@/services/config-provider');
 
@@ -168,5 +169,29 @@ describe('ConnectionManager.vue', () => {
 
     const errorMessage = wrapper.find('.connection-manager__error-message');
     expect(errorMessage.text().length).toBeGreaterThan(0); // For some reason does `isVisible` not work here.
+  });
+
+  test('provider dialog button is enabled if provider is available', () => {
+    jest.spyOn(InjectedProvider, 'isAvailable', 'get').mockReturnValueOnce(true);
+    const wrapper = createWrapper();
+
+    const providerDialogButton = wrapper
+      .findAll('.connection-manager__provider-dialog-button')
+      .at(1)
+      .get('button');
+
+    expect(providerDialogButton.attributes('disabled')).toBeFalsy();
+  });
+
+  test('provider dialog button is disabled if provider is not available', () => {
+    jest.spyOn(InjectedProvider, 'isAvailable', 'get').mockReturnValueOnce(false);
+    const wrapper = createWrapper();
+
+    const providerDialogButton = wrapper
+      .findAll('.connection-manager__provider-dialog-button')
+      .at(1)
+      .get('button');
+
+    expect(providerDialogButton.attributes('disabled')).toBeTruthy();
   });
 });

--- a/raiden-dapp/tests/unit/components/dialogs/injected-provider-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/dialogs/injected-provider-dialog.spec.ts
@@ -1,0 +1,81 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { $t } from '../../utils/mocks';
+
+import type { Wrapper } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import Vue from 'vue';
+import Vuetify from 'vuetify';
+
+import ActionButton from '@/components/ActionButton.vue';
+import InjectedProviderDialog from '@/components/dialogs/InjectedProviderDialog.vue';
+import { InjectedProvider } from '@/services/ethereum-provider';
+
+jest.mock('@/services/ethereum-provider/injected-provider');
+
+Vue.use(Vuetify);
+
+const vuetify = new Vuetify();
+
+function createWrapper(): Wrapper<InjectedProviderDialog> {
+  return mount(InjectedProviderDialog, {
+    vuetify,
+    stubs: { 'action-button': ActionButton },
+    mocks: { $t },
+  });
+}
+
+async function clickLinkButton(wrapper: Wrapper<InjectedProviderDialog>): Promise<void> {
+  const button = wrapper.findComponent(ActionButton).get('button');
+  button.trigger('click');
+  await flushPromises();
+}
+
+describe('InjectedProviderDialog.vue', () => {
+  test('can link', async () => {
+    const wrapper = createWrapper();
+
+    await clickLinkButton(wrapper);
+
+    expect(InjectedProvider.link).toHaveBeenCalledTimes(1);
+  });
+
+  test('successful link emits linked provider instance', async () => {
+    const wrapper = createWrapper();
+
+    await clickLinkButton(wrapper);
+
+    expect(wrapper.emitted().linkEstablished?.length).toBe(1);
+  });
+
+  test('shows error when linking fails', async () => {
+    const wrapper = createWrapper();
+    let errorMessage = wrapper.find('.injected-provider__error-message');
+    expect(errorMessage.exists()).toBeFalsy();
+
+    (InjectedProvider as any).link.mockRejectedValueOnce(new Error('canceled'));
+    await clickLinkButton(wrapper);
+
+    errorMessage = wrapper.find('.injected-provider__error-message');
+    expect(errorMessage.exists()).toBeTruthy();
+    expect(errorMessage.text()).toMatch(
+      'connection-manager.dialogs.injected-provider.error-message',
+    );
+  });
+
+  test('linking again after error hides error message', async () => {
+    const wrapper = createWrapper();
+
+    (InjectedProvider as any).link.mockRejectedValueOnce(new Error('canceled'));
+    await clickLinkButton(wrapper);
+
+    let errorMessage = wrapper.find('.injected-provider__error-message');
+    expect(errorMessage.exists()).toBeTruthy();
+
+    // Failing mock was only **once**.
+    await clickLinkButton(wrapper);
+
+    errorMessage = wrapper.find('.injected-provider__error-message');
+    expect(errorMessage.exists()).toBeFalsy();
+  });
+});

--- a/raiden-dapp/tests/unit/components/dialogs/wallet-connect-provider-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/dialogs/wallet-connect-provider-dialog.spec.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { $t } from '../../utils/mocks';
+
 import type { Wrapper } from '@vue/test-utils';
 import { mount } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
@@ -8,7 +10,7 @@ import Vuex from 'vuex';
 
 import ActionButton from '@/components/ActionButton.vue';
 import WalletConnectProviderDialog from '@/components/dialogs/WalletConnectProviderDialog.vue';
-import { WalletConnectProvider } from '@/services/ethereum-provider/wallet-connect-provider';
+import { WalletConnectProvider } from '@/services/ethereum-provider';
 
 jest.mock('@/services/ethereum-provider/wallet-connect-provider');
 
@@ -18,10 +20,10 @@ Vue.use(Vuetify);
 const vuetify = new Vuetify();
 const saveEthereumProviderOptionsMock = jest.fn();
 
-const createWrapper = (options?: {
+function createWrapper(options?: {
   infuraId?: string;
   bridgeUrl?: string;
-}): Wrapper<WalletConnectProviderDialog> => {
+}): Wrapper<WalletConnectProviderDialog> {
   const getters = {
     getEthereumProviderOptions: () => () => ({
       infuraId: options?.infuraId,
@@ -46,12 +48,10 @@ const createWrapper = (options?: {
   return mount(WalletConnectProviderDialog, {
     vuetify,
     store,
-    stubs: { 'v-dialog': true, 'action-button': ActionButton },
-    mocks: {
-      $t: (msg: string) => msg,
-    },
+    stubs: { 'action-button': ActionButton },
+    mocks: { $t },
   });
-};
+}
 
 async function clickBridgeUrlOptionToggle(
   wrapper: Wrapper<WalletConnectProviderDialog>,
@@ -212,8 +212,6 @@ describe('WalletConnectProviderDialog.vue', () => {
     expect(errorMessage.text()).toMatch(
       'connection-manager.dialogs.wallet-connect-provider.error-message',
     );
-    expect(WalletConnectProvider.link).toHaveBeenCalledTimes(1);
-    expect(wrapper.emitted().linkEstablished).toBeUndefined();
   });
 
   test('linking again after error hides error message', async () => {


### PR DESCRIPTION
Based on #2714

**Short description**
Next provider for the connection manager. No refactoring for the boilerplate code yet.
No CHANGELOG entry as it is no real new functionality and we don't have an issue for it. 😆 

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [x] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Open the dApp
2. Connect with MetaMask as usually
3. Disconnect and disable your MetaMask plugin
4. Reload the dApp
5. Make sure the injected provider button is disabled
