### PR TITLE
Some more unit tests for Raiden class

### DIFF
--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -96,6 +96,7 @@
     "@ethersproject/wallet": "^5.1.0",
     "abort-controller": "^3.0.0",
     "bignumber.js": "^9.0.1",
+    "ethers": "^5.1.4",
     "fp-ts": "^2.10.5",
     "io-ts": "^2.2.16",
     "isomorphic-fetch": "^3.0.0",

--- a/raiden-ts/tests/unit/raiden.spec.ts
+++ b/raiden-ts/tests/unit/raiden.spec.ts
@@ -325,13 +325,19 @@ describe('Raiden', () => {
     expect(raiden.address).toBe(dummyState.address);
   });
 
-  test('start', async () => {
+  test('start & synced', async () => {
     const deps = makeDummyDependencies();
     const raiden = new Raiden(dummyState, deps, combineRaidenEpics([initEpicMock]), dummyReducer);
     expect(raiden.network).toEqual({ name: 'test', chainId: 1337 });
-    expect(raiden.log).toEqual(expect.objectContaining({ name: `raiden:${raiden.address}` }));
+    expect(raiden.log).toMatchObject({ name: `raiden:${raiden.address}` });
     expect(raiden.started).toBeUndefined();
-    await expect(raiden.start()).resolves.toBeUndefined();
+    const startPromise = raiden.start();
+    await expect(raiden.synced).resolves.toEqual({
+      tookMs: expect.any(Number),
+      initialBlock: expect.any(Number),
+      currentBlock: expect.any(Number),
+    });
+    await expect(startPromise).resolves.toBeUndefined();
     expect(raiden.started).toEqual(true);
   });
 


### PR DESCRIPTION
Part of #2588 

**Short description**
Implements unit tests for:
- `create` async factory
- `mint`
- `getTokenList`
- `userDepositTokenAddress` property
- `getTokenInfo`
- `synced` promise property

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Unit tests pass
2. Respective functions are fully covered
