### PR TITLE
Token registration

### DIFF
--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+- [#1576] Add functionality to deploy token networks
+
+[#1576]: https://github.com/raiden-network/light-client/issues/1576
+
 ## [0.16.0] - 2021-04-01
 ### Changed
 - [#2570] Support list of additional services URLs to be passed to `--pathfindingServiceAddress`

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- [#1576] Add functionality to deploy token networks
+
+[#1576]: https://github.com/raiden-network/light-client/issues/1576
+
 ### Changed
 - [#2669] Update to Raiden contracts `v0.37.5`
 - [#2677] Removed the dependency on reactive notifications of peer's presences changes and updated WebRTC signaling algorithm

--- a/raiden-ts/src/errors.json
+++ b/raiden-ts/src/errors.json
@@ -49,6 +49,9 @@
   "RDN_ASSERT_ERROR": "An unknown assertion failed.",
   "RDN_MINT_FAILED": "Failed to mint tokens.",
   "RDN_MINT_MAINNET": "Minting is only allowed on test networks.",
+  "RDN_REGISTER_TOKEN_FAILED": "Failed to register tokens.",
+  "RDN_REGISTER_TOKEN_MAINNET": "Registering a token is only allowed on test networks.",
+  "RDN_REGISTER_TOKEN_REGISTERED": "Token is already registered.",
   "RDN_APPROVE_TRANSACTION_FAILED": "Approve transaction has failed.",
   "RDN_DEPOSIT_TRANSACTION_FAILED": "Deposit transaction has failed.",
   "RDN_TRANSFER_ONCHAIN_BALANCE_FAILED": "Failed to transfer on-chain balance.",
@@ -96,4 +99,3 @@
   "UDC_WITHDRAW_NO_PLAN": "No plan currently registered; you must call Raiden.planUDCWithdraw first",
   "UDC_WITHDRAW_TOO_LARGE": "Your current plan is not enough to withdraw the requested amount"
 }
-


### PR DESCRIPTION
Fixes #1576 

**Short description**

Implements token registration in the SDK and CLI.

I tried testing, butthe tx hangs on goerli: 
https://goerli.etherscan.io/tx/0xcb29bcb35bf5c7a23b1ec7e3df1e627e193743da826a15715c0522822e9c3240

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Run CLI on testnet
2. Register a token: `http PUT http://localhost:5001/api/v1/tokens/0x7af963cF6D228E564e2A0aA0DdBF06210B38615D`
