### PR TITLE
dapp: fix moved use raiden account setting

### DIFF
--- a/raiden-dapp/src/components/account/AccountContent.vue
+++ b/raiden-dapp/src/components/account/AccountContent.vue
@@ -33,7 +33,7 @@
           </span>
         </v-col>
       </v-row>
-      <v-row v-if="usingRaidenAccount" class="account-content__account-details__eth" dense>
+      <v-row v-if="useRaidenAccount" class="account-content__account-details__eth" dense>
         <v-col cols="3">
           <span class="account-content__account-details__eth__account">
             {{ $t('account-content.account.raiden') }}
@@ -84,7 +84,7 @@
 
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator';
-import { mapGetters, mapState } from 'vuex';
+import { createNamespacedHelpers, mapState } from 'vuex';
 
 import AddressDisplay from '@/components/AddressDisplay.vue';
 import NavigationMixin from '@/mixins/navigation-mixin';
@@ -97,13 +97,15 @@ interface MenuItem {
   route: () => void;
 }
 
+const { mapState: mapStateUserSettings } = createNamespacedHelpers('userSettings');
+
 @Component({
   components: {
     AddressDisplay,
   },
   computed: {
     ...mapState(['isConnected', 'defaultAccount', 'accountBalance', 'raidenAccountBalance']),
-    ...mapGetters(['usingRaidenAccount']),
+    ...mapStateUserSettings(['useRaidenAccount']),
   },
 })
 export default class AccountContent extends Mixins(NavigationMixin) {
@@ -112,6 +114,7 @@ export default class AccountContent extends Mixins(NavigationMixin) {
   accountBalance!: string;
   raidenAccountBalance!: string;
   isConnected!: boolean;
+  useRaidenAccount!: boolean;
 
   async disconnect() {
     await this.$raiden.disconnect();
@@ -151,7 +154,7 @@ export default class AccountContent extends Mixins(NavigationMixin) {
         },
       });
 
-      if (this.$raiden.usingSubkey) {
+      if (this.useRaidenAccount) {
         const raidenAccount = {
           icon: 'account_eth.svg',
           title: this.$t('account-content.menu-items.raiden-account.title') as string,

--- a/raiden-dapp/src/views/account/UDC.vue
+++ b/raiden-dapp/src/views/account/UDC.vue
@@ -64,7 +64,7 @@
 <script lang="ts">
 import { constants } from 'ethers';
 import { Component, Vue } from 'vue-property-decorator';
-import { mapGetters, mapState } from 'vuex';
+import { createNamespacedHelpers, mapGetters, mapState } from 'vuex';
 
 import ActionButton from '@/components/ActionButton.vue';
 import AmountDisplay from '@/components/AmountDisplay.vue';
@@ -75,6 +75,9 @@ import Spinner from '@/components/icons/Spinner.vue';
 import PlannedUdcWithdrawalInformation from '@/components/PlannedUdcWithdrawalInformation.vue';
 import type { Token } from '@/model/types';
 import type { PlannedUdcWithdrawal } from '@/store/user-deposit-contract';
+
+const { mapState: mapStateUserSettings } = createNamespacedHelpers('userSettings');
+const { mapState: mapStateUserDepositContract } = createNamespacedHelpers('userDepositContract');
 
 @Component({
   components: {
@@ -88,11 +91,12 @@ import type { PlannedUdcWithdrawal } from '@/store/user-deposit-contract';
   },
   computed: {
     ...mapState(['blockNumber', 'accountBalance', 'raidenAccountBalance']),
-    ...mapState('userDepositContract', {
+    ...mapStateUserSettings(['useRaidenAccount']),
+    ...mapStateUserDepositContract({
       udcToken: 'token',
       plannedUdcWithdrawal: 'plannedWithdrawal',
     }),
-    ...mapGetters(['mainnet', 'usingRaidenAccount']),
+    ...mapGetters(['mainnet']),
   },
 })
 export default class UDC extends Vue {
@@ -105,7 +109,7 @@ export default class UDC extends Vue {
   mainnet!: boolean;
   udcToken!: Token;
   plannedUdcWithdrawal!: PlannedUdcWithdrawal | undefined;
-  usingRaidenAccount!: boolean;
+  useRaidenAccount!: boolean;
   showUdcDeposit = false;
   withdrawFromUdc = false;
 
@@ -114,7 +118,7 @@ export default class UDC extends Vue {
   }
 
   get relevantEthBalanceForWithdrawal(): string {
-    return this.usingRaidenAccount ? this.raidenAccountBalance : this.accountBalance;
+    return this.useRaidenAccount ? this.raidenAccountBalance : this.accountBalance;
   }
 
   async mounted() {

--- a/raiden-dapp/tests/unit/components/account/account-content.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/account-content.spec.ts
@@ -20,10 +20,9 @@ const $router = new VueRouter() as Mocked<VueRouter>;
 async function createWrapper(
   defaultAccount = '0xAccount',
   accountBalance = '0',
-  usingRaidenAccount = false,
+  useRaidenAccount = false,
   raidenAccountBalance = '0',
   isConnected = true,
-  useSubkey = false,
 ): Promise<Wrapper<AccountContent>> {
   const vuetify = new Vuetify();
   const state = {
@@ -33,15 +32,15 @@ async function createWrapper(
     raidenAccountBalance,
   };
 
-  const getters = {
-    usingRaidenAccount: () => usingRaidenAccount,
+  const userSettings = {
+    namespaced: true,
+    state: { useRaidenAccount },
   };
 
-  const store = new Vuex.Store({ state, getters });
+  const store = new Vuex.Store({ state, modules: { userSettings } });
 
   const $raiden = {
-    usingSubkey: useSubkey,
-    getAccount: jest.fn(() => (useSubkey ? '0xAccount' : undefined)),
+    getAccount: jest.fn(() => (useRaidenAccount ? '0xAccount' : undefined)),
   };
 
   const wrapper = mount(AccountContent, {
@@ -143,7 +142,7 @@ describe('AccountContent.vue', () => {
   });
 
   test('udc menu item', async () => {
-    const wrapper = await createWrapper();
+    const wrapper = await createWrapper(undefined, undefined, false);
     const udcMenuItem = wrapper.findAll('.account-content__menu__list-items').at(0);
     const udcMenuTitle = udcMenuItem.find('.v-list-item__title');
     const udcMenuSubtitle = udcMenuItem.find('.v-list-item__subtitle');
@@ -162,14 +161,7 @@ describe('AccountContent.vue', () => {
   });
 
   test('show raiden account menu item, if connected via sub key', async () => {
-    const wrapper = await createWrapper(
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      true,
-    );
+    const wrapper = await createWrapper(undefined, undefined, true, undefined, undefined);
     expect(wrapper.vm.$data.menuItems[0].title).toEqual(
       'account-content.menu-items.raiden-account.title',
     );
@@ -205,28 +197,14 @@ describe('AccountContent.vue', () => {
   });
 
   test('does not display "Disconnect" button when not connected', async () => {
-    const wrapper = await createWrapper(
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      false,
-      undefined,
-    );
+    const wrapper = await createWrapper(undefined, undefined, undefined, undefined, false);
     const disconnectButton = getDisconnectButton(wrapper);
 
     expect(disconnectButton.exists()).toBe(false);
   });
 
   test('displays "Disconnect" button when connected', async () => {
-    const wrapper = await createWrapper(
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      true,
-      undefined,
-    );
+    const wrapper = await createWrapper(undefined, undefined, undefined, undefined, true);
     const disconnectButton = getDisconnectButton(wrapper);
 
     expect(disconnectButton.exists()).toBe(true);

--- a/raiden-dapp/tests/unit/views/account/udc.spec.ts
+++ b/raiden-dapp/tests/unit/views/account/udc.spec.ts
@@ -23,7 +23,7 @@ const token = generateToken();
 
 async function createWrapper(
   mainnet = false,
-  usingRaidenAccount = false,
+  useRaidenAccount = false,
   udcCapacity = constants.Zero,
   monitoringReward = constants.One,
 ): Promise<Wrapper<UDC>> {
@@ -43,10 +43,14 @@ async function createWrapper(
 
   const getters = {
     mainnet: () => mainnet,
-    usingRaidenAccount: () => usingRaidenAccount,
   };
 
-  const userDepositContractModule = {
+  const userSettings = {
+    namespaced: true,
+    state: { useRaidenAccount },
+  };
+
+  const userDepositContract = {
     namespaced: true,
     state: { token },
   };
@@ -54,7 +58,7 @@ async function createWrapper(
   const store = new Vuex.Store({
     state,
     getters,
-    modules: { userDepositContract: userDepositContractModule },
+    modules: { userDepositContract, userSettings },
   });
 
   const wrapper = mount(UDC, {


### PR DESCRIPTION
Follow up/fix of #2708

**Short description**
Our type checks for this part of the code base are horrible. We can't use refactoring tools and also linting does not find these issues.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Go to the account page
2. Make sure there is no error in the console from the Vuex store
3. Do the same for the UDC screen

