### PR TITLE
dapp: remove obsolete cypress retry plugin

### DIFF
--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -78,7 +78,6 @@
     "copy-webpack-plugin": "^6.4.1",
     "cypress": "7.2.0",
     "cypress-jest-adapter": "^0.1.1",
-    "cypress-plugin-retries": "^1.5.2",
     "eslint": "^7.25.0",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-vue": "^7.9.0",

--- a/raiden-dapp/tests/e2e/plugins/index.js
+++ b/raiden-dapp/tests/e2e/plugins/index.js
@@ -1,4 +1,3 @@
-// require('cypress-plugin-retries')
 const path = require('path');
 
 const wp = require('@cypress/webpack-preprocessor');

--- a/yarn.lock
+++ b/yarn.lock
@@ -6896,13 +6896,6 @@ cypress-jest-adapter@^0.1.1:
     jest-jquery-matchers "^2.1.0"
     jquery "^3.4.0"
 
-cypress-plugin-retries@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/cypress-plugin-retries/-/cypress-plugin-retries-1.5.2.tgz#21d5247cd77013b95bbfdd914f2de66f91f76a2e"
-  integrity sha512-o1xVIGtv4WvNVxoVJ2X08eAuvditPHrePRzHqhwwHbMKu3C2rtxCdanRCZdO5fjh8ww+q4v4V0e9GmysbOvu3A==
-  dependencies:
-    chalk "^3.0.0"
-
 cypress@7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-7.2.0.tgz#6a3364e18972f898fff1fb12c1ff747939e45ddc"
@@ -8331,7 +8324,6 @@ ethereum-cryptography@^0.1.3:
 
 "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.8"
-  uid "1a27c59c15ab1e95ee8e5c4ed6ad814c49cc439e"
   resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#1a27c59c15ab1e95ee8e5c4ed6ad814c49cc439e"
   dependencies:
     bn.js "^4.11.8"


### PR DESCRIPTION
Cypress was complaining that this plugin is still installed. This functionality is now part of the core package. Apparently this plugin wasn't even used anymore.

If the CI runs though with its end-to-end tests that should be it.
