### PR TITLE
Feature/dapp add direct rpc provider to connection manager

### DIFF
--- a/raiden-dapp/.env.e2e
+++ b/raiden-dapp/.env.e2e
@@ -1,4 +1,3 @@
-VUE_APP_CONFIGURATION_URL=./e2e.json
 VUE_APP_DEPLOYMENT_INFO=./deployment_private_net.json
 VUE_APP_DEPLOYMENT_SERVICES_INFO=./deployment_services_private_net.json
 VUE_APP_PFS=http://localhost:5555

--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -12,12 +12,16 @@
 - [#2685] Add a hint dialog when the connection process takes very long
 - [#2690] Allow user to reset connections while in progress
 - [#2630] Allow user to customize WalletConnection options
+- [#2598] Allow user to customize direct RPC provider options
+- [#2689] Add new connection manager to let the user select and configure provider
 
 [#2671]: https://github.com/raiden-network/light-client/issues/2671
 [#2599]: https://github.com/raiden-network/light-client/issues/2599
 [#2685]: https://github.com/raiden-network/light-client/issues/2685
 [#2690]: https://github.com/raiden-network/light-client/issues/2690
 [#2630]: https://github.com/raiden-network/light-client/issues/2630
+[#2598]: https://github.com/raiden-network/light-client/issues/2598
+[#2589]: https://github.com/raiden-network/light-client/issues/2598
 
 ## [0.16.0] - 2021-04-01
 

--- a/raiden-dapp/public/config.json.example
+++ b/raiden-dapp/public/config.json.example
@@ -1,6 +1,4 @@
 {
-  "rpc_endpoint": "goerli.infura.io/v3/6d333faba41b4c3d8ae979417e281832",
-  "private_key": "0x6d333faba41b4c3d8ae979417e2818326d333faba41b4c3d8ae979417e281832",
   "per_network": {
     "5": {
       "monitored": [

--- a/raiden-dapp/src/components/ConnectionManager.vue
+++ b/raiden-dapp/src/components/ConnectionManager.vue
@@ -12,17 +12,17 @@
     <template v-if="showProviderButtons">
       <action-button
         class="connection-manager__provider-dialog-button"
-        :enabled="walletConnectProviderAvailable"
-        :text="$t('connection-manager.dialogs.wallet-connect-provider.header')"
-        width="280px"
-        @click="openWalletConnectProviderDialog"
-      />
-      <action-button
-        class="connection-manager__provider-dialog-button"
         :enabled="injectedProviderAvailable"
         :text="$t('connection-manager.dialogs.injected-provider.header')"
         width="280px"
         @click="openInjectedProviderDialog"
+      />
+      <action-button
+        class="connection-manager__provider-dialog-button"
+        :enabled="walletConnectProviderAvailable"
+        :text="$t('connection-manager.dialogs.wallet-connect-provider.header')"
+        width="280px"
+        @click="openWalletConnectProviderDialog"
       />
       <action-button
         class="connection-manager__provider-dialog-button"
@@ -34,15 +34,16 @@
       />
     </template>
 
-    <wallet-connect-provider-dialog
-      v-if="walletConnectProviderDialogVisible"
-      @linkEstablished="onProviderLinkEstablished"
-      @cancel="closeWalletConnectProviderDialog"
-    />
     <injected-provider-dialog
       v-if="injectedProviderDialogVisible"
       @linkEstablished="onProviderLinkEstablished"
       @cancel="closeInjectedProviderDialog"
+    />
+
+    <wallet-connect-provider-dialog
+      v-if="walletConnectProviderDialogVisible"
+      @linkEstablished="onProviderLinkEstablished"
+      @cancel="closeWalletConnectProviderDialog"
     />
 
     <direct-rpc-provider-dialog
@@ -105,8 +106,8 @@ export default class ConnectionManager extends Vue {
   stateBackup!: string;
   useRaidenAccount!: boolean;
 
-  walletConnectProviderDialogVisible = false;
   injectedProviderDialogVisible = false;
+  walletConnectProviderDialogVisible = false;
   directRpcProviderDialogVisible = false;
   inProgress = false;
   errorCode: ErrorCode | null = null;
@@ -124,24 +125,16 @@ export default class ConnectionManager extends Vue {
     }
   }
 
-  get walletConnectProviderAvailable(): boolean {
-    return WalletConnectProvider.isAvailable;
-  }
-
   get injectedProviderAvailable(): boolean {
     return InjectedProvider.isAvailable;
   }
 
+  get walletConnectProviderAvailable(): boolean {
+    return WalletConnectProvider.isAvailable;
+  }
+
   get directRpcProviderAvailable(): boolean {
     return DirectRpcProvider.isAvailable;
-  }
-
-  openWalletConnectProviderDialog(): void {
-    this.walletConnectProviderDialogVisible = true;
-  }
-
-  closeWalletConnectProviderDialog(): void {
-    this.walletConnectProviderDialogVisible = false;
   }
 
   openInjectedProviderDialog(): void {
@@ -150,6 +143,14 @@ export default class ConnectionManager extends Vue {
 
   closeInjectedProviderDialog(): void {
     this.injectedProviderDialogVisible = false;
+  }
+
+  openWalletConnectProviderDialog(): void {
+    this.walletConnectProviderDialogVisible = true;
+  }
+
+  closeWalletConnectProviderDialog(): void {
+    this.walletConnectProviderDialogVisible = false;
   }
 
   openDirectRpcProviderDialog(): void {
@@ -161,8 +162,8 @@ export default class ConnectionManager extends Vue {
   }
 
   closeAllProviderDialogs(): void {
-    this.closeWalletConnectProviderDialog();
     this.closeInjectedProviderDialog();
+    this.closeWalletConnectProviderDialog();
     this.closeDirectRpcProviderDialog();
   }
 

--- a/raiden-dapp/src/components/ConnectionManager.vue
+++ b/raiden-dapp/src/components/ConnectionManager.vue
@@ -26,6 +26,7 @@
       />
       <action-button
         class="connection-manager__provider-dialog-button"
+        data-cy="connection-manager__provider-dialog-button"
         :enabled="directRpcProviderAvailable"
         :text="$t('connection-manager.dialogs.direct-rpc-provider.header')"
         width="280px"
@@ -133,20 +134,6 @@ export default class ConnectionManager extends Vue {
 
   get directRpcProviderAvailable(): boolean {
     return DirectRpcProvider.isAvailable;
-  }
-
-  /**
-   * This is a workaround to make the end-to-end tests working while the
-   * connection manager does not support user configured direct RPC provider
-   * connections.
-   */
-  async created(): Promise<void> {
-    const { rpc_endpoint: rpcUrl, private_key: privateKey } = await ConfigProvider.configuration();
-
-    if (rpcUrl && privateKey) {
-      const provider = await DirectRpcProvider.link({ rpcUrl, privateKey });
-      this.connect(provider);
-    }
   }
 
   openWalletConnectProviderDialog(): void {

--- a/raiden-dapp/src/components/ConnectionManager.vue
+++ b/raiden-dapp/src/components/ConnectionManager.vue
@@ -211,6 +211,11 @@ export default class ConnectionManager extends Vue {
 
   &__error-message {
     min-height: 70px;
+    margin: 0 90px;
+
+    @include respond-to(handhelds) {
+      margin: 0 10px;
+    }
 
     &--hidden {
       visibility: hidden; // Make sure it still takes its height to avoid jumping

--- a/raiden-dapp/src/components/ConnectionManager.vue
+++ b/raiden-dapp/src/components/ConnectionManager.vue
@@ -24,6 +24,13 @@
         width="280px"
         @click="openInjectedProviderDialog"
       />
+      <action-button
+        class="connection-manager__provider-dialog-button"
+        :enabled="directRpcProviderAvailable"
+        :text="$t('connection-manager.dialogs.direct-rpc-provider.header')"
+        width="280px"
+        @click="openDirectRpcProviderDialog"
+      />
     </template>
 
     <wallet-connect-provider-dialog
@@ -35,6 +42,12 @@
       v-if="injectedProviderDialogVisible"
       @linkEstablished="onProviderLinkEstablished"
       @cancel="closeInjectedProviderDialog"
+    />
+
+    <direct-rpc-provider-dialog
+      v-if="directRpcProviderDialogVisible"
+      @linkEstablished="onProviderLinkEstablished"
+      @cancel="closeDirectRpcProviderDialog"
     />
 
     <template v-if="inProgress">
@@ -49,6 +62,7 @@ import { createNamespacedHelpers, mapState } from 'vuex';
 
 import ActionButton from '@/components/ActionButton.vue';
 import ConnectionPendingDialog from '@/components/dialogs/ConnectionPendingDialog.vue';
+import DirectRpcProviderDialog from '@/components/dialogs/DirectRpcProviderDialog.vue';
 import InjectedProviderDialog from '@/components/dialogs/InjectedProviderDialog.vue';
 import WalletConnectProviderDialog from '@/components/dialogs/WalletConnectProviderDialog.vue';
 import { ErrorCode } from '@/model/types';
@@ -80,6 +94,7 @@ const { mapState: mapUserSettingsState } = createNamespacedHelpers('userSettings
   components: {
     ActionButton,
     ConnectionPendingDialog,
+    DirectRpcProviderDialog,
     InjectedProviderDialog,
     WalletConnectProviderDialog,
   },
@@ -91,6 +106,7 @@ export default class ConnectionManager extends Vue {
 
   walletConnectProviderDialogVisible = false;
   injectedProviderDialogVisible = false;
+  directRpcProviderDialogVisible = false;
   inProgress = false;
   errorCode: ErrorCode | null = null;
 
@@ -113,6 +129,10 @@ export default class ConnectionManager extends Vue {
 
   get injectedProviderAvailable(): boolean {
     return InjectedProvider.isAvailable;
+  }
+
+  get directRpcProviderAvailable(): boolean {
+    return DirectRpcProvider.isAvailable;
   }
 
   /**
@@ -145,9 +165,18 @@ export default class ConnectionManager extends Vue {
     this.injectedProviderDialogVisible = false;
   }
 
+  openDirectRpcProviderDialog(): void {
+    this.directRpcProviderDialogVisible = true;
+  }
+
+  closeDirectRpcProviderDialog(): void {
+    this.directRpcProviderDialogVisible = false;
+  }
+
   closeAllProviderDialogs(): void {
     this.closeWalletConnectProviderDialog();
     this.closeInjectedProviderDialog();
+    this.closeDirectRpcProviderDialog();
   }
 
   async onProviderLinkEstablished(linkedProvider: EthereumProvider): Promise<void> {

--- a/raiden-dapp/src/components/TextInputWithToggle.vue
+++ b/raiden-dapp/src/components/TextInputWithToggle.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="text-input-with-toggle">
+    <h3>{{ name }}</h3>
+    <span>{{ details }}</span>
+    <v-switch
+      v-if="optional"
+      v-model="disabled"
+      class="text-input-with-toggle__toggle"
+      :true-value="false"
+      :false-value="true"
+    />
+    <input
+      v-model.trim="syncedValue"
+      class="text-input-with-toggle__input"
+      :disabled="disabled"
+      :placeholder="placeholder"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, ModelSync, Prop, Vue } from 'vue-property-decorator';
+
+@Component
+export default class TextInputWithToggle extends Vue {
+  @ModelSync('value', 'input', { type: String })
+  readonly syncedValue!: string;
+
+  @Prop({ type: String, required: true })
+  name!: string;
+
+  @Prop({ type: String, required: true })
+  details!: string;
+
+  @Prop({ type: String, default: '' })
+  placeholder!: string;
+
+  @Prop({ type: Boolean, default: false })
+  optional!: boolean;
+
+  disabled = this.optional;
+
+  created(): void {
+    if (this.optional && this.syncedValue.length > 0) {
+      this.disabled = false;
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+@import '@/scss/colors';
+@import '@/scss/mixins';
+
+.text-input-with-toggle {
+  position: relative; // Required for absolute toggle position.
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  color: $color-gray;
+  background-color: $input-background;
+  border-radius: 8px !important;
+  font-size: 14px;
+  text-align: left;
+  margin: 20px 0;
+  padding: 16px;
+
+  @include respond-to(handhelds) {
+    margin: 10px 0;
+  }
+
+  &__toggle {
+    position: absolute;
+    top: 0;
+    right: 10px;
+    height: 32px;
+  }
+
+  &__input {
+    background-color: $input-background;
+    border-radius: 8px;
+    color: $color-gray;
+    height: 36px;
+    margin-top: 8px;
+    padding: 8px 8px 8px 16px;
+    width: 100%;
+
+    &:disabled {
+      opacity: 30%;
+    }
+  }
+}
+</style>

--- a/raiden-dapp/src/components/dialogs/DirectRpcProviderDialog.vue
+++ b/raiden-dapp/src/components/dialogs/DirectRpcProviderDialog.vue
@@ -1,0 +1,65 @@
+<template>
+  <ethereum-provider-base-dialog
+    :header="$t('connection-manager.dialogs.direct-rpc-provider.header')"
+    :can-link="canLink"
+    :linking-in-progress="linkingInProgress"
+    :linking-failed="linkingFailed"
+    :error-message="$t('connection-manager.dialogs.direct-rpc-provider.error-message')"
+    @link="link"
+    @cancel="emitCancel"
+  >
+    <text-input-with-toggle
+      v-model="rpcUrl"
+      class="direct-rpc-provider__options__rpc-url"
+      :name="$t('connection-manager.dialogs.direct-rpc-provider.options.rpc-url.name')"
+      :details="$t('connection-manager.dialogs.direct-rpc-provider.options.rpc-url.details')"
+      :placeholder="
+        $t('connection-manager.dialogs.direct-rpc-provider.options.rpc-url.placeholder')
+      "
+    />
+
+    <text-input-with-toggle
+      v-model="privateKey"
+      class="direct-rpc-provider__options__private-key"
+      :name="$t('connection-manager.dialogs.direct-rpc-provider.options.private-key.name')"
+      :details="$t('connection-manager.dialogs.direct-rpc-provider.options.private-key.details')"
+      :placeholder="
+        $t('connection-manager.dialogs.direct-rpc-provider.options.private-key.placeholder')
+      "
+    />
+  </ethereum-provider-base-dialog>
+</template>
+
+<script lang="ts">
+import { Component, Mixins } from 'vue-property-decorator';
+
+import EthereumProviderBaseDialog from '@/components/dialogs/EthereumProviderBaseDialog.vue';
+import TextInputWithToggle from '@/components/TextInputWithToggle.vue';
+import EthereumProviderDialogMixin from '@/mixins/ethereum-provider-dialog-mixin';
+import { DirectRpcProvider } from '@/services/ethereum-provider';
+
+type DirectRpcProviderOptions = Parameters<typeof DirectRpcProvider.link>[0];
+
+@Component({
+  components: {
+    EthereumProviderBaseDialog,
+    TextInputWithToggle,
+  },
+})
+export default class WalletConnectProviderDialog extends Mixins(EthereumProviderDialogMixin) {
+  providerFactory = DirectRpcProvider;
+  rpcUrl = '';
+  privateKey = '';
+
+  get canLink(): boolean {
+    return !!this.rpcUrl && !!this.privateKey;
+  }
+
+  get providerOptions(): DirectRpcProviderOptions {
+    return {
+      rpcUrl: this.rpcUrl,
+      privateKey: this.privateKey,
+    };
+  }
+}
+</script>

--- a/raiden-dapp/src/components/dialogs/DirectRpcProviderDialog.vue
+++ b/raiden-dapp/src/components/dialogs/DirectRpcProviderDialog.vue
@@ -1,5 +1,6 @@
 <template>
   <ethereum-provider-base-dialog
+    data-cy="direct-rpc-provider"
     :header="$t('connection-manager.dialogs.direct-rpc-provider.header')"
     :can-link="canLink"
     :linking-in-progress="linkingInProgress"
@@ -11,6 +12,7 @@
     <text-input-with-toggle
       v-model="rpcUrl"
       class="direct-rpc-provider__options__rpc-url"
+      data-cy="direct-rpc-provider__options__rpc-url"
       :name="$t('connection-manager.dialogs.direct-rpc-provider.options.rpc-url.name')"
       :details="$t('connection-manager.dialogs.direct-rpc-provider.options.rpc-url.details')"
       :placeholder="
@@ -21,6 +23,7 @@
     <text-input-with-toggle
       v-model="privateKey"
       class="direct-rpc-provider__options__private-key"
+      data-cy="direct-rpc-provider__options__private-key"
       :name="$t('connection-manager.dialogs.direct-rpc-provider.options.private-key.name')"
       :details="$t('connection-manager.dialogs.direct-rpc-provider.options.private-key.details')"
       :placeholder="

--- a/raiden-dapp/src/components/dialogs/DirectRpcProviderDialog.vue
+++ b/raiden-dapp/src/components/dialogs/DirectRpcProviderDialog.vue
@@ -2,6 +2,7 @@
   <ethereum-provider-base-dialog
     data-cy="direct-rpc-provider"
     :header="$t('connection-manager.dialogs.direct-rpc-provider.header')"
+    :description="$t('connection-manager.dialogs.direct-rpc-provider.description')"
     :can-link="canLink"
     :linking-in-progress="linkingInProgress"
     :linking-failed="linkingFailed"

--- a/raiden-dapp/src/components/dialogs/EthereumProviderBaseDialog.vue
+++ b/raiden-dapp/src/components/dialogs/EthereumProviderBaseDialog.vue
@@ -1,0 +1,80 @@
+<template>
+  <raiden-dialog
+    class="ethereum-provider-base-dialog"
+    width="472"
+    :visible="true"
+    @close="emitCancel"
+  >
+    <v-card-title class="ethereum-provider-base-dialog__header">{{ header }}</v-card-title>
+
+    <v-card-text>
+      <slot v-if="!linkingInProgress" />
+
+      <spinner v-if="linkingInProgress" />
+
+      <v-alert
+        v-if="linkingFailed"
+        class="ethereum-provider-base-dialog__error text-left font-weight-light"
+        color="error"
+        icon="warning"
+      >
+        {{ errorMessage }}
+      </v-alert>
+    </v-card-text>
+
+    <v-card-actions>
+      <action-button
+        :enabled="buttonEnabled"
+        :text="$t('connection-manager.dialogs.base.link-button')"
+        width="200px"
+        @click="emitLink"
+      />
+    </v-card-actions>
+  </raiden-dialog>
+</template>
+
+<script lang="ts">
+import { Component, Emit, Prop, Vue } from 'vue-property-decorator';
+
+import ActionButton from '@/components/ActionButton.vue';
+import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
+import Spinner from '@/components/icons/Spinner.vue';
+
+@Component({
+  components: {
+    ActionButton,
+    RaidenDialog,
+    Spinner,
+  },
+})
+export default class EthereumProviderBaseDialog extends Vue {
+  @Prop({ type: String, required: true })
+  header!: string;
+
+  @Prop({ type: Boolean, required: true })
+  canLink!: boolean;
+
+  @Prop({ type: Boolean, required: true })
+  linkingInProgress!: boolean;
+
+  @Prop({ type: Boolean, required: true })
+  linkingFailed!: boolean;
+
+  @Prop({ type: String, required: true })
+  errorMessage!: string;
+
+  get buttonEnabled(): boolean {
+    return this.canLink && !this.linkingInProgress;
+  }
+
+  @Emit('cancel')
+  emitCancel(): void {
+    // pass
+  }
+
+  @Emit('link')
+  emitLink(): void {
+    // pass
+  }
+}
+</script>

--- a/raiden-dapp/src/components/dialogs/EthereumProviderBaseDialog.vue
+++ b/raiden-dapp/src/components/dialogs/EthereumProviderBaseDialog.vue
@@ -8,6 +8,10 @@
     <v-card-title class="ethereum-provider-base-dialog__header">{{ header }}</v-card-title>
 
     <v-card-text>
+      <p v-if="description" class="ethereum-provider-base-dialog__description">
+        {{ description }}
+      </p>
+
       <slot v-if="!linkingInProgress" />
 
       <spinner v-if="linkingInProgress" />
@@ -51,6 +55,9 @@ import Spinner from '@/components/icons/Spinner.vue';
 export default class EthereumProviderBaseDialog extends Vue {
   @Prop({ type: String, required: true })
   header!: string;
+
+  @Prop({ type: String })
+  description!: string;
 
   @Prop({ type: Boolean, required: true })
   canLink!: boolean;

--- a/raiden-dapp/src/components/dialogs/EthereumProviderBaseDialog.vue
+++ b/raiden-dapp/src/components/dialogs/EthereumProviderBaseDialog.vue
@@ -24,6 +24,7 @@
 
     <v-card-actions>
       <action-button
+        data-cy="ethereum-provider-base-dialog__button"
         :enabled="buttonEnabled"
         :text="$t('connection-manager.dialogs.base.link-button')"
         width="200px"

--- a/raiden-dapp/src/components/dialogs/InjectedProviderDialog.vue
+++ b/raiden-dapp/src/components/dialogs/InjectedProviderDialog.vue
@@ -1,50 +1,23 @@
 <template>
-  <raiden-dialog width="472" class="injected-provider" :visible="true" @close="emitCancel">
-    <v-card-title>
-      {{ $t('connection-manager.dialogs.wallet-connect-provider.header') }}
-    </v-card-title>
-
-    <v-card-text>
-      <spinner v-if="linkingInProgress" />
-
-      <v-alert
-        v-if="linkingFailed"
-        class="injected-provider__error-message text-left font-weight-light"
-        color="error"
-        icon="warning"
-      >
-        {{ $t('connection-manager.dialogs.injected-provider.error-message') }}
-      </v-alert>
-    </v-card-text>
-
-    <v-card-actions>
-      <action-button
-        :enabled="!linkingInProgress"
-        class="injected-provider__link-button"
-        :text="$t('connection-manager.dialogs.injected-provider.link-button')"
-        width="200px"
-        @click="link"
-      />
-    </v-card-actions>
-  </raiden-dialog>
+  <ethereum-provider-base-dialog
+    :header="$t('connection-manager.dialogs.injected-provider.header')"
+    :can-link="canLink"
+    :linking-in-progress="linkingInProgress"
+    :linking-failed="linkingFailed"
+    :error-message="$t('connection-manager.dialogs.injected-provider.error-message')"
+    @link="link"
+    @cancel="emitCancel"
+  />
 </template>
 
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator';
 
-import ActionButton from '@/components/ActionButton.vue';
-import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
-import Spinner from '@/components/icons/Spinner.vue';
+import EthereumProviderBaseDialog from '@/components/dialogs/EthereumProviderBaseDialog.vue';
 import EthereumProviderDialogMixin from '@/mixins/ethereum-provider-dialog-mixin';
 import { InjectedProvider } from '@/services/ethereum-provider';
 
-@Component({
-  components: {
-    ActionButton,
-    RaidenDialog,
-    Spinner,
-  },
-})
+@Component({ components: { EthereumProviderBaseDialog } })
 export default class InjectedProviderDialog extends Mixins(EthereumProviderDialogMixin) {
   providerFactory = InjectedProvider;
 }

--- a/raiden-dapp/src/components/dialogs/InjectedProviderDialog.vue
+++ b/raiden-dapp/src/components/dialogs/InjectedProviderDialog.vue
@@ -5,10 +5,10 @@
     </v-card-title>
 
     <v-card-text>
-      <spinner v-if="inProgress" />
+      <spinner v-if="linkingInProgress" />
 
       <v-alert
-        v-if="linkFailed"
+        v-if="linkingFailed"
         class="injected-provider__error-message text-left font-weight-light"
         color="error"
         icon="warning"
@@ -19,7 +19,7 @@
 
     <v-card-actions>
       <action-button
-        :enabled="!inProgress"
+        :enabled="!linkingInProgress"
         class="injected-provider__link-button"
         :text="$t('connection-manager.dialogs.injected-provider.link-button')"
         width="200px"
@@ -30,11 +30,12 @@
 </template>
 
 <script lang="ts">
-import { Component, Emit, Vue } from 'vue-property-decorator';
+import { Component, Mixins } from 'vue-property-decorator';
 
 import ActionButton from '@/components/ActionButton.vue';
 import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
 import Spinner from '@/components/icons/Spinner.vue';
+import EthereumProviderDialogMixin from '@/mixins/ethereum-provider-dialog-mixin';
 import { InjectedProvider } from '@/services/ethereum-provider';
 
 @Component({
@@ -44,31 +45,7 @@ import { InjectedProvider } from '@/services/ethereum-provider';
     Spinner,
   },
 })
-export default class WalletConnectProviderDialog extends Vue {
-  linkFailed = false;
-  inProgress = false;
-
-  async link(): Promise<void> {
-    this.linkFailed = false;
-    this.inProgress = true;
-
-    try {
-      const provider = await InjectedProvider.link();
-      this.emitLinkEstablished(provider);
-    } catch {
-      this.linkFailed = true;
-      this.inProgress = false;
-    }
-  }
-
-  @Emit('linkEstablished')
-  emitLinkEstablished(linkedProvider: InjectedProvider): InjectedProvider {
-    return linkedProvider;
-  }
-
-  @Emit('cancel')
-  emitCancel(): void {
-    // pass
-  }
+export default class InjectedProviderDialog extends Mixins(EthereumProviderDialogMixin) {
+  providerFactory = InjectedProvider;
 }
 </script>

--- a/raiden-dapp/src/components/dialogs/InjectedProviderDialog.vue
+++ b/raiden-dapp/src/components/dialogs/InjectedProviderDialog.vue
@@ -1,6 +1,7 @@
 <template>
   <ethereum-provider-base-dialog
     :header="$t('connection-manager.dialogs.injected-provider.header')"
+    :description="$t('connection-manager.dialogs.injected-provider.description')"
     :can-link="canLink"
     :linking-in-progress="linkingInProgress"
     :linking-failed="linkingFailed"

--- a/raiden-dapp/src/components/dialogs/WalletConnectProviderDialog.vue
+++ b/raiden-dapp/src/components/dialogs/WalletConnectProviderDialog.vue
@@ -1,6 +1,7 @@
 <template>
   <ethereum-provider-base-dialog
     :header="$t('connection-manager.dialogs.wallet-connect-provider.header')"
+    :description="$t('connection-manager.dialogs.wallet-connect-provider.description')"
     :can-link="canLink"
     :linking-in-progress="linkingInProgress"
     :linking-failed="linkingFailed"

--- a/raiden-dapp/src/components/dialogs/WalletConnectProviderDialog.vue
+++ b/raiden-dapp/src/components/dialogs/WalletConnectProviderDialog.vue
@@ -1,83 +1,63 @@
 <template>
-  <raiden-dialog width="472" class="wallet-connect-provider" :visible="true" @close="emitCancel">
-    <v-card-title>
-      {{ $t('connection-manager.dialogs.wallet-connect-provider.header') }}
-    </v-card-title>
+  <ethereum-provider-base-dialog
+    :header="$t('connection-manager.dialogs.wallet-connect-provider.header')"
+    :can-link="canLink"
+    :linking-in-progress="linkingInProgress"
+    :linking-failed="linkingFailed"
+    :error-message="$t('connection-manager.dialogs.wallet-connect-provider.error-message')"
+    @link="link"
+    @cancel="emitCancel"
+  >
+    <text-input-with-toggle
+      v-model="bridgeUrl"
+      class="wallet-connect-provider__options__bridge-url"
+      :name="$t('connection-manager.dialogs.wallet-connect-provider.options.bridge-url.name')"
+      :details="
+        $t('connection-manager.dialogs.wallet-connect-provider.options.bridge-url.details')
+      "
+      :placeholder="
+        $t('connection-manager.dialogs.wallet-connect-provider.options.bridge-url.placeholder')
+      "
+      optional
+    />
 
-    <v-card-text>
-      <text-input-with-toggle
-        v-model="bridgeUrl"
-        class="wallet-connect-provider__options__bridge-url"
-        :name="$t('connection-manager.dialogs.wallet-connect-provider.options.bridge-url.name')"
-        :details="
-          $t('connection-manager.dialogs.wallet-connect-provider.options.bridge-url.details')
-        "
-        :placeholder="
-          $t('connection-manager.dialogs.wallet-connect-provider.options.bridge-url.placeholder')
-        "
-        optional
-      />
+    <v-btn-toggle mandatory>
+      <v-btn class="wallet-connect-provider__option-toggle-button" @click="showInfuraIdOption">
+        {{ $t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.name') }}
+      </v-btn>
+      <v-btn class="wallet-connect-provider__option-toggle-button" @click="showRpcUrlOption">
+        {{ $t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.name') }}
+      </v-btn>
+    </v-btn-toggle>
 
-      <v-btn-toggle mandatory>
-        <v-btn class="wallet-connect-provider__option-toggle-button" @click="showInfuraIdOption">
-          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.name') }}
-        </v-btn>
-        <v-btn class="wallet-connect-provider__option-toggle-button" @click="showRpcUrlOption">
-          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.name') }}
-        </v-btn>
-      </v-btn-toggle>
+    <text-input-with-toggle
+      v-if="infuraIdOptionVisible"
+      v-model="infuraId"
+      class="wallet-connect-provider__options__infura-id"
+      :name="$t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.name')"
+      :details="$t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.details')"
+      :placeholder="
+        $t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.placeholder')
+      "
+    />
 
-      <text-input-with-toggle
-        v-if="infuraIdOptionVisible"
-        v-model="infuraId"
-        class="wallet-connect-provider__options__infura-id"
-        :name="$t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.name')"
-        :details="
-          $t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.details')
-        "
-        :placeholder="
-          $t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.placeholder')
-        "
-      />
-
-      <text-input-with-toggle
-        v-if="rpcUrlOptionVisible"
-        v-model="rpcUrl"
-        class="wallet-connect-provider__options__rpc-url"
-        :name="$t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.name')"
-        :details="$t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.details')"
-        :placeholder="
-          $t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.placeholder')
-        "
-      />
-
-      <v-alert
-        v-if="linkingFailed"
-        class="wallet-connect-provider__error-message text-left font-weight-light"
-        color="error"
-        icon="warning"
-      >
-        {{ $t('connection-manager.dialogs.wallet-connect-provider.error-message') }}
-      </v-alert>
-    </v-card-text>
-
-    <v-card-actions>
-      <action-button
-        :enabled="canLink"
-        class="wallet-connect-provider__link-button"
-        :text="$t('connection-manager.dialogs.wallet-connect-provider.link-button')"
-        width="200px"
-        @click="link"
-      />
-    </v-card-actions>
-  </raiden-dialog>
+    <text-input-with-toggle
+      v-if="rpcUrlOptionVisible"
+      v-model="rpcUrl"
+      class="wallet-connect-provider__options__rpc-url"
+      :name="$t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.name')"
+      :details="$t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.details')"
+      :placeholder="
+        $t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.placeholder')
+      "
+    />
+  </ethereum-provider-base-dialog>
 </template>
 
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator';
 
-import ActionButton from '@/components/ActionButton.vue';
-import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
+import EthereumProviderBaseDialog from '@/components/dialogs/EthereumProviderBaseDialog.vue';
 import TextInputWithToggle from '@/components/TextInputWithToggle.vue';
 import EthereumProviderDialogMixin from '@/mixins/ethereum-provider-dialog-mixin';
 import { WalletConnectProvider } from '@/services/ethereum-provider';
@@ -91,9 +71,8 @@ type WalletConnectProviderOptions = Parameters<typeof WalletConnectProvider.link
 
 @Component({
   components: {
-    ActionButton,
+    EthereumProviderBaseDialog,
     TextInputWithToggle,
-    RaidenDialog,
   },
 })
 export default class WalletConnectProviderDialog extends Mixins(EthereumProviderDialogMixin) {

--- a/raiden-dapp/src/components/dialogs/WalletConnectProviderDialog.vue
+++ b/raiden-dapp/src/components/dialogs/WalletConnectProviderDialog.vue
@@ -5,72 +5,51 @@
     </v-card-title>
 
     <v-card-text>
-      <div class="wallet-connect-provider__options__bridge-url">
-        <h3>
-          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.bridge-url.header') }}
-        </h3>
-        <span>
-          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.bridge-url.details') }}
-        </span>
-        <v-switch
-          class="wallet-connect-provider__options__bridge-url__toggle"
-          @change="toggleBridgeUrlOption"
-        />
-        <input
-          v-model.trim="bridgeUrlOption"
-          class="
-            wallet-connect-provider__input wallet-connect-provider__options__bridge-url__input
-          "
-          :disabled="bridgeUrlOptionDisabled"
-          :placeholder="
-            $t('connection-manager.dialogs.wallet-connect-provider.options.bridge-url.placeholder')
-          "
-          @input="hideErrorMessage"
-        />
-      </div>
+      <text-input-with-toggle
+        v-model="bridgeUrlOption"
+        class="wallet-connect-provider__options__bridge-url"
+        :name="$t('connection-manager.dialogs.wallet-connect-provider.options.bridge-url.name')"
+        :details="
+          $t('connection-manager.dialogs.wallet-connect-provider.options.bridge-url.details')
+        "
+        :placeholder="
+          $t('connection-manager.dialogs.wallet-connect-provider.options.bridge-url.placeholder')
+        "
+        optional
+      />
 
       <v-btn-toggle mandatory>
         <v-btn class="wallet-connect-provider__option-toggle-button" @click="showInfuraIdOption">
-          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.header') }}
+          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.name') }}
         </v-btn>
         <v-btn class="wallet-connect-provider__option-toggle-button" @click="showRpcUrlOption">
-          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.header') }}
+          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.name') }}
         </v-btn>
       </v-btn-toggle>
 
-      <div v-if="infuraIdOptionVisible" class="wallet-connect-provider__options__infura-id">
-        <h3>
-          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.header') }}
-        </h3>
-        <span>
-          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.details') }}
-        </span>
-        <input
-          v-model.trim="infuraIdOption"
-          class="wallet-connect-provider__input wallet-connect-provider__options__infura-id__input"
-          :placeholder="
-            $t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.placeholder')
-          "
-          @input="hideErrorMessage"
-        />
-      </div>
+      <text-input-with-toggle
+        v-if="infuraIdOptionVisible"
+        v-model="infuraIdOption"
+        class="wallet-connect-provider__options__infura-id"
+        :name="$t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.name')"
+        :details="
+          $t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.details')
+        "
+        :placeholder="
+          $t('connection-manager.dialogs.wallet-connect-provider.options.infura-id.placeholder')
+        "
+      />
 
-      <div v-if="rpcUrlOptionVisible" class="wallet-connect-provider__options__rpc-url">
-        <h3>
-          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.header') }}
-        </h3>
-        <span>
-          {{ $t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.details') }}
-        </span>
-        <input
-          v-model.trim="rpcUrlOption"
-          class="wallet-connect-provider__input wallet-connect-provider__options__rpc-url__input"
-          :placeholder="
-            $t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.placeholder')
-          "
-          @input="hideErrorMessage"
-        />
-      </div>
+      <text-input-with-toggle
+        v-if="rpcUrlOptionVisible"
+        v-model="rpcUrlOption"
+        class="wallet-connect-provider__options__rpc-url"
+        :name="$t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.name')"
+        :details="$t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.details')"
+        :placeholder="
+          $t('connection-manager.dialogs.wallet-connect-provider.options.rpc-url.placeholder')
+        "
+      />
 
       <v-alert
         v-if="linkFailed"
@@ -100,6 +79,7 @@ import { createNamespacedHelpers } from 'vuex';
 
 import ActionButton from '@/components/ActionButton.vue';
 import RaidenDialog from '@/components/dialogs/RaidenDialog.vue';
+import TextInputWithToggle from '@/components/TextInputWithToggle.vue';
 import { WalletConnectProvider } from '@/services/ethereum-provider';
 
 enum OptionToggle {
@@ -113,8 +93,9 @@ const { mapGetters, mapMutations } = createNamespacedHelpers('userSettings');
 
 @Component({
   components: {
-    RaidenDialog,
     ActionButton,
+    TextInputWithToggle,
+    RaidenDialog,
   },
   methods: {
     ...mapGetters(['getEthereumProviderOptions']),
@@ -123,7 +104,6 @@ const { mapGetters, mapMutations } = createNamespacedHelpers('userSettings');
 })
 export default class WalletConnectProviderDialog extends Vue {
   bridgeUrlOption = '';
-  bridgeUrlOptionDisabled = true;
   infuraIdOption = '';
   rpcUrlOption = '';
   optionToggleState = OptionToggle.INFURA_ID;
@@ -181,10 +161,6 @@ export default class WalletConnectProviderDialog extends Vue {
     this.optionToggleState = OptionToggle.RPC_URL;
   }
 
-  toggleBridgeUrlOption(): void {
-    this.bridgeUrlOptionDisabled = !this.bridgeUrlOptionDisabled;
-  }
-
   hideErrorMessage(): void {
     this.linkFailed = false;
   }
@@ -234,57 +210,7 @@ export default class WalletConnectProviderDialog extends Vue {
 </script>
 
 <style lang="scss" scoped>
-@import '@/scss/mixins';
-@import '@/scss/colors';
-
 .wallet-connect-provider {
-  // TODO: This is not nice. We need to get rid of it.
-  &__input {
-    background-color: $input-background;
-    border-radius: 8px;
-    color: $color-gray;
-    height: 36px;
-    margin-top: 8px;
-    padding: 8px 8px 8px 16px;
-    width: 100%;
-
-    &:disabled {
-      opacity: 30%;
-    }
-  }
-
-  &__options {
-    &__bridge-url,
-    &__infura-id,
-    &__rpc-url {
-      display: flex;
-      flex-direction: column;
-      align-items: start;
-      color: $color-gray;
-      background-color: $input-background;
-      border-radius: 8px !important;
-      font-size: 14px;
-      text-align: left;
-      margin: 20px 0;
-      padding: 16px;
-
-      @include respond-to(handhelds) {
-        margin: 10px 0;
-      }
-    }
-
-    &__bridge-url {
-      position: relative;
-
-      &__toggle {
-        position: absolute;
-        top: 0;
-        right: 10px;
-        height: 32px;
-      }
-    }
-  }
-
   &__option-toggle-button {
     width: 92px;
   }

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -771,14 +771,15 @@
   },
   "connection-manager": {
     "dialogs": {
+      "base": {
+        "link-button": "Connect"
+      },
       "injected-provider": {
         "header": "Injected Provider",
-        "link-button": "Link Provider",
         "error-message": "Failed to link to provider. Please make sure to grant the requested permissions."
       },
       "wallet-connect-provider": {
         "header": "WalletConnect",
-        "link-button": "Link Wallet",
         "error-message": "Failed to link via WalletConnect. Please make sure the given parmaters are correct and confirm the connection in the wallet.",
         "options": {
           "bridge-url": {

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -774,6 +774,22 @@
       "base": {
         "link-button": "Connect"
       },
+      "direct-rpc-provider": {
+        "header": "Direct RPC Provider",
+        "error-message": "Failed to link to configured provider. Please make sure the given parmaters and the service is available.",
+        "options": {
+          "rpc-url": {
+            "name": "RPC",
+            "details": "Provide the URL for an RPC endpoint",
+            "placeholder": "https://"
+          },
+          "private-key": {
+            "name": "Private Key",
+            "details": "Hex encoded private key of your Ethereum account.",
+            "placeholder": "f0a78..."
+          }
+        }
+      },
       "injected-provider": {
         "header": "Injected Provider",
         "error-message": "Failed to link to provider. Please make sure to grant the requested permissions."

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -782,17 +782,17 @@
         "error-message": "Failed to link via WalletConnect. Please make sure the given parmaters are correct and confirm the connection in the wallet.",
         "options": {
           "bridge-url": {
-            "header": "Bridge Server",
+            "name": "Bridge Server",
             "details": "Provide the URL for an alternative bridge server",
             "placeholder": "https://"
           },
           "infura-id": {
-            "header": "Infura",
+            "name": "Infura",
             "details": "Provide the ID for an Infura project",
             "placeholder": "Project ID"
           },
           "rpc-url": {
-            "header": "RPC",
+            "name": "RPC",
             "details": "Provide the URL for an RPC endpoint",
             "placeholder": "https://"
           }

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -776,7 +776,8 @@
       },
       "direct-rpc-provider": {
         "header": "Direct RPC Provider",
-        "error-message": "Failed to link to configured provider. Please make sure the given parmaters and the service is available.",
+        "description": "Connect directly to an Ethereum node and use your accounts private key. This approach is NOT RECOMMENDED for security concerns.",
+        "error-message": "Failed to link to configured provider. Please make sure the given paramaters and the service is available.",
         "options": {
           "rpc-url": {
             "name": "RPC",
@@ -792,10 +793,12 @@
       },
       "injected-provider": {
         "header": "Injected Provider",
+        "description": "Connect with a provider in your web browser.",
         "error-message": "Failed to link to provider. Please make sure to grant the requested permissions."
       },
       "wallet-connect-provider": {
         "header": "WalletConnect",
+        "description": "Connect with any mobile wallet app that supports WalletConnect.",
         "error-message": "Failed to link via WalletConnect. Please make sure the given parmaters are correct and confirm the connection in the wallet.",
         "options": {
           "bridge-url": {

--- a/raiden-dapp/src/mixins/__mocks__/ethereum-provider-dialog-mixin.ts
+++ b/raiden-dapp/src/mixins/__mocks__/ethereum-provider-dialog-mixin.ts
@@ -1,0 +1,31 @@
+import { Component, Emit, Vue } from 'vue-property-decorator';
+
+import type { EthereumProvider, EthereumProviderFactory } from '@/services/ethereum-provider';
+
+@Component
+export default class EthereumProviderDialogMixin extends Vue {
+  providerFactory!: EthereumProviderFactory;
+
+  get canLink() {
+    return true;
+  }
+
+  get providerOptions() {
+    return {};
+  }
+
+  async link() {
+    const provider = await this.providerFactory.link(this.providerOptions);
+    this.emitLinkEstablished(provider);
+  }
+
+  @Emit('linkEstablished')
+  emitLinkEstablished(linkedProvider: EthereumProvider) {
+    return linkedProvider;
+  }
+
+  @Emit('cancel')
+  emitCancel() {
+    // pass
+  }
+}

--- a/raiden-dapp/src/mixins/ethereum-provider-dialog-mixin.ts
+++ b/raiden-dapp/src/mixins/ethereum-provider-dialog-mixin.ts
@@ -1,0 +1,97 @@
+import { Component, Emit, Vue } from 'vue-property-decorator';
+import { createNamespacedHelpers } from 'vuex';
+
+import type {
+  EthereumProvider,
+  EthereumProviderFactory,
+  EthereumProviderOptions,
+} from '@/services/ethereum-provider';
+
+const { mapGetters, mapMutations } = createNamespacedHelpers('userSettings');
+
+@Component({
+  methods: {
+    ...mapGetters(['getEthereumProviderOptions']),
+    ...mapMutations(['saveEthereumProviderOptions']),
+  },
+})
+export default class EthereumProviderDialogMixin extends Vue {
+  linkingFailed = false;
+  linkingInProgress = false;
+  providerFactory!: EthereumProviderFactory;
+
+  getEthereumProviderOptions!: () => (providerName: string) => EthereumProviderOptions;
+  saveEthereumProviderOptions!: (payload: {
+    providerName: string;
+    providerOptions: EthereumProviderOptions;
+  }) => void;
+
+  // Overwrite if necessary (i.e. if some options are required to be set).
+  get canLink(): boolean {
+    return true;
+  }
+
+  // Overwrite if there are any options to use.
+  get providerOptions(): EthereumProviderOptions {
+    return {};
+  }
+
+  created(): void {
+    this.checkCorrectMixinUsage();
+    this.loadSavedProviderOptions();
+  }
+
+  checkCorrectMixinUsage(): void {
+    if (this.providerFactory === undefined) {
+      throw new Error('Incorrect usage of mixin. Missing definition of provider to use.');
+    }
+
+    // TODO: check if all provider options are defined in components state.
+  }
+
+  loadSavedProviderOptions(): void {
+    const savedProviderOptions = this.getEthereumProviderOptions()(
+      this.providerFactory.providerName,
+    );
+
+    for (const [optionName, optionValue] of Object.entries(savedProviderOptions)) {
+      (this as any)[optionName] = optionValue; // eslint-disable-line @typescript-eslint/no-explicit-any
+    }
+  }
+
+  saveProviderOptions(): void {
+    this.saveEthereumProviderOptions({
+      providerName: this.providerFactory.providerName,
+      providerOptions: this.providerOptions,
+    });
+  }
+
+  async link(): Promise<void> {
+    if (!this.canLink || this.linkingInProgress) {
+      throw new Error('Can not link now!');
+    }
+
+    this.linkingFailed = false;
+    this.linkingInProgress = true;
+
+    try {
+      const provider = await this.providerFactory.link(this.providerOptions);
+      this.saveProviderOptions();
+      this.emitLinkEstablished(provider);
+    } catch {
+      this.linkingFailed = true;
+    } finally {
+      this.linkingInProgress = false;
+    }
+  }
+
+  @Emit('linkEstablished')
+  emitLinkEstablished(linkedProvider: EthereumProvider): EthereumProvider {
+    return linkedProvider;
+  }
+
+  @Emit('cancel')
+  emitCancel(): void {
+    // pass
+  }
+}

--- a/raiden-dapp/src/services/config-provider.ts
+++ b/raiden-dapp/src/services/config-provider.ts
@@ -33,8 +33,6 @@ export class ConfigProvider {
 }
 
 export interface Configuration {
-  readonly rpc_endpoint?: string;
-  readonly private_key?: string;
   readonly per_network: { [key: string]: NetworkConfiguration };
 }
 

--- a/raiden-dapp/src/services/ethereum-provider/__mocks__/direct-rpc-provider.ts
+++ b/raiden-dapp/src/services/ethereum-provider/__mocks__/direct-rpc-provider.ts
@@ -1,4 +1,5 @@
 export class DirectRpcProvider {
+  public static readonly providerName = 'direct_rpc_provider_mock';
   public readonly account = 0;
   private chainId: number;
 
@@ -6,9 +7,9 @@ export class DirectRpcProvider {
     this.chainId = chainId;
   }
 
-  public static async link(options?: { chainId?: number }) {
-    return new this(options?.chainId);
-  }
+  public static link = jest.fn(async (options?: { chainId?: number }) => {
+    return new DirectRpcProvider(options?.chainId);
+  });
 
   get provider() {
     return {

--- a/raiden-dapp/src/services/ethereum-provider/__mocks__/injected-provider.ts
+++ b/raiden-dapp/src/services/ethereum-provider/__mocks__/injected-provider.ts
@@ -6,5 +6,5 @@ export class InjectedProvider {
     return true;
   }
 
-  public static link = jest.fn().mockResolvedValue(undefined);
+  public static link = jest.fn(async () => new InjectedProvider());
 }

--- a/raiden-dapp/src/services/ethereum-provider/__mocks__/wallet-connect-provider.ts
+++ b/raiden-dapp/src/services/ethereum-provider/__mocks__/wallet-connect-provider.ts
@@ -2,5 +2,5 @@ export class WalletConnectProvider {
   public static readonly providerName = 'wallet_connect_mock';
   public readonly account = 0;
 
-  public static link = jest.fn().mockResolvedValue(undefined);
+  public static link = jest.fn(async () => new WalletConnectProvider());
 }

--- a/raiden-dapp/src/services/ethereum-provider/injected-provider.ts
+++ b/raiden-dapp/src/services/ethereum-provider/injected-provider.ts
@@ -11,9 +11,9 @@ export class InjectedProvider extends EthereumProvider {
     return !!window.ethereum || !!window.web3;
   }
 
-  private constructor(injetedProvider: providers.ExternalProvider) {
+  private constructor(injectedProvider: providers.ExternalProvider) {
     super();
-    this.provider = new providers.Web3Provider(injetedProvider);
+    this.provider = new providers.Web3Provider(injectedProvider);
   }
 
   public static async link(): Promise<InjectedProvider> {

--- a/raiden-dapp/src/services/ethereum-provider/types.ts
+++ b/raiden-dapp/src/services/ethereum-provider/types.ts
@@ -6,11 +6,18 @@ import type { providers } from 'ethers';
 // later and being explicit about it at all places.
 export type EthereumProviderOptions = any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
+export interface EthereumProviderFactory {
+  providerName: string;
+  isAvailable: boolean;
+  link: (options: EthereumProviderOptions) => Promise<EthereumProvider>;
+}
+
 // TOOD: watch-out when `static abstract` becomes possible in TypeScript
 export abstract class EthereumProvider {
   static providerName: string;
   static isAvailable = false;
   static link: (options: EthereumProviderOptions) => Promise<EthereumProvider>;
+
   abstract provider: providers.JsonRpcProvider;
   abstract account: string | number;
 

--- a/raiden-dapp/tests/e2e/e2e.json
+++ b/raiden-dapp/tests/e2e/e2e.json
@@ -1,4 +1,0 @@
-{
-  "rpc_endpoint": "http://localhost:8545",
-  "private_key": "0x6d333faba41b4c3d8ae979417e2818326d333faba41b4c3d8ae979417e281832"
-}

--- a/raiden-dapp/tests/e2e/specs/scenario.spec.ts
+++ b/raiden-dapp/tests/e2e/specs/scenario.spec.ts
@@ -30,7 +30,7 @@ import {
 import {
   acceptDisclaimer,
   closeNotificationPanel,
-  // connectToDApp,
+  connectToDApp,
   deleteTopNotification,
   downloadState,
   enterAndSelectHub,
@@ -61,7 +61,7 @@ describe('dApp e2e tests', () => {
     cy.viewport('macbook-13');
     navigateToDisclaimer();
     acceptDisclaimer();
-    // connectToDApp();
+    connectToDApp();
     navigateToSelectHub();
     mintAndDepositUtilityTokenFromSelectHubScreen();
     mintConnectedTokenFromSelectHubScreen();
@@ -80,7 +80,7 @@ describe('dApp e2e tests', () => {
     navigateToAccountMenu();
     navigateToBackupState();
     downloadState();
-    // connectToDApp();
+    connectToDApp();
     navigateToTokenSelect();
     navigateToConnectNewTokenFromTokenOverlay();
     navigateBackToTransferScreenFromOverlay();

--- a/raiden-dapp/tests/e2e/utils/user-interaction.ts
+++ b/raiden-dapp/tests/e2e/utils/user-interaction.ts
@@ -16,7 +16,17 @@ export function acceptDisclaimer() {
 export function connectToDApp() {
   // cypress selectors: raiden-dapp/src/views/Home.vue
   cy.get('[data-cy=home]').should('exist');
-  cy.get('[data-cy=home_connect_button]').click();
+  cy.get('[data-cy=connection-manager__provider-dialog-button]').click();
+  cy.get('[data-cy=direct-rpc-provider]').should('exist');
+  cy.get('[data-cy=direct-rpc-provider__options__rpc-url]')
+    .find('.text-input-with-toggle__input')
+    .clear()
+    .type('http://localhost:8545');
+  cy.get('[data-cy=direct-rpc-provider__options__private-key]')
+    .find('.text-input-with-toggle__input')
+    .clear()
+    .type('0x6d333faba41b4c3d8ae979417e2818326d333faba41b4c3d8ae979417e281832');
+  cy.get('[data-cy=ethereum-provider-base-dialog__button]').click();
   cy.getWithCustomTimeout('[data-cy=home]').should('not.exist');
 }
 

--- a/raiden-dapp/tests/unit/components/connection-manager.spec.ts
+++ b/raiden-dapp/tests/unit/components/connection-manager.spec.ts
@@ -189,7 +189,7 @@ describe('ConnectionManager.vue', () => {
 
     const providerDialogButton = wrapper
       .findAll('.connection-manager__provider-dialog-button')
-      .at(1)
+      .at(0)
       .get('button');
 
     expect(providerDialogButton.attributes('disabled')).toBeTruthy();

--- a/raiden-dapp/tests/unit/components/dialogs/direct-rpc-provider-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/dialogs/direct-rpc-provider-dialog.spec.ts
@@ -1,0 +1,87 @@
+import { $t } from '../../utils/mocks';
+
+import type { Wrapper } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import Vue from 'vue';
+import Vuetify from 'vuetify';
+
+import ActionButton from '@/components/ActionButton.vue';
+import DirectRpcProviderDialog from '@/components/dialogs/DirectRpcProviderDialog.vue';
+import { DirectRpcProvider } from '@/services/ethereum-provider';
+
+jest.mock('@/mixins/ethereum-provider-dialog-mixin');
+jest.mock('@/services/ethereum-provider/direct-rpc-provider');
+
+Vue.use(Vuetify);
+
+const vuetify = new Vuetify();
+
+function createWrapper(): Wrapper<DirectRpcProviderDialog> {
+  return mount(DirectRpcProviderDialog, {
+    vuetify,
+    stubs: { 'v-dialog': true, 'action-button': ActionButton },
+    mocks: { $t },
+  });
+}
+
+async function insertRpcUrlOption(
+  wrapper: Wrapper<DirectRpcProviderDialog>,
+  input = 'testUrl',
+): Promise<void> {
+  const rpcUrlOption = wrapper.get('.direct-rpc-provider__options__rpc-url').find('input');
+  (rpcUrlOption.element as HTMLInputElement).value = input;
+  rpcUrlOption.trigger('input');
+  await wrapper.vm.$nextTick();
+}
+
+async function insertPrivateKeyOption(
+  wrapper: Wrapper<DirectRpcProviderDialog>,
+  input = 'testKey',
+): Promise<void> {
+  const privateKeyOption = wrapper.get('.direct-rpc-provider__options__private-key').find('input');
+  (privateKeyOption.element as HTMLInputElement).value = input;
+  privateKeyOption.trigger('input');
+  await wrapper.vm.$nextTick();
+}
+
+async function clickLinkButton(wrapper: Wrapper<DirectRpcProviderDialog>): Promise<void> {
+  const button = wrapper.findComponent(ActionButton).get('button');
+  button.trigger('click');
+  await flushPromises();
+}
+
+describe('DirectRpcProviderDialog.vue', () => {
+  test('can not link with RPC URL option only', async () => {
+    const wrapper = createWrapper();
+
+    await insertRpcUrlOption(wrapper);
+    await clickLinkButton(wrapper);
+
+    expect(DirectRpcProvider.link).not.toHaveBeenCalled();
+    expect(wrapper.emitted('linkEstablished')).toBeUndefined();
+  });
+
+  test('can not link with private key option only', async () => {
+    const wrapper = createWrapper();
+
+    await insertPrivateKeyOption(wrapper);
+    await clickLinkButton(wrapper);
+
+    expect(DirectRpcProvider.link).not.toHaveBeenCalled();
+    expect(wrapper.emitted('linkEstablished')).toBeUndefined();
+  });
+
+  test('can link with RPC URL and private key option', async () => {
+    const wrapper = createWrapper();
+
+    await insertRpcUrlOption(wrapper, 'url');
+    await insertPrivateKeyOption(wrapper, 'key');
+    await clickLinkButton(wrapper);
+
+    expect(DirectRpcProvider.link).toHaveBeenCalledTimes(1);
+    expect(DirectRpcProvider.link).toHaveBeenCalledWith({ rpcUrl: 'url', privateKey: 'key' });
+    expect(wrapper.emitted('linkEstablished')?.length).toBe(1);
+    expect(wrapper.emitted('linkEstablished')?.[0][0]).toBeInstanceOf(DirectRpcProvider);
+  });
+});

--- a/raiden-dapp/tests/unit/components/dialogs/ethereum-provider-base-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/dialogs/ethereum-provider-base-dialog.spec.ts
@@ -15,6 +15,7 @@ const vuetify = new Vuetify();
 
 function createWrapper(options?: {
   header?: string;
+  description?: string;
   canLink?: boolean;
   linkingInProgress?: boolean;
   linkingFailed?: boolean;
@@ -24,6 +25,7 @@ function createWrapper(options?: {
     vuetify,
     propsData: {
       header: options?.header ?? 'header',
+      description: options?.description,
       canLink: options?.canLink ?? true,
       linkingInProgress: options?.linkingInProgress ?? false,
       linkingFailed: options?.linkingFailed ?? false,
@@ -41,6 +43,14 @@ describe('EthereumProviderBaseDialog.vue', () => {
 
     expect(header.isVisible()).toBeTruthy();
     expect(header.text()).toMatch('testHeader');
+  });
+
+  test('shows description it given', () => {
+    const wrapper = createWrapper({ description: 'testDescription' });
+    const description = wrapper.find('.ethereum-provider-base-dialog__description');
+
+    expect(description.isVisible()).toBeTruthy();
+    expect(description.text()).toMatch('testDescription');
   });
 
   test('shows spinner if in progress', () => {

--- a/raiden-dapp/tests/unit/components/dialogs/ethereum-provider-base-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/dialogs/ethereum-provider-base-dialog.spec.ts
@@ -1,0 +1,99 @@
+import { $t } from '../../utils/mocks';
+
+import type { Wrapper } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
+import Vue from 'vue';
+import Vuetify from 'vuetify';
+
+import ActionButton from '@/components/ActionButton.vue';
+import EthereumProviderBaseDialog from '@/components/dialogs/EthereumProviderBaseDialog.vue';
+import Spinner from '@/components/icons/Spinner.vue';
+
+Vue.use(Vuetify);
+
+const vuetify = new Vuetify();
+
+function createWrapper(options?: {
+  header?: string;
+  canLink?: boolean;
+  linkingInProgress?: boolean;
+  linkingFailed?: boolean;
+  errorMessage?: string;
+}): Wrapper<EthereumProviderBaseDialog> {
+  return mount(EthereumProviderBaseDialog, {
+    vuetify,
+    propsData: {
+      header: options?.header ?? 'header',
+      canLink: options?.canLink ?? true,
+      linkingInProgress: options?.linkingInProgress ?? false,
+      linkingFailed: options?.linkingFailed ?? false,
+      errorMessage: options?.errorMessage ?? 'error',
+    },
+    stubs: { 'v-dialog': true },
+    mocks: { $t },
+  });
+}
+
+describe('EthereumProviderBaseDialog.vue', () => {
+  test('shows header', () => {
+    const wrapper = createWrapper({ header: 'testHeader' });
+    const header = wrapper.find('.ethereum-provider-base-dialog__header');
+
+    expect(header.isVisible()).toBeTruthy();
+    expect(header.text()).toMatch('testHeader');
+  });
+
+  test('shows spinner if in progress', () => {
+    const wrapper = createWrapper({ linkingInProgress: true });
+    const spinner = wrapper.findComponent(Spinner);
+
+    expect(spinner.isVisible()).toBeTruthy();
+  });
+
+  test('shows given error message when linking failed', () => {
+    const wrapper = createWrapper({ linkingFailed: true, errorMessage: 'failed' });
+    const error = wrapper.find('.ethereum-provider-base-dialog__error');
+
+    expect(error.isVisible()).toBeTruthy();
+    expect(error.text()).toMatch('failed');
+  });
+
+  test('shows button to link', () => {
+    const wrapper = createWrapper({ linkingInProgress: true });
+    const button = wrapper.findComponent(ActionButton).find('button');
+
+    expect(button.isVisible()).toBeTruthy();
+    expect(button.text()).toBe('connection-manager.dialogs.base.link-button');
+  });
+
+  test('button is disabled when linking in progress', () => {
+    const wrapper = createWrapper({ linkingInProgress: true });
+    const button = wrapper.findComponent(ActionButton).find('button');
+
+    expect(button.attributes('disabled')).toBeTruthy();
+  });
+
+  test('button is disabled when linking not possible', () => {
+    const wrapper = createWrapper({ canLink: false });
+    const button = wrapper.findComponent(ActionButton).find('button');
+
+    expect(button.attributes('disabled')).toBeTruthy();
+  });
+
+  test('button is enabled when linking possible and not in progress', () => {
+    const wrapper = createWrapper({ canLink: true, linkingInProgress: false });
+    const button = wrapper.findComponent(ActionButton).find('button');
+
+    expect(button.attributes('disabled')).toBeFalsy();
+  });
+
+  test('button emits link event on click', () => {
+    const wrapper = createWrapper();
+    const button = wrapper.findComponent(ActionButton).find('button');
+    expect(wrapper.emitted('link')).toBeUndefined();
+
+    button.trigger('click');
+
+    expect(wrapper.emitted('link')?.length).toBe(1);
+  });
+});

--- a/raiden-dapp/tests/unit/components/dialogs/wallet-connect-provider-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/dialogs/wallet-connect-provider-dialog.spec.ts
@@ -57,8 +57,9 @@ async function clickBridgeUrlOptionToggle(
   wrapper: Wrapper<WalletConnectProviderDialog>,
 ): Promise<void> {
   const bridgeUrlOptionToggle = wrapper
-    .get('.wallet-connect-provider__options__bridge-url__toggle')
-    .find('input');
+    .get('.wallet-connect-provider__options__bridge-url')
+    .findAll('input')
+    .at(0);
   bridgeUrlOptionToggle.trigger('click');
   await wrapper.vm.$nextTick();
 }
@@ -68,8 +69,9 @@ async function insertBridgeUrlOption(
   input = 'testUrl',
 ): Promise<void> {
   const bridgeUrlInputOption = wrapper
-    .get('.wallet-connect-provider__options__bridge-url__input')
-    .find('input');
+    .get('.wallet-connect-provider__options__bridge-url')
+    .findAll('input')
+    .at(1);
   (bridgeUrlInputOption.element as HTMLInputElement).value = input;
   bridgeUrlInputOption.trigger('input');
   await wrapper.vm.$nextTick();
@@ -89,7 +91,7 @@ async function insertInfuraIdOption(
 ): Promise<void> {
   await selectInfuraIdOption(wrapper);
   const infuraIdInputOption = wrapper
-    .get('.wallet-connect-provider__options__infura-id__input')
+    .get('.wallet-connect-provider__options__infura-id')
     .find('input');
   (infuraIdInputOption.element as HTMLInputElement).value = input;
   infuraIdInputOption.trigger('input');
@@ -110,7 +112,7 @@ async function insertRpcUrlOption(
 ): Promise<void> {
   await selectRpcUrlOption(wrapper);
   const rpcUrlInputOption = wrapper
-    .get('.wallet-connect-provider__options__rpc-url__input')
+    .get('.wallet-connect-provider__options__rpc-url')
     .find('input');
   (rpcUrlInputOption.element as HTMLInputElement).value = input;
   rpcUrlInputOption.trigger('input');
@@ -140,16 +142,6 @@ describe('WalletConnectProviderDialog.vue', () => {
     await selectInfuraIdOption(wrapper);
     infuraIdOption = wrapper.get('.wallet-connect-provider__options__infura-id');
     expect(infuraIdOption.isVisible()).toBeTruthy();
-  });
-
-  test('can enable bridge server input field', async () => {
-    const wrapper = createWrapper();
-    const bridgeServerURLInput = wrapper.findAll('.wallet-connect-provider__input').at(0);
-    expect(bridgeServerURLInput.attributes('disabled')).toBeTruthy();
-
-    await clickBridgeUrlOptionToggle(wrapper);
-
-    expect(bridgeServerURLInput.attributes('disabled')).toBeFalsy();
   });
 
   test('can link with Infura ID option only', async () => {

--- a/raiden-dapp/tests/unit/components/dialogs/wallet-connect-provider-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/dialogs/wallet-connect-provider-dialog.spec.ts
@@ -5,7 +5,6 @@ import { mount } from '@vue/test-utils';
 import flushPromises from 'flush-promises';
 import Vue from 'vue';
 import Vuetify from 'vuetify';
-import Vuex from 'vuex';
 
 import ActionButton from '@/components/ActionButton.vue';
 import WalletConnectProviderDialog from '@/components/dialogs/WalletConnectProviderDialog.vue';
@@ -14,7 +13,6 @@ import { WalletConnectProvider } from '@/services/ethereum-provider';
 jest.mock('@/mixins/ethereum-provider-dialog-mixin');
 jest.mock('@/services/ethereum-provider/wallet-connect-provider');
 
-Vue.use(Vuex);
 Vue.use(Vuetify);
 
 const vuetify = new Vuetify();

--- a/raiden-dapp/tests/unit/components/mixins/ethereum-provider-dialog-mixin.spec.ts
+++ b/raiden-dapp/tests/unit/components/mixins/ethereum-provider-dialog-mixin.spec.ts
@@ -1,0 +1,164 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Wrapper } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
+import Vue from 'vue';
+import { Component, Mixins } from 'vue-property-decorator';
+import Vuex from 'vuex';
+
+import EthereumProviderDialogMixin from '@/mixins/ethereum-provider-dialog-mixin';
+import { DirectRpcProvider } from '@/services/ethereum-provider';
+
+jest.mock('@/services/ethereum-provider/direct-rpc-provider');
+
+Vue.use(Vuex);
+
+@Component({ template: '<div></div>' })
+class TestComponent extends Mixins(EthereumProviderDialogMixin) {
+  providerFactory = DirectRpcProvider;
+  rpcUrl = '';
+  privateKey = '';
+}
+
+const saveEthereumProviderOptions = jest.fn();
+const getEthereumProviderOptions = jest.fn().mockReturnValue({});
+const mutations = { saveEthereumProviderOptions };
+const getters = { getEthereumProviderOptions: () => getEthereumProviderOptions };
+const userSettings = {
+  namespaced: true,
+  getters,
+  mutations,
+};
+
+function createWrapper(options?: {
+  linkingInProgress?: boolean;
+  canLink?: boolean;
+  providerOptions?: unknown;
+}): Wrapper<TestComponent> {
+  const store = new Vuex.Store({
+    modules: { userSettings },
+  });
+
+  const wrapper = shallowMount(TestComponent, { store });
+  wrapper.setData({ linkingInProgress: options?.linkingInProgress ?? false });
+
+  if (options?.canLink !== undefined) {
+    Object.defineProperty(wrapper.vm, 'canLink', { get: () => options.canLink });
+  }
+
+  if (options?.providerOptions !== undefined) {
+    Object.defineProperty(wrapper.vm, 'providerOptions', { get: () => options.providerOptions });
+  }
+
+  return wrapper;
+}
+
+describe('EthereumProviderDialogMixin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('enables linking per default', () => {
+    const wrapper = createWrapper();
+
+    expect(wrapper.vm.canLink).toBeTruthy();
+  });
+
+  test('has empty provider options per default', () => {
+    const wrapper = createWrapper();
+
+    expect(wrapper.vm.providerOptions).toMatchObject({});
+  });
+
+  test('loads saved provider options from store on creation', () => {
+    getEthereumProviderOptions.mockReturnValueOnce({ rpcUrl: 'testUrl', privateKey: 'testKey' });
+    const wrapper = createWrapper();
+
+    expect(getEthereumProviderOptions).toHaveBeenCalledTimes(1);
+    expect(wrapper.vm.rpcUrl).toBe('testUrl');
+    expect(wrapper.vm.privateKey).toBe('testKey');
+  });
+
+  test('linking fails if not enabled', () => {
+    const wrapper = createWrapper({ canLink: false });
+
+    expect(wrapper.vm.link()).rejects.toThrowError('Can not link now!');
+  });
+
+  test('linking fails if already in progress', () => {
+    const wrapper = createWrapper({ linkingInProgress: true });
+
+    expect(wrapper.vm.link()).rejects.toThrowError('Can not link now!');
+  });
+
+  test('changes internal state to failed if provider factory throws', async () => {
+    (DirectRpcProvider as any).link.mockRejectedValueOnce(new Error('failed'));
+    const wrapper = createWrapper();
+    expect(wrapper.vm.linkingFailed).toBeFalsy();
+
+    await wrapper.vm.link();
+
+    expect(wrapper.vm.linkingFailed).toBeTruthy();
+  });
+
+  test('resets the in progress state after linking finishes', async () => {
+    const wrapper = createWrapper();
+    expect(wrapper.vm.linkingInProgress).toBeFalsy();
+
+    // TODO: can we somehow check that it changes in-between?
+    await wrapper.vm.link();
+
+    expect(wrapper.vm.linkingInProgress).toBeFalsy();
+  });
+
+  test('linking calls the the factories link function with the correct options', async () => {
+    const wrapper = createWrapper({
+      providerOptions: { rpcUrl: 'testUrl', privateKey: 'testKey' },
+    });
+    expect(DirectRpcProvider.link).not.toHaveBeenCalled();
+
+    await wrapper.vm.link();
+
+    expect(DirectRpcProvider.link).toHaveBeenCalledTimes(1);
+    expect(DirectRpcProvider.link).toHaveBeenLastCalledWith({
+      rpcUrl: 'testUrl',
+      privateKey: 'testKey',
+    });
+  });
+
+  test('successful link saves provider options to store', async () => {
+    const wrapper = createWrapper({
+      providerOptions: { rpcUrl: 'testUrl', privateKey: 'testKey' },
+    });
+    expect(saveEthereumProviderOptions).not.toHaveBeenCalled();
+
+    await wrapper.vm.link();
+
+    expect(saveEthereumProviderOptions).toHaveBeenCalledTimes(1);
+    expect(saveEthereumProviderOptions).toHaveBeenCalledWith(expect.anything(), {
+      providerName: 'direct_rpc_provider_mock',
+      providerOptions: { rpcUrl: 'testUrl', privateKey: 'testKey' },
+    });
+  });
+
+  test('successful link emits linkEstablished event', async () => {
+    const wrapper = createWrapper();
+    expect(wrapper.emitted('linkEstablished')).toBeUndefined();
+
+    await wrapper.vm.link();
+
+    expect(wrapper.emitted('linkEstablished')?.length).toBe(1);
+    expect(wrapper.emitted('linkEstablished')?.[0][1]).toBeInstanceOf(DirectRpcProvider);
+  });
+
+  test('linking successfully again after a failure resets the failure state', async () => {
+    const wrapper = createWrapper();
+
+    (DirectRpcProvider as any).link.mockRejectedValueOnce(new Error('failed'));
+    await wrapper.vm.link();
+    expect(wrapper.vm.linkingFailed).toBeTruthy();
+
+    // Failing mock was only **once**.
+    await wrapper.vm.link();
+    expect(wrapper.vm.linkingFailed).toBeFalsy();
+  });
+});

--- a/raiden-dapp/tests/unit/components/text-input-with-toggle.spec.ts
+++ b/raiden-dapp/tests/unit/components/text-input-with-toggle.spec.ts
@@ -1,0 +1,98 @@
+import type { Wrapper } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
+import Vue from 'vue';
+import Vuetify from 'vuetify';
+
+import TextInputWithToggle from '@/components/TextInputWithToggle.vue';
+
+Vue.use(Vuetify);
+
+const vuetify = new Vuetify();
+
+function createWrapper(options?: {
+  value?: string;
+  name?: string;
+  details?: string;
+  placeholder?: string;
+  optional?: boolean;
+}): Wrapper<TextInputWithToggle> {
+  return mount(TextInputWithToggle, {
+    vuetify,
+    propsData: {
+      value: options?.value ?? '',
+      name: options?.name ?? 'testName',
+      details: options?.details ?? 'testDetails',
+      placeholder: options?.placeholder,
+      optional: options?.optional,
+    },
+  });
+}
+
+describe('TextInputWithToggle.vue', () => {
+  test('displays setting its name', () => {
+    const wrapper = createWrapper({ name: 'test setting name' });
+    const name = wrapper.find('h3');
+
+    expect(name.exists()).toBeTruthy();
+    expect(name.text()).toMatch('test setting name');
+  });
+
+  test('displays settings details text', () => {
+    const wrapper = createWrapper({ details: 'some details' });
+    const details = wrapper.find('span');
+
+    expect(details.exists()).toBeTruthy();
+    expect(details.text()).toMatch('some details');
+  });
+
+  test('uses optional placeholder text', () => {
+    const wrapper = createWrapper({ placeholder: 'input placeholder' });
+    const input = wrapper.get('.text-input-with-toggle__input');
+
+    expect(input.attributes('placeholder')).toMatch('input placeholder');
+  });
+
+  test('non optional settings are always enabled', () => {
+    const wrapper = createWrapper({ optional: false });
+    const input = wrapper.get('.text-input-with-toggle__input');
+
+    expect(input.attributes('disabled')).toBeFalsy();
+  });
+
+  test('optional settings are enabled per default', () => {
+    const wrapper = createWrapper({ optional: true });
+    const input = wrapper.get('.text-input-with-toggle__input');
+
+    expect(input.attributes('disabled')).toBeTruthy();
+  });
+
+  test('can toggle optional settings input field', async () => {
+    const wrapper = createWrapper({ optional: true });
+    const toggle = wrapper.get('.text-input-with-toggle__toggle').find('input');
+    const input = wrapper.get('.text-input-with-toggle__input');
+    expect(input.attributes('disabled')).toBeTruthy();
+
+    toggle.trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect(input.attributes('disabled')).toBeFalsy();
+  });
+
+  test('optional settings with initial value get enabled automatically', () => {
+    const wrapper = createWrapper({ value: 'initial value', optional: true });
+    const input = wrapper.get('.text-input-with-toggle__input');
+
+    expect(input.attributes('disabled')).toBeFalsy();
+  });
+
+  test('emits input event on value change', async () => {
+    const wrapper = createWrapper({ value: 'initial value', optional: true });
+    const input = wrapper.get('.text-input-with-toggle__input');
+
+    (input.element as HTMLInputElement).value = 'typed text';
+    input.trigger('input');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('input')?.length).toBe(1);
+  });
+});

--- a/raiden-dapp/vue.config.js
+++ b/raiden-dapp/vue.config.js
@@ -120,13 +120,6 @@ module.exports = {
       );
     }
 
-    if (process.env.E2E) {
-      patterns.push({
-        from: path.resolve(__dirname, 'tests', 'e2e', 'e2e.json'),
-        to: distributionDirectoryPath,
-      });
-    }
-
     if (patterns.length > 0) {
       config.plugins.push(
         new CopyWebpackPlugin({


### PR DESCRIPTION
Fixes #2598 
Fixes #2631

**Short description**
This adds the currently last Ethereum provider to the connection manager. In contrast to the last one, this goes first into some refactoring of the UI components to make the shared logic and templates re-usable between all dialogs. This makes it incredibly easy to add or remove new providers.
Finally the end-to-end test are now testing properly again without the temporally fix. 
The configuration file was reduced to a minimum as it is the users task to select and configure the providers now

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Run the dApp
2. Connect to it using the direct RPC provider (maybe copy the options from the `mobile-app-setup` branch)