### PR TITLE
Bugfix/dapp connect token screen shows transfer header

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - [#2671] Fix preventing transfers to partners with closed channel
+- [#2675] Fix insecure behavior on navigation without connected token
 
 ### Added
 
@@ -22,6 +23,7 @@
 [#2630]: https://github.com/raiden-network/light-client/issues/2630
 [#2598]: https://github.com/raiden-network/light-client/issues/2598
 [#2589]: https://github.com/raiden-network/light-client/issues/2598
+[#2675]: https://github.com/raiden-network/light-client/issues/2675
 
 ## [0.16.0] - 2021-04-01
 

--- a/raiden-dapp/src/components/notification-panel/NotificationSnackbar.vue
+++ b/raiden-dapp/src/components/notification-panel/NotificationSnackbar.vue
@@ -1,25 +1,24 @@
 <template>
   <v-snackbar
-    v-if="notification.display"
-    v-model="notification.display"
+    v-if="isVisible"
+    v-model="notificationToShow.display"
+    :value="isVisible"
     class="notification-snackbar"
-    :timeout="notification.duration"
+    :timeout="notificationToShow.duration"
     app
     rounded
     max-width="550px"
     color="primary"
-    @input="setNotificationShown(notification.id)"
+    @input="dismiss"
   >
-    <v-row no-gutters class="notification-snackbar__area" @click="open">
-      <v-col cols="2">
-        <img :src="require('@/assets/notifications/notification_block.svg')" />
-      </v-col>
-      <v-col class="notification-snackbar__area__title">
-        <span>
-          {{ notification.title }}
-        </span>
-      </v-col>
-    </v-row>
+    <div class="notification-snackbar__area" @click="open">
+      <img :src="require('@/assets/notifications/notification_block.svg')" />
+
+      <span class="notification-snackbar__area__title">
+        {{ notificationToShow.title }}
+      </span>
+    </div>
+
     <template #action="{ attrs }">
       <v-btn
         data-cy="notification-snackbar__dismiss-button"
@@ -35,62 +34,46 @@
 </template>
 
 <script lang="ts">
-import { Component, Mixins, Watch } from 'vue-property-decorator';
-import { mapGetters, mapMutations } from 'vuex';
+import { Component, Mixins } from 'vue-property-decorator';
+import { createNamespacedHelpers } from 'vuex';
 
 import NavigationMixin from '@/mixins/navigation-mixin';
-import { NotificationContext } from '@/store/notifications/notification-context';
-import { NotificationImportance } from '@/store/notifications/notification-importance';
 import type { NotificationPayload } from '@/store/notifications/types';
 
-const emptyNotification: NotificationPayload = {
-  id: -1,
-  title: '',
-  description: '',
-  icon: '',
-  display: false,
-  duration: 5000,
-  importance: NotificationImportance.LOW,
-  context: NotificationContext.NONE,
-  received: new Date(),
-};
+const { mapGetters, mapMutations } = createNamespacedHelpers('notifications');
 
 @Component({
   computed: {
-    ...mapGetters('notifications', ['notificationQueue']),
+    ...mapGetters(['notificationQueue']),
   },
   methods: {
-    ...mapMutations('notifications', ['setNotificationShown']),
+    ...mapMutations(['setNotificationShown']),
   },
 })
 export default class NotificationSnackbar extends Mixins(NavigationMixin) {
-  notification: NotificationPayload = emptyNotification;
   notificationQueue!: NotificationPayload[];
   setNotificationShown!: (notificationId: number) => void;
 
-  @Watch('notificationQueue', { immediate: true, deep: true })
-  onQueueChange(): void {
-    if (!this.notification.display && this.notificationQueue.length > 0) {
-      const nextNotification = this.notificationQueue.shift();
-      if (!nextNotification) {
-        return;
-      }
-      this.$nextTick(() => (this.notification = nextNotification));
+  get notificationToShow(): NotificationPayload | undefined {
+    return this.notificationQueue[0];
+  }
+
+  get isVisible(): boolean {
+    return this.notificationToShow !== undefined;
+  }
+
+  // This will trigger a change of the notification queue which then result
+  // into the next notification in the queue to display via the reactive
+  // getter.
+  dismiss(): void {
+    if (this.notificationToShow) {
+      this.setNotificationShown(this.notificationToShow.id);
     }
   }
 
-  created(): void {
-    this.notification = emptyNotification;
-  }
-
-  dismiss(): void {
-    this.setNotificationShown(this.notification.id);
-    this.notification = { ...this.notification, display: false };
-  }
-
   open(): void {
-    this.navigateToNotifications();
     this.dismiss();
+    this.navigateToNotifications();
   }
 }
 </script>
@@ -100,12 +83,14 @@ export default class NotificationSnackbar extends Mixins(NavigationMixin) {
 
 .notification-snackbar {
   &__area {
+    display: flex;
     cursor: pointer;
 
     &__title {
+      margin-left: 10px;
       font-size: 16px;
       font-weight: 500;
-      padding-top: 3px;
+      padding-top: 2px;
     }
   }
 }

--- a/raiden-dapp/src/components/overlays/TokenOverlay.vue
+++ b/raiden-dapp/src/components/overlays/TokenOverlay.vue
@@ -27,7 +27,7 @@
 
     <div class="token-overlay__connected-tokens mt-8">
       <token-list
-        :header="$t('tokens.connected.header')"
+        :header="$t('tokens.connected-tokens')"
         :tokens="tokens"
         @select="handleTokenClick"
       />

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -411,9 +411,7 @@
     "state-migration-failed": "Cannot replace state with older uploaded state."
   },
   "tokens": {
-    "connected": {
-      "header": "Connected Tokens"
-    },
+    "connected-tokens": "Connected Tokens",
     "connect-new": "Connect new token",
     "disconnect-dialog": {
       "header": "Disconnect token",

--- a/raiden-dapp/src/router/guards/connection.ts
+++ b/raiden-dapp/src/router/guards/connection.ts
@@ -1,26 +1,23 @@
 import { RouteNames } from '../route-names';
 import type { NavigationGuardChild } from './types';
 
-const accountRoutes = [
+const freeAccountRoutes = [
   RouteNames.ACCOUNT_ROOT,
   RouteNames.ACCOUNT_BACKUP,
-  RouteNames.ACCOUNT_RAIDEN,
   RouteNames.ACCOUNT_SETTINGS,
-  RouteNames.ACCOUNT_WITHDRAWAL,
-  RouteNames.ACCOUNT_UDC,
 ] as string[];
 
 export const redirectIfNotConnected: NavigationGuardChild = (to, store) => {
   const { isConnected } = store.state;
-  const routingToAccount = accountRoutes.includes(to.name ?? '');
-  const routingToHome = to.name === RouteNames.HOME;
+  const routingToFreeAccountRoute = freeAccountRoutes.includes(to.name ?? '');
+  const routingToHomeRoute = to.name === RouteNames.HOME;
 
-  if (routingToAccount) return undefined;
+  if (routingToFreeAccountRoute) return undefined;
 
-  if (!isConnected && !routingToHome)
+  if (!isConnected && !routingToHomeRoute)
     return { name: RouteNames.HOME, query: { redirectTo: to.fullPath } };
 
-  if (!isConnected && routingToHome) return null;
+  if (!isConnected && routingToHomeRoute) return null;
 
-  if (isConnected && routingToHome) return { name: RouteNames.TRANSFER };
+  if (isConnected && routingToHomeRoute) return { name: RouteNames.TRANSFER };
 };

--- a/raiden-dapp/src/router/guards/connection.ts
+++ b/raiden-dapp/src/router/guards/connection.ts
@@ -1,9 +1,5 @@
-import type { Route } from 'vue-router';
-
-import store from '@/store';
-
 import { RouteNames } from '../route-names';
-import type { NavigationGuardNextArgument } from './types';
+import type { NavigationGuardChild } from './types';
 
 const accountRoutes = [
   RouteNames.ACCOUNT_ROOT,
@@ -14,11 +10,7 @@ const accountRoutes = [
   RouteNames.ACCOUNT_UDC,
 ] as string[];
 
-/**
- * @param to - navigation target
- * @returns eventual navigation instruction for middleware of global guard
- */
-export function redirectIfNotConnected(to: Route): NavigationGuardNextArgument | undefined {
+export const redirectIfNotConnected: NavigationGuardChild = (to, store) => {
   const { isConnected } = store.state;
   const routingToAccount = accountRoutes.includes(to.name ?? '');
   const routingToHome = to.name === RouteNames.HOME;
@@ -31,4 +23,4 @@ export function redirectIfNotConnected(to: Route): NavigationGuardNextArgument |
   if (!isConnected && routingToHome) return null;
 
   if (isConnected && routingToHome) return { name: RouteNames.TRANSFER };
-}
+};

--- a/raiden-dapp/src/router/guards/connection.ts
+++ b/raiden-dapp/src/router/guards/connection.ts
@@ -1,7 +1,7 @@
 import { RouteNames } from '../route-names';
 import type { NavigationGuardChild } from './types';
 
-const freeAccountRoutes = [
+const unprotectedAccountRoutes = [
   RouteNames.ACCOUNT_ROOT,
   RouteNames.ACCOUNT_BACKUP,
   RouteNames.ACCOUNT_SETTINGS,
@@ -9,7 +9,7 @@ const freeAccountRoutes = [
 
 export const redirectIfNotConnected: NavigationGuardChild = (to, store) => {
   const { isConnected } = store.state;
-  const routingToFreeAccountRoute = freeAccountRoutes.includes(to.name ?? '');
+  const routingToFreeAccountRoute = unprotectedAccountRoutes.includes(to.name ?? '');
   const routingToHomeRoute = to.name === RouteNames.HOME;
 
   if (routingToFreeAccountRoute) return undefined;

--- a/raiden-dapp/src/router/guards/disclaimer.ts
+++ b/raiden-dapp/src/router/guards/disclaimer.ts
@@ -1,17 +1,7 @@
-import type { Route } from 'vue-router';
-
-import store from '@/store';
-
 import { RouteNames } from '../route-names';
-import type { NavigationGuardNextArgument } from './types';
+import type { NavigationGuardChild } from './types';
 
-/**
- * @param to - navigation target
- * @returns eventual navigation instruction for middleware of global guard
- */
-export function redirectIfDisclaimerIsNotAccepted(
-  to: Route,
-): NavigationGuardNextArgument | undefined {
+export const redirectIfDisclaimerIsNotAccepted: NavigationGuardChild = (to, store) => {
   const { disclaimerAccepted } = store.state;
   const routingToDisclaimer = to.name === RouteNames.DISCLAIMER;
 
@@ -21,4 +11,4 @@ export function redirectIfDisclaimerIsNotAccepted(
   if (!disclaimerAccepted && routingToDisclaimer) return null;
 
   if (disclaimerAccepted && routingToDisclaimer) return { name: RouteNames.HOME };
-}
+};

--- a/raiden-dapp/src/router/guards/global.ts
+++ b/raiden-dapp/src/router/guards/global.ts
@@ -1,22 +1,26 @@
 import type { NavigationGuardNext, Route } from 'vue-router';
+import type { Store } from 'vuex';
+
+import type { CombinedStoreState } from '@/store';
 
 import type { NavigationGuardChild } from './types';
 
 /**
  * @param this - bound function conext
  * @param this.children - list of navigation guard children
+ * @param this.store - store to read state data from
  * @param to - navigation target
  * @param _from - navigation origin (ignored)
  * @param next - middleware function
  */
 export function globalNavigationGuard(
-  this: { children: NavigationGuardChild[] },
+  this: { store: Store<CombinedStoreState>; children: NavigationGuardChild[] },
   to: Route,
   _from: Route,
   next: NavigationGuardNext,
 ) {
   for (const guardChild of this.children) {
-    const redirectLocation = guardChild(to);
+    const redirectLocation = guardChild(to, this.store);
 
     if (redirectLocation === null) {
       next();

--- a/raiden-dapp/src/router/guards/index.ts
+++ b/raiden-dapp/src/router/guards/index.ts
@@ -2,5 +2,6 @@ export * from './account';
 export * from './connection';
 export * from './disclaimer';
 export * from './global';
+export * from './no-connected-token';
 export * from './notifications';
 export * from './types';

--- a/raiden-dapp/src/router/guards/no-connected-token.ts
+++ b/raiden-dapp/src/router/guards/no-connected-token.ts
@@ -1,0 +1,35 @@
+import { RouteNames } from '../route-names';
+import type { NavigationGuardChild } from './types';
+
+const accountRoutes = [
+  RouteNames.ACCOUNT_ROOT,
+  RouteNames.ACCOUNT_BACKUP,
+  RouteNames.ACCOUNT_RAIDEN,
+  RouteNames.ACCOUNT_SETTINGS,
+  RouteNames.ACCOUNT_WITHDRAWAL,
+  RouteNames.ACCOUNT_UDC,
+] as string[];
+
+const connectTokenRoutes = [
+  RouteNames.SELECT_TOKEN,
+  RouteNames.SELECT_HUB,
+  RouteNames.OPEN_CHANNEL,
+] as string[];
+
+export const redirectIfNoConnectedToken: NavigationGuardChild = (to, store) => {
+  const { tokensWithChannels } = store.getters;
+  const noTokenWithChannel = Object.keys(tokensWithChannels).length === 0;
+  const routingToNoTokens = to.name === RouteNames.NO_CONNECTED_TOKEN;
+  const routingToAccountRoute = accountRoutes.includes(to.name ?? '');
+  const routingToConnectTokenRoute = connectTokenRoutes.includes(to.name ?? '');
+
+  if (routingToAccountRoute) return undefined;
+
+  if (routingToConnectTokenRoute) return null;
+
+  if (noTokenWithChannel && !routingToNoTokens) return { name: RouteNames.NO_CONNECTED_TOKEN };
+
+  if (noTokenWithChannel && routingToNoTokens) return null;
+
+  if (!noTokenWithChannel && routingToNoTokens) return { name: RouteNames.TRANSFER };
+};

--- a/raiden-dapp/src/router/guards/types.ts
+++ b/raiden-dapp/src/router/guards/types.ts
@@ -1,4 +1,7 @@
 import type { NavigationGuardNext, RawLocation, Route } from 'vue-router';
+import type { Store } from 'vuex';
+
+import type { CombinedStoreState } from '@/store';
 
 export type GuardArguments = [Route, Route, NavigationGuardNext];
 
@@ -17,4 +20,7 @@ export type NavigationGuardNextArgument = RawLocation | false | null;
  * Note that a returned location of `void` (or `null`) causes an immediate
  * routing to the already targeting location.
  */
-export type NavigationGuardChild = (to: Route) => NavigationGuardNextArgument | undefined;
+export type NavigationGuardChild = (
+  to: Route,
+  store: Store<CombinedStoreState>,
+) => NavigationGuardNextArgument | undefined;

--- a/raiden-dapp/src/router/index.ts
+++ b/raiden-dapp/src/router/index.ts
@@ -6,6 +6,7 @@ import store from '@/store';
 import {
   globalNavigationGuard,
   redirectIfDisclaimerIsNotAccepted,
+  redirectIfNoConnectedToken,
   redirectIfNotConnected,
 } from './guards';
 import { routes } from './routes';
@@ -24,6 +25,7 @@ router.beforeEach(
     children: [
       redirectIfDisclaimerIsNotAccepted,
       redirectIfNotConnected,
+      redirectIfNoConnectedToken,
     ],
   }),
 );

--- a/raiden-dapp/src/router/index.ts
+++ b/raiden-dapp/src/router/index.ts
@@ -1,6 +1,8 @@
 import Vue from 'vue';
 import Router from 'vue-router';
 
+import store from '@/store';
+
 import {
   globalNavigationGuard,
   redirectIfDisclaimerIsNotAccepted,
@@ -18,7 +20,11 @@ const router = new Router({
 
 router.beforeEach(
   globalNavigationGuard.bind({
-    children: [redirectIfDisclaimerIsNotAccepted, redirectIfNotConnected],
+    store,
+    children: [
+      redirectIfDisclaimerIsNotAccepted,
+      redirectIfNotConnected,
+    ],
   }),
 );
 

--- a/raiden-dapp/src/router/route-names.ts
+++ b/raiden-dapp/src/router/route-names.ts
@@ -5,6 +5,7 @@ export enum RouteNames {
   SELECT_TOKEN = 'select-token',
   SELECT_HUB = 'select-hub',
   HOME = 'home',
+  NO_CONNECTED_TOKEN = 'no-connected-token',
   CHANNELS = 'channels',
   OPEN_CHANNEL = 'open-channel',
   ACCOUNT_ROOT = 'account-root',

--- a/raiden-dapp/src/router/routes.ts
+++ b/raiden-dapp/src/router/routes.ts
@@ -31,6 +31,15 @@ export const routes: RouteConfig[] = [
     component: Home,
   },
   {
+    path: '/no_connected_token',
+    name: RouteNames.NO_CONNECTED_TOKEN,
+    meta: {
+      title: 'Connect',
+      cannotNavigateBack: true,
+    },
+    component: () => import('../views/NoConnectedTokenRoute.vue'),
+  },
+  {
     path: '/transfer/:token?',
     name: RouteNames.TRANSFER,
     meta: {

--- a/raiden-dapp/src/store/notifications/getters.ts
+++ b/raiden-dapp/src/store/notifications/getters.ts
@@ -4,24 +4,25 @@ import { NotificationImportance } from '@/store/notifications/notification-impor
 import type { NotificationPayload, NotificationsState } from '@/store/notifications/types';
 import type { RootState } from '@/types';
 
+function compareById(a: NotificationPayload, b: NotificationPayload): number {
+  return b.id - a.id;
+}
+
 type Getters = {
   notifications(state: NotificationsState): NotificationPayload[];
-  nextNotificationId({ notifications }: NotificationsState): number;
   notificationQueue(state: NotificationsState): NotificationPayload[];
 };
 
 export const getters: GetterTree<NotificationsState, RootState> & Getters = {
   notifications: (state: NotificationsState): NotificationPayload[] => {
-    return Object.values(state.notifications).sort((a, b) => b.id - a.id);
-  },
-  nextNotificationId: ({ notifications }: NotificationsState): number => {
-    const id = Object.values(notifications).map((notification) => notification.id);
-    return Math.max(...id, 0) + 1;
+    return Object.values(state.notifications).sort(compareById);
   },
   notificationQueue: (state: NotificationsState): NotificationPayload[] => {
-    return Object.values(state.notifications).filter(
-      (notification) =>
-        notification.importance === NotificationImportance.HIGH && notification.display === true,
-    );
+    return Object.values(state.notifications)
+      .filter(
+        (notification) =>
+          notification.importance === NotificationImportance.HIGH && notification.display === true,
+      )
+      .sort(compareById);
   },
 };

--- a/raiden-dapp/src/views/NoConnectedTokenRoute.vue
+++ b/raiden-dapp/src/views/NoConnectedTokenRoute.vue
@@ -1,0 +1,23 @@
+<template>
+  <v-container class="no-connected-token fill-height flex-column justify-center" fluid>
+    <v-btn
+      data-cy="no-connected-token__connect-button"
+      class="no-connected-token__connect-button"
+      color="primary"
+      fab
+      @click="navigateToTokenSelect()"
+    >
+      <v-icon large>mdi-plus</v-icon>
+    </v-btn>
+    <span class="no-connected-token__connect-label pt-4">{{ $t('tokens.connect-new') }}</span>
+  </v-container>
+</template>
+
+<script lang="ts">
+import { Component, Mixins } from 'vue-property-decorator';
+
+import NavigationMixin from '@/mixins/navigation-mixin';
+
+@Component
+export default class NoConnectedTokenRoute extends Mixins(NavigationMixin) {}
+</script>

--- a/raiden-dapp/src/views/TransferRoute.vue
+++ b/raiden-dapp/src/views/TransferRoute.vue
@@ -1,24 +1,21 @@
 <template>
   <v-container class="transfer" fluid>
-    <no-tokens v-if="noTokenWithOpenChannel" />
-    <template v-else>
-      <transfer-headers
-        class="transfer__menus"
-        :token="token"
-        :no-channels="noChannels"
-        :total-capacity="totalCapacity"
-      />
-      <transfer-inputs
-        class="transfer__inputs"
-        :token.sync="token"
-        :transfer-amount.sync="transferAmount"
-        :target-address.sync="targetAddress"
-        :no-channels="noChannels"
-        :max-channel-capacity="maxChannelCapacity"
-      />
-      <transaction-list class="transfer__list" :token="token" />
-      <no-channels-dialog :visible="!openChannels" />
-    </template>
+    <transfer-headers
+      class="transfer__menus"
+      :token="token"
+      :no-channels="noChannels"
+      :total-capacity="totalCapacity"
+    />
+    <transfer-inputs
+      class="transfer__inputs"
+      :token.sync="token"
+      :transfer-amount.sync="transferAmount"
+      :target-address.sync="targetAddress"
+      :no-channels="noChannels"
+      :max-channel-capacity="maxChannelCapacity"
+    />
+    <transaction-list class="transfer__list" :token="token" />
+    <no-channels-dialog :visible="!openChannels" />
   </v-container>
 </template>
 
@@ -73,10 +70,6 @@ export default class TransferRoute extends Vue {
   transferAmount = '';
   targetAddress = '';
 
-  get noTokenWithOpenChannel(): boolean {
-    return Object.keys(this.tokensWithChannels).length === 0;
-  }
-
   get noChannels(): boolean {
     if (this.token) {
       return this.channels(this.token.address).length === 0;
@@ -130,15 +123,6 @@ export default class TransferRoute extends Vue {
     }
   }
 
-  @Watch('noTokenWithOpenChannel')
-  onNoTokenWithOpenChannelChange(now: boolean, before: boolean): void {
-    const switchFromNoTokenWithOpenChannelToSome = before && !now;
-
-    if (switchFromNoTokenWithOpenChannelToSome) {
-      this.selectFirstAvailableTokenIfAny();
-    }
-  }
-
   @Watch('$route.query.amount', { immediate: true })
   async onAmountQueryParameterChanged(transferAmount: string | undefined) {
     this.transferAmount = transferAmount ?? '';
@@ -160,9 +144,7 @@ export default class TransferRoute extends Vue {
   }
 
   selectFirstAvailableTokenIfAny(): void {
-    if (!this.noTokenWithOpenChannel) {
-      this.token = Object.values(this.tokensWithChannels)[0];
-    }
+    this.token = Object.values(this.tokensWithChannels)[0];
   }
 
   handleBackupNotification(): void {

--- a/raiden-dapp/tests/e2e/specs/scenario.spec.ts
+++ b/raiden-dapp/tests/e2e/specs/scenario.spec.ts
@@ -32,7 +32,6 @@ import {
   closeNotificationPanel,
   connectToDApp,
   deleteTopNotification,
-  dismissNotificationSnackbar,
   downloadState,
   enterAndSelectHub,
   enterChannelDepositAmount,
@@ -70,9 +69,8 @@ describe('dApp e2e tests', () => {
     enterChannelDepositAmount(uiTimeout);
     openChannel();
     navigateToNotificationPanel();
-    deleteTopNotification();
+    deleteTopNotification(); // This must be the sticky backup notification.
     closeNotificationPanel();
-    dismissNotificationSnackbar(); // This is the backup reminder which blocks sticky buttons.
     enterTransferAddress(uiTimeout, partnerAddress);
     enterTransferAmount(uiTimeout);
     makeDirectTransfer(uiTimeout);

--- a/raiden-dapp/tests/e2e/utils/navigation.ts
+++ b/raiden-dapp/tests/e2e/utils/navigation.ts
@@ -12,8 +12,8 @@ export function navigateToDisclaimer() {
  */
 export function navigateToSelectHub() {
   // cypress selectors: raiden-dapp/src/components/NoTokens.vue
-  cy.getWithCustomTimeout('[data-cy=no_tokens_add]').should('exist');
-  cy.get('[data-cy=no_tokens_add]').click();
+  cy.getWithCustomTimeout('[data-cy=no-connected-token__connect-button]').should('exist');
+  cy.get('[data-cy=no-connected-token__connect-button]').click();
   // cypress selectors: raiden-dapp/src/components/tokens/TokenListItem.vue
   cy.getWithCustomTimeout('[data-cy=token_list_item]').eq(0).should('exist');
   cy.get('[data-cy=token_list_item]').eq(0).click();

--- a/raiden-dapp/tests/e2e/utils/user-interaction.ts
+++ b/raiden-dapp/tests/e2e/utils/user-interaction.ts
@@ -16,6 +16,7 @@ export function acceptDisclaimer() {
 export function connectToDApp() {
   // cypress selectors: raiden-dapp/src/views/Home.vue
   cy.get('[data-cy=home]').should('exist');
+  cy.get('[data-cy=connection-manager__provider-dialog-button]').should('exist');
   cy.get('[data-cy=connection-manager__provider-dialog-button]').click();
   cy.get('[data-cy=direct-rpc-provider]').should('exist');
   cy.get('[data-cy=direct-rpc-provider__options__rpc-url]')
@@ -77,15 +78,6 @@ export function closeNotificationPanel() {
   cy.get('[data-cy=notification_panel_content_close_button]').should('exist');
   cy.get('[data-cy=notification_panel_content_close_button]').click();
   cy.getWithCustomTimeout('[data-cy=notification_panel]').should('not.exist');
-}
-
-/**
- *
- */
-export function dismissNotificationSnackbar() {
-  cy.get('[data-cy=notification-snackbar__dismiss-button]').should('exist');
-  cy.get('[data-cy=notification-snackbar__dismiss-button]').click();
-  cy.getWithCustomTimeout('[data-cy=notification-snackbar__dismiss-button]').should('not.exist');
 }
 
 /**

--- a/raiden-dapp/tests/unit/router/guards/connection.spec.ts
+++ b/raiden-dapp/tests/unit/router/guards/connection.spec.ts
@@ -14,21 +14,11 @@ const {
   [RouteNames.HOME]: homeRoute,
   [RouteNames.ACCOUNT_ROOT]: accountRootRoute,
   [RouteNames.ACCOUNT_BACKUP]: accountBackupRoute,
-  [RouteNames.ACCOUNT_RAIDEN]: accountRaidenRoute,
   [RouteNames.ACCOUNT_SETTINGS]: accountSettingsRoute,
-  [RouteNames.ACCOUNT_WITHDRAWAL]: accountWithdrawalRoute,
-  [RouteNames.ACCOUNT_UDC]: accountUdcRoute,
   ...protectedRoutes
 } = transformRouteConfigsToRoutes();
 
-const accountRoutes = [
-  accountRootRoute,
-  accountBackupRoute,
-  accountRaidenRoute,
-  accountSettingsRoute,
-  accountWithdrawalRoute,
-  accountUdcRoute,
-];
+const freeAccountRoutes = [accountRootRoute, accountBackupRoute, accountSettingsRoute];
 
 function createStore(options?: { isConnected?: boolean }): Store<CombinedStoreState> {
   const state = {
@@ -81,10 +71,10 @@ describe('redirectIfNotConnected()', () => {
     });
   });
 
-  test('do nothing if not connected and navigating to any account route', () => {
+  test('do nothing if navigating to a free account route', () => {
     const store = createStore({ isConnected: false });
 
-    Object.values(accountRoutes).forEach((route) => {
+    Object.values(freeAccountRoutes).forEach((route) => {
       expect(redirectIfNotConnected(route, store)).toBeUndefined();
     });
   });

--- a/raiden-dapp/tests/unit/router/guards/connection.spec.ts
+++ b/raiden-dapp/tests/unit/router/guards/connection.spec.ts
@@ -18,7 +18,7 @@ const {
   ...protectedRoutes
 } = transformRouteConfigsToRoutes();
 
-const freeAccountRoutes = [accountRootRoute, accountBackupRoute, accountSettingsRoute];
+const unprotectedAccountRoutes = [accountRootRoute, accountBackupRoute, accountSettingsRoute];
 
 function createStore(options?: { isConnected?: boolean }): Store<CombinedStoreState> {
   const state = {
@@ -74,7 +74,7 @@ describe('redirectIfNotConnected()', () => {
   test('do nothing if navigating to a free account route', () => {
     const store = createStore({ isConnected: false });
 
-    Object.values(freeAccountRoutes).forEach((route) => {
+    Object.values(unprotectedAccountRoutes).forEach((route) => {
       expect(redirectIfNotConnected(route, store)).toBeUndefined();
     });
   });

--- a/raiden-dapp/tests/unit/router/guards/connection.spec.ts
+++ b/raiden-dapp/tests/unit/router/guards/connection.spec.ts
@@ -1,8 +1,14 @@
+import { createLocalVue } from '@vue/test-utils';
+import Vuex, { Store } from 'vuex';
+
 import { redirectIfNotConnected } from '@/router/guards/connection';
 import { RouteNames } from '@/router/route-names';
-import store from '@/store';
+import type { CombinedStoreState } from '@/store';
 
 import { transformRouteConfigsToRoutes } from '../../utils/router-utils';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
 
 const {
   [RouteNames.HOME]: homeRoute,
@@ -24,60 +30,62 @@ const accountRoutes = [
   accountUdcRoute,
 ];
 
-describe('redirectIfNotConnected()', () => {
-  beforeEach(() => {
-    store.commit('setDisconnected');
-  });
+function createStore(options?: { isConnected?: boolean }): Store<CombinedStoreState> {
+  const state = {
+    isConnected: options?.isConnected ?? false,
+  };
 
+  return new Store({ state }) as Store<CombinedStoreState>;
+}
+
+describe('redirectIfNotConnected()', () => {
   test('redirect to home route if not connected', () => {
-    expect(store.state.isConnected).toBe(false);
+    const store = createStore({ isConnected: false });
 
     Object.values(protectedRoutes).forEach((route) => {
-      expect(redirectIfNotConnected(route)).toEqual(
+      expect(redirectIfNotConnected(route, store)).toEqual(
         expect.objectContaining({ name: RouteNames.HOME }),
       );
     });
   });
 
   test('add redirect query parameter to original target when redirecting to home route', () => {
-    expect(store.state.isConnected).toBe(false);
+    const store = createStore({ isConnected: false });
 
     Object.values(protectedRoutes).forEach((route) => {
-      expect(redirectIfNotConnected(route)).toEqual(
+      expect(redirectIfNotConnected(route, store)).toEqual(
         expect.objectContaining({ query: { redirectTo: route.fullPath } }),
       );
     });
   });
 
   test('continue navigation if not connected, but navigate to home route already', () => {
-    expect(store.state.isConnected).toBe(false);
+    const store = createStore({ isConnected: false });
 
-    expect(redirectIfNotConnected(homeRoute)).toBeNull();
+    expect(redirectIfNotConnected(homeRoute, store)).toBeNull();
   });
 
   test('skip home route if already connected', () => {
-    store.commit('setConnected');
-    expect(store.state.isConnected).toBe(true);
+    const store = createStore({ isConnected: true });
 
-    expect(redirectIfNotConnected(homeRoute)).toEqual({
+    expect(redirectIfNotConnected(homeRoute, store)).toEqual({
       name: RouteNames.TRANSFER,
     });
   });
 
   test('do nothing if connected and not navigating to home route', () => {
-    store.commit('setConnected');
-    expect(store.state.isConnected).toBe(true);
+    const store = createStore({ isConnected: true });
 
     Object.values(protectedRoutes).forEach((route) => {
-      expect(redirectIfNotConnected(route)).toBeUndefined();
+      expect(redirectIfNotConnected(route, store)).toBeUndefined();
     });
   });
 
   test('do nothing if not connected and navigating to any account route', () => {
-    expect(store.state.isConnected).toBe(false);
+    const store = createStore({ isConnected: false });
 
     Object.values(accountRoutes).forEach((route) => {
-      expect(redirectIfNotConnected(route)).toBeUndefined();
+      expect(redirectIfNotConnected(route, store)).toBeUndefined();
     });
   });
 });

--- a/raiden-dapp/tests/unit/router/guards/disclaimer.spec.ts
+++ b/raiden-dapp/tests/unit/router/guards/disclaimer.spec.ts
@@ -1,68 +1,66 @@
+import { createLocalVue } from '@vue/test-utils';
+import Vuex, { Store } from 'vuex';
+
 import { redirectIfDisclaimerIsNotAccepted } from '@/router/guards/disclaimer';
 import { RouteNames } from '@/router/route-names';
-import store from '@/store';
+import type { CombinedStoreState } from '@/store';
 
 import { transformRouteConfigsToRoutes } from '../../utils/router-utils';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
 
 const { [RouteNames.DISCLAIMER]: disclaimerRoute, ...routesWithoutDisclaimer } =
   transformRouteConfigsToRoutes();
 
-function acceptDisclaimer() {
-  store.commit('acceptDisclaimer', true);
+function createStore(options?: { disclaimerAccepted?: boolean }): Store<CombinedStoreState> {
+  const state = {
+    disclaimerAccepted: options?.disclaimerAccepted ?? false,
+  };
+
+  return new Store({ state }) as Store<CombinedStoreState>;
 }
 
 describe('redirectIfDisclaimerIsNotAccepted()', () => {
   test('redirect to disclaimer route if disclaimer is not accepted', () => {
-    expect(store.state.disclaimerAccepted).toBe(false);
+    const store = createStore({ disclaimerAccepted: false });
 
     Object.values(routesWithoutDisclaimer).forEach((route) => {
-      expect(redirectIfDisclaimerIsNotAccepted(route)).toEqual(
+      expect(redirectIfDisclaimerIsNotAccepted(route, store)).toEqual(
         expect.objectContaining({ name: RouteNames.DISCLAIMER }),
       );
     });
   });
 
   test('add redirect query parameter to original target when redirecting to disclaimer route', () => {
-    expect(store.state.disclaimerAccepted).toBe(false);
+    const store = createStore({ disclaimerAccepted: false });
 
     Object.values(routesWithoutDisclaimer).forEach((route) => {
-      expect(redirectIfDisclaimerIsNotAccepted(route)).toEqual(
+      expect(redirectIfDisclaimerIsNotAccepted(route, store)).toEqual(
         expect.objectContaining({ query: { redirectTo: route.fullPath } }),
       );
     });
   });
 
   test('continue navigation if disclaimer is not accepted, but navigate to disclaimer route already', () => {
-    expect(store.state.disclaimerAccepted).toBe(false);
+    const store = createStore({ disclaimerAccepted: false });
 
-    expect(redirectIfDisclaimerIsNotAccepted(disclaimerRoute)).toBeNull();
+    expect(redirectIfDisclaimerIsNotAccepted(disclaimerRoute, store)).toBeNull();
   });
 
   test('skip disclaimer route if disclaimer is accepted', () => {
-    acceptDisclaimer();
+    const store = createStore({ disclaimerAccepted: true });
 
-    expect(redirectIfDisclaimerIsNotAccepted(disclaimerRoute)).toEqual({
+    expect(redirectIfDisclaimerIsNotAccepted(disclaimerRoute, store)).toEqual({
       name: RouteNames.HOME,
     });
   });
 
   test('do nothing if disclaimer is accepted and not navigating to disclaimer route', () => {
-    acceptDisclaimer();
+    const store = createStore({ disclaimerAccepted: true });
 
     Object.values(routesWithoutDisclaimer).forEach((route) => {
-      expect(redirectIfDisclaimerIsNotAccepted(route)).toBeUndefined();
+      expect(redirectIfDisclaimerIsNotAccepted(route, store)).toBeUndefined();
     });
   });
-
-  // test('define redirect query when  causes redirect', async () => {
-  //   const guardArguments: GuardArguments = [otherRoute, anyRoute, next];
-  //   globalNavigationGuard.apply(
-  //     { children: [firstChildGuard] },
-  //     guardArguments
-  //   );
-  //   expect(next).toHaveBeenCalledWith({
-  //     name: 'first-route',
-  //     query: { redirectTo: '/other-path' }
-  //   });
-  // });
 });

--- a/raiden-dapp/tests/unit/router/guards/no-connected-token.spec.ts
+++ b/raiden-dapp/tests/unit/router/guards/no-connected-token.spec.ts
@@ -37,7 +37,7 @@ const connectTokenRoutes = [selectTokenRoute, selectHubRoute, openChannelRoute];
 
 const tokens = {
   '0xtoken': {
-    '0xpartner': 1, // just something...
+    '0xpartner': 'channel-data',
   },
 };
 

--- a/raiden-dapp/tests/unit/router/guards/no-connected-token.spec.ts
+++ b/raiden-dapp/tests/unit/router/guards/no-connected-token.spec.ts
@@ -1,0 +1,100 @@
+import { createLocalVue } from '@vue/test-utils';
+import Vuex, { Store } from 'vuex';
+
+import { redirectIfNoConnectedToken } from '@/router/guards/no-connected-token';
+import { RouteNames } from '@/router/route-names';
+import type { CombinedStoreState } from '@/store';
+
+import { transformRouteConfigsToRoutes } from '../../utils/router-utils';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+const {
+  [RouteNames.NO_CONNECTED_TOKEN]: noConnectedTokenRoute,
+  [RouteNames.ACCOUNT_ROOT]: accountRootRoute,
+  [RouteNames.ACCOUNT_BACKUP]: accountBackupRoute,
+  [RouteNames.ACCOUNT_RAIDEN]: accountRaidenRoute,
+  [RouteNames.ACCOUNT_SETTINGS]: accountSettingsRoute,
+  [RouteNames.ACCOUNT_WITHDRAWAL]: accountWithdrawalRoute,
+  [RouteNames.ACCOUNT_UDC]: accountUdcRoute,
+  [RouteNames.SELECT_TOKEN]: selectTokenRoute,
+  [RouteNames.SELECT_HUB]: selectHubRoute,
+  [RouteNames.OPEN_CHANNEL]: openChannelRoute,
+  ...protectedRoutes
+} = transformRouteConfigsToRoutes();
+
+const accountRoutes = [
+  accountRootRoute,
+  accountBackupRoute,
+  accountRaidenRoute,
+  accountSettingsRoute,
+  accountWithdrawalRoute,
+  accountUdcRoute,
+];
+
+const connectTokenRoutes = [selectTokenRoute, selectHubRoute, openChannelRoute];
+
+const tokens = {
+  '0xtoken': {
+    '0xpartner': 1, // just something...
+  },
+};
+
+function createStore(options?: { hasConnectedToken?: boolean }): Store<CombinedStoreState> {
+  const getters = {
+    tokensWithChannels: () => (options?.hasConnectedToken ? tokens : {}),
+  };
+
+  return new Store({ getters }) as Store<CombinedStoreState>;
+}
+
+describe('redirectIfNoConnectedToken()', () => {
+  test('redirect to no connected token route if no tokens is connected', () => {
+    const store = createStore({ hasConnectedToken: false });
+
+    Object.values(protectedRoutes).forEach((route) => {
+      expect(redirectIfNoConnectedToken(route, store)).toEqual(
+        expect.objectContaining({ name: RouteNames.NO_CONNECTED_TOKEN }),
+      );
+    });
+  });
+
+  test('always continue navigation if navigate to token connection related route', () => {
+    const store = createStore();
+
+    Object.values(connectTokenRoutes).forEach((route) => {
+      expect(redirectIfNoConnectedToken(route, store)).toBeNull();
+    });
+  });
+
+  test('continue navigation if no token is connected, but navigate to no connected token route already', () => {
+    const store = createStore({ hasConnectedToken: false });
+
+    expect(redirectIfNoConnectedToken(noConnectedTokenRoute, store)).toBeNull();
+  });
+
+  test('skip no connected token route if there is a connected token', () => {
+    const store = createStore({ hasConnectedToken: true });
+
+    expect(redirectIfNoConnectedToken(noConnectedTokenRoute, store)).toEqual({
+      name: RouteNames.TRANSFER,
+    });
+  });
+
+  test('do nothing if there is a connected token and not navigating to no connected token route', () => {
+    const store = createStore({ hasConnectedToken: true });
+
+    Object.values(protectedRoutes).forEach((route) => {
+      expect(redirectIfNoConnectedToken(route, store)).toBeUndefined();
+    });
+  });
+
+  test('do nothing if navigating to any account related route', () => {
+    const store = createStore({ hasConnectedToken: false });
+
+    Object.values(accountRoutes).forEach((route) => {
+      expect(redirectIfNoConnectedToken(route, store)).toBeUndefined();
+    });
+  });
+});

--- a/raiden-dapp/tests/unit/utils/data-generator.ts
+++ b/raiden-dapp/tests/unit/utils/data-generator.ts
@@ -5,6 +5,8 @@ import type { Address, RaidenChannel, RaidenTransfer } from 'raiden-ts';
 import { ChannelState } from 'raiden-ts';
 
 import type { Token } from '@/model/types';
+import { NotificationContext } from '@/store/notifications/notification-context';
+import { NotificationImportance } from '@/store/notifications/notification-importance';
 import type { NotificationPayload } from '@/store/notifications/types';
 import type { SuggestedPartner } from '@/types';
 
@@ -142,4 +144,24 @@ export function generateSuggestedPartner(
     uptime: 788,
     ...partialSuggestedPartner,
   } as SuggestedPartner;
+}
+
+/**
+ * @param partialNotification - NotificationPayload overrides
+ * @returns NotificationPyalod mocked object
+ */
+export function generateNotification(
+  partialNotification: Partial<NotificationPayload> = {},
+): NotificationPayload {
+  return {
+    id: 1,
+    title: 'Channel Settlement',
+    description: 'Channel with 0x09123456789 was settled.',
+    display: true,
+    duration: 5000,
+    importance: NotificationImportance.HIGH,
+    context: NotificationContext.NONE,
+    received: new Date('June 5, 1986'),
+    ...partialNotification,
+  } as NotificationPayload;
 }

--- a/raiden-dapp/tests/unit/views/no-connected-token-route.spec.ts
+++ b/raiden-dapp/tests/unit/views/no-connected-token-route.spec.ts
@@ -1,0 +1,52 @@
+import { $t } from '../utils/mocks';
+
+import type { Wrapper } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
+import Vue from 'vue';
+import VueRouter from 'vue-router';
+import Vuetify from 'vuetify';
+
+import { RouteNames } from '@/router/route-names';
+import NoConnectedTokenRoute from '@/views/NoConnectedTokenRoute.vue';
+
+jest.mock('vue-router');
+
+Vue.use(Vuetify);
+
+const vuetify = new Vuetify();
+const $router = new VueRouter();
+
+function createWrapper(): Wrapper<NoConnectedTokenRoute> {
+  return mount(NoConnectedTokenRoute, { vuetify, mocks: { $router, $t } });
+}
+
+describe('NoConnetedTokenRoute.vue', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('displays button to connect new token', () => {
+    const wrapper = createWrapper();
+    const connectButton = wrapper.find('.no-connected-token__connect-button');
+
+    expect(connectButton.isVisible()).toBeTruthy();
+  });
+
+  test('displays label to guide the user', () => {
+    const wrapper = createWrapper();
+    const connectLabel = wrapper.find('.no-connected-token__connect-label');
+
+    expect(connectLabel.isVisible()).toBeTruthy();
+    expect(connectLabel.text()).toBe('tokens.connect-new');
+  });
+
+  test('navigates to select token route when clicking button', async () => {
+    const wrapper = createWrapper();
+    const connectButton = wrapper.get('.no-connected-token__connect-button');
+
+    connectButton.trigger('click');
+
+    expect($router.push).toHaveBeenCalledTimes(1);
+    expect($router.push).toHaveBeenCalledWith({ name: RouteNames.SELECT_TOKEN });
+  });
+});

--- a/raiden-dapp/tests/unit/views/transfer-route.spec.ts
+++ b/raiden-dapp/tests/unit/views/transfer-route.spec.ts
@@ -9,7 +9,6 @@ import Vuex from 'vuex';
 import type { RaidenChannel } from 'raiden-ts';
 
 import NoChannelsDialog from '@/components/dialogs/NoChannelsDialog.vue';
-import NoTokens from '@/components/NoTokens.vue';
 import TransactionList from '@/components/transaction-history/TransactionList.vue';
 import TransferHeaders from '@/components/transfer/TransferHeaders.vue';
 import TransferInputs from '@/components/transfer/TransferInputs.vue';
@@ -95,22 +94,25 @@ describe('TransferRoute.vue', () => {
     jest.clearAllMocks();
   });
 
-  // TODO: This and the following test case their description are a hint that
-  // the components template is not too nice.
-  test('displays no tokens component if there are no tokens and hide rest', async () => {
+  test('displays transfer headers', async () => {
     const wrapper = await createWrapper({ tokens: {} });
-    expect(wrapper.findComponent(NoTokens).exists()).toBe(true);
-    expect(wrapper.findComponent(TransferHeaders).exists()).toBe(false);
-    expect(wrapper.findComponent(TransferInputs).exists()).toBe(false);
-    expect(wrapper.findComponent(TransactionList).exists()).toBe(false);
+    const transferHeaders = wrapper.findComponent(TransferHeaders);
+
+    expect(transferHeaders.isVisible()).toBeTruthy();
   });
 
-  test('does not display no tokens component if there are no tokens, but rest', async () => {
-    const wrapper = await createWrapper();
-    expect(wrapper.findComponent(NoTokens).exists()).toBe(false);
-    expect(wrapper.findComponent(TransferHeaders).exists()).toBe(true);
-    expect(wrapper.findComponent(TransferInputs).exists()).toBe(true);
-    expect(wrapper.findComponent(TransactionList).exists()).toBe(true);
+  test('displays transfer inputs', async () => {
+    const wrapper = await createWrapper({ tokens: {} });
+    const transferInputs = wrapper.findComponent(TransferInputs);
+
+    expect(transferInputs.isVisible()).toBeTruthy();
+  });
+
+  test('displays transation list', async () => {
+    const wrapper = await createWrapper({ tokens: {} });
+    const transactionList = wrapper.findComponent(TransactionList);
+
+    expect(transactionList.isVisible()).toBeTruthy();
   });
 
   test('shows dialog if there are no open channels', async () => {


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2675

**Short description**

Solution description with background details in the linked issue. All other infos in the according commits. 
This includes some nice improvements of the router guards.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Connect to the dApp and use an account you never used for it before
2. Make sure you see the route to connect your frist token
3. Try to access the transfer route for example and make sure you get redirected again
4. Make sure you can still access all account routes (e.g. to transfer ETH or deposit to UDC)
5. Add your first token/open a channel and make sure all routes are accessible for that
6. Make sure you finally can access the transfer route (also after reload/re-connect)
