### PR TITLE
dapp: fix flaky end-to-end tests

### DIFF
--- a/raiden-dapp/src/components/notification-panel/NotificationSnackbar.vue
+++ b/raiden-dapp/src/components/notification-panel/NotificationSnackbar.vue
@@ -21,7 +21,13 @@
       </v-col>
     </v-row>
     <template #action="{ attrs }">
-      <v-btn icon left v-bind="attrs" @click="dismiss()">
+      <v-btn
+        data-cy="notification-snackbar__dismiss-button"
+        icon
+        left
+        v-bind="attrs"
+        @click="dismiss()"
+      >
         <v-icon>mdi-close</v-icon>
       </v-btn>
     </template>

--- a/raiden-dapp/src/views/TransferRoute.vue
+++ b/raiden-dapp/src/views/TransferRoute.vue
@@ -179,7 +179,7 @@ export default class TransferRoute extends Vue {
       link: this.$t('notifications.backup-state.link') as string,
       dappRoute: RouteNames.ACCOUNT_BACKUP,
       description: this.$t('notifications.backup-state.description') as string,
-      duration: 60000,
+      duration: -1,
       importance: NotificationImportance.HIGH,
       context: NotificationContext.WARNING,
     } as NotificationPayload;

--- a/raiden-dapp/tests/e2e/specs/scenario.spec.ts
+++ b/raiden-dapp/tests/e2e/specs/scenario.spec.ts
@@ -32,6 +32,7 @@ import {
   closeNotificationPanel,
   // connectToDApp,
   deleteTopNotification,
+  dismissNotificationSnackbar,
   downloadState,
   enterAndSelectHub,
   enterChannelDepositAmount,
@@ -71,6 +72,7 @@ describe('dApp e2e tests', () => {
     navigateToNotificationPanel();
     deleteTopNotification();
     closeNotificationPanel();
+    dismissNotificationSnackbar(); // This is the backup reminder which blocks sticky buttons.
     enterTransferAddress(uiTimeout, partnerAddress);
     enterTransferAmount(uiTimeout);
     makeDirectTransfer(uiTimeout);

--- a/raiden-dapp/tests/e2e/utils/user-interaction.ts
+++ b/raiden-dapp/tests/e2e/utils/user-interaction.ts
@@ -70,6 +70,15 @@ export function closeNotificationPanel() {
 }
 
 /**
+ *
+ */
+export function dismissNotificationSnackbar() {
+  cy.get('[data-cy=notification-snackbar__dismiss-button]').should('exist');
+  cy.get('[data-cy=notification-snackbar__dismiss-button]').click();
+  cy.getWithCustomTimeout('[data-cy=notification-snackbar__dismiss-button]').should('not.exist');
+}
+
+/**
  * @param uiTimeout - Timeout to wait
  * @param partnerAddress - Partner address
  */


### PR DESCRIPTION
The end-to-end tests of the dApp have started to fail sometimes. After long research it turned out that this is a timing issue. The issue that bubbles up as a result was that certain sticky buttons where hidden by a notification snackbar. Therefore they could not be clicked and tests failed.

The snackbar that was hiding the button was the backup reminder. It gets displayed for 60s when the user does not dismiss it manually. Also removing the notification from the panel has no effect on it. On older versions, the tests apparently took a little longer. At this time in the  scenario the snackbar already disappeared when one of these button should be clicked.
Now this was apparently a  game of a view (milli)seconds where the snackbar either disappeared too late or early enough.

The solution for this issue is to make the backup reminder notification to never disappear automatically and dismiss the snackbar in the tests. It must not disappear automatically, because else it would remain the uncertainty if the snackbar is still there when it get attempted to be closed. Though there could have been established a conditional interaction, having a sticky snackbar for this notification is fine. Doing a backup is important and the user should dismiss it himself. That's a common behavior among many dApps.

---

PS:
After both changes are fine by themselves even without the end-to-end issue. As I already argues it makes sense to to automatically dismiss the snackbar for this notification. And manually dismissing it in the tests is also a valid interaction/test.