### PR TITLE
dapp: fix token overlay for small screens

### DIFF
--- a/raiden-dapp/src/components/overlays/TokenOverlay.vue
+++ b/raiden-dapp/src/components/overlays/TokenOverlay.vue
@@ -12,16 +12,14 @@
         class="token-overlay__connect-new"
         @click="navigateToTokenSelect()"
       >
-        <v-col cols="2">
-          <v-list-item-avatar>
-            <v-btn class="mx-2" fab dark small color="primary">
-              <v-icon dark large>mdi-plus</v-icon>
-            </v-btn>
-          </v-list-item-avatar>
-        </v-col>
-        <v-col cols="10" align-self="center" class="font-weight-bold">
+        <v-list-item-avatar>
+          <v-btn fab color="primary">
+            <v-icon>mdi-plus</v-icon>
+          </v-btn>
+        </v-list-item-avatar>
+        <v-list-item-content class="font-weight-bold">
           {{ $t('tokens.connect-new') }}
-        </v-col>
+        </v-list-item-content>
       </v-list-item>
     </v-list>
 


### PR DESCRIPTION

Fixes part of [this comment](https://github.com/raiden-network/light-client/issues/2604#issuecomment-822344517) in #2604

**Short description**
Just simpler code that is more stable.
Please note that the alignment of the component has changed. I would argue that this is now correct as the appereance before was actually not intended (at least not visible in code). @taleldayekh please tell me if this was actually required.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Click  on the token dropdown
2. Inspect the view (especially the "connect new token" part) on different and especially very small screen widths and make the icon does not reshape.
