### PR TITLE
dapp: Use demo env on staging temporarily

### DIFF
--- a/raiden-dapp/.env.staging
+++ b/raiden-dapp/.env.staging
@@ -1,5 +1,8 @@
 VUE_APP_PUBLIC_PATH=/staging/
 VUE_APP_HUB=hub.raiden.eth
 VUE_APP_ALLOW_MAINNET=false
+VUE_APP_PFS=https://pfs.demo001.env.raiden.network
+VUE_APP_MATRIX_SERVER=https://transport.demo001.env.raiden.network
+VUE_APP_UDC_ADDRESS=0x0794F09913AA8C77C8c5bdd1Ec4Bb51759Ee0cC5
 VUE_APP_IMPRINT=https://raiden.network/privacy.html
 VUE_APP_TERMS=https://github.com/raiden-network/light-client/blob/master/TERMS.md


### PR DESCRIPTION
Otherwise the dApp cannot be used at all until `next` is merged

Once merged, I'll revert this commit on `next`.
