### PR TITLE
Passthrough metadata unchanged

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- [#2766] Add `Capabilities.IMMUTABLE_METADATA` (true on LC, fallback to falsy for backwards compatibility) to allow opting in of not prunning metadata.route and allowing to pass it through mediators unchanged
+
 ### Fixed
 - [#2831] Force PFS to acknowledge our capabilities updates
 
+[#2766]: https://github.com/raiden-network/light-client/pull/2766
 [#2831]: https://github.com/raiden-network/light-client/issues/2831
 
 ## [1.0.0] - 2021-06-16

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -134,6 +134,7 @@ export function makeDefaultConfig(
           [Capabilities.DELIVERY]: 0,
           [Capabilities.MEDIATE]: 0,
           [Capabilities.TO_DEVICE]: 1,
+          [Capabilities.IMMUTABLE_METADATA]: 1,
           ...overwrites?.caps,
         };
   return {

--- a/raiden-ts/src/constants.ts
+++ b/raiden-ts/src/constants.ts
@@ -22,6 +22,7 @@ export enum Capabilities {
   MEDIATE = 'Mediate', // whether to mediate transfers; requires receiving
   WEBRTC = 'webRTC', // use WebRTC channels for p2p messaging
   TO_DEVICE = 'toDevice', // use ToDevice messages instead of rooms
+  IMMUTABLE_METADATA = 'immutableMetadata', // passthrough metadata unchanged
 }
 
 export const CapsFallback = {
@@ -30,6 +31,7 @@ export const CapsFallback = {
   [Capabilities.MEDIATE]: 1,
   [Capabilities.WEBRTC]: 0,
   [Capabilities.TO_DEVICE]: 1,
+  [Capabilities.IMMUTABLE_METADATA]: 0,
 } as const;
 
 export const RAIDEN_DEVICE_ID = 'RAIDEN';

--- a/raiden-ts/src/messages/types.ts
+++ b/raiden-ts/src/messages/types.ts
@@ -121,9 +121,6 @@ const _RouteMetadata = t.readonly(
 );
 export interface RouteMetadata extends t.TypeOf<typeof _RouteMetadata> {}
 export interface RouteMetadataC extends t.Type<RouteMetadata, t.OutputOf<typeof _RouteMetadata>> {}
-// FIXME: remove all this decoding workaround when additional_hash is hash of exact canonicalized
-// metadata, without changes; it's needed while PC hashes the checksummed addresses but sends the
-// lowercased serialized version
 const routeMetadataPredicate = (u: RouteMetadata) =>
   !u.address_metadata || t.array(Address).is(Object.keys(u.address_metadata));
 export const RouteMetadata: RouteMetadataC = new t.RefinementType(
@@ -171,7 +168,10 @@ const LockedTransferBase = t.readonly(
       lock: Lock,
       target: Address,
       initiator: Address,
-      metadata: Metadata,
+      // unknown metadata ensures decoder may not change it, and just passthrough; this allows us
+      // to properly verify its signature; therefore, anything is accepted, and you must decode
+      // wherever you need to access its properties (e.g. to inspect routes)
+      metadata: t.unknown,
     }),
     EnvelopeMessage,
   ]),

--- a/raiden-ts/src/messages/utils.ts
+++ b/raiden-ts/src/messages/utils.ts
@@ -16,7 +16,7 @@ import { encode, jsonParse, jsonStringify } from '../utils/data';
 import type { Address, Hash, HexString } from '../utils/types';
 import { decode, Signature, Signed } from '../utils/types';
 import { messageReceived } from './actions';
-import type { AddressMetadata, EnvelopeMessage, Metadata } from './types';
+import type { AddressMetadata, EnvelopeMessage } from './types';
 import { Message, MessageType } from './types';
 
 const CMDIDs: { readonly [T in MessageType]: number } = {
@@ -51,7 +51,7 @@ export enum MessageTypeId {
  * @param metadata - The LockedTransfer metadata
  * @returns Hash of the metadata.
  */
-function createMetadataHash(metadata: Metadata): Hash {
+function createMetadataHash(metadata: unknown): Hash {
   return keccak256(toUtf8Bytes(canonicalize(metadata))) as Hash;
 }
 

--- a/raiden-ts/src/transfers/actions.ts
+++ b/raiden-ts/src/transfers/actions.ts
@@ -5,7 +5,6 @@ import { BalanceProof } from '../channels/types';
 import {
   LockedTransfer,
   LockExpired,
-  Metadata,
   Processed,
   SecretRequest,
   SecretReveal,
@@ -53,7 +52,7 @@ export const transfer = createAsyncAction(
       target: Address,
       value: UInt(32),
       paymentId: UInt(8),
-      metadata: Metadata,
+      metadata: t.unknown,
       fee: Int(32),
       partner: Address,
     }),

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -169,7 +169,7 @@ function makeAndSignTransfer$(
     ', to',
     action.payload.target,
     ', through routes',
-    action.payload.metadata.routes,
+    action.payload.metadata,
     ', paying',
     fee.toString(),
     'in fees.',

--- a/raiden-ts/src/transfers/state.ts
+++ b/raiden-ts/src/transfers/state.ts
@@ -2,7 +2,6 @@ import type { BigNumber } from '@ethersproject/bignumber';
 import * as t from 'io-ts';
 import invert from 'lodash/invert';
 
-import type { Metadata } from '../messages/types';
 import {
   LockedTransfer,
   LockExpired,
@@ -125,7 +124,7 @@ export interface RaidenTransfer {
   initiator: Address; // us
   partner: Address; // receiver/partner/hub
   target: Address; // final receiver of the transfer
-  metadata: Metadata; // chosen routes
+  metadata: unknown; // chosen routes
   paymentId: BigNumber;
   chainId: number;
   token: Address; // token address

--- a/raiden-ts/tests/e2e/e2e.spec.ts
+++ b/raiden-ts/tests/e2e/e2e.spec.ts
@@ -230,7 +230,9 @@ describe('e2e', () => {
     );
 
     const routes: RaidenPaths = await raiden.findRoutes(getToken(), partner2, amount2);
-    expect(routes).toMatchObject([{ fee: BigNumber.from(0), path: [partner1, partner2] }]);
+    expect(routes).toMatchObject([
+      { fee: BigNumber.from(0), path: [raiden.address, partner1, partner2] },
+    ]);
 
     key = await raiden.transfer(getToken(), partner2, amount2, { paths: routes });
     await raiden.waitTransfer(key);
@@ -292,7 +294,9 @@ describe('e2e', () => {
     const sendAmount = 35;
 
     const routes2: RaidenPaths = await raiden.findRoutes(getToken(), partner2, sendAmount);
-    expect(routes2).toMatchObject([{ fee: BigNumber.from(0), path: [raiden2.address, partner2] }]);
+    expect(routes2).toMatchObject([
+      { fee: BigNumber.from(0), path: [raiden.address, raiden2.address, partner2] },
+    ]);
 
     key = await raiden.transfer(getToken(), partner2, sendAmount, { paths: routes2 });
     await raiden.waitTransfer(key);

--- a/raiden-ts/tests/integration/fixtures.ts
+++ b/raiden-ts/tests/integration/fixtures.ts
@@ -416,16 +416,16 @@ export function expectChannelsAreInSync([raiden, partner]: [MockedRaiden, Mocked
  * @returns metadataFromPaths for a tansfer.request's payload
  */
 export function metadataFromClients<T extends Address | MockedRaiden>(
-  [raiden, ...hops]: readonly [T, ...T[]],
+  clients: readonly [T, ...T[]],
   fee_ = fee,
 ) {
   const isRaiden = (c: T): c is T & MockedRaiden => typeof c !== 'string';
   return metadataFromPaths([
     {
-      path: hops.map((c) => (isRaiden(c) ? c.address : (c as Address))),
+      path: clients.map((c) => (isRaiden(c) ? c.address : (c as Address))),
       fee: fee_,
       address_metadata: Object.fromEntries(
-        [raiden, ...hops].filter(isRaiden).map(({ address, store, deps }) => {
+        clients.filter(isRaiden).map(({ address, store, deps }) => {
           const setup = store.getState().transport.setup!;
           let latest!: Latest;
           deps.latest$.pipe(first()).subscribe((l) => (latest = l));

--- a/raiden-ts/tests/integration/path.spec.ts
+++ b/raiden-ts/tests/integration/path.spec.ts
@@ -103,7 +103,12 @@ describe('PFS: pfsRequestEpic', () => {
 
     mockedPfsResponse.mockImplementation(async () => {
       const result = {
-        result: [{ path: [partner.address, target.address], estimated_fee: fee.toNumber() }],
+        result: [
+          {
+            path: [raiden.address, partner.address, target.address],
+            estimated_fee: fee.toNumber(),
+          },
+        ],
       };
       return {
         status: 200,
@@ -308,7 +313,10 @@ describe('PFS: pfsRequestEpic', () => {
       pathFind.success(
         {
           paths: [
-            { path: [partner.address, target.address], fee: fee.mul(pfsSafetyMargin) as Int<32> },
+            {
+              path: [raiden.address, partner.address, target.address],
+              fee: fee.mul(pfsSafetyMargin) as Int<32>,
+            },
           ],
         },
         pathFindMeta,
@@ -345,7 +353,10 @@ describe('PFS: pfsRequestEpic', () => {
       pathFind.success(
         {
           paths: [
-            { path: [partner.address, target.address], fee: fee.mul(pfsSafetyMargin) as Int<32> },
+            {
+              path: [raiden.address, partner.address, target.address],
+              fee: fee.mul(pfsSafetyMargin) as Int<32>,
+            },
           ],
         },
         pathFindMeta,
@@ -371,7 +382,7 @@ describe('PFS: pfsRequestEpic', () => {
         {
           paths: [
             {
-              path: [partner.address],
+              path: [raiden.address, partner.address],
               fee: Zero as Int<32>,
               address_metadata: expect.objectContaining({ [raiden.address]: expect.anything() }),
             },
@@ -415,7 +426,7 @@ describe('PFS: pfsRequestEpic', () => {
         {
           paths: [
             {
-              path: [partner.address, target.address],
+              path: [raiden.address, partner.address, target.address],
               fee: fee.mul(pfsSafetyMargin) as Int<32>,
             },
           ],
@@ -442,7 +453,7 @@ describe('PFS: pfsRequestEpic', () => {
         {
           paths: [
             {
-              path: [partner.address, target.address],
+              path: [raiden.address, partner.address, target.address],
               fee: fee.mul(pfsSafetyMargin) as Int<32>,
             },
           ],
@@ -528,7 +539,7 @@ describe('PFS: pfsRequestEpic', () => {
         {
           paths: [
             {
-              path: [partner.address, target.address],
+              path: [raiden.address, partner.address, target.address],
               fee: fee.mul(pfsSafetyMargin) as Int<32>,
             },
           ],
@@ -672,7 +683,10 @@ describe('PFS: pfsRequestEpic', () => {
       pathFind.success(
         {
           paths: [
-            { path: [partner.address, target.address], fee: fee.mul(pfsSafetyMargin) as Int<32> },
+            {
+              path: [raiden.address, partner.address, target.address],
+              fee: fee.mul(pfsSafetyMargin) as Int<32>,
+            },
           ],
         },
         pathFindMeta,
@@ -705,7 +719,10 @@ describe('PFS: pfsRequestEpic', () => {
       pathFind.success(
         {
           paths: [
-            { path: [partner.address, target.address], fee: fee.mul(pfsSafetyMargin) as Int<32> },
+            {
+              path: [raiden.address, partner.address, target.address],
+              fee: fee.mul(pfsSafetyMargin) as Int<32>,
+            },
           ],
         },
         pathFindMeta,
@@ -724,21 +741,23 @@ describe('PFS: pfsRequestEpic', () => {
   });
 
   test('success from config but filter out invalid pfs result routes', async () => {
-    // Original test(old version) fails
     expect.assertions(1);
 
+    raiden.store.dispatch(raidenConfigUpdate({ pfsMaxPaths: 7 }));
     const result = {
       result: [
         // token isn't a valid channel, should be removed from output
-        { path: [token, target.address], estimated_fee: 0 },
+        { path: [raiden.address, token, target.address], estimated_fee: 0 },
         // another route going through token, also should be removed
-        { path: [token, partner.address, target.address], estimated_fee: 0 },
+        { path: [raiden.address, token, partner.address, target.address], estimated_fee: 0 },
+        // we're not first address
+        { path: [tokenNetwork, target.address], estimated_fee: 0 },
         // valid route
-        { path: [partner.address, target.address], estimated_fee: 1 },
+        { path: [raiden.address, partner.address, target.address], estimated_fee: 1 },
         // another "valid" route through partner, filtered out because different fee
-        { path: [partner.address, token, target.address], estimated_fee: 5 },
+        { path: [raiden.address, partner.address, token, target.address], estimated_fee: 5 },
         // another invalid route, but we already selected partner first
-        { path: [tokenNetwork, target.address], estimated_fee: 10 },
+        { path: [raiden.address, tokenNetwork, target.address], estimated_fee: 10 },
       ],
     };
     mockedPfsResponse.mockResolvedValueOnce({
@@ -761,7 +780,10 @@ describe('PFS: pfsRequestEpic', () => {
       pathFind.success(
         {
           paths: [
-            { path: [partner.address, target.address], fee: One.mul(pfsSafetyMargin) as Int<32> },
+            {
+              path: [raiden.address, partner.address, target.address],
+              fee: One.mul(pfsSafetyMargin) as Int<32>,
+            },
           ],
         },
         pathFindMeta,


### PR DESCRIPTION
**Proposal** on how protocol regarding metadata should be.
1st bulletpoint of #2730
Implements https://github.com/raiden-network/spec/issues/343

**Short description**
- A new capability is added: `immutableMetadata`
  - Falls back to falsy, which is current (PC) behavior
    - Route must be cleared/prunned: partner expects to be first address in route
    - `LockedTransfer`'s `additionalHash` is generated from the JCS serialization **of the metadata transformed to checksummed addresses**, not necessarily what was received
  - Defaults to truthy (opt-in) on LC
  - When true (new behavior, below), tells partners client is able to receive routes where they're not first hop in `metadata.routes[*].route` array and passthrough metadata unchanged if next hop supports it
- `TransferLocked`'s `metadata` on mediation is passed **as is**, completely unchanged; this includes `route` being passed as is, without prunning
- It's signature (`additionalHash`) is validated as the **exact** signature of the JCS serialized received metadata (no transform in any way).
- Only when/where needed **internally**, we decode `metadata` **known fields** and change it to match a given schema: e.g. that addresses are in the checksum format; these mappings are only used for internal logic, and doesn't reach the created/relayed message or signature validation.
  - We try our best to support any format received here, and if we can't for something critical, instead of failing validation (which would put us out-of-sync), we fail the corresponding effect, e.g. fail to mediate the transfer, but still accept the received nonce (which will expire later, obviously).
 - Anything unknown in `metadata` is forwarded as is, and we sign it as is.
   - This could be a security risk (arbitrary hashes), but since this is signed strictly as part of a larger message (`LockedTransfer`), which is EIP191-prefixed, and also is guaranteed to contain at least some known fields (or else we couldn't route the transfer), there's no risk of it being used elsewhere/replayed.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
