### PR TITLE
Feature/dapp allow to disable ethereum providers

### DIFF
--- a/raiden-dapp/.env.production
+++ b/raiden-dapp/.env.production
@@ -5,3 +5,4 @@ VUE_APP_HUB=hub.raiden.eth
 VUE_APP_ALLOW_MAINNET=false
 VUE_APP_IMPRINT=https://raiden.network/privacy.html
 VUE_APP_TERMS=https://github.com/raiden-network/light-client/blob/master/TERMS.md
+VUE_APP_CONFIGURATION_URL=config.production.json

--- a/raiden-dapp/public/config.json.example
+++ b/raiden-dapp/public/config.json.example
@@ -6,5 +6,6 @@
         "0xC563388e2e2fdD422166eD5E76971D11eD37A466"
       ]
     }
-  }
+  },
+  "disabled_ethereum_providers": ["direct_rpc_provider"]
 }

--- a/raiden-dapp/public/config.production.json
+++ b/raiden-dapp/public/config.production.json
@@ -1,0 +1,11 @@
+{
+  "per_network": {
+    "5": {
+      "monitored": [
+        "0x59105441977ecD9d805A4f5b060E34676F50F806",
+        "0xC563388e2e2fdD422166eD5E76971D11eD37A466"
+      ]
+    }
+  },
+  "disabled_ethereum_providers": ["direct_rpc_provider"]
+}

--- a/raiden-dapp/src/components/ConnectionManager.vue
+++ b/raiden-dapp/src/components/ConnectionManager.vue
@@ -15,6 +15,7 @@
           v-if="!isProviderDisabled(providerName)"
           :key="'button_' + providerName"
           class="connection-manager__provider-dialog-button"
+          :data-cy="'connection-manager__provider-dialog-button__' + providerName"
           :enabled="providerEntry.factory.isAvailable"
           :text="$t(providerEntry.buttonText)"
           width="280px"

--- a/raiden-dapp/src/components/ConnectionManager.vue
+++ b/raiden-dapp/src/components/ConnectionManager.vue
@@ -11,6 +11,7 @@
 
     <template v-if="showProviderButtons">
       <action-button
+        v-if="!injectedProviderDisabled"
         class="connection-manager__provider-dialog-button"
         :enabled="injectedProviderAvailable"
         :text="$t('connection-manager.dialogs.injected-provider.header')"
@@ -18,6 +19,7 @@
         @click="openInjectedProviderDialog"
       />
       <action-button
+        v-if="!walletConnectProviderDisabled"
         class="connection-manager__provider-dialog-button"
         :enabled="walletConnectProviderAvailable"
         :text="$t('connection-manager.dialogs.wallet-connect-provider.header')"
@@ -25,6 +27,7 @@
         @click="openWalletConnectProviderDialog"
       />
       <action-button
+        v-if="!directRpcProviderDisabled"
         class="connection-manager__provider-dialog-button"
         data-cy="connection-manager__provider-dialog-button"
         :enabled="directRpcProviderAvailable"
@@ -106,9 +109,14 @@ export default class ConnectionManager extends Vue {
   stateBackup!: string;
   useRaidenAccount!: boolean;
 
+  injectedProviderDisabled = true;
+  walletConnectProviderDisabled = true;
+  directRpcProviderDisabled = true;
+
   injectedProviderDialogVisible = false;
   walletConnectProviderDialogVisible = false;
   directRpcProviderDialogVisible = false;
+
   inProgress = false;
   errorCode: ErrorCode | null = null;
 
@@ -135,6 +143,18 @@ export default class ConnectionManager extends Vue {
 
   get directRpcProviderAvailable(): boolean {
     return DirectRpcProvider.isAvailable;
+  }
+
+  async created(): Promise<void> {
+    this.checkProvidersForBeingDisabled();
+  }
+
+  async checkProvidersForBeingDisabled(): Promise<void> {
+    InjectedProvider.isDisabled().then((disabled) => (this.injectedProviderDisabled = disabled));
+    WalletConnectProvider.isDisabled().then(
+      (disabled) => (this.walletConnectProviderDisabled = disabled),
+    );
+    DirectRpcProvider.isDisabled().then((disabled) => (this.directRpcProviderDisabled = disabled));
   }
 
   openInjectedProviderDialog(): void {

--- a/raiden-dapp/src/services/config-provider.ts
+++ b/raiden-dapp/src/services/config-provider.ts
@@ -34,6 +34,7 @@ export class ConfigProvider {
 
 export interface Configuration {
   readonly per_network: { [key: string]: NetworkConfiguration };
+  readonly disabled_ethereum_providers?: string[];
 }
 
 export interface NetworkConfiguration {

--- a/raiden-dapp/src/services/ethereum-provider/__mocks__/direct-rpc-provider.ts
+++ b/raiden-dapp/src/services/ethereum-provider/__mocks__/direct-rpc-provider.ts
@@ -7,6 +7,8 @@ export class DirectRpcProvider {
     this.chainId = chainId;
   }
 
+  public static isDisabled = jest.fn().mockResolvedValue(false);
+
   public static link = jest.fn(async (options?: { chainId?: number }) => {
     return new DirectRpcProvider(options?.chainId);
   });

--- a/raiden-dapp/src/services/ethereum-provider/__mocks__/injected-provider.ts
+++ b/raiden-dapp/src/services/ethereum-provider/__mocks__/injected-provider.ts
@@ -6,5 +6,6 @@ export class InjectedProvider {
     return true;
   }
 
+  public static isDisabled = jest.fn().mockResolvedValue(false);
   public static link = jest.fn(async () => new InjectedProvider());
 }

--- a/raiden-dapp/src/services/ethereum-provider/__mocks__/wallet-connect-provider.ts
+++ b/raiden-dapp/src/services/ethereum-provider/__mocks__/wallet-connect-provider.ts
@@ -2,5 +2,6 @@ export class WalletConnectProvider {
   public static readonly providerName = 'wallet_connect_mock';
   public readonly account = 0;
 
+  public static isDisabled = jest.fn().mockResolvedValue(false);
   public static link = jest.fn(async () => new WalletConnectProvider());
 }

--- a/raiden-dapp/src/services/ethereum-provider/types.ts
+++ b/raiden-dapp/src/services/ethereum-provider/types.ts
@@ -1,5 +1,7 @@
 import type { providers } from 'ethers';
 
+import { ConfigProvider } from '@/services/config-provider';
+
 // The type evaluation for static class members works slightly different for
 // the moment. Thereby it is not possible to have any better type restrictions
 // here. Though having the named type here in place will allows us to adopt it
@@ -9,6 +11,7 @@ export type EthereumProviderOptions = any; // eslint-disable-line @typescript-es
 export interface EthereumProviderFactory {
   providerName: string;
   isAvailable: boolean;
+  isDisabled: () => Promise<boolean>;
   link: (options: EthereumProviderOptions) => Promise<EthereumProvider>;
 }
 
@@ -27,5 +30,11 @@ export abstract class EthereumProvider {
     if (!isAvailable) {
       throw new Error('The provider is not available.');
     }
+  }
+
+  static async isDisabled(): Promise<boolean> {
+    const configuration = await ConfigProvider.configuration();
+    const disabled_ethereum_providers = configuration.disabled_ethereum_providers ?? [];
+    return disabled_ethereum_providers.includes(this.providerName);
   }
 }

--- a/raiden-dapp/tests/e2e/utils/user-interaction.ts
+++ b/raiden-dapp/tests/e2e/utils/user-interaction.ts
@@ -16,8 +16,10 @@ export function acceptDisclaimer() {
 export function connectToDApp() {
   // cypress selectors: raiden-dapp/src/views/Home.vue
   cy.get('[data-cy=home]').should('exist');
-  cy.get('[data-cy=connection-manager__provider-dialog-button]').should('exist');
-  cy.get('[data-cy=connection-manager__provider-dialog-button]').click();
+  cy.getWithCustomTimeout(
+    '[data-cy=connection-manager__provider-dialog-button__direct_rpc_provider]',
+  ).should('exist');
+  cy.get('[data-cy=connection-manager__provider-dialog-button__direct_rpc_provider]').click();
   cy.get('[data-cy=direct-rpc-provider]').should('exist');
   cy.get('[data-cy=direct-rpc-provider__options__rpc-url]')
     .find('.text-input-with-toggle__input')

--- a/raiden-dapp/tests/unit/components/connection-manager.spec.ts
+++ b/raiden-dapp/tests/unit/components/connection-manager.spec.ts
@@ -13,8 +13,9 @@ import ConnectionManager from '@/components/ConnectionManager.vue';
 import { DirectRpcProvider, InjectedProvider } from '@/services/ethereum-provider';
 import RaidenService from '@/services/raiden-service';
 
-jest.mock('@/services/ethereum-provider/direct-rpc-provider');
 jest.mock('@/services/ethereum-provider/injected-provider');
+jest.mock('@/services/ethereum-provider/wallet-connect-provider');
+jest.mock('@/services/ethereum-provider/direct-rpc-provider');
 jest.mock('@/services/raiden-service');
 jest.mock('@/services/config-provider');
 
@@ -25,12 +26,12 @@ const vuetify = new Vuetify();
 const storeCommitMock = jest.fn();
 const $raiden = new (RaidenService as any)();
 
-function createWrapper(options?: {
+async function createWrapper(options?: {
   isConnected?: boolean;
   stateBackup?: string;
   useRaidenAccount?: boolean;
   inProgress?: boolean;
-}): Wrapper<ConnectionManager> {
+}): Promise<Wrapper<ConnectionManager>> {
   const state = {
     isConnected: options?.isConnected ?? false,
     stateBackup: options?.stateBackup ?? '',
@@ -45,7 +46,7 @@ function createWrapper(options?: {
 
   store.commit = storeCommitMock;
 
-  return shallowMount(ConnectionManager, {
+  const wrapper = shallowMount(ConnectionManager, {
     vuetify,
     store,
     mocks: {
@@ -56,6 +57,10 @@ function createWrapper(options?: {
       'action-button': ActionButton,
     },
   });
+
+  await flushPromises();
+  await wrapper.vm.$nextTick();
+  return wrapper;
 }
 
 /*
@@ -79,34 +84,34 @@ describe('ConnectionManager.vue', () => {
     delete process.env.VUE_APP_ALLOW_MAINNET;
   });
 
-  test('can not connect when already being connected', () => {
+  test('can not connect when already being connected', async () => {
     // Note that this is a theoretical case that should not be possible via the
     // UI. Though it is important, so it must be guaranteed.
     expect.assertions(1);
-    const wrapper = createWrapper({ isConnected: true });
+    const wrapper = await createWrapper({ isConnected: true });
     expect(dialogEmitLinkEstablished(wrapper)).rejects.toThrowError('Can only connect once!');
   });
 
   test('when a provider link got established the raiden service gets connected', async () => {
-    const wrapper = createWrapper();
+    const wrapper = await createWrapper();
     await dialogEmitLinkEstablished(wrapper);
     expect($raiden.connect).toHaveBeenCalledTimes(1);
   });
 
   test('when a provider link got established the store state gets reset', async () => {
-    const wrapper = createWrapper();
+    const wrapper = await createWrapper();
     await dialogEmitLinkEstablished(wrapper);
     expect(storeCommitMock).toHaveBeenCalledWith('reset');
   });
 
   test('when the raiden service connects successfully the store state get set to be connected', async () => {
-    const wrapper = createWrapper();
+    const wrapper = await createWrapper();
     await dialogEmitLinkEstablished(wrapper);
     expect(storeCommitMock).toHaveBeenCalledWith('setConnected');
   });
 
   test('uses the user settings to connect the raiden service', async () => {
-    const wrapper = createWrapper({ useRaidenAccount: true });
+    const wrapper = await createWrapper({ useRaidenAccount: true });
     await dialogEmitLinkEstablished(wrapper);
     expect($raiden.connect).toHaveBeenLastCalledWith(
       expect.anything(),
@@ -118,7 +123,7 @@ describe('ConnectionManager.vue', () => {
   });
 
   test('uses the state backup of the user to connect the raiden service', async () => {
-    const wrapper = createWrapper({ stateBackup: 'testBackup' });
+    const wrapper = await createWrapper({ stateBackup: 'testBackup' });
     await dialogEmitLinkEstablished(wrapper);
     expect($raiden.connect).toHaveBeenLastCalledWith(
       expect.anything(),
@@ -130,13 +135,13 @@ describe('ConnectionManager.vue', () => {
   });
 
   test('when the connection was successful the state backup in the store gets cleared', async () => {
-    const wrapper = createWrapper();
+    const wrapper = await createWrapper();
     await dialogEmitLinkEstablished(wrapper);
     expect(storeCommitMock).toHaveBeenCalledWith('clearBackupState');
   });
 
   test('show error when provider links to mainnet but it is not allowed', async () => {
-    const wrapper = createWrapper();
+    const wrapper = await createWrapper();
     let errorMessage = wrapper.find('.connection-manager__error-message');
     expect(errorMessage.text().length).toBe(0); // For some reason does `isVisible` not work here.
 
@@ -149,7 +154,7 @@ describe('ConnectionManager.vue', () => {
   });
 
   test('accept that provider of connection links to mainnet if it is allowed', async () => {
-    const wrapper = createWrapper();
+    const wrapper = await createWrapper();
 
     process.env.VUE_APP_ALLOW_MAINNET = 'true';
     await dialogEmitLinkEstablished(wrapper, { chainId: 1 });
@@ -160,7 +165,7 @@ describe('ConnectionManager.vue', () => {
   });
 
   test('show error when raiden service connection throws', async () => {
-    const wrapper = createWrapper();
+    const wrapper = await createWrapper();
     (wrapper.vm as any).$raiden.connect = jest
       .fn()
       .mockRejectedValue(new Error('No deploy info provided'));
@@ -171,21 +176,21 @@ describe('ConnectionManager.vue', () => {
     expect(errorMessage.text().length).toBeGreaterThan(0); // For some reason does `isVisible` not work here.
   });
 
-  test('provider dialog button is enabled if provider is available', () => {
+  test('provider dialog button is enabled if provider is available', async () => {
     jest.spyOn(InjectedProvider, 'isAvailable', 'get').mockReturnValueOnce(true);
-    const wrapper = createWrapper();
+    const wrapper = await createWrapper();
 
     const providerDialogButton = wrapper
       .findAll('.connection-manager__provider-dialog-button')
-      .at(1)
+      .at(0)
       .get('button');
 
     expect(providerDialogButton.attributes('disabled')).toBeFalsy();
   });
 
-  test('provider dialog button is disabled if provider is not available', () => {
+  test('provider dialog button is disabled if provider is not available', async () => {
     jest.spyOn(InjectedProvider, 'isAvailable', 'get').mockReturnValueOnce(false);
-    const wrapper = createWrapper();
+    const wrapper = await createWrapper();
 
     const providerDialogButton = wrapper
       .findAll('.connection-manager__provider-dialog-button')
@@ -193,5 +198,15 @@ describe('ConnectionManager.vue', () => {
       .get('button');
 
     expect(providerDialogButton.attributes('disabled')).toBeTruthy();
+  });
+
+  test('provider dialog button is not displayed if provider is disabled', async () => {
+    jest.spyOn(InjectedProvider, 'isDisabled').mockResolvedValue(true);
+    const wrapper = await createWrapper();
+
+    const providerDialogButtons = wrapper.findAll('.connection-manager__provider-dialog-button');
+
+    // There are three providers in the manager.
+    expect(providerDialogButtons.length).toBe(2);
   });
 });

--- a/raiden-dapp/tests/unit/services/ethereum-provider/injected-provider.spec.ts
+++ b/raiden-dapp/tests/unit/services/ethereum-provider/injected-provider.spec.ts
@@ -19,7 +19,6 @@ describe('InjectedProvider', () => {
     window.ethereum = undefined;
     window.web3 = undefined;
     jest.clearAllMocks();
-    jest.resetAllMocks();
   });
 
   test('is not available when no injected provider is available', () => {

--- a/raiden-dapp/tests/unit/services/ethereum-provider/types.spec.ts
+++ b/raiden-dapp/tests/unit/services/ethereum-provider/types.spec.ts
@@ -1,0 +1,57 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { providers } from 'ethers';
+
+import { ConfigProvider } from '@/services/config-provider';
+import { EthereumProvider } from '@/services/ethereum-provider';
+
+jest.mock('@/services/config-provider');
+
+class TestProvider extends EthereumProvider {
+  static providerName = 'test_provider';
+  account = 0;
+  provider = new providers.JsonRpcProvider('https://test.provider');
+}
+
+describe('EthereumProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('providers are not available per default', () => {
+    expect(TestProvider.isAvailable).toBeFalsy();
+  });
+
+  test('can not instantiate provider if marked as not available', () => {
+    expect(() => new TestProvider()).toThrow('The provider is not available.');
+  });
+
+  test('provider is not disabled if configuration does not include list of disabled providers', () => {
+    expect.assertions(1);
+
+    (ConfigProvider.configuration as any).mockResolvedValueOnce({
+      disabled_ethereum_providers: undefined,
+    });
+
+    expect(TestProvider.isDisabled()).resolves.toBeFalsy();
+  });
+
+  test('provider is not disabled if configuration does not include the providers name', () => {
+    expect.assertions(1);
+
+    (ConfigProvider.configuration as any).mockResolvedValueOnce({
+      disabled_ethereum_providers: ['other_provider'],
+    });
+
+    expect(TestProvider.isDisabled()).resolves.toBeFalsy();
+  });
+
+  test('provider is disabled if configuration includes the providers name', () => {
+    expect.assertions(1);
+
+    (ConfigProvider.configuration as any).mockResolvedValueOnce({
+      disabled_ethereum_providers: ['test_provider'],
+    });
+
+    expect(TestProvider.isDisabled()).resolves.toBeTruthy();
+  });
+});


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Fixes #2742

**Short description**
The last commit includes some code refactorings of the ConnectionManager component. Its got got too cluttered now and it was time to take action. It was a known issue.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Run the dApp in development mode and verify all three providers are presented
2. Run the dApp in production mode and verify that only two providers are presented (private key is missing)
