### PR TITLE
dapp: fix broken download state icon

### DIFF
--- a/raiden-dapp/src/components/account/backup-state/DownloadStateDialog.vue
+++ b/raiden-dapp/src/components/account/backup-state/DownloadStateDialog.vue
@@ -85,8 +85,8 @@ export default class DownloadStateDialog extends Mixins(NavigationMixin) {
 <style scoped lang="scss">
 .download-state {
   &__warning {
-    height: 110px;
-    width: 110px;
+    height: 105px;
+    width: 120px;
     margin: 0 auto;
   }
 }


### PR DESCRIPTION
Fixes #2763

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Open the dialog to download the state
2. Verify that the icon looks good.
