### PR TITLE
dapp: fix flaky end-to-end tests

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#2671] Fix preventing transfers to partners with closed channel
 - [#2675] Fix insecure behavior on navigation without connected token
 - [#2754] Fix empty logs in production mode
+- [#2774] Fix duplicated navigation error after doing a backup
 
 ### Added
 
@@ -28,6 +29,7 @@
 [#2675]: https://github.com/raiden-network/light-client/issues/2675
 [#2754]: https://github.com/raiden-network/light-client/issues/2754
 [#2604]: https://github.com/raiden-network/light-client/issues/2604
+[#2774]: https://github.com/raiden-network/light-client/issues/2774
 
 ## [0.16.0] - 2021-04-01
 

--- a/raiden-dapp/src/components/account/backup-state/DownloadStateDialog.vue
+++ b/raiden-dapp/src/components/account/backup-state/DownloadStateDialog.vue
@@ -52,12 +52,11 @@ export default class DownloadStateDialog extends Mixins(NavigationMixin) {
 
     downloadLink.click();
     this.revokeDownloadURL(stateFileURL, downloadLink);
-    this.navigateToHome();
   }
 
   /* istanbul ignore next */
   async getStateFileURL(filename: string): Promise<string> {
-    const state = await this.$raiden.getState();
+    const state = await this.$raiden.stopAndGetDatabaseDump();
     const stateJSON = JSON.stringify(state);
     const file = new File([stateJSON], filename, { type: 'application/json' });
     return URL.createObjectURL(file);

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -623,7 +623,7 @@ export default class RaidenService {
   }
 
   /* istanbul ignore next */
-  async getState() {
+  async stopAndGetDatabaseDump() {
     this._raiden!.stop();
     return this._raiden!.dumpDatabase();
   }


### PR DESCRIPTION
Fixes #2774

In fact it fixes the duplicated navigation error after a backup. Apparently this solves the end-to-end tests which fail right after doing a backup. The CI has succeed many times in a row. So fingers crossed this was the awkward cause for the bug. After all it does fix the navigation error.