### PR TITLE
Feature/chore add GitHub action for fixup commits

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -21,3 +21,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PROJECT_ROOTS: '["raiden-ts", "raiden-dapp"]'
           CHANGELOG_FILE: 'CHANGELOG.md'
+
+  block-fixup:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2.0.0
+        - name: 'Block Fixup Commit Merge'
+          uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
Fixup commits are a very useful tool when working on bigger features or react to feedback of a PR review. But before the PR gets merged they must be squashed into their referring commits. Sometimes this get forgotten and a fixup commits makes it into the master branch. This is not nice and should be avoided.
Therefore this adds a new action to the GitHub worflow checks of a PR to verify that there are no fixup commits. If the action fails, the merging is blocked and the author must first resolve it.

The second commit is just an empty fixup commit to verify that the action works.