### PR TITLE
cli: Enable mediation by default

### DIFF
--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -150,9 +150,8 @@ async function parseArguments() {
       },
       enableMediation: {
         type: 'boolean',
-        default: false,
-        desc: 'Enables support for mediated payments (unsupported).',
-        hidden: true, // hidden from help because not officially supported
+        default: true,
+        desc: 'Enables support for mediated payments.',
       },
       flatFee: {
         type: 'string',


### PR DESCRIPTION
**Thank you for submitting this pull request :)**

Part of https://github.com/raiden-network/team/issues/881

**Short description**

Enable mediation support in the CLI by default.

We now have mediation fees (partly) implemented and want to have the same behavior as the PC, so we can enable mediation in the CLI by default.


An alternative solution would be to remove the parameter completely.

**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
