### PR TITLE
Support customising gasPrice strategy

### DIFF
--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -5,9 +5,11 @@
 ### Added
 - [#1576] Add functionality to deploy token networks
 - [#2577] Add `--proportional-imbalance-fee` and `--cap-mediation-fees` options for imbalance fees
+- [#2795] Add `--gas-price` option to control gasPrice strategy as a multiplier of provider-returned `eth_gasPrice`
 
 [#1576]: https://github.com/raiden-network/light-client/issues/1576
 [#2577]: https://github.com/raiden-network/light-client/issues/2577
+[#2795]: https://github.com/raiden-network/light-client/issues/2795
 
 ## [0.16.0] - 2021-04-01
 ### Changed

--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -176,6 +176,24 @@ async function parseArguments() {
         default: true,
         desc: 'Enables capping mediation fees to not allow them to be negative (output transfers amount always less than or equal input transfers)',
       },
+      gasPrice: {
+        desc: 'Set gasPrice strategy for transactions, as a multiplier of ETH node returned "eth_gasPrice"; some aliases: medium=1.05, fast=1.2, rapid=1.5',
+        coerce(val): number | undefined {
+          if (!val) return;
+          switch (val) {
+            case 'medium':
+              return 1.05;
+            case 'fast':
+              return 1.2;
+            case 'rapid':
+              return 1.5;
+            default:
+              val = +val;
+              assert(val && 0.1 <= val && val <= 10, 'invalid gasPrice');
+              return val;
+          }
+        },
+      },
     })
     .help()
     .alias('h', 'help')
@@ -311,6 +329,7 @@ function createRaidenConfig(
     pfsMaxPaths: argv.pathfindingMaxPaths,
     pfsMaxFee: argv.pathfindingMaxFee,
     pfsIouTimeout: argv.pathfindingIouTimeout,
+    ...(argv.gasPrice ? { gasPriceFactor: argv.gasPrice } : undefined),
   };
 
   if (argv.matrixServer !== 'auto') config = { ...config, matrixServer: argv.matrixServer };

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -4,9 +4,11 @@
 ### Added
 - [#1576] Add functionality to deploy token networks
 - [#2577] Add imbalance penalty mediation fees
+- [#2795] Add `config.gasPriceFactor` option, to increase the transactions `gasPrice` as a multiplier of provider-returned `eth_gasPrice`
 
 [#1576]: https://github.com/raiden-network/light-client/issues/1576
 [#2577]: https://github.com/raiden-network/light-client/issues/2577
+[#2795]: https://github.com/raiden-network/light-client/issues/2795
 
 ### Changed
 - [#2669] Update to Raiden contracts `v0.37.5`

--- a/raiden-ts/src/channels/actions.ts
+++ b/raiden-ts/src/channels/actions.ts
@@ -23,6 +23,9 @@ export interface blockTime extends ActionType<typeof blockTime> {}
 export const blockStale = createAction('block/stale', t.type({ stale: t.boolean }));
 export interface blockStale extends ActionType<typeof blockStale> {}
 
+export const blockGasprice = createAction('block/gasPrice', t.type({ gasPrice: UInt(32) }));
+export interface blockGasprice extends ActionType<typeof blockGasprice> {}
+
 /**
  * A new token network is detected in the TokenNetworkRegistry instance
  * fromBlock is only set on the first time, to fetch and handle past events

--- a/raiden-ts/src/channels/epics.ts
+++ b/raiden-ts/src/channels/epics.ts
@@ -815,17 +815,27 @@ export function channelMonitoredEpic(
  * @param deps.provider - Provider instance
  * @param deps.getTokenNetworkContract - TokenNetwork contract instance getter
  * @param deps.config$ - Config observable
+ * @param deps.latest$ - Latest observable
  * @returns Observable of channelOpen.failure actions
  */
 export function channelOpenEpic(
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-  { log, signer, address, main, provider, getTokenNetworkContract, config$ }: RaidenEpicDeps,
+  {
+    log,
+    signer,
+    address,
+    main,
+    provider,
+    getTokenNetworkContract,
+    config$,
+    latest$,
+  }: RaidenEpicDeps,
 ): Observable<channelOpen.failure | channelDeposit.request> {
   return action$.pipe(
     filter(isActionOf(channelOpen.request)),
-    withLatestFrom(state$, config$),
-    mergeMap(([action, state, { settleTimeout, subkey: configSubkey }]) => {
+    withLatestFrom(state$, config$, latest$),
+    mergeMap(([action, state, { settleTimeout, subkey: configSubkey }, { gasPrice }]) => {
       const { tokenNetwork, partner } = action.meta;
       const channelState = state.channels[channelKey(action.meta)]?.state;
       // fails if channel already exist
@@ -858,11 +868,12 @@ export function channelOpenEpic(
 
       return concat(
         deposit$,
-        defer(() =>
+        defer(async () =>
           tokenNetworkContract.openChannel(
             address,
             partner,
             action.payload.settleTimeout ?? settleTimeout,
+            { gasPrice },
           ),
         ).pipe(
           assertTx('openChannel', ErrorCodes.CNL_OPENCHANNEL_FAILED, { log, provider }),
@@ -895,8 +906,9 @@ function makeDeposit$(
   [sender, address, partner]: [Address, Address, Address],
   deposit: UInt<32>,
   channelId$: Observable<number>,
-  { log, provider, config$ }: Pick<RaidenEpicDeps, 'log' | 'provider' | 'config$'>,
+  deps: Pick<RaidenEpicDeps, 'log' | 'provider' | 'config$' | 'latest$'>,
 ) {
+  const { log, provider, config$, latest$ } = deps;
   // retryWhile from here
   return defer(() =>
     Promise.all([
@@ -906,15 +918,15 @@ function makeDeposit$(
       >,
     ]),
   ).pipe(
-    withLatestFrom(config$),
-    mergeMap(([[balance, allowance], { minimumAllowance }]) =>
+    withLatestFrom(config$, latest$),
+    mergeMap(([[balance, allowance], { minimumAllowance }, { gasPrice }]) =>
       approveIfNeeded$(
         [balance, allowance, deposit],
         tokenContract,
         tokenNetworkContract.address as Address,
         ErrorCodes.CNL_APPROVE_TRANSACTION_FAILED,
-        { provider },
-        { log, minimumAllowance },
+        deps,
+        { minimumAllowance, gasPrice },
       ),
     ),
     mergeMapTo(channelId$),
@@ -925,9 +937,12 @@ function makeDeposit$(
         .getChannelParticipantInfo(id, address, partner)
         .then(({ 0: totalDeposit }) => [id, totalDeposit] as const),
     ),
+    withLatestFrom(latest$),
     // send setTotalDeposit transaction
-    mergeMap(async ([id, totalDeposit]) =>
-      tokenNetworkContract.setTotalDeposit(id, address, totalDeposit.add(deposit), partner),
+    mergeMap(async ([[id, totalDeposit], { gasPrice }]) =>
+      tokenNetworkContract.setTotalDeposit(id, address, totalDeposit.add(deposit), partner, {
+        gasPrice,
+      }),
     ),
     assertTx('setTotalDeposit', ErrorCodes.CNL_SETTOTALDEPOSIT_FAILED, { log, provider }),
     // retry also txFail errors, since estimateGas can lag behind just-opened channel or
@@ -962,18 +977,10 @@ function makeDeposit$(
 export function channelDepositEpic(
   action$: Observable<RaidenAction>,
   {}: Observable<RaidenState>,
-  {
-    log,
-    signer,
-    address,
-    main,
-    getTokenContract,
-    getTokenNetworkContract,
-    provider,
-    config$,
-    latest$,
-  }: RaidenEpicDeps,
+  deps: RaidenEpicDeps,
 ): Observable<channelDeposit.failure> {
+  const { signer, address, main, getTokenContract, getTokenNetworkContract, config$, latest$ } =
+    deps;
   return action$.pipe(
     filter(isActionOf(channelDeposit.request)),
     groupBy((action) => action.meta.tokenNetwork),
@@ -1036,7 +1043,7 @@ export function channelDepositEpic(
                     [onchainAddress, address, partner],
                     action.payload.deposit,
                     channelId$,
-                    { log, provider, config$ },
+                    deps,
                   ),
                 ),
                 // ignore success tx so it's picked by channelEventsEpic
@@ -1069,6 +1076,7 @@ export function channelDepositEpic(
  * @param deps.network - Current network
  * @param deps.getTokenNetworkContract - TokenNetwork contract instance getter
  * @param deps.config$ - Config observable
+ * @param deps.latest$ - Latest observable
  * @returns Observable of channelClose.failure actions
  */
 export function channelCloseEpic(
@@ -1083,12 +1091,13 @@ export function channelCloseEpic(
     network,
     getTokenNetworkContract,
     config$,
+    latest$,
   }: RaidenEpicDeps,
 ): Observable<channelClose.failure> {
   return action$.pipe(
     filter(isActionOf(channelClose.request)),
-    withLatestFrom(state$, config$),
-    mergeMap(([action, state, { subkey: configSubkey }]) => {
+    withLatestFrom(state$, config$, latest$),
+    mergeMap(([action, state, { subkey: configSubkey }, { gasPrice }]) => {
       const { tokenNetwork, partner } = action.meta;
       const { signer: onchainSigner } = chooseOnchainAccount(
         { signer, address, main },
@@ -1137,6 +1146,7 @@ export function channelCloseEpic(
               additionalHash,
               nonClosingSignature,
               closingSignature,
+              { gasPrice },
             ),
           ).pipe(
             assertTx('closeChannel', ErrorCodes.CNL_CLOSECHANNEL_FAILED, { log, provider }),
@@ -1183,6 +1193,7 @@ export function channelCloseEpic(
  * @param deps.network - Current network
  * @param deps.getTokenNetworkContract - TokenNetwork contract instance getter
  * @param deps.config$ - Config observable
+ * @param deps.latest$ - Latest observable
  * @returns Empty observable
  */
 export function channelUpdateEpic(
@@ -1197,6 +1208,7 @@ export function channelUpdateEpic(
     network,
     getTokenNetworkContract,
     config$,
+    latest$,
   }: RaidenEpicDeps,
 ): Observable<never> {
   return action$.pipe(
@@ -1205,7 +1217,7 @@ export function channelUpdateEpic(
     // wait a newBlock go through after channelClose confirmation, to ensure any pending
     // channelSettle could have been processed
     delayWhen(() => action$.pipe(filter(newBlock.is))),
-    withLatestFrom(state$, config$),
+    withLatestFrom(state$, config$, latest$),
     filter(([action, state]) => {
       const channel = state.channels[channelKey(action.meta)];
       return (
@@ -1217,7 +1229,7 @@ export function channelUpdateEpic(
         channel.closeParticipant !== address // we're not the closing end
       );
     }),
-    mergeMap(([action, state, { subkey }]) => {
+    mergeMap(([action, state, { subkey }, { gasPrice }]) => {
       const { tokenNetwork, partner } = action.meta;
       const { signer: onchainSigner } = chooseOnchainAccount({ signer, address, main }, subkey);
       const tokenNetworkContract = getContractWithSigner(
@@ -1255,6 +1267,7 @@ export function channelUpdateEpic(
               additionalHash,
               closingSignature,
               nonClosingSignature,
+              { gasPrice },
             ),
           ).pipe(
             assertTx('updateNonClosingBalanceProof', ErrorCodes.CNL_UPDATE_NONCLOSING_BP_FAILED, {
@@ -1351,13 +1364,24 @@ export function channelAutoSettleEpic(
  * @param deps.provider - Provider instance
  * @param deps.getTokenNetworkContract - TokenNetwork contract instance getter
  * @param deps.config$ - Config observable
+ * @param deps.latest$ - Latest observable
  * @param deps.db - Database instance
  * @returns Observable of channelSettle.failure actions
  */
 export function channelSettleEpic(
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-  { log, signer, address, main, provider, getTokenNetworkContract, config$, db }: RaidenEpicDeps,
+  {
+    log,
+    signer,
+    address,
+    main,
+    provider,
+    getTokenNetworkContract,
+    config$,
+    latest$,
+    db,
+  }: RaidenEpicDeps,
 ): Observable<channelSettle.failure> {
   return action$.pipe(
     filter(isActionOf(channelSettle.request)),
@@ -1455,7 +1479,8 @@ export function channelSettleEpic(
                   [partner, partnerBP],
                 ] as const;
             }),
-            mergeMap(([part1, part2]) =>
+            withLatestFrom(latest$),
+            mergeMap(([[part1, part2], { gasPrice }]) =>
               defer(() =>
                 tokenNetworkContract.settleChannel(
                   channel.id,
@@ -1467,6 +1492,7 @@ export function channelSettleEpic(
                   part2[1].transferredAmount,
                   part2[1].lockedAmount,
                   part2[1].locksroot,
+                  { gasPrice },
                 ),
               ).pipe(
                 assertTx('settleChannel', ErrorCodes.CNL_SETTLE_FAILED, { log, provider }),
@@ -1546,20 +1572,30 @@ export function channelSettleableEpic(
  * @param deps.provider - Provider instance
  * @param deps.getTokenNetworkContract - TokenNetwork contract instance getter
  * @param deps.config$ - Config observable
+ * @param deps.latest$ - Latest observable
  * @returns Empty observable
  */
 export function channelUnlockEpic(
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-  { log, signer, address, main, provider, getTokenNetworkContract, config$ }: RaidenEpicDeps,
+  {
+    log,
+    signer,
+    address,
+    main,
+    provider,
+    getTokenNetworkContract,
+    config$,
+    latest$,
+  }: RaidenEpicDeps,
 ): Observable<channelSettle.failure> {
   return action$.pipe(
     filter(isActionOf(channelSettle.success)),
     filter((action) => !!(action.payload.confirmed && action.payload.locks?.length)),
-    withLatestFrom(state$, config$),
+    withLatestFrom(state$, config$, latest$),
     // ensure there's no channel, or if yes, it's a different (by channelId)
     filter(([action, state]) => state.channels[channelKey(action.meta)]?.id !== action.payload.id),
-    mergeMap(([action, , { subkey }]) => {
+    mergeMap(([action, , { subkey }, { gasPrice }]) => {
       const { tokenNetwork, partner } = action.meta;
       const tokenNetworkContract = getContractWithSigner(
         getTokenNetworkContract(tokenNetwork),
@@ -1579,7 +1615,7 @@ export function channelUnlockEpic(
 
       // send unlock transaction
       return defer(() =>
-        tokenNetworkContract.unlock(action.payload.id, address, partner, locks),
+        tokenNetworkContract.unlock(action.payload.id, address, partner, locks, { gasPrice }),
       ).pipe(
         assertTx('unlock', ErrorCodes.CNL_ONCHAIN_UNLOCK_FAILED, { log, provider }),
         retryWhile(intervalFromConfig(config$), {

--- a/raiden-ts/src/config.ts
+++ b/raiden-ts/src/config.ts
@@ -61,6 +61,8 @@ const RTCIceServer = t.type({ urls: t.union([t.string, t.array(t.string)]) });
  * - autoUDCWithdraw - Whether to udcWithdraw.request planned withdraws automatically
  * - mediationFees - deps.mediationFeeCalculator config. It's typed as unknown because it'll be
  *     validated and decoded by [[FeeModel.decodeConfig]].
+ * - gasPriceFactor - Multiplier to be applied over `eth_gasPrice` for initial transactions gas prices;
+ *      1.1 means gasPrice returned by ETH node is added of 10% for every transaction sent
  * - matrixServer? - Specify a matrix server to use.
  * - subkey? - When using subkey, this sets the behavior when { subkey } option isn't explicitly
  *    set in on-chain method calls. false (default) = use main key; true = use subkey
@@ -100,6 +102,7 @@ export const RaidenConfig = t.readonly(
       autoSettle: t.boolean,
       autoUDCWithdraw: t.boolean,
       mediationFees: t.unknown,
+      gasPriceFactor: t.number,
     }),
     t.partial({
       matrixServer: t.string,
@@ -170,6 +173,7 @@ export function makeDefaultConfig(
     autoSettle: false,
     autoUDCWithdraw: true,
     mediationFees: {},
+    gasPriceFactor: 1.0,
     ...overwrites,
     caps, // merged caps overwrites 'overwrites.caps'
   };

--- a/raiden-ts/src/transfers/epics/withdraw.ts
+++ b/raiden-ts/src/transfers/epics/withdraw.ts
@@ -166,7 +166,7 @@ export function withdrawSendTxEpic(
     concatMap((action) =>
       latest$.pipe(
         first(),
-        mergeMap(({ state, config }) => {
+        mergeMap(({ state, config, gasPrice }) => {
           const { subkey: configSubkey, revealTimeout } = config;
           // don't send on-chain tx if we're 'revealTimeout' blocks from expiration
           // this is our confidence threshold when we can get a tx inside timeout
@@ -199,6 +199,7 @@ export function withdrawSendTxEpic(
               action.meta.expiration,
               req.signature,
               action.payload.message.signature,
+              { gasPrice },
             ),
           ).pipe(
             assertTx('setTotalWithdraw', ErrorCodes.CNL_WITHDRAW_TRANSACTION_FAILED, {

--- a/raiden-ts/src/types.ts
+++ b/raiden-ts/src/types.ts
@@ -45,6 +45,7 @@ export interface Latest {
   udcDeposit: { balance: UInt<32>; totalDeposit: UInt<32> };
   blockTime: number;
   stale: boolean;
+  gasPrice: UInt<32>;
 }
 
 export interface RaidenEpicDeps {

--- a/raiden-ts/tests/integration/mocks.ts
+++ b/raiden-ts/tests/integration/mocks.ts
@@ -681,6 +681,7 @@ export async function makeRaiden(
       } as any),
   );
   jest.spyOn(provider, 'getTransaction');
+  jest.spyOn(provider, 'getGasPrice').mockResolvedValue(BigNumber.from(1e9));
   jest.spyOn(provider, 'listAccounts').mockResolvedValue([address]);
   // See: https://github.com/cartant/rxjs-marbles/issues/11
   jest.spyOn(provider, 'getBlockNumber').mockImplementation(async () => provider.blockNumber);
@@ -883,10 +884,7 @@ export async function makeRaiden(
       initialState = decode(RaidenState, await getRaidenState(db));
     } catch (e) {}
   if (!initialState) {
-    initialState = makeInitialState(
-      { network, address, contractsInfo },
-      { blockNumber: provider.blockNumber },
-    );
+    initialState = makeInitialState({ network, address, contractsInfo }, { blockNumber: 1 });
     await putRaidenState(db, initialState);
   }
 

--- a/raiden-ts/tests/integration/receive.spec.ts
+++ b/raiden-ts/tests/integration/receive.spec.ts
@@ -516,7 +516,7 @@ describe('receive transfers', () => {
     // advance to some block inside the danger zone, secret get registered
     await waitBlock(sentState.expiration - raiden.config.revealTimeout + 1);
     expect(raiden.output).toContainEqual(transferSecretRegister.request({ secret }, receivedMeta));
-    expect(secretRegistryContract.registerSecret).toHaveBeenCalledWith(secret);
+    expect(secretRegistryContract.registerSecret).toHaveBeenCalledWith(secret, expect.anything());
     // give some time to confirm register tx
     await waitBlock();
     await waitBlock(

--- a/raiden-ts/tests/integration/udc.spec.ts
+++ b/raiden-ts/tests/integration/udc.spec.ts
@@ -101,10 +101,15 @@ describe('udcDepositEpic', () => {
       ),
     );
     expect(tokenContract.approve).toHaveBeenCalledTimes(2);
-    expect(tokenContract.approve).toHaveBeenCalledWith(userDepositContract.address, 0);
+    expect(tokenContract.approve).toHaveBeenCalledWith(
+      userDepositContract.address,
+      0,
+      expect.anything(),
+    );
     expect(tokenContract.approve).toHaveBeenCalledWith(
       userDepositContract.address,
       raiden.config.minimumAllowance,
+      expect.anything(),
     );
   });
 
@@ -186,11 +191,16 @@ describe('udcDepositEpic', () => {
     );
     expect(tokenContract.approve).toHaveBeenCalledTimes(3);
     expect(approveTx.wait).toHaveBeenCalledTimes(2);
-    expect(tokenContract.approve).toHaveBeenCalledWith(userDepositContract.address, MaxUint256);
+    expect(tokenContract.approve).toHaveBeenCalledWith(
+      userDepositContract.address,
+      MaxUint256,
+      expect.anything(),
+    );
     expect(userDepositContract.deposit).toHaveBeenCalledTimes(1);
     expect(userDepositContract.deposit).toHaveBeenCalledWith(
       raiden.address,
       deposit.add(prevDeposit),
+      expect.anything(),
     );
     expect(depositTx.wait).toHaveBeenCalledTimes(1);
   });

--- a/raiden-ts/tests/integration/withdraw.spec.ts
+++ b/raiden-ts/tests/integration/withdraw.spec.ts
@@ -215,6 +215,7 @@ describe('withdraw send request', () => {
       expiration,
       request.signature,
       confirmation.signature,
+      expect.objectContaining({ gasPrice: expect.any(BigNumber) }),
     );
     // this only works because Capabilities.DELIVERY is enabled
     // LC-to-LC confirms with WithdrawConfirmation instead


### PR DESCRIPTION
Fixes #2795 

**Short description**
This allows some control of `gasPrice` with which transactions are sent. On dApp/Metamask, this controls only the default presented `gasPrice` in MM's tx prompt. On CLI, `--gas-price` also can receive some aliases, like `fast` (1.2) or `medium` (1.05). When not set, the default is 1.0. This is a multiplier for the current ETH-provider-returned `eth_gasPrice`.

A better fix, presented on the issue, is to instead be able to even use lower gasPrices by default, but be able to bump them for priority transactions (txs with deadlines, like `register secret` or `channel update`, but this should be good enough for now. Eventually, those strategies could also be exposed through the API and let the user set it per operation.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Check CLI with `--gas-price fast` option makes scenarios send transactions with +20% the current avg `gasPrice`
