### PR TITLE
Fix withdraw expired nonce retry issue

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -6,16 +6,19 @@
 - [#2577] Add imbalance penalty mediation fees
 - [#2795] Add `config.gasPriceFactor` option, to increase the transactions `gasPrice` as a multiplier of provider-returned `eth_gasPrice`
 
-[#1576]: https://github.com/raiden-network/light-client/issues/1576
-[#2577]: https://github.com/raiden-network/light-client/issues/2577
-[#2795]: https://github.com/raiden-network/light-client/issues/2795
-
 ### Changed
 - [#2669] Update to Raiden contracts `v0.37.5`
 - [#2677] Removed the dependency on reactive notifications of peer's presences changes and updated WebRTC signaling algorithm
 
+### Fixed
+- [#2797] Fixed a non-critical bug where withdraw expiration messages would not stop being retried
+
+[#1576]: https://github.com/raiden-network/light-client/issues/1576
+[#2577]: https://github.com/raiden-network/light-client/issues/2577
 [#2669]: https://github.com/raiden-network/light-client/issues/2669
 [#2677]: https://github.com/raiden-network/light-client/issues/2677
+[#2795]: https://github.com/raiden-network/light-client/issues/2795
+[#2797]: https://github.com/raiden-network/light-client/issues/2797
 
 ## [0.16.0] - 2021-04-01
 ### Added

--- a/raiden-ts/src/errors.json
+++ b/raiden-ts/src/errors.json
@@ -27,6 +27,8 @@
   "CNL_UPDATE_NONCLOSING_BP_FAILED": "updateNonClosingBalanceProof transaction reverted.",
   "CNL_ONCHAIN_UNLOCK_FAILED": "on-chain unlock transaction reverted.",
 
+  "CNL_WITHDRAW_PENDING": "There's already a withdraw request pending.",
+  "CNL_WITHDRAW_RETRY_CONFIRMATION": "Retrying pending WithdrawConfirmation. Confirm or try again later.",
   "CNL_WITHDRAW_TRANSACTION_FAILED": "Withdraw transaction has failed.",
   "CNL_WITHDRAW_EXPIRES_SOON": "Withdraw request expired or expires too soon.",
   "CNL_WITHDRAW_EXPIRED": "Withdraw request expired.",

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -878,10 +878,7 @@ function sendWithdrawExpired(
         expiration: req.expiration,
       };
       return from(signMessage(signer, expired, { log })).pipe(
-        mergeMap(function* (message) {
-          yield withdrawExpire.success({ message }, action.meta);
-          yield withdraw.failure(new RaidenError(ErrorCodes.CNL_WITHDRAW_EXPIRED), action.meta);
-        }),
+        map((message) => withdrawExpire.success({ message }, action.meta)),
       );
     }),
     catchError((err) => of(withdrawExpire.failure(err, action.meta))),

--- a/raiden-ts/src/transfers/epics/withdraw.ts
+++ b/raiden-ts/src/transfers/epics/withdraw.ts
@@ -6,8 +6,8 @@ import {
   filter,
   first,
   map,
-  mapTo,
   mergeMap,
+  mergeMapTo,
   pluck,
   share,
   take,
@@ -27,7 +27,7 @@ import type { RaidenState } from '../../state';
 import { getNoDeliveryPeers } from '../../transport/utils';
 import type { RaidenEpicDeps } from '../../types';
 import { isActionOf } from '../../utils/actions';
-import { assert, commonTxErrors, ErrorCodes } from '../../utils/error';
+import { assert, commonTxErrors, ErrorCodes, RaidenError } from '../../utils/error';
 import { LruCache } from '../../utils/lru';
 import { retryWhile } from '../../utils/rx';
 import { Signed } from '../../utils/types';
@@ -343,7 +343,7 @@ export function withdrawSendExpireMessageEpic(
   action$: Observable<RaidenAction>,
   {}: Observable<RaidenState>,
   { config$ }: RaidenEpicDeps,
-): Observable<messageSend.request | withdrawCompleted> {
+): Observable<messageSend.request | withdraw.failure | withdrawCompleted> {
   return action$.pipe(
     filter(withdrawExpire.success.is),
     filter((action) => action.meta.direction === Direction.SENT),
@@ -361,8 +361,11 @@ export function withdrawSendExpireMessageEpic(
             a.meta.address === action.meta.partner &&
             a.payload.message.message_identifier.eq(message.message_identifier),
         ),
-        mapTo(withdrawCompleted(undefined, action.meta)),
         take(1),
+        mergeMapTo([
+          withdraw.failure(new RaidenError(ErrorCodes.CNL_WITHDRAW_EXPIRED), action.meta),
+          withdrawCompleted(undefined, action.meta),
+        ]),
         share(),
       );
       // besides using notifier to stop retry, also merge the withdrawCompleted output action

--- a/raiden-ts/src/transfers/epics/withdraw.ts
+++ b/raiden-ts/src/transfers/epics/withdraw.ts
@@ -163,7 +163,7 @@ export function withdrawSendTxEpic(
   return action$.pipe(
     filter(withdrawMessage.success.is),
     filter((action) => action.meta.direction === Direction.SENT),
-    concatMap((action) =>
+    mergeMap((action) =>
       latest$.pipe(
         first(),
         mergeMap(({ state, config, gasPrice }) => {
@@ -206,7 +206,11 @@ export function withdrawSendTxEpic(
               log,
               provider,
             }),
-            retryWhile(intervalFromConfig(config$), { onErrors: commonTxErrors, log: log.debug }),
+            retryWhile(intervalFromConfig(config$), {
+              maxRetries: 3,
+              onErrors: commonTxErrors,
+              log: log.debug,
+            }),
           );
         }),
         map(([, receipt]) =>


### PR DESCRIPTION
Fixes #2797 

**Short description**
This was caused by a race where the sending node would emit `withdraw.failure` as soon as the `WithdrawExpired` was sent, which did shutdown the node on SP, without waiting for the partner to send the `Processed` for it (which clears the Withdraw it in both sides). Therefore, when the nodes were restarted, the sending side started retrying this message, but the receiver had already handled it with a nonce change and would reject new retries.

The fix involves both ensuring the sender side waits for the respective `Processed` before failing the `withdraw` attempt, as well as allowing the receiver to handle older messages and send the respective `Processed` for it, even if it was already handled locally.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
