### PR TITLE
cli: support multiple --gas-price but use only last

### DIFF
--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -178,8 +178,10 @@ async function parseArguments() {
       },
       gasPrice: {
         desc: 'Set gasPrice strategy for transactions, as a multiplier of ETH node returned "eth_gasPrice"; some aliases: medium=1.05, fast=1.2, rapid=1.5',
-        coerce(val): number | undefined {
+        coerce(val?: string | string[]): number | undefined {
           if (!val) return;
+          if (Array.isArray(val)) val = val[val.length - 1];
+          let value;
           switch (val) {
             case 'medium':
               return 1.05;
@@ -188,9 +190,9 @@ async function parseArguments() {
             case 'rapid':
               return 1.5;
             default:
-              val = +val;
-              assert(val && 0.1 <= val && val <= 10, 'invalid gasPrice');
-              return val;
+              value = +val;
+              assert(value && 0.1 <= value && value <= 10, 'invalid gasPrice');
+              return value;
           }
         },
       },


### PR DESCRIPTION
SP passes `--gas-price` option multiple repeated times, and yargs
converts this in an array. We need to support this case, but only
consider the last passed option.

Fixes # 

**Short description**


**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
