### PR TITLE
Confirm confirmation on open/depositChannel methods

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [#1576] Add functionality to deploy token networks
 - [#2577] Add imbalance penalty mediation fees
 - [#2795] Add `config.gasPriceFactor` option, to increase the transactions `gasPrice` as a multiplier of provider-returned `eth_gasPrice`
+- [#2813] `open`/`depositChannel` have a new option (`confirmConfirmation`, `true` by default) to wait `+confirmationBlocks` (default=5) after last transaction to give more time for it to be synced on partners and services
 
 ### Changed
 - [#2669] Update to Raiden contracts `v0.37.5`
@@ -19,6 +20,7 @@
 [#2677]: https://github.com/raiden-network/light-client/issues/2677
 [#2795]: https://github.com/raiden-network/light-client/issues/2795
 [#2797]: https://github.com/raiden-network/light-client/issues/2797
+[#2813]: https://github.com/raiden-network/light-client/issues/2813
 
 ## [0.16.0] - 2021-04-01
 ### Added

--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -349,15 +349,16 @@ export async function callAndWaitMined<
 }
 
 /**
- * Waits for a given receipt to be confirmed; throws if it gets removed by a reorg instead
+ * Waits for receipt to have at least `confBlocks` confirmations; resolves immediately if already;
+ * throws if it gets removed by a reorg.
  *
  * @param receipt - Receipt to wait for confirmation
  * @param deps - RaidenEpicDeps
  * @param deps.latest$ - Latest observable
  * @param deps.config$ - Config observable
  * @param deps.provider - Eth provider
- * @param confBlocks - Overwrites config
- * @returns Promise final block of transaction
+ * @param confBlocks - Confirmation blocks, defaults to `config.confirmationBlocks`
+ * @returns Promise to final blockNumber of transaction
  */
 export async function waitConfirmation(
   receipt: ContractReceipt,

--- a/raiden-ts/tests/unit/raiden.spec.ts
+++ b/raiden-ts/tests/unit/raiden.spec.ts
@@ -139,7 +139,7 @@ function makeDummyDependencies(): RaidenEpicDeps {
     getGasPrice: jest.fn(async () => BigNumber.from(5)),
     getTransactionReceipt: jest.fn(async (txHash) => ({
       blockNumber: 118,
-      confirmations: 6,
+      confirmations: 11,
       transactionHash: txHash,
     })),
   });
@@ -772,7 +772,7 @@ describe('Raiden', () => {
               settleTimeout,
               isFirstParticipant,
               txHash: channelOpenHash,
-              txBlock: 9,
+              txBlock: 118,
               confirmed: true,
             },
             { tokenNetwork, partner },
@@ -783,7 +783,7 @@ describe('Raiden', () => {
               participant: address as Address,
               totalDeposit: deposit as UInt<32>,
               txHash: channelDepositHash,
-              txBlock: 11,
+              txBlock: 118,
               confirmed: true,
             },
             { tokenNetwork, partner },
@@ -799,7 +799,7 @@ describe('Raiden', () => {
       token_to_token_networks: jest.fn(async () => tokenNetwork),
     } as any;
     const raiden = new Raiden(
-      dummyState,
+      { ...dummyState, blockNumber: 129 },
       deps,
       combineRaidenEpics([initEpicMock, channelOpenEpicMock]),
       channelOpenSuccessReducer,
@@ -1054,7 +1054,7 @@ describe('Raiden', () => {
                 participant: address as Address,
                 totalDeposit: deposit as UInt<32>,
                 txHash,
-                txBlock: 11,
+                txBlock: 118,
                 confirmed: true,
               },
               { tokenNetwork, partner },
@@ -1073,7 +1073,7 @@ describe('Raiden', () => {
     const raiden = new Raiden(
       makeInitialState(
         { address, network, contractsInfo },
-        { tokens: { [token]: tokenNetwork }, channels: { [key]: getChannel() } },
+        { blockNumber: 129, tokens: { [token]: tokenNetwork }, channels: { [key]: getChannel() } },
       ),
       deps,
       combineRaidenEpics([initEpicMock, channelDepositEpicMock]),


### PR DESCRIPTION
Fixes #2813 

**Short description**
Check issue's description for a breakdown of the race. This PR doesn't touch state machine, and just wait at the public method level, so the only significant impact should be a +5 blocks (~1min15) increase in `open`/`depositChannel` requests, which is awaited before allowing API to resolve in order to ensure partners and services have enoguh time to react to those events.
On dApp, the user is able to close the dialog and get the notification/see the deposit got confirmed and proceed to perform the transfers, if they want, so this is more of a safeguard for the race on these on-chain operations.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Check +5 blocks are awaited after **confirmed** `channel/deposit/success` before the deposit dialog is auto-closed
