### PR TITLE
dapp: fix service worker registration

### DIFF
--- a/raiden-dapp/src/plugins/service-worker-assistant-plugin.ts
+++ b/raiden-dapp/src/plugins/service-worker-assistant-plugin.ts
@@ -27,7 +27,8 @@ export async function ServiceWorkerAssistantPlugin(
 
   const serviceWorkerIsSupported = 'serviceWorker' in navigator;
   const serviceWorkerShouldBeRegistered =
-    process.env.NODE_ENV === 'production' && !process.env.VUE_APP_SERVICE_WORKER_DISABLED;
+    process.env.NODE_ENV === 'production' &&
+    process.env.VUE_APP_SERVICE_WORKER_DISABLED !== 'true';
 
   if (serviceWorkerIsSupported && serviceWorkerShouldBeRegistered) {
     window.onload = registerServiceWorker;


### PR DESCRIPTION
The parsed environment variable is a string, not a boolean. Therefore it would
never register a service worker.

**Short description**
Environment variables are no real booleans but strings.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Build dApp for production
2. Serve the dApp locally
3. Verify with the browser tools that the service worker gets registered.
