### PR TITLE
dapp: fix caching of too big vendor chunk

### DIFF
--- a/raiden-dapp/vue.config.js
+++ b/raiden-dapp/vue.config.js
@@ -37,6 +37,7 @@ function setupServiceWorkerRelatedPlugins(config) {
   const injectServiceWorkerPlugin = new InjectManifest({
     swSrc: path.join(sourceDirectoryPath, 'service-worker', 'worker'),
     swDest: 'service-worker.js',
+    maximumFileSizeToCacheInBytes: 20e6,
   });
 
   config.plugins.push(


### PR DESCRIPTION
The workbox plugin for webpack does filters per default too big assets so they
don't get cached. Because our dependencies have grown, the vendor script chunk
hit this limit. As result the dApp was not working offline anymore as this asset
was missing.
The limit got increased quite high to prevent this issue from happening again.
Especially because it is so unexpected and hard to notice.
