### PR TITLE
codecov: fix codecov's dapp config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,7 +16,8 @@ coverage:
     project:
       default: off
       dapp:
-        flags: dapp
+        flags:
+          - dapp
         target: 80%
         threshold: 1.00%
       sdk:


### PR DESCRIPTION
Fixes # 

**Short description**
Codecov hadn't updated our decrease of dApp's coverage threshold because the `flags` field was not an array

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
