### PR TITLE
cli: fix preserving default mediation fees in cli

### DIFF
--- a/raiden-cli/src/config.json
+++ b/raiden-cli/src/config.json
@@ -8,7 +8,6 @@
     "Mediate": 1
   },
   "mediationFees": {
-    "cap": true,
     "0x0000000000000000000000000000000000000000": {
       "cap": true,
       "flat": 0, 

--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -319,13 +319,12 @@ function registerShutdownHooks(this: Cli): void {
 type Await<T> = T extends Promise<infer U> ? U : T;
 
 function constructMediationFeeConfiguration(
+  mediationFeeConfiguration: MediationFeeConfiguration = {},
   cap: boolean,
   flatFees?: AddressToFeeValue,
   proportionalFees?: AddressToFeeValue,
   imbalanceFees?: AddressToFeeValue,
 ): MediationFeeConfiguration {
-  let mediationFeeConfiguration = {} as MediationFeeConfiguration;
-
   for (const [address, value] of Object.entries(flatFees ?? {})) {
     mediationFeeConfiguration = {
       ...mediationFeeConfiguration,
@@ -349,9 +348,7 @@ function constructMediationFeeConfiguration(
 
   for (const [address, configurationOfToken] of Object.entries(mediationFeeConfiguration)) {
     mediationFeeConfiguration[address] = {
-      flat: 0,
-      proportional: 4000,
-      imbalance: 3000,
+      ...mediationFeeConfiguration[ethers.constants.AddressZero],
       ...configurationOfToken,
       cap,
     };
@@ -394,6 +391,7 @@ function createRaidenConfig(
   if (!argv.enableMonitoring) config = { ...config, monitoringReward: null };
 
   const mediationFees = constructMediationFeeConfiguration(
+    config.mediationFees as MediationFeeConfiguration | undefined,
     argv.capMediationFees,
     argv.flatFee as unknown as AddressToFeeValue,
     argv.proportionalFee as unknown as AddressToFeeValue,


### PR DESCRIPTION
Fixes # 

**Short description**
Hotfix for CLI not preserving mediation fees

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
