### PR TITLE
docs: Fix broken links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 
 The Raiden Light Client SDK is a [Raiden Network](https://raiden.network) compatible client written in JavaScript/Typescript, capable of running in modern web3-enabled browsers, wallets and Node.js environments.
 
-The Raiden CLI is a reference implementation that provides a HTTP REST server which is fully compatible with the [Raiden API specification](https://docs.raiden.network/raiden-api-1/resources).
+The Raiden CLI is a reference implementation that provides a HTTP REST server which is fully compatible with the [Raiden API specification](https://raiden-network.readthedocs.io/en/stable/rest_api.html).
 
 The [Raiden dApp](#raiden-dapp) is a reference implementation of the Raiden Light Client SDK, which can be used with web3 wallets like [Metamask](https://metamask.io/) (Desktop) or [imToken](https://token.im/download) (mobile).
 

--- a/raiden-ts/docs-source/private-chain.md
+++ b/raiden-ts/docs-source/private-chain.md
@@ -144,11 +144,11 @@ To finalize the setup, you also need to change MetaMask's RPC provider. Simply g
 
 [instructions]: ../installing-dapp/README.md
 [`createRaiden`]: https://github.com/raiden-network/light-client/blob/3c2df8e496f329fac6f8b0ceafd4edaf40c1b736/raiden-dapp/src/services/raiden-service.ts#L18
-[cloning]: https://raiden-network.readthedocs.io/en/latest/private_net_tutorial.html#install-raiden-and-dependencies
-[tutorial]: https://raiden-network.readthedocs.io/en/latest/private_net_tutorial.html
+[cloning]: https://raiden-network.readthedocs.io/en/latest/custom-setups/private_net_tutorial.html#install-raiden-and-dependencies
+[tutorial]: https://raiden-network.readthedocs.io/en/latest/custom-setups/private_net_tutorial.html
 [`Blame`]: https://github.com/raiden-network/raiden/blame/81e535808f6f4d047495b76a555f623d3a6838f0/requirements/requirements.txt#L66
 [requirements.txt]: https://github.com/raiden-network/raiden/blob/develop/requirements/requirements.txt#L66
 [Raiden]: https://github.com/raiden-network/raiden
 [GitHub]: https://github.com/raiden-network/light-client
-[Raiden on Private Network Tutorial]: https://raiden-network.readthedocs.io/en/latest/private_net_tutorial.html
+[Raiden on Private Network Tutorial]: https://raiden-network.readthedocs.io/en/latest/custom-setups/private_net_tutorial.html
 [SDK installation]: ../installing-sdk/README.md


### PR DESCRIPTION
**Short description**

As our gitbook documentation was completely moved to readthedocs, a few links were broken. This fixes them.