### PR TITLE
Improve capabilities updates and transport syncing order

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- [#2831] Force PFS to acknowledge our capabilities updates
+
+[#2831]: https://github.com/raiden-network/light-client/issues/2831
+
 ## [1.0.0] - 2021-06-16
 ### Removed
 - [#2571] **BREAKING** Remove ability to join and send messages to global service rooms

--- a/raiden-ts/src/epics.ts
+++ b/raiden-ts/src/epics.ts
@@ -156,6 +156,7 @@ export function getLatest$(
   const initialStale = false;
   const udcDeposit$ = action$.pipe(
     filter(udcDeposit.success.is),
+    filter((action) => !('confirmed' in action.payload) || !!action.payload.confirmed),
     map((action) => ({ balance: action.payload.balance, totalDeposit: action.meta.totalDeposit })),
     // starts with max, to prevent receiving starting as disabled before actual balance is fetched
     startWith(initialUdcDeposit),

--- a/raiden-ts/src/transport/epics/presence.ts
+++ b/raiden-ts/src/transport/epics/presence.ts
@@ -15,7 +15,6 @@ import {
   map,
   mergeMap,
   pluck,
-  skip,
   switchMap,
   tap,
   timeout,
@@ -156,7 +155,7 @@ export function matrixMonitorChannelPresenceEpic(
 }
 
 /**
- * Update our matrix's avatarUrl on config.caps changes
+ * Update our matrix's avatarUrl on config.caps on startup and changes
  *
  * @param action$ - Observable of RaidenActions
  * @param state$ - Observable of RaidenStates
@@ -174,7 +173,6 @@ export function matrixUpdateCapsEpic(
     completeWith(action$),
     pluck('caps'),
     distinctUntilChanged(isEqual),
-    skip(1), // skip replay(1) and act only on changes
     switchMap((caps) =>
       matrix$.pipe(
         mergeMap((matrix) =>

--- a/raiden-ts/tests/integration/transport.spec.ts
+++ b/raiden-ts/tests/integration/transport.spec.ts
@@ -108,7 +108,7 @@ describe('initMatrixEpic', () => {
   afterEach(() => jest.restoreAllMocks());
 
   test('matrix stored setup', async () => {
-    expect.assertions(4);
+    expect.assertions(3);
 
     const userId = `@${raiden.address.toLowerCase()}:${matrixServer}`;
     const displayName = await raiden.deps.signer.signMessage(userId);
@@ -138,14 +138,6 @@ describe('initMatrixEpic', () => {
     );
     // ensure if stored setup works, servers list don't need to be fetched
     expect(fetch).not.toHaveBeenCalled();
-
-    // test presence got set again after some time, to overcome presence bug
-    await sleep(2 * raiden.config.httpTimeout);
-    // test presence got set again after some time, to overcome presence bug
-    expect(matrix.setPresence).toHaveBeenCalledWith({
-      presence: 'online',
-      status_msg: expect.any(String),
-    });
   });
 
   test('matrix server config set without stored setup', async () => {

--- a/raiden-ts/tests/integration/udc.spec.ts
+++ b/raiden-ts/tests/integration/udc.spec.ts
@@ -170,7 +170,6 @@ describe('udcDepositEpic', () => {
 
     const depositTx = makeTransaction(undefined, { to: userDepositContract.address });
     userDepositContract.deposit.mockResolvedValue(depositTx);
-    userDepositContract.effectiveBalance.mockResolvedValue(balance);
 
     await raiden.start();
     raiden.store.dispatch(udcDeposit.request({ deposit }, { totalDeposit: balance }));


### PR DESCRIPTION
Fixes #2831

**Short description**
We implemented the workaround to quickly toggle our transport status between `offline` and back `online` to trigger PFS to be informed of our new capabilities. Additionally, some needed fixes went into transport code handling capabilities updates: `udcDepositEpic` won't push outdated `balance` when mining the transaction, which did cause a wrong `udcDeposit.success` update and respective `Receive=0` capability to be set for a short period of time. Also, transport now is prepared before but started only when `synced`, to only then appear as `online` and start receiving transport events. Finally, some previous presence workaround tries were cleaned up, since they don't make sense anymore with PFS-based presence mechanism.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Have capabilities change while client is running (e.g. by UDC depositing or withdrawing across `monitoringReward`)
2. Check it got updated in `curl -vL https://pfs-goerli-with-fee.services-dev.raiden.network/api/v1/address/<address>/metadata`
