### PR TITLE
Feature/dapp add service worker unit tests

### DIFF
--- a/raiden-dapp/jest.config.js
+++ b/raiden-dapp/jest.config.js
@@ -6,7 +6,9 @@ module.exports = {
     '^.+\\.vue$': 'vue-jest',
     '.+\\.(css|styl|less|sass|scss|svg|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub',
     '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.js$': 'babel-jest',
   },
+  transformIgnorePatterns: ['<rootDir>/node_modules/(?!workbox.*/.*)'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },

--- a/raiden-dapp/jest.setup.js
+++ b/raiden-dapp/jest.setup.js
@@ -1,3 +1,5 @@
+import { MockedIDBObjectStore } from './tests/unit/utils/mocks/service-worker/indexeddb.ts';
+
 if (!('IntersectionObserver' in global)) {
   class IntersectionObserver {
     constructor() {}
@@ -44,3 +46,5 @@ class EventTarget {
 }
 
 Object.assign(global, { EventTarget });
+
+Object.assign(global, { IDBObjectStore: MockedIDBObjectStore });

--- a/raiden-dapp/src/service-worker/worker/cache.js
+++ b/raiden-dapp/src/service-worker/worker/cache.js
@@ -1,13 +1,18 @@
 import { cacheNames } from 'workbox-core';
 
 /**
- * Checks if the cache was already created.
- * This does not check its content nor if there is any content.
+ * Checks if the cache was already created and is not empty.
  *
- * @returns cache does exist
+ * @returns cache does exist and is not empty
  */
 export async function doesCacheExist() {
-  return await caches.has(cacheNames.precache);
+  if (await caches.has(cacheNames.precache)) {
+    const cache = await caches.open(cacheNames.precache);
+    const keys = await cache.keys();
+    return keys.length > 0;
+  } else {
+    return false;
+  }
 }
 
 /**
@@ -21,7 +26,7 @@ export async function doesCacheExist() {
  * @returns boolean if the cache is evaluated as valid
  */
 export async function isCacheInvalid() {
-  if (!(await doesCacheExist())) {
+  if (!(await caches.has(cacheNames.precache))) {
     return true;
   }
 

--- a/raiden-dapp/src/service-worker/worker/database.js
+++ b/raiden-dapp/src/service-worker/worker/database.js
@@ -1,16 +1,41 @@
-import { openDB } from 'idb';
 import { cacheNames } from 'workbox-core';
 
 const DATABASE_NAME = 'ServiceWorker';
-const STORE_NAME = cacheNames.precache;
+const OBJECT_STORE_NAME = cacheNames.precache;
 const PRECACHE_ENTRIES_KEY = 'precacheEntries';
 
-async function getDatabase() {
-  return await openDB(DATABASE_NAME, 1, {
-    upgrade(database) {
-      database.createObjectStore(STORE_NAME);
-    },
+function resolveTransaction(transaction) {
+  return new Promise((resolve, reject) => {
+    transaction.addEventListener('complete', () => resolve());
+    transaction.addEventListener('error', () => reject(transaction.error));
   });
+}
+
+function resolveRequest(request) {
+  return new Promise((resolve, reject) => {
+    request.addEventListener('success', () => resolve(request.result));
+    request.addEventListener('error', () => reject(request.error));
+  });
+}
+
+async function getDatabase() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DATABASE_NAME);
+    request.addEventListener('success', () => resolve(request.result));
+    request.addEventListener('error', () => reject(request.error));
+    request.addEventListener('upgradeneeded', async () => {
+      const database = request.result;
+      const objectStore = database.createObjectStore(OBJECT_STORE_NAME);
+      await resolveTransaction(objectStore.transaction);
+      resolve(database);
+    });
+  });
+}
+
+async function getPrecacheObjectStore(mode = 'readonly') {
+  const database = await getDatabase();
+  const transaction = database.transaction(OBJECT_STORE_NAME, mode);
+  return transaction.objectStore(OBJECT_STORE_NAME);
 }
 
 /**
@@ -20,8 +45,9 @@ async function getDatabase() {
  * @param precacheEntries - list of precache entries to save
  */
 export async function saveToPreservePrecacheEntries(precacheEntries) {
-  const database = await getDatabase();
-  database.put(STORE_NAME, precacheEntries, PRECACHE_ENTRIES_KEY);
+  const objectStore = await getPrecacheObjectStore('readwrite');
+  const request = objectStore.put(precacheEntries, PRECACHE_ENTRIES_KEY);
+  await resolveRequest(request);
 }
 
 /**
@@ -30,14 +56,16 @@ export async function saveToPreservePrecacheEntries(precacheEntries) {
  * @returns precache entry list or undefined
  */
 export async function getPreservedPrecacheEntries() {
-  const database = await getDatabase();
-  return database.get(STORE_NAME, PRECACHE_ENTRIES_KEY);
+  const objectStore = await getPrecacheObjectStore();
+  const request = objectStore.get(PRECACHE_ENTRIES_KEY);
+  return resolveRequest(request);
 }
 
 /**
  * Remove the list of precache entries in the database.
  */
 export async function deletePreservedPrecacheEntries() {
-  const database = await getDatabase();
-  await database.delete(STORE_NAME, PRECACHE_ENTRIES_KEY);
+  const objectStore = await getPrecacheObjectStore('readwrite');
+  const request = objectStore.delete(PRECACHE_ENTRIES_KEY);
+  await resolveRequest(request);
 }

--- a/raiden-dapp/src/service-worker/worker/index.js
+++ b/raiden-dapp/src/service-worker/worker/index.js
@@ -35,7 +35,7 @@ async function onInstall(event) {
 
   if (!cacheExists) {
     this.shouldUpdate = true;
-    this.precacheEntries = self.__WB_MANIFEST;
+    this.precacheEntries = self.__WB_MANIFEST; // Note that `self` is used due to the functionality of the workbox plugin.
     this.controller.addToCacheList(this.precacheEntries);
     this.controller.install(event);
   } else if (cacheExists && preservedPrecacheEntries) {
@@ -97,9 +97,9 @@ async function onRouteError() {
   return Response.error();
 }
 
-self.oninstall = (event) => event.waitUntil(onInstall.call(self, event));
-self.onactivate = (event) => event.waitUntil(onActivate.call(self, event));
-self.onmessage = (event) => event.waitUntil(onMessage.call(self, event));
+self.addEventListener('install', (event) => event.waitUntil(onInstall.call(self, event)));
+self.addEventListener('activate', (event) => event.waitUntil(onActivate.call(self, event)));
+self.addEventListener('message', (event) => event.waitUntil(onMessage.call(self, event)));
 
 registerRoute(self.route.match, self.route.handler); // TODO: Why can't we pass the route directly?
 setCatchHandler(onRouteError.bind(self));

--- a/raiden-dapp/src/service-worker/worker/index.js
+++ b/raiden-dapp/src/service-worker/worker/index.js
@@ -35,7 +35,7 @@ async function onInstall(event) {
 
   if (!cacheExists) {
     this.shouldUpdate = true;
-    this.precacheEntries = self.__WB_MANIFEST; // Note that `self` is used due to the functionality of the workbox plugin.
+    this.precacheEntries = self.__WB_PRECACHE_ENTRIES;
     this.controller.addToCacheList(this.precacheEntries);
     this.controller.install(event);
   } else if (cacheExists && preservedPrecacheEntries) {

--- a/raiden-dapp/tests/unit/service-worker/worker/cache.spec.ts
+++ b/raiden-dapp/tests/unit/service-worker/worker/cache.spec.ts
@@ -1,0 +1,104 @@
+import { mockCacheStorageInEnvironment, MockedCache, MockedCacheStorage } from '../../utils/mocks';
+
+import { PrecacheController } from 'workbox-precaching';
+
+import { deleteCache, doesCacheExist, isCacheInvalid } from '@/service-worker/worker/cache';
+
+describe('service worker cache', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('doesCacheExist()', () => {
+    test('is false if specific cache does not exist', async () => {
+      const caches = new MockedCacheStorage('other-cache');
+      mockCacheStorageInEnvironment({ caches });
+
+      const exists = await doesCacheExist();
+
+      expect(exists).toBeFalsy();
+    });
+
+    test('is false if specific cache does exist but is empty', async () => {
+      const cache = new MockedCache([]);
+      const caches = new MockedCacheStorage('workbox-precache-v2', cache);
+      mockCacheStorageInEnvironment({ caches });
+
+      const exists = await doesCacheExist();
+
+      expect(exists).toBeFalsy();
+    });
+
+    test('is true if specific cache exists and is not empty', async () => {
+      const cache = new MockedCache(['https://test.tld/asset']);
+      mockCacheStorageInEnvironment({ cache });
+
+      const exists = await doesCacheExist();
+
+      expect(exists).toBeTruthy();
+    });
+  });
+
+  describe('isCacheInvalid()', () => {
+    test('is invalid if the specific cache does not exist', async () => {
+      const caches = new MockedCacheStorage('other-cache');
+      mockCacheStorageInEnvironment({ caches });
+
+      const isInvalid = await isCacheInvalid();
+
+      expect(isInvalid).toBeTruthy();
+    });
+
+    test('is invalid if the cache is empty', async () => {
+      const cache = new MockedCache([]);
+      const caches = new MockedCacheStorage('workbox-precache-v2', cache);
+      mockCacheStorageInEnvironment({ caches });
+
+      const controller = new PrecacheController();
+      controller.addToCacheList([{ url: 'https://test.tld/asset', revision: '1' }]);
+
+      const isInvalid = await isCacheInvalid.call({ controller });
+
+      expect(isInvalid).toBeTruthy();
+    });
+
+    test('is invalid if a cache entry is missing', async () => {
+      const cache = new MockedCache(['https://test.tld/asset-one?__WB_REVISION__=1']);
+      mockCacheStorageInEnvironment({ cache });
+
+      const controller = new PrecacheController();
+      controller.addToCacheList([
+        { url: 'https://test.tld/asset-one', revision: '1' },
+        { url: 'https://test.tld/asset-two', revision: '1' },
+      ]);
+
+      const isInvalid = await isCacheInvalid.call({ controller });
+
+      expect(isInvalid).toBeTruthy();
+    });
+
+    test('is valid if all cache entries are there', async () => {
+      const cache = new MockedCache(['https://test.tld/asset?__WB_REVISION__=1']);
+      mockCacheStorageInEnvironment({ cache });
+
+      const controller = new PrecacheController();
+      controller.addToCacheList([{ url: 'https://test.tld/asset', revision: '1' }]);
+
+      const isInvalid = await isCacheInvalid.call({ controller });
+
+      expect(isInvalid).toBeFalsy();
+    });
+  });
+
+  describe('deleteCache()', () => {
+    test('deletes specific cache', async () => {
+      const caches = new MockedCacheStorage('workbox-precache-v2');
+      mockCacheStorageInEnvironment({ caches });
+
+      await deleteCache();
+
+      expect(caches.delete).toHaveBeenCalledTimes(1);
+      expect(caches.delete).toHaveBeenLastCalledWith('workbox-precache-v2');
+    });
+  });
+});

--- a/raiden-dapp/tests/unit/service-worker/worker/clients.spec.ts
+++ b/raiden-dapp/tests/unit/service-worker/worker/clients.spec.ts
@@ -1,0 +1,57 @@
+import { MockedClient, MockedClients } from '../../utils/mocks';
+
+import { isAnyClientAvailable, sendMessageToClients } from '@/service-worker/worker/clients';
+
+describe('service worker clients', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('isAnyClientAvailable', () => {
+    test('is false if no client is connected at all', async () => {
+      const clients = new MockedClients([]);
+
+      await expect(isAnyClientAvailable.call({ clients })).resolves.toBeFalsy();
+    });
+
+    test('is true if one client is connected', async () => {
+      const client = new MockedClient('client-id');
+      const clients = new MockedClients([client]);
+
+      await expect(isAnyClientAvailable.call({ clients })).resolves.toBeTruthy();
+    });
+
+    test('is true if multiple clients are connected', async () => {
+      const clientOne = new MockedClient('client-id-one');
+      const clientTwo = new MockedClient('client-id-two');
+      const clients = new MockedClients([clientOne, clientTwo]);
+
+      await expect(isAnyClientAvailable.call({ clients })).resolves.toBeTruthy();
+    });
+  });
+
+  describe('sendMessageToClients()', () => {
+    test('sends message to a single connected client', async () => {
+      const client = new MockedClient('client-id');
+      const clients = new MockedClients([client]);
+
+      await sendMessageToClients.call({ clients }, 'message', { data: 1 });
+
+      expect(client.postMessage).toHaveBeenCalledTimes(1);
+      expect(client.postMessage).toHaveBeenLastCalledWith('message', { data: 1 });
+    });
+
+    test('sends message to multiple connected clients', async () => {
+      const clientOne = new MockedClient('client-id-one');
+      const clientTwo = new MockedClient('client-id-two');
+      const clients = new MockedClients([clientOne, clientTwo]);
+
+      await sendMessageToClients.call({ clients }, 'message', { data: 1 });
+
+      expect(clientOne.postMessage).toHaveBeenCalledTimes(1);
+      expect(clientOne.postMessage).toHaveBeenLastCalledWith('message', { data: 1 });
+      expect(clientTwo.postMessage).toHaveBeenCalledTimes(1);
+      expect(clientTwo.postMessage).toHaveBeenLastCalledWith('message', { data: 1 });
+    });
+  });
+});

--- a/raiden-dapp/tests/unit/service-worker/worker/database.spec.ts
+++ b/raiden-dapp/tests/unit/service-worker/worker/database.spec.ts
@@ -1,0 +1,87 @@
+import {
+  deletePreservedPrecacheEntries,
+  getPreservedPrecacheEntries,
+  saveToPreservePrecacheEntries,
+} from '@/service-worker/worker/database';
+
+import {
+  MockedIDBDatabase,
+  MockedIDBObjectStore,
+  mockIndexedDatabaseInEnvironment,
+} from '../../utils/mocks/service-worker';
+
+describe('service worker database', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('saveToPreservePrecacheEntries()', () => {
+    test('uses readwrite mode to get access to the object store', async () => {
+      const database = new MockedIDBDatabase();
+      mockIndexedDatabaseInEnvironment({ database });
+
+      await saveToPreservePrecacheEntries([]);
+
+      expect(database.transaction).toHaveBeenCalledTimes(1);
+      expect(database.transaction).toHaveBeenLastCalledWith('workbox-precache-v2', 'readwrite');
+    });
+
+    test('puts precache entries into object store for specific key', async () => {
+      const objectStore = new MockedIDBObjectStore();
+      mockIndexedDatabaseInEnvironment({ objectStore });
+
+      await saveToPreservePrecacheEntries([{ url: 'https://test.tld/asset' }]);
+
+      expect(objectStore.put).toHaveBeenCalledTimes(1);
+      expect(objectStore.put).toHaveBeenLastCalledWith(
+        [{ url: 'https://test.tld/asset' }],
+        'precacheEntries',
+      );
+    });
+  });
+
+  describe('getPreservedPrecacheEntries', () => {
+    test('uses readonly mode to get access to the object store', async () => {
+      const database = new MockedIDBDatabase();
+      mockIndexedDatabaseInEnvironment({ database });
+
+      await getPreservedPrecacheEntries();
+
+      expect(database.transaction).toHaveBeenCalledTimes(1);
+      expect(database.transaction).toHaveBeenLastCalledWith('workbox-precache-v2', 'readonly');
+    });
+
+    test('gets precache entries from object store for specific key', async () => {
+      const objectStore = new MockedIDBObjectStore('precacheEntries', [
+        { url: 'https://test.tld/asset' },
+      ]);
+      mockIndexedDatabaseInEnvironment({ objectStore });
+
+      const precacheEntries = await getPreservedPrecacheEntries();
+
+      expect(precacheEntries).toEqual([{ url: 'https://test.tld/asset' }]);
+    });
+  });
+
+  describe('deletePreservedPrecacheEntries', () => {
+    test('uses readwrite mode to get access to the object store', async () => {
+      const database = new MockedIDBDatabase();
+      mockIndexedDatabaseInEnvironment({ database });
+
+      await deletePreservedPrecacheEntries();
+
+      expect(database.transaction).toHaveBeenCalledTimes(1);
+      expect(database.transaction).toHaveBeenLastCalledWith('workbox-precache-v2', 'readwrite');
+    });
+
+    test('deletes precache entries from object store for specific key', async () => {
+      const objectStore = new MockedIDBObjectStore();
+      mockIndexedDatabaseInEnvironment({ objectStore });
+
+      await deletePreservedPrecacheEntries();
+
+      expect(objectStore.delete).toHaveBeenCalledTimes(1);
+      expect(objectStore.delete).toHaveBeenLastCalledWith('precacheEntries');
+    });
+  });
+});

--- a/raiden-dapp/tests/unit/service-worker/worker/index.spec.ts
+++ b/raiden-dapp/tests/unit/service-worker/worker/index.spec.ts
@@ -1,0 +1,321 @@
+import {
+  MockedCache,
+  MockedCacheStorage,
+  MockedClient,
+  MockedClients,
+  MockedExtendableEvent,
+  MockedFetchEvent,
+  MockedIDBFactory,
+  MockedIDBObjectStore,
+  MockedMessageEvent,
+  MockedRegistration,
+  MockedRequest,
+  mockEnvironmentForServiceWorker,
+} from '../../utils/mocks';
+
+async function installServiceWorker(context: EventTarget): Promise<void> {
+  require('@/service-worker/worker');
+
+  const installEvent = new MockedExtendableEvent('install');
+  context.dispatchEvent(installEvent);
+  await installEvent.waitToFinish();
+}
+
+async function activateServiceWorker(context: EventTarget): Promise<void> {
+  const activateEvent = new MockedExtendableEvent('activate');
+  context.dispatchEvent(activateEvent);
+  await activateEvent.waitToFinish();
+}
+
+async function installAndActivateServiceWorker(context: EventTarget): Promise<void> {
+  await installServiceWorker(context);
+  await activateServiceWorker(context);
+}
+
+async function sendMessageToServiceWorker(
+  context: EventTarget,
+  data: string,
+  installServiceWorker = true,
+): Promise<void> {
+  if (installServiceWorker) {
+    await installAndActivateServiceWorker(context);
+  }
+
+  jest.clearAllMocks(); // Forget recorded data of previous installation and activation steps.
+  const messageEvent = new MockedMessageEvent('message', data);
+  context.dispatchEvent(messageEvent);
+  await messageEvent.waitToFinish();
+}
+
+async function fetchUrlViaServiceWorker(
+  context: EventTarget,
+  url: string,
+  installServiceWorker = true,
+): Promise<MockedFetchEvent> {
+  if (installServiceWorker) {
+    await installAndActivateServiceWorker(context);
+  }
+
+  jest.clearAllMocks(); // Forget recorded data of previous installation and activation steps.
+  const fetchEvent = new MockedFetchEvent('fetch', url);
+  context.dispatchEvent(fetchEvent);
+  await fetchEvent.waitToFinish();
+  await new Promise((resolve) => setTimeout(resolve, 50)); // For some rason this is necessary...
+  return fetchEvent;
+}
+
+describe('service worker index', () => {
+  beforeEach(() => {
+    jest.resetModules(); // Required so that the service worker script does not get cached.
+    jest.restoreAllMocks();
+  });
+
+  describe('installation and activation phases', () => {
+    test('saves manifest entries to cache if cache and database are empty', async () => {
+      const cache = new MockedCache([]);
+      const indexedDB = new MockedIDBFactory();
+      const manifest = [{ url: 'https://test.tld/asset', revision: '1' }];
+      const context = mockEnvironmentForServiceWorker({ cache, indexedDB, manifest });
+
+      await installServiceWorker(context);
+
+      expect(cache.put).toHaveBeenCalledTimes(1);
+      expect(cache.put.mock.calls.map((call) => call[0].url)).toEqual([
+        'https://test.tld/asset?__WB_REVISION__=1',
+      ]);
+    });
+
+    test('saves manifest to database if cache and database are empty', async () => {
+      const cache = new MockedCache([]);
+      const objectStore = new MockedIDBObjectStore();
+      const manifest = [{ url: 'https://test.tld/asset', revision: '1' }];
+      const context = mockEnvironmentForServiceWorker({ cache, objectStore, manifest });
+
+      await installAndActivateServiceWorker(context);
+
+      expect(objectStore.put).toHaveBeenCalledTimes(1);
+      expect(objectStore.put).toHaveBeenLastCalledWith(
+        [{ url: 'https://test.tld/asset', revision: '1' }],
+        'precacheEntries',
+      );
+    });
+
+    test('takes over previous cache if finding manifest in database', async () => {
+      const cache = new MockedCache(['https://test.tld/old-asset']);
+      const objectStore = new MockedIDBObjectStore('precacheEntries', [
+        { url: 'https://test.tld/old-asset' },
+      ]);
+      const context = mockEnvironmentForServiceWorker({ cache, objectStore });
+
+      await installAndActivateServiceWorker(context);
+
+      expect(cache.put).not.toHaveBeenCalled();
+      expect(objectStore.put).not.toHaveBeenCalled();
+    });
+
+    test('sends window reload message after activation', async () => {
+      const client = new MockedClient();
+      const context = mockEnvironmentForServiceWorker({ client });
+
+      await installServiceWorker(context);
+      expect(client.postMessage).not.toHaveBeenCalled();
+
+      await activateServiceWorker(context);
+      expect(client.postMessage).toHaveBeenCalledTimes(1);
+      expect(client.postMessage).toHaveBeenLastCalledWith('reload_window', undefined);
+    });
+
+    test('takes control of all clients when getting activated', async () => {
+      const clients = new MockedClients();
+      const context = mockEnvironmentForServiceWorker({ clients });
+
+      await installServiceWorker(context);
+      expect(clients.claim).not.toHaveBeenCalled();
+
+      await activateServiceWorker(context);
+      expect(clients.claim).toHaveBeenCalledTimes(1);
+    });
+
+    test('sends installation error message to clients if cache exists but no database', async () => {
+      const cache = new MockedCache(['https://test.tls/asset']);
+      const client = new MockedClient();
+      const indexedDB = new MockedIDBFactory();
+      const context = mockEnvironmentForServiceWorker({ cache, client, indexedDB });
+
+      await installAndActivateServiceWorker(context);
+
+      expect(client.postMessage).toHaveBeenCalledTimes(1);
+      expect(client.postMessage).toHaveBeenLastCalledWith(
+        'installation_error',
+        new Error('Cache given, but precache entries are missing!'),
+      );
+    });
+  });
+
+  describe('acts on fetch requests of client', () => {
+    test('replies with cached responses for requests in manifest', async () => {
+      const manifest = [{ url: 'https://test.tld/asset', revision: '1' }];
+      const context = mockEnvironmentForServiceWorker({ manifest });
+
+      const fetchEvent = await fetchUrlViaServiceWorker(context, 'https://test.tld/asset');
+
+      expect(fetchEvent.respondWith).toHaveBeenCalledTimes(1);
+      expect(fetchEvent.respondWith).toHaveBeenLastCalledWith(expect.any(Object));
+    });
+
+    test('ignores requests not in manifest', async () => {
+      const manifest = [{ url: 'https://test.tld/asset', revision: '1' }];
+      const context = mockEnvironmentForServiceWorker({ manifest });
+
+      const fetchEvent = await fetchUrlViaServiceWorker(context, 'https://something-else.tld');
+
+      expect(fetchEvent.respondWith).not.toHaveBeenCalled();
+    });
+
+    test('can serve from cache of old version', async () => {
+      const cache = new MockedCache(['https://test.tld/old-asset']);
+      const objectStore = new MockedIDBObjectStore('precacheEntries', [
+        { url: 'https://test.tld/old-asset' },
+      ]);
+      const manifest = [{ url: 'https://test.tld/new-asset', revision: '1' }];
+      const context = mockEnvironmentForServiceWorker({ cache, objectStore, manifest });
+
+      let fetchEvent = await fetchUrlViaServiceWorker(context, 'https://test.tld/old-asset');
+      expect(fetchEvent.respondWith).toHaveBeenCalledTimes(1);
+      expect(fetchEvent.respondWith).toHaveBeenLastCalledWith(expect.any(Object));
+
+      fetchEvent = await fetchUrlViaServiceWorker(context, 'https://test.tld/new-asset');
+      expect(fetchEvent.respondWith).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('on update message', () => {
+    test('deletes cache for current version', async () => {
+      const caches = new MockedCacheStorage();
+      const context = mockEnvironmentForServiceWorker({ caches });
+
+      await sendMessageToServiceWorker(context, 'update');
+
+      expect(caches.delete).toHaveBeenCalledTimes(1);
+      expect(caches.delete).toHaveBeenLastCalledWith('workbox-precache-v2');
+    });
+
+    test('deletes database precache-entries', async () => {
+      const objectStore = new MockedIDBObjectStore('precacheEntries', []);
+      const context = mockEnvironmentForServiceWorker({ objectStore });
+
+      await sendMessageToServiceWorker(context, 'update');
+
+      expect(objectStore.delete).toHaveBeenCalledTimes(1);
+      expect(objectStore.delete).toHaveBeenLastCalledWith('precacheEntries');
+    });
+
+    test('unregisters itself', async () => {
+      const registration = new MockedRegistration();
+      const context = mockEnvironmentForServiceWorker({ registration });
+
+      await sendMessageToServiceWorker(context, 'update');
+
+      expect(registration.unregister).toHaveBeenCalledTimes(1);
+    });
+
+    test('sends window reload message', async () => {
+      const client = new MockedClient();
+      const context = mockEnvironmentForServiceWorker({ client });
+
+      await sendMessageToServiceWorker(context, 'update');
+
+      expect(client.postMessage).toHaveBeenCalledTimes(1);
+      expect(client.postMessage).toHaveBeenLastCalledWith('reload_window', undefined);
+    });
+  });
+
+  describe('on verify cache message', () => {
+    test('sends cache is invalid message if cache is missing', async () => {
+      const caches = new MockedCacheStorage();
+      const client = new MockedClient();
+      const context = mockEnvironmentForServiceWorker({ caches, client });
+      await installAndActivateServiceWorker(context);
+
+      await caches.delete('workbox-precache-v2');
+      await sendMessageToServiceWorker(context, 'verify_cache', false);
+
+      expect(client.postMessage).toHaveBeenCalledTimes(1);
+      expect(client.postMessage).toHaveBeenLastCalledWith('cache_is_invalid', undefined);
+    });
+
+    test('sends cache is invalid message if cache does not exist', async () => {
+      const caches = new MockedCacheStorage();
+      const client = new MockedClient();
+      const context = mockEnvironmentForServiceWorker({ caches, client });
+      await installAndActivateServiceWorker(context);
+
+      await caches.delete('workbox-precache-v2');
+      await sendMessageToServiceWorker(context, 'verify_cache', false);
+
+      expect(client.postMessage).toHaveBeenCalledTimes(1);
+      expect(client.postMessage).toHaveBeenLastCalledWith('cache_is_invalid', undefined);
+    });
+
+    test('sends cache is invalid message if cache is missing an entry', async () => {
+      const cache = new MockedCache();
+      const client = new MockedClient();
+      const manifest = [
+        { url: 'https://test.tld/asset-one', revision: '1' },
+        { url: 'https://test.tld/asset-two', revision: '1' },
+      ];
+      const context = mockEnvironmentForServiceWorker({ cache, client, manifest });
+      await installAndActivateServiceWorker(context);
+
+      await cache.delete(new MockedRequest('https://test.tld/asset-one?__WB_REVISION__=1'));
+      await sendMessageToServiceWorker(context, 'verify_cache', false);
+
+      expect(client.postMessage).toHaveBeenCalledTimes(1);
+      expect(client.postMessage).toHaveBeenLastCalledWith('cache_is_invalid', undefined);
+    });
+  });
+
+  describe('on routing errors', () => {
+    test('sends cache is invalid message if detecting invalid cache and a client is available', async () => {
+      const client = new MockedClient();
+      const cache = new MockedCache();
+      const manifest = [{ url: 'https://test.tld/asset', revision: '1' }];
+      const context = mockEnvironmentForServiceWorker({ client, cache, manifest });
+      await installAndActivateServiceWorker(context);
+
+      await cache.delete(new MockedRequest('https://test.tld/asset?__WB_REVISION__=1'));
+      await fetchUrlViaServiceWorker(context, 'https://test.tld/asset', false);
+
+      expect(client.postMessage).toHaveBeenCalledTimes(1);
+      expect(client.postMessage).toHaveBeenLastCalledWith('cache_is_invalid', undefined);
+    });
+
+    test('initates update if detecting invalid cache and no client is available', async () => {
+      const cache = new MockedCache();
+      const caches = new MockedCacheStorage('workbox-precache-v2', cache);
+      const clients = new MockedClients([]);
+      const objectStore = new MockedIDBObjectStore('precacheEntries', []);
+      const registration = new MockedRegistration();
+      const manifest = [{ url: 'https://test.tld/asset', revision: '1' }];
+      const context = mockEnvironmentForServiceWorker({
+        caches,
+        clients,
+        objectStore,
+        registration,
+        manifest,
+      });
+      await installAndActivateServiceWorker(context);
+
+      await cache.delete(new MockedRequest('https://test.tld/asset?__WB_REVISION__=1'));
+      await fetchUrlViaServiceWorker(context, 'https://test.tld/asset', false);
+
+      // Only check some basics of absolute required actions. We have detailed
+      // tests for full updates.
+      expect(caches.delete).toHaveBeenCalledTimes(1);
+      expect(caches.delete).toHaveBeenLastCalledWith('workbox-precache-v2');
+      expect(objectStore.delete).toHaveBeenCalledTimes(1);
+      expect(objectStore.delete).toHaveBeenLastCalledWith('precacheEntries');
+      expect(registration.unregister).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/raiden-dapp/tests/unit/service-worker/worker/index.spec.ts
+++ b/raiden-dapp/tests/unit/service-worker/worker/index.spec.ts
@@ -71,11 +71,11 @@ describe('service worker index', () => {
   });
 
   describe('installation and activation phases', () => {
-    test('saves manifest entries to cache if cache and database are empty', async () => {
+    test('saves the precache entries to cache if cache and database are empty', async () => {
       const cache = new MockedCache([]);
       const indexedDB = new MockedIDBFactory();
-      const manifest = [{ url: 'https://test.tld/asset', revision: '1' }];
-      const context = mockEnvironmentForServiceWorker({ cache, indexedDB, manifest });
+      const precacheEntries = [{ url: 'https://test.tld/asset', revision: '1' }];
+      const context = mockEnvironmentForServiceWorker({ cache, indexedDB, precacheEntries });
 
       await installServiceWorker(context);
 
@@ -85,11 +85,11 @@ describe('service worker index', () => {
       ]);
     });
 
-    test('saves manifest to database if cache and database are empty', async () => {
+    test('saves the precache entries to database if cache and database are empty', async () => {
       const cache = new MockedCache([]);
       const objectStore = new MockedIDBObjectStore();
-      const manifest = [{ url: 'https://test.tld/asset', revision: '1' }];
-      const context = mockEnvironmentForServiceWorker({ cache, objectStore, manifest });
+      const precacheEntries = [{ url: 'https://test.tld/asset', revision: '1' }];
+      const context = mockEnvironmentForServiceWorker({ cache, objectStore, precacheEntries });
 
       await installAndActivateServiceWorker(context);
 
@@ -100,7 +100,7 @@ describe('service worker index', () => {
       );
     });
 
-    test('takes over previous cache if finding manifest in database', async () => {
+    test('takes over previous cache if finding the precache entries in database', async () => {
       const cache = new MockedCache(['https://test.tld/old-asset']);
       const objectStore = new MockedIDBObjectStore('precacheEntries', [
         { url: 'https://test.tld/old-asset' },
@@ -153,9 +153,9 @@ describe('service worker index', () => {
   });
 
   describe('acts on fetch requests of client', () => {
-    test('replies with cached responses for requests in manifest', async () => {
-      const manifest = [{ url: 'https://test.tld/asset', revision: '1' }];
-      const context = mockEnvironmentForServiceWorker({ manifest });
+    test('replies with cached responses for requests in pre-cache entries', async () => {
+      const precacheEntries = [{ url: 'https://test.tld/asset', revision: '1' }];
+      const context = mockEnvironmentForServiceWorker({ precacheEntries });
 
       const fetchEvent = await fetchUrlViaServiceWorker(context, 'https://test.tld/asset');
 
@@ -163,9 +163,9 @@ describe('service worker index', () => {
       expect(fetchEvent.respondWith).toHaveBeenLastCalledWith(expect.any(Object));
     });
 
-    test('ignores requests not in manifest', async () => {
-      const manifest = [{ url: 'https://test.tld/asset', revision: '1' }];
-      const context = mockEnvironmentForServiceWorker({ manifest });
+    test('ignores requests not in pre-cache entries', async () => {
+      const precacheEntries = [{ url: 'https://test.tld/asset', revision: '1' }];
+      const context = mockEnvironmentForServiceWorker({ precacheEntries });
 
       const fetchEvent = await fetchUrlViaServiceWorker(context, 'https://something-else.tld');
 
@@ -177,8 +177,8 @@ describe('service worker index', () => {
       const objectStore = new MockedIDBObjectStore('precacheEntries', [
         { url: 'https://test.tld/old-asset' },
       ]);
-      const manifest = [{ url: 'https://test.tld/new-asset', revision: '1' }];
-      const context = mockEnvironmentForServiceWorker({ cache, objectStore, manifest });
+      const precacheEntries = [{ url: 'https://test.tld/new-asset', revision: '1' }];
+      const context = mockEnvironmentForServiceWorker({ cache, objectStore, precacheEntries });
 
       let fetchEvent = await fetchUrlViaServiceWorker(context, 'https://test.tld/old-asset');
       expect(fetchEvent.respondWith).toHaveBeenCalledTimes(1);
@@ -260,11 +260,11 @@ describe('service worker index', () => {
     test('sends cache is invalid message if cache is missing an entry', async () => {
       const cache = new MockedCache();
       const client = new MockedClient();
-      const manifest = [
+      const precacheEntries = [
         { url: 'https://test.tld/asset-one', revision: '1' },
         { url: 'https://test.tld/asset-two', revision: '1' },
       ];
-      const context = mockEnvironmentForServiceWorker({ cache, client, manifest });
+      const context = mockEnvironmentForServiceWorker({ cache, client, precacheEntries });
       await installAndActivateServiceWorker(context);
 
       await cache.delete(new MockedRequest('https://test.tld/asset-one?__WB_REVISION__=1'));
@@ -279,8 +279,8 @@ describe('service worker index', () => {
     test('sends cache is invalid message if detecting invalid cache and a client is available', async () => {
       const client = new MockedClient();
       const cache = new MockedCache();
-      const manifest = [{ url: 'https://test.tld/asset', revision: '1' }];
-      const context = mockEnvironmentForServiceWorker({ client, cache, manifest });
+      const precacheEntries = [{ url: 'https://test.tld/asset', revision: '1' }];
+      const context = mockEnvironmentForServiceWorker({ client, cache, precacheEntries });
       await installAndActivateServiceWorker(context);
 
       await cache.delete(new MockedRequest('https://test.tld/asset?__WB_REVISION__=1'));
@@ -296,13 +296,13 @@ describe('service worker index', () => {
       const clients = new MockedClients([]);
       const objectStore = new MockedIDBObjectStore('precacheEntries', []);
       const registration = new MockedRegistration();
-      const manifest = [{ url: 'https://test.tld/asset', revision: '1' }];
+      const precacheEntries = [{ url: 'https://test.tld/asset', revision: '1' }];
       const context = mockEnvironmentForServiceWorker({
         caches,
         clients,
         objectStore,
         registration,
-        manifest,
+        precacheEntries,
       });
       await installAndActivateServiceWorker(context);
 

--- a/raiden-dapp/tests/unit/utils/mocks/index.ts
+++ b/raiden-dapp/tests/unit/utils/mocks/index.ts
@@ -1,5 +1,7 @@
 import type VueI18n from 'vue-i18n';
 
+export * from './service-worker';
+
 export const $identicon = () => ({
   getIdenticon: jest.fn().mockReturnValue(''),
 });

--- a/raiden-dapp/tests/unit/utils/mocks/service-worker/cache-storage.ts
+++ b/raiden-dapp/tests/unit/utils/mocks/service-worker/cache-storage.ts
@@ -1,0 +1,87 @@
+import { MockedRequest, MockedResponse } from './';
+
+export class MockedCacheStorage {
+  private caches: { [name: string]: MockedCache } = {};
+
+  constructor(cacheName?: string, cache?: MockedCache) {
+    if (cacheName !== undefined) {
+      if (cache === undefined) {
+        cache = new MockedCache();
+      }
+
+      this.caches[cacheName] = cache;
+    }
+  }
+
+  has = jest.fn().mockImplementation(async (name: string) => {
+    return !!this.caches[name];
+  });
+
+  keys = jest.fn().mockImplementation(async () => {
+    return Object.keys(this.caches);
+  });
+
+  open = jest.fn().mockImplementation(async (name: string) => {
+    if (!(name in this.caches)) {
+      this.caches[name] = new MockedCache();
+    }
+
+    return this.caches[name];
+  });
+
+  match = jest.fn().mockImplementation(async (request: MockedRequest) => {
+    for (const cache of Object.values(this.caches)) {
+      if (await cache.match(request)) {
+        return true;
+      }
+    }
+
+    return false;
+  });
+
+  delete = jest.fn().mockImplementation(async (name: string) => {
+    delete this.caches[name];
+  });
+}
+
+export class MockedCache {
+  private nextId = 0;
+  private data: { [id: number]: { request: MockedRequest; response: MockedResponse } } = {};
+
+  constructor(requestUrls?: string[]) {
+    (requestUrls ?? []).forEach((url) => {
+      const request = new MockedRequest(url);
+      const response = new MockedResponse(url);
+      this.data[this.nextId] = { request, response };
+      this.nextId += 1;
+    });
+  }
+
+  async keys() {
+    return Object.values(this.data).map((entry) => entry.request);
+  }
+
+  match = jest.fn().mockImplementation(async (request: MockedRequest) => {
+    for (const entry of Object.values(this.data)) {
+      if (entry.request.url == request.url) {
+        return entry.response;
+      }
+    }
+  });
+
+  put = jest.fn().mockImplementation(async (request: MockedRequest, response: MockedResponse) => {
+    this.data[this.nextId] = { request, response };
+    this.nextId += 1;
+  });
+
+  delete = jest.fn().mockImplementation(async (request: MockedRequest) => {
+    for (const [id, entry] of Object.entries(this.data)) {
+      if (entry.request.url == request.url) {
+        delete this.data[parseInt(id)];
+        return true;
+      }
+    }
+
+    return false;
+  });
+}

--- a/raiden-dapp/tests/unit/utils/mocks/service-worker/clients.ts
+++ b/raiden-dapp/tests/unit/utils/mocks/service-worker/clients.ts
@@ -1,0 +1,25 @@
+export const postClientMessageMock = jest.fn();
+
+export class MockedClients {
+  private clients: { [id: string]: MockedClient } = {};
+
+  constructor(clients?: MockedClient[]) {
+    (clients ?? []).forEach((client) => {
+      this.clients[client.id] = client;
+    });
+  }
+
+  get = jest.fn().mockImplementation(async (id: string) => this.clients[id]);
+  matchAll = jest.fn().mockImplementation(async () => Object.values(this.clients));
+  claim = jest.fn();
+}
+
+export class MockedClient {
+  public id: string;
+
+  constructor(id?: string) {
+    this.id = id ?? 'client-id';
+  }
+
+  postMessage = jest.fn();
+}

--- a/raiden-dapp/tests/unit/utils/mocks/service-worker/environment.ts
+++ b/raiden-dapp/tests/unit/utils/mocks/service-worker/environment.ts
@@ -74,7 +74,7 @@ type ServiceWorkerEnvironment = CacheStorageEnvironment &
     client: MockedClient;
     clients: MockedClients;
     registration: MockedRegistration;
-    manifest: { url: string; revision?: string }[];
+    precacheEntries: { url: string; revision?: string }[];
   };
 
 /**
@@ -94,8 +94,8 @@ export function mockEnvironmentForServiceWorker(
 ): EventTarget {
   const client = environment?.client ?? new MockedClient();
   const clients = environment?.clients ?? new MockedClients([client]);
-  const manifest = environment?.manifest ?? [];
   const registration = environment?.registration ?? new MockedRegistration();
+  const precacheEntries = environment?.precacheEntries ?? [];
   const context = new EventTarget();
   const { caches } = mockCacheStorageInEnvironment({ ...environment });
   mockIndexedDatabaseInEnvironment({ ...environment });
@@ -112,7 +112,7 @@ export function mockEnvironmentForServiceWorker(
     caches,
     clients,
     registration,
-    __WB_MANIFEST: manifest,
+    __WB_PRECACHE_ENTRIES: precacheEntries,
     __WB_DISABLE_DEV_LOGS: true, // Can be temporally enabled for debugging purposes.
   });
 

--- a/raiden-dapp/tests/unit/utils/mocks/service-worker/environment.ts
+++ b/raiden-dapp/tests/unit/utils/mocks/service-worker/environment.ts
@@ -1,8 +1,39 @@
 import {
-  MockedIDBFactory,
+  MockedCache,
+  MockedCacheStorage,
   MockedIDBDatabase,
+  MockedIDBFactory,
   MockedIDBObjectStore,
 } from './';
+
+type CacheStorageEnvironment = {
+  cache: MockedCache;
+  caches: MockedCacheStorage;
+};
+
+/**
+ * Please make sure to call `jest.restoreAllMocks()` to "tear down" the
+ * environment again.
+ *
+ * @param environment - set of particular instances to use for environment
+ * @returns final environment as mocked
+ */
+export function mockCacheStorageInEnvironment(
+  environment?: Partial<CacheStorageEnvironment>,
+): CacheStorageEnvironment {
+  const cache = environment?.cache ?? new MockedCache();
+  const caches = environment?.caches ?? new MockedCacheStorage('workbox-precache-v2', cache);
+
+  Object.defineProperty(global, 'caches', {
+    configurable: true,
+    get: () => undefined,
+  });
+
+  const cachesGetSpy = jest.spyOn(global, 'caches', 'get');
+  cachesGetSpy.mockReturnValue(caches);
+
+  return { cache, caches };
+}
 
 type IndexedDatabaseEnvironment = {
   objectStore: MockedIDBObjectStore;

--- a/raiden-dapp/tests/unit/utils/mocks/service-worker/environment.ts
+++ b/raiden-dapp/tests/unit/utils/mocks/service-worker/environment.ts
@@ -1,0 +1,31 @@
+import {
+  MockedIDBFactory,
+  MockedIDBDatabase,
+  MockedIDBObjectStore,
+} from './';
+
+type IndexedDatabaseEnvironment = {
+  objectStore: MockedIDBObjectStore;
+  database: MockedIDBDatabase;
+  indexedDB: MockedIDBFactory;
+};
+
+/**
+ * Please make sure to call `jest.restoreAllMocks()` to "tear down" the
+ * environment again.
+ *
+ * @param environment - set of particular instances to use for environment
+ * @returns final environment as mocked
+ */
+export function mockIndexedDatabaseInEnvironment(
+  environment?: Partial<IndexedDatabaseEnvironment>,
+): IndexedDatabaseEnvironment {
+  const objectStore = environment?.objectStore ?? new MockedIDBObjectStore();
+  const database =
+    environment?.database ?? new MockedIDBDatabase('workbox-precache-v2', objectStore);
+  const indexedDB = environment?.indexedDB ?? new MockedIDBFactory('ServiceWorker', database);
+
+  Object.assign(global, { indexedDB, IDBObjectStore: MockedIDBObjectStore });
+
+  return { objectStore, database, indexedDB };
+}

--- a/raiden-dapp/tests/unit/utils/mocks/service-worker/events.ts
+++ b/raiden-dapp/tests/unit/utils/mocks/service-worker/events.ts
@@ -1,0 +1,37 @@
+import { MockedRequest } from './';
+
+export class MockedExtendableEvent extends Event {
+  private extendLifetimePromises: Promise<unknown>[] = [];
+
+  waitUntil(promise: Promise<unknown>): void {
+    this.extendLifetimePromises.push(promise);
+  }
+
+  // Note that new promises can be added while the current one is still about to
+  // get resolved. This is important to be handled.
+  async waitToFinish(): Promise<void> {
+    let promise;
+
+    while ((promise = this.extendLifetimePromises.pop())) {
+      await promise;
+    }
+  }
+}
+
+export class MockedMessageEvent extends MockedExtendableEvent {
+  constructor(type: string, data?: unknown) {
+    super(type);
+    Object.assign(this, { data });
+  }
+}
+
+export class MockedFetchEvent extends MockedExtendableEvent {
+  public request: MockedRequest;
+
+  constructor(type: string, url: string) {
+    super(type);
+    this.request = new MockedRequest(url);
+  }
+
+  respondWith = jest.fn();
+}

--- a/raiden-dapp/tests/unit/utils/mocks/service-worker/fetch.ts
+++ b/raiden-dapp/tests/unit/utils/mocks/service-worker/fetch.ts
@@ -1,0 +1,51 @@
+export const mockedFetch = jest
+  .fn()
+  .mockImplementation(async (_url: string) => new MockedResponse('<body></body>'));
+
+export class MockedRequest {
+  private input: string | MockedRequest;
+  private init: RequestInit | undefined;
+
+  constructor(input: string | MockedRequest, init?: RequestInit) {
+    this.input = input;
+    this.init = init;
+  }
+
+  get url(): string {
+    return this.input instanceof MockedRequest ? this.input.url : this.input;
+  }
+
+  get method(): string {
+    return this.init?.method ?? 'GET';
+  }
+
+  clone = jest.fn().mockImplementation(() => {
+    return new MockedRequest(this.input, this.init);
+  });
+}
+
+export class MockedResponse {
+  private body: string;
+  private init: ResponseInit | undefined;
+
+  constructor(body: string, init?: ResponseInit) {
+    this.body = body;
+    this.init = init;
+  }
+
+  get status(): number {
+    return this.init?.status ?? 200;
+  }
+
+  clone = jest.fn().mockImplementation(() => {
+    return new MockedResponse(this.body, this.init);
+  });
+
+  static error = jest.fn().mockImplementation(() => {
+    return new MockedResponse('error', { status: 400 });
+  });
+
+  blob = jest.fn().mockImplementation(async () => {
+    return new Blob([this.body], { type: 'text/html' });
+  });
+}

--- a/raiden-dapp/tests/unit/utils/mocks/service-worker/index.ts
+++ b/raiden-dapp/tests/unit/utils/mocks/service-worker/index.ts
@@ -1,3 +1,4 @@
 export * from './cache-storage';
+export * from './clients';
 export * from './environment';
 export * from './indexeddb';

--- a/raiden-dapp/tests/unit/utils/mocks/service-worker/index.ts
+++ b/raiden-dapp/tests/unit/utils/mocks/service-worker/index.ts
@@ -1,4 +1,7 @@
 export * from './cache-storage';
 export * from './clients';
 export * from './environment';
+export * from './events';
+export * from './fetch';
 export * from './indexeddb';
+export * from './registration';

--- a/raiden-dapp/tests/unit/utils/mocks/service-worker/index.ts
+++ b/raiden-dapp/tests/unit/utils/mocks/service-worker/index.ts
@@ -1,2 +1,3 @@
+export * from './cache-storage';
 export * from './environment';
 export * from './indexeddb';

--- a/raiden-dapp/tests/unit/utils/mocks/service-worker/index.ts
+++ b/raiden-dapp/tests/unit/utils/mocks/service-worker/index.ts
@@ -1,0 +1,2 @@
+export * from './environment';
+export * from './indexeddb';

--- a/raiden-dapp/tests/unit/utils/mocks/service-worker/indexeddb.ts
+++ b/raiden-dapp/tests/unit/utils/mocks/service-worker/indexeddb.ts
@@ -1,0 +1,88 @@
+export class MockedIDBFactory {
+  private databases: { [name: string]: MockedIDBDatabase } = {};
+
+  constructor(databaseName?: string, database?: MockedIDBDatabase) {
+    if (databaseName && database) {
+      this.databases[databaseName] = database;
+    }
+  }
+
+  open = jest.fn().mockImplementation((name: string) => {
+    if (!(name in this.databases)) {
+      this.databases[name] = new MockedIDBDatabase();
+    }
+
+    return new MockedIDBRequest(this.databases[name]);
+  });
+}
+
+export class MockedIDBRequest extends EventTarget {
+  readonly result: unknown | undefined;
+
+  constructor(result?: unknown) {
+    super();
+    this.result = result;
+  }
+
+  addEventListener(type: string, callback: (event: Event) => void): void {
+    super.addEventListener(type, callback);
+    const event = new Event(type);
+    setTimeout(() => this.dispatchEvent(event), 10);
+  }
+}
+
+export class MockedIDBDatabase {
+  private objectStores: { [name: string]: MockedIDBObjectStore } = {};
+
+  constructor(objectStoreName?: string, objectStore?: MockedIDBObjectStore) {
+    if (objectStoreName && objectStore) {
+      this.objectStores[objectStoreName] = objectStore;
+    }
+  }
+
+  createObjectStore = jest.fn().mockImplementation(() => {
+    return new MockedIDBObjectStore();
+  });
+
+  transaction = jest.fn().mockImplementation((objectStoreName: string) => {
+    if (!(objectStoreName in this.objectStores)) {
+      this.objectStores[objectStoreName] = new MockedIDBObjectStore();
+    }
+
+    const objectStore = () => this.objectStores[objectStoreName];
+    return { objectStore };
+  });
+}
+
+export class MockedIDBObjectStore {
+  private data: { [key: string]: unknown } = {};
+  protected transaction: MockedIDBTransaction;
+
+  constructor(key?: string, value?: unknown) {
+    if (key && value) {
+      this.data[key] = value;
+    }
+
+    this.transaction = new MockedIDBTransaction();
+  }
+
+  put = jest.fn().mockImplementation((value: unknown, key: string) => {
+    this.data[key] = value;
+    return new MockedIDBRequest();
+  });
+
+  get = jest.fn().mockImplementation((key: string) => {
+    return new MockedIDBRequest(this.data[key]);
+  });
+
+  delete = jest.fn().mockImplementation((key: string) => {
+    delete this.data[key];
+    return new MockedIDBRequest();
+  });
+}
+
+export class MockedIDBTransaction extends MockedIDBRequest {
+  constructor() {
+    super();
+  }
+}

--- a/raiden-dapp/tests/unit/utils/mocks/service-worker/registration.ts
+++ b/raiden-dapp/tests/unit/utils/mocks/service-worker/registration.ts
@@ -1,0 +1,3 @@
+export class MockedRegistration {
+  unregister = jest.fn();
+}

--- a/raiden-dapp/tsconfig.json
+++ b/raiden-dapp/tsconfig.json
@@ -11,6 +11,7 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
+    "allowJs": true,
     "baseUrl": ".",
     "paths": {
       "@/*": [

--- a/raiden-dapp/vue.config.js
+++ b/raiden-dapp/vue.config.js
@@ -16,7 +16,7 @@ function getPackageVersion() {
 /*
  * Note that it is not necessary to exclude the version file from the to
  * cache assets. The version file gets generated during the build and is
- * thereby not included in the pre-cache manifest. The same goes for the
+ * thereby not included in the precache entries. The same goes for the
  * worker script itself.
  */
 function setupServiceWorkerRelatedPlugins(config) {
@@ -37,6 +37,7 @@ function setupServiceWorkerRelatedPlugins(config) {
   const injectServiceWorkerPlugin = new InjectManifest({
     swSrc: path.join(sourceDirectoryPath, 'service-worker', 'worker'),
     swDest: 'service-worker.js',
+    injectionPoint: 'self.__WB_PRECACHE_ENTRIES',
     maximumFileSizeToCacheInBytes: 20e6,
   });
 


### PR DESCRIPTION
Fixes #2836

**Short description**
Note that these "unit" tests are partially integration tests, as they also test the whole service worker with all modules and also the Workbox dependency. This is on purpose, as we don't have any integration tests, and this way we can be more sure everything works as intended and detect when the dependency usage breaks with updates.

The main suite for the service worker is quite long. I tried to shim the reduce the code per test cases to a minimum but still make them fully express what they are about and how they work. The mass comes from the sheer amount of various cases the service worker must fulfill. If you think this is too big, we could consider to split it.

Many of the added lines of code are part of the big mocking effort for the service worker environment it runs withing a browser. I suppose it is not necessary to invest too much time on this part of the review. But if you are willed to, I would be very happy. The mocks just implement the minimal required parts of the API following mostly their official specification with some shortcuts here and there to keep it simple enough.

As always, and especially for bigger PRs, I recommend to review commit by commit. It protects from getting overwhelmed. Plus it makes all displayed changes belong together with the respective message.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Just run the unit tests...
2. Maybe try that the service worker still works in practice as there were a few code changes to it.
