### PR TITLE
Cooperative settle

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- [#2839] Cooperative settle - allow users to exchange withdraw signatures enabling settling a channel instantly. This is the new default behavior on `Raiden.closeChannel`, falling back to default uncooperative close if needed.
+
+[#2839]: https://github.com/raiden-network/light-client/issues/2839
 
 ## [1.1.0] - 2021-08-09
 ### Added

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -61,6 +61,7 @@
     "@types/pouchdb-adapter-memory": "^6.1.3",
     "@types/pouchdb-find": "^6.3.7",
     "@types/redux-logger": "^3.0.9",
+    "@types/semver": "^7.3.8",
     "@types/tiny-async-pool": "^1.0.0",
     "jest": "^26.6.3",
     "jest-environment-node": "^26.6.2",
@@ -115,7 +116,8 @@
     "redux-devtools-extension": "^2.13.9",
     "redux-logger": "^3.0.6",
     "redux-observable": "^2.0.0",
-    "rxjs": "^7.3.0"
+    "rxjs": "^7.3.0",
+    "semver": "^7.3.5"
   },
   "optionalDependencies": {
     "pouchdb-adapter-indexeddb": "^7.2.2",

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -61,7 +61,6 @@
     "@types/pouchdb-adapter-memory": "^6.1.3",
     "@types/pouchdb-find": "^6.3.7",
     "@types/redux-logger": "^3.0.9",
-    "@types/semver": "^7.3.8",
     "@types/tiny-async-pool": "^1.0.0",
     "jest": "^26.6.3",
     "jest-environment-node": "^26.6.2",
@@ -116,8 +115,7 @@
     "redux-devtools-extension": "^2.13.9",
     "redux-logger": "^3.0.6",
     "redux-observable": "^2.0.0",
-    "rxjs": "^7.3.0",
-    "semver": "^7.3.5"
+    "rxjs": "^7.3.0"
   },
   "optionalDependencies": {
     "pouchdb-adapter-indexeddb": "^7.2.2",

--- a/raiden-ts/src/channels/actions.ts
+++ b/raiden-ts/src/channels/actions.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 import * as t from 'io-ts';
 
+import { WithdrawConfirmation, WithdrawRequest } from '../messages';
 import type { ActionType } from '../utils/actions';
 import { createAction, createAsyncAction } from '../utils/actions';
-import { Address, Hash, UInt } from '../utils/types';
+import { Address, Hash, Signed, UInt } from '../utils/types';
 import { Lock } from './types';
 
 // interfaces need to be exported, and we need/want to support `import * as RaidenActions`
@@ -142,10 +143,18 @@ export const channelSettleable = createAction(
 );
 export interface channelSettleable extends ActionType<typeof channelSettleable> {}
 
+const WithdrawPair = t.tuple([Signed(WithdrawRequest), Signed(WithdrawConfirmation)]);
+
 export const channelSettle = createAsyncAction(
   ChannelId,
   'channel/settle',
-  t.union([t.partial({ subkey: t.boolean }), t.undefined]),
+  t.union([
+    t.partial({
+      subkey: t.boolean,
+      coopSettle: t.tuple([WithdrawPair, WithdrawPair]),
+    }),
+    t.undefined,
+  ]),
   t.intersection([
     t.type({
       id: t.number,

--- a/raiden-ts/src/errors.json
+++ b/raiden-ts/src/errors.json
@@ -23,6 +23,7 @@
   "CNL_CLOSECHANNEL_FAILED": "TokenNetwork.closeChannel transaction reverted.",
   "CNL_SETTLE_INVALID_BALANCEHASH": "Could not find BalanceProof matching on-chain closing data. This client may have had its state cleared and can't settle.",
   "CNL_SETTLE_FAILED": "TokenNetwork.settleChannel transaction reverted.",
+  "CNL_COOP_SETTLE_FAILED": "TokenNetwork.cooperativeSettle transaction reverted.",
   "CNL_SETTLE_AUTO_ENABLED": "Interactive channel settlement disabled when config.autoSettle is enabled; request will be made automatically",
   "CNL_UPDATE_NONCLOSING_BP_FAILED": "updateNonClosingBalanceProof transaction reverted.",
   "CNL_ONCHAIN_UNLOCK_FAILED": "on-chain unlock transaction reverted.",

--- a/raiden-ts/src/errors.json
+++ b/raiden-ts/src/errors.json
@@ -34,6 +34,7 @@
   "CNL_WITHDRAW_EXPIRED": "Withdraw request expired.",
   "CNL_WITHDRAW_AMOUNT_TOO_LOW": "Withdraw request contains an amount smaller than already withdrawn.",
   "CNL_WITHDRAW_AMOUNT_TOO_HIGH": "Withdraw request contains an amount bigger than channel's liquidity.",
+  "CNL_COOP_SETTLE_NOT_POSSIBLE": "Can not create or answer channel cooperative settle request",
 
   "XFER_EXPIRED": "Transfer expired.",
   "XFER_CHANNEL_CLOSED_PREMATURELY": "Channel was closed before secret got reveiled or transfer unlocked.",

--- a/raiden-ts/src/messages/types.ts
+++ b/raiden-ts/src/messages/types.ts
@@ -236,9 +236,8 @@ const WithdrawBase = t.readonly(
 
 const _WithdrawRequest = t.readonly(
   t.intersection([
-    t.type({
-      type: t.literal(MessageType.WITHDRAW_REQUEST),
-    }),
+    t.type({ type: t.literal(MessageType.WITHDRAW_REQUEST) }),
+    t.partial({ coop_settle: t.boolean }),
     WithdrawBase,
     RetrieableMessage,
   ]),

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -771,11 +771,6 @@ export class Raiden {
     // try coop-settle first
     try {
       const channel = this.state.channels[channelKey({ tokenNetwork, partner })];
-      assert(
-        channel?.state === ChannelState.open,
-        ErrorCodes.CNL_NO_OPEN_CHANNEL_FOUND,
-        this.log.error,
-      );
       const { ownTotalWithdrawable: totalWithdraw } = channelAmounts(channel);
       const expiration =
         this.state.blockNumber + this.config.revealTimeout + this.config.confirmationBlocks;
@@ -790,7 +785,7 @@ export class Raiden {
       const coopPromise = asyncActionToPromise(withdraw, coopMeta, this.action$, true).then(
         ({ txHash }) => txHash,
       );
-      this.store.dispatch(withdraw.request({ coopSettle: true }, coopMeta));
+      this.store.dispatch(withdrawResolve({ coopSettle: true }, coopMeta));
       return await coopPromise;
     } catch (err) {
       this.log.info('Could not settle cooperatively, performing uncooperative close', err);

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -76,7 +76,7 @@ import type { IOU, RaidenPaths, RaidenPFS, SuggestedPartner } from './services/t
 import { Paths, PFS, PfsMode, SuggestedPartners } from './services/types';
 import { pfsListInfo } from './services/utils';
 import type { RaidenState } from './state';
-import { transfer, transferSigned, withdraw } from './transfers/actions';
+import { transfer, transferSigned, withdraw, withdrawResolve } from './transfers/actions';
 import type { RaidenTransfer } from './transfers/state';
 import { Direction, TransferState } from './transfers/state';
 import {
@@ -1483,7 +1483,50 @@ export class Raiden {
     const promise = asyncActionToPromise(withdraw, meta, this.action$, true).then(
       ({ txHash }) => txHash,
     );
-    this.store.dispatch(withdraw.request(undefined, meta));
+    this.store.dispatch(withdrawResolve(undefined, meta));
+    return promise;
+  }
+
+  /**
+   * Requests to withdraw from channel
+   *
+   * The requested amount defaults to the maximum withdrawable amount, which is exposed in
+   * [[channels$]] observable as the [[RaidenChannel.ownWithdrawable]] member.
+   * This involves requesting partner a signature which confirms they agree that we have the right
+   * for this amount of tokens, then a transaction is sent on-chain to withdraw tokens to the
+   * effective account.
+   * If this process fails, the amount remains locked until it can be expired later (defaults to
+   * 2 * config.revealTimeout blocks).
+   *
+   * @param token - Token address on currently configured token network registry
+   * @param partner - Partner address
+   * @returns Promise to the hash of the mined withdraw transaction
+   */
+  public async coopSettleChannel(token: string, partner: string): Promise<Hash> {
+    assert(Address.is(token), [ErrorCodes.DTA_INVALID_ADDRESS, { token }], this.log.info);
+    assert(Address.is(partner), [ErrorCodes.DTA_INVALID_ADDRESS, { partner }], this.log.info);
+    const tokenNetwork = this.state.tokens[token];
+    assert(tokenNetwork, ErrorCodes.RDN_UNKNOWN_TOKEN_NETWORK, this.log.info);
+    const channel = this.state.channels[channelKey({ tokenNetwork, partner })];
+    assert(
+      channel?.state === ChannelState.open,
+      ErrorCodes.CNL_NO_OPEN_CHANNEL_FOUND,
+      this.log.error,
+    );
+    const { ownTotalWithdrawable: totalWithdraw } = channelAmounts(channel);
+    const expiration = this.state.blockNumber + 2 * this.config.revealTimeout;
+
+    const meta = {
+      direction: Direction.SENT,
+      tokenNetwork,
+      partner,
+      totalWithdraw,
+      expiration,
+    };
+    const promise = asyncActionToPromise(withdraw, meta, this.action$, true).then(
+      ({ txHash }) => txHash,
+    );
+    this.store.dispatch(withdraw.request({ coopSettle: true }, meta));
     return promise;
   }
 

--- a/raiden-ts/src/transfers/actions.ts
+++ b/raiden-ts/src/transfers/actions.ts
@@ -208,6 +208,16 @@ const WithdrawId = t.type({
 });
 
 /**
+ * Request withdrawResolveEpic to resolve and emit a withdraw.request
+ */
+export const withdrawResolve = createAction(
+  'withdraw/resolve',
+  t.union([t.undefined, t.type({ coopSettle: t.boolean })]),
+  WithdrawId,
+);
+export interface withdrawResolve extends ActionType<typeof withdrawResolve> {}
+
+/**
  * Start a withdraw
  * - request: request to start a withdraw
  * - success: withdraw finished on-chain

--- a/raiden-ts/src/transfers/actions.ts
+++ b/raiden-ts/src/transfers/actions.ts
@@ -254,6 +254,13 @@ export namespace withdrawMessage {
 }
 
 /**
+ * Signals this withdraw is "busy" performing contract's transaction (either setTotalWithdraw
+ * or cooperativeSettle). Is "unlocked" by the respective withdraw.success|failure
+ */
+export const withdrawBusy = createAction('withdraw/busy', t.undefined, WithdrawId);
+export interface withdrawBusy extends ActionType<typeof withdrawBusy> {}
+
+/**
  * Expires a withdraw
  * - request: request to expire a past request
  * - success: WithdrawExpired sent or received

--- a/raiden-ts/src/transfers/actions.ts
+++ b/raiden-ts/src/transfers/actions.ts
@@ -216,7 +216,7 @@ const WithdrawId = t.type({
 export const withdraw = createAsyncAction(
   WithdrawId,
   'withdraw',
-  t.undefined,
+  t.union([t.undefined, t.type({ coopSettle: t.boolean })]),
   t.type({ txHash: Hash, txBlock: t.number, confirmed: t.union([t.undefined, t.boolean]) }),
 );
 export namespace withdraw {

--- a/raiden-ts/src/transfers/actions.ts
+++ b/raiden-ts/src/transfers/actions.ts
@@ -212,7 +212,7 @@ const WithdrawId = t.type({
  */
 export const withdrawResolve = createAction(
   'withdraw/resolve',
-  t.union([t.undefined, t.type({ coopSettle: t.boolean })]),
+  t.union([t.undefined, t.type({ coopSettle: t.literal(true) })]),
   WithdrawId,
 );
 export interface withdrawResolve extends ActionType<typeof withdrawResolve> {}

--- a/raiden-ts/src/transfers/epics/coopsettle.ts
+++ b/raiden-ts/src/transfers/epics/coopsettle.ts
@@ -1,0 +1,198 @@
+import pick from 'lodash/pick';
+import type { Observable } from 'rxjs';
+import { combineLatest, EMPTY, of } from 'rxjs';
+import {
+  catchError,
+  concatMap,
+  filter,
+  first,
+  groupBy,
+  map,
+  mergeMap,
+  startWith,
+  withLatestFrom,
+} from 'rxjs/operators';
+
+import type { RaidenAction } from '../../actions';
+import { ChannelState } from '../../channels';
+import { channelSettle } from '../../channels/actions';
+import { channelAmounts, channelKey } from '../../channels/utils';
+import type { WithdrawRequest } from '../../messages';
+import { MessageType } from '../../messages';
+import type { RaidenState } from '../../state';
+import type { RaidenEpicDeps } from '../../types';
+import { assert } from '../../utils/error';
+import { dispatchRequestAndGetResponse } from '../../utils/rx';
+import type { Signed } from '../../utils/types';
+import { withdraw, withdrawBusy, withdrawMessage } from '../actions';
+import { Direction } from '../state';
+import { checkContractHasMethod$, matchWithdraw, withdrawMetaFromRequest } from './utils';
+
+/**
+ * Upon valid [[WithdrawConfirmation]] for a [[WithdrawRequest]].coop_settle=true from partner,
+ * also send a [[WithdrawRequest]] with whole balance
+ *
+ * @param action$ - Observable of withdrawMessage.success actions
+ * @param state$ - Observable of RaidenStates
+ * @param deps - Epics dependencies
+ * @param deps.log - Logger instance
+ * @param deps.getTokenNetworkContract - TokenNetwork contract getter
+ * @returns Observable of withdraw.request(coop_settle=false) actions
+ */
+export function coopSettleWithdrawReplyEpic(
+  action$: Observable<RaidenAction>,
+  state$: Observable<RaidenState>,
+  { log, getTokenNetworkContract }: RaidenEpicDeps,
+): Observable<withdraw.request> {
+  return action$.pipe(
+    filter(withdrawMessage.success.is),
+    filter((action) => action.meta.direction === Direction.RECEIVED),
+    withLatestFrom(state$),
+    mergeMap(([action, state]) => {
+      const tokenNetworkContract = getTokenNetworkContract(action.meta.tokenNetwork);
+      return checkContractHasMethod$(tokenNetworkContract, 'cooperativeSettle').pipe(
+        mergeMap(() => {
+          const channel = state.channels[channelKey(action.meta)];
+          assert(channel?.state === ChannelState.open, 'channel not open');
+          const req = channel.partner.pendingWithdraws.find(
+            matchWithdraw(MessageType.WITHDRAW_REQUEST, action.payload.message),
+          );
+          assert(req, 'no matching WithdrawRequest found'); // shouldn't happen
+
+          // only reply if this is a coop settle request from partner
+          if (!req.coop_settle) return EMPTY;
+
+          const { ownTotalWithdrawable } = channelAmounts(channel);
+          return of(
+            withdraw.request(
+              { coopSettle: false },
+              {
+                ...action.meta,
+                direction: Direction.SENT,
+                totalWithdraw: ownTotalWithdrawable,
+              },
+            ),
+          );
+        }),
+        catchError((error) => {
+          log.warn('Could not reply to CoopSettle request, ignoring', { action, error });
+          return EMPTY;
+        }),
+      );
+    }),
+  );
+}
+
+/**
+ * When both valid [[WithdrawConfirmation]] for a [[WithdrawRequest]].coop_settle=true from us,
+ * send a channelSettle.request
+ *
+ * @param action$ - Observable of withdrawMessage.success actions
+ * @param state$ - Observable of RaidenStates
+ * @param deps - Epics dependencies
+ * @param deps.latest$ - Latest observable
+ * @param deps.config$ - Config observable
+ * @param deps.log - Logger instance
+ * @returns Observable of channelSettle.request|withdraw.failure|success|withdrawBusy actions
+ */
+export function coopSettleEpic(
+  action$: Observable<RaidenAction>,
+  {}: Observable<RaidenState>,
+  { latest$, config$, log }: RaidenEpicDeps,
+): Observable<channelSettle.request | withdraw.failure | withdraw.success | withdrawBusy> {
+  return action$.pipe(
+    dispatchRequestAndGetResponse(channelSettle, (requestSettle$) =>
+      action$.pipe(
+        filter(withdrawMessage.success.is),
+        groupBy((action) => channelKey(action.meta)),
+        mergeMap((grouped$) =>
+          grouped$.pipe(
+            concatMap((action) =>
+              // observable inside concatMap ensures the body is evaluated at subscription time
+              combineLatest([latest$, config$]).pipe(
+                first(),
+                mergeMap(([{ state }, { revealTimeout }]) => {
+                  const channel = state.channels[channelKey(action.meta)];
+                  assert(channel?.state === ChannelState.open, 'channel not open');
+
+                  const {
+                    ownCapacity,
+                    partnerCapacity,
+                    ownTotalWithdrawable,
+                    partnerTotalWithdrawable,
+                  } = channelAmounts(channel);
+                  // when both capacities are zero, both sides should be ready; before that, just
+                  // skip silently, a matching state may come later or withdraw will expire
+                  assert(
+                    (!channel.own.locks.length &&
+                      !channel.partner.locks.length &&
+                      ownCapacity.isZero()) ||
+                      partnerCapacity.isZero(),
+                    '',
+                  );
+
+                  const ownReq = channel.own.pendingWithdraws.find(
+                    (msg): msg is Signed<WithdrawRequest> =>
+                      msg.type === MessageType.WITHDRAW_REQUEST &&
+                      msg.expiration.gte(state.blockNumber + revealTimeout) &&
+                      msg.total_withdraw.eq(ownTotalWithdrawable) &&
+                      !!msg.coop_settle, // only requests where coop_settle is true
+                  );
+                  // not our request or expires too soon
+                  assert(ownReq && !ownReq.expiration.lt(state.blockNumber + revealTimeout), '');
+
+                  const ownConfirmation = channel.own.pendingWithdraws.find(
+                    matchWithdraw(MessageType.WITHDRAW_CONFIRMATION, ownReq),
+                  );
+                  const partnerReq = channel.partner.pendingWithdraws.find(
+                    (msg): msg is Signed<WithdrawRequest> =>
+                      msg.type === MessageType.WITHDRAW_REQUEST &&
+                      msg.expiration.gte(state.blockNumber + revealTimeout) &&
+                      msg.total_withdraw.eq(partnerTotalWithdrawable),
+                  );
+                  assert(partnerReq, 'partner request not found'); // shouldn't happen
+                  const partnerConfirmation = channel.partner.pendingWithdraws.find(
+                    matchWithdraw(MessageType.WITHDRAW_CONFIRMATION, partnerReq),
+                  );
+                  assert(ownConfirmation && partnerConfirmation, [
+                    'no matching WithdrawConfirmations found',
+                    { ownConfirmation, partnerConfirmation },
+                  ]);
+
+                  const withdrawMeta = withdrawMetaFromRequest(ownReq, channel);
+                  return requestSettle$(
+                    channelSettle.request(
+                      {
+                        coopSettle: [
+                          [ownReq, ownConfirmation],
+                          [partnerReq, partnerConfirmation],
+                        ],
+                      },
+                      { tokenNetwork: withdrawMeta.tokenNetwork, partner: withdrawMeta.partner },
+                    ),
+                  ).pipe(
+                    map((success) =>
+                      withdraw.success(
+                        pick(success.payload, ['txBlock', 'txHash', 'confirmed'] as const),
+                        withdrawMeta,
+                      ),
+                    ),
+                    catchError((err) => of(withdraw.failure(err, withdrawMeta))),
+                    // prevents this withdraw from expire-failing while we're trying to settle
+                    startWith(withdrawBusy(undefined, withdrawMeta)),
+                  );
+                }),
+                catchError((err) => {
+                  if (err.message) log.info(err.message, err.details);
+                  // these errors are just the asserts, to be ignored;
+                  // []actual errors are only the catched inside requestSettle$'s pipe
+                  return EMPTY;
+                }),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/raiden-ts/src/transfers/epics/index.ts
+++ b/raiden-ts/src/transfers/epics/index.ts
@@ -1,4 +1,5 @@
 export * from '../mediate/epics';
+export * from './coopsettle';
 export * from './expire';
 export * from './init';
 export * from './locked';

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -841,10 +841,6 @@ function sendWithdrawRequest(
       ]);
 
       assert(
-        action.meta.totalWithdraw.gt(channel.own.withdraw),
-        ErrorCodes.CNL_WITHDRAW_AMOUNT_TOO_LOW,
-      );
-      assert(
         action.meta.totalWithdraw.lte(channelAmounts(channel).ownTotalWithdrawable),
         ErrorCodes.CNL_WITHDRAW_AMOUNT_TOO_HIGH,
       );
@@ -861,6 +857,10 @@ function sendWithdrawRequest(
           [ErrorCodes.CNL_COOP_SETTLE_NOT_POSSIBLE, { ownLocked, partnerLocked, partnerCapacity }],
         );
       } else {
+        assert(
+          action.meta.totalWithdraw.gt(channel.own.withdraw),
+          ErrorCodes.CNL_WITHDRAW_AMOUNT_TOO_LOW,
+        );
         assert(
           action.meta.expiration >= state.blockNumber + revealTimeout,
           ErrorCodes.CNL_WITHDRAW_EXPIRES_SOON,

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -854,8 +854,8 @@ function sendWithdrawRequest(
         const { ownLocked, partnerLocked, ownTotalWithdrawable, partnerCapacity } =
           channelAmounts(channel);
         assert(
-          ownLocked.isZero() &&
-            partnerLocked.isZero() &&
+          !channel.own.locks.length &&
+            !channel.partner.locks.length &&
             action.meta.totalWithdraw.eq(ownTotalWithdrawable) &&
             (action.payload.coopSettle || partnerCapacity.isZero()),
           [ErrorCodes.CNL_COOP_SETTLE_NOT_POSSIBLE, { ownLocked, partnerLocked, partnerCapacity }],

--- a/raiden-ts/src/transfers/epics/withdraw.ts
+++ b/raiden-ts/src/transfers/epics/withdraw.ts
@@ -1,3 +1,4 @@
+import pick from 'lodash/pick';
 import type { Observable } from 'rxjs';
 import { combineLatest, defer, EMPTY, from, merge, of } from 'rxjs';
 import {
@@ -8,9 +9,10 @@ import {
   groupBy,
   ignoreElements,
   map,
+  mapTo,
   mergeMap,
-  mergeMapTo,
   pluck,
+  scan,
   share,
   startWith,
   take,
@@ -19,6 +21,7 @@ import {
 } from 'rxjs/operators';
 
 import type { RaidenAction } from '../../actions';
+import type { Channel } from '../../channels';
 import { ChannelState } from '../../channels';
 import { channelSettle, newBlock } from '../../channels/actions';
 import { assertTx, channelAmounts, channelKey } from '../../channels/utils';
@@ -35,9 +38,10 @@ import { isActionOf, isConfirmationResponseOf } from '../../utils/actions';
 import { assert, commonTxErrors, ErrorCodes, RaidenError } from '../../utils/error';
 import { LruCache } from '../../utils/lru';
 import { dispatchRequestAndGetResponse, retryWhile } from '../../utils/rx';
-import { isntNil, Signed } from '../../utils/types';
+import { Signed } from '../../utils/types';
 import {
   withdraw,
+  withdrawBusy,
   withdrawCompleted,
   withdrawExpire,
   withdrawMessage,
@@ -45,6 +49,19 @@ import {
 } from '../actions';
 import { Direction } from '../state';
 import { matchWithdraw, retrySendUntil$ } from './utils';
+
+function withdrawMetaFromRequest(
+  req: WithdrawRequest,
+  channel: Channel,
+): withdraw.request['meta'] {
+  return {
+    tokenNetwork: channel.tokenNetwork,
+    partner: channel.partner.address,
+    direction: req.participant === channel.partner.address ? Direction.RECEIVED : Direction.SENT,
+    expiration: req.expiration.toNumber(),
+    totalWithdraw: req.total_withdraw,
+  };
+}
 
 /**
  * Emits withdraw action once for each own non-confirmed message at startup
@@ -201,7 +218,7 @@ export function withdrawSendTxEpic(
     latest$,
     config$,
   }: RaidenEpicDeps,
-): Observable<withdraw.success | withdraw.failure> {
+): Observable<withdraw.success | withdraw.failure | withdrawBusy> {
   return action$.pipe(
     filter(withdrawMessage.success.is),
     filter((action) => action.meta.direction === Direction.SENT),
@@ -213,13 +230,6 @@ export function withdrawSendTxEpic(
           combineLatest([latest$, config$]).pipe(
             first(),
             mergeMap(([{ state, gasPrice }, { subkey: configSubkey, revealTimeout }]) => {
-              // don't send on-chain tx if we're 'revealTimeout' blocks from expiration
-              // this is our confidence threshold when we can get a tx inside timeout
-              assert(
-                action.meta.expiration >= state.blockNumber + revealTimeout,
-                ErrorCodes.CNL_WITHDRAW_EXPIRES_SOON,
-              );
-
               const channel = state.channels[grouped$.key];
               assert(channel?.state === ChannelState.open, 'channel not open');
               assert(
@@ -231,6 +241,13 @@ export function withdrawSendTxEpic(
                 matchWithdraw(MessageType.WITHDRAW_REQUEST, action.payload.message),
               );
               assert(req, 'no matching WithdrawRequest found');
+
+              // don't send on-chain tx if we're 'revealTimeout' blocks from expiration
+              // this is our confidence threshold when we can get a tx inside timeout
+              assert(
+                req.expiration.gte(state.blockNumber + revealTimeout),
+                ErrorCodes.CNL_WITHDRAW_EXPIRES_SOON,
+              );
 
               // don't send withdraw rx if this is a coop_settle request (back or forth)
               if ('coop_settle' in req) return EMPTY;
@@ -284,6 +301,7 @@ export function withdrawSendTxEpic(
                     ),
                   ),
                 ),
+                startWith(withdrawBusy(undefined, action.meta)),
               );
             }),
             catchError((err) => of(withdraw.failure(err, action.meta))),
@@ -357,6 +375,10 @@ export function withdrawMessageProcessedEpic(
   );
 }
 
+function withdrawKey(meta: withdraw.request['meta']) {
+  return `${channelKey(meta)}|${meta.expiration}|${meta.totalWithdraw.toString()}`;
+}
+
 /**
  * Dispatch withdrawExpire.request when one of our sent WithdrawRequests expired
  *
@@ -370,28 +392,64 @@ export function autoWithdrawExpireEpic(
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
   { config$ }: RaidenEpicDeps,
-): Observable<withdrawExpire.request> {
+): Observable<withdrawExpire.request | withdraw.failure> {
+  const alreadyFailed = new Set<string>();
+  const busyWithdraws = new Set<string>();
   return action$.pipe(
     filter(newBlock.is),
     pluck('payload', 'blockNumber'),
-    withLatestFrom(state$, config$),
-    mergeMap(function* ([blockNumber, state, { confirmationBlocks }]) {
+    withLatestFrom(
+      state$,
+      config$,
+      action$.pipe(
+        filter(isActionOf([withdrawBusy, withdraw.success, withdraw.failure])),
+        scan((acc, action) => {
+          // a string representing uniquely this withdraw.meta
+          const key = withdrawKey(action.meta);
+          // 'busy' adds withdraw to set, preventing these withdraws from failing due to expiration
+          // too soon; withdraw.success|failure clears it
+          if (withdrawBusy.is(action)) acc.add(key);
+          else acc.delete(key);
+          return acc;
+        }, busyWithdraws),
+        startWith(busyWithdraws),
+      ),
+    ),
+    mergeMap(function* ([
+      blockNumber,
+      state,
+      { confirmationBlocks, revealTimeout },
+      busyWithdraws,
+    ]) {
       for (const channel of Object.values(state.channels)) {
         if (channel.state !== ChannelState.open) continue;
         const requestMessages = channel.own.pendingWithdraws.filter(
           matchWithdraw(MessageType.WITHDRAW_REQUEST),
         );
         for (const req of requestMessages) {
-          if (req.expiration.add(confirmationBlocks * 2).gte(blockNumber)) continue;
-          if (channel.own.pendingWithdraws.some(matchWithdraw(MessageType.WITHDRAW_EXPIRED, req)))
-            continue;
-          yield withdrawExpire.request(undefined, {
-            direction: Direction.SENT,
-            tokenNetwork: channel.tokenNetwork,
-            partner: channel.partner.address,
-            expiration: req.expiration.toNumber(),
-            totalWithdraw: req.total_withdraw,
-          });
+          // do not withdraw.failure early for withdraws currently being processed
+          if (busyWithdraws.has(withdrawKey(withdrawMetaFromRequest(req, channel)))) continue;
+          if (req.expiration.lt(state.blockNumber + revealTimeout)) {
+            const coopSettleFailedKey = req.message_identifier.toHexString();
+            if (!alreadyFailed.has(coopSettleFailedKey)) {
+              alreadyFailed.add(coopSettleFailedKey);
+              yield withdraw.failure(
+                new RaidenError(ErrorCodes.CNL_WITHDRAW_EXPIRED),
+                withdrawMetaFromRequest(req, channel),
+              );
+            }
+          }
+          if (
+            req.expiration.lt(blockNumber + confirmationBlocks * 2) &&
+            !channel.own.pendingWithdraws.some(matchWithdraw(MessageType.WITHDRAW_EXPIRED, req))
+          )
+            yield withdrawExpire.request(undefined, {
+              direction: Direction.SENT,
+              tokenNetwork: channel.tokenNetwork,
+              partner: channel.partner.address,
+              expiration: req.expiration.toNumber(),
+              totalWithdraw: req.total_withdraw,
+            });
         }
       }
     }),
@@ -411,7 +469,7 @@ export function withdrawSendExpireMessageEpic(
   action$: Observable<RaidenAction>,
   {}: Observable<RaidenState>,
   { config$ }: RaidenEpicDeps,
-): Observable<messageSend.request | withdraw.failure | withdrawCompleted> {
+): Observable<messageSend.request | withdrawCompleted> {
   return action$.pipe(
     filter(withdrawExpire.success.is),
     filter((action) => action.meta.direction === Direction.SENT),
@@ -430,10 +488,7 @@ export function withdrawSendExpireMessageEpic(
             a.payload.message.message_identifier.eq(message.message_identifier),
         ),
         take(1),
-        mergeMapTo([
-          withdraw.failure(new RaidenError(ErrorCodes.CNL_WITHDRAW_EXPIRED), action.meta),
-          withdrawCompleted(undefined, action.meta),
-        ]),
+        mapTo(withdrawCompleted(undefined, action.meta)),
         share(),
       );
       // besides using notifier to stop retry, also merge the withdrawCompleted output action
@@ -452,42 +507,22 @@ export function withdrawSendExpireMessageEpic(
  * @param action$ - Observable of withdrawMessage.success actions
  * @param state$ - Observable of RaidenStates
  * @param deps - Epics dependencies
- * @param deps.config$ - Config observable
  * @param deps.log - Logger instance
  * @returns Observable of withdraw.request(coop_settle=false) actions
  */
 export function coopSettleWithdrawReplyEpic(
   action$: Observable<RaidenAction>,
   state$: Observable<RaidenState>,
-  { config$, log }: RaidenEpicDeps,
+  { log }: RaidenEpicDeps,
 ): Observable<withdraw.request> {
   return action$.pipe(
     filter(withdrawMessage.success.is),
     filter((action) => action.meta.direction === Direction.RECEIVED),
-    withLatestFrom(state$, config$),
-    mergeMap(([action, state, { revealTimeout }]) =>
+    withLatestFrom(state$),
+    mergeMap(([action, state]) =>
       defer(() => {
-        // don't act if request expires too soon
-        assert(
-          action.meta.expiration >= state.blockNumber + revealTimeout,
-          ErrorCodes.CNL_WITHDRAW_EXPIRES_SOON,
-        );
-
         const channel = state.channels[channelKey(action.meta)];
         assert(channel?.state === ChannelState.open, 'channel not open');
-
-        const { ownTotalWithdrawable, partnerCapacity } = channelAmounts(channel);
-        assert(
-          !channel.own.locks.length && !channel.partner.locks.length && partnerCapacity.isZero(),
-          [
-            ErrorCodes.CNL_COOP_SETTLE_NOT_POSSIBLE,
-            {
-              ownLocks: channel.own.locks,
-              partnerLocks: channel.partner.locks,
-              partnerCapacity,
-            },
-          ],
-        );
 
         const req = channel.partner.pendingWithdraws.find(
           matchWithdraw(MessageType.WITHDRAW_REQUEST, action.payload.message),
@@ -497,6 +532,7 @@ export function coopSettleWithdrawReplyEpic(
         // only reply if this is a coop settle request from partner
         if (!req.coop_settle) return EMPTY;
 
+        const { ownTotalWithdrawable } = channelAmounts(channel);
         return of(
           withdraw.request(
             { coopSettle: false },
@@ -524,75 +560,104 @@ export function coopSettleWithdrawReplyEpic(
  * @param action$ - Observable of withdrawMessage.success actions
  * @param state$ - Observable of RaidenStates
  * @param deps - Epics dependencies
+ * @param deps.latest$ - Latest observable
  * @param deps.config$ - Config observable
  * @param deps.log - Logger instance
- * @returns Observable of channelSettle.request actions
+ * @returns Observable of channelSettle.request|withdraw.failure|success|withdrawBusy actions
  */
 export function coopSettleEpic(
   action$: Observable<RaidenAction>,
-  state$: Observable<RaidenState>,
-  { config$, log }: RaidenEpicDeps,
-): Observable<channelSettle.request | withdraw.failure> {
+  {}: Observable<RaidenState>,
+  { latest$, config$, log }: RaidenEpicDeps,
+): Observable<channelSettle.request | withdraw.failure | withdraw.success | withdrawBusy> {
   return action$.pipe(
-    filter(withdrawMessage.success.is),
-    withLatestFrom(state$, config$),
-    map(([action, state, { revealTimeout }]) => {
-      // don't act if request expires too soon
-      if (action.meta.expiration < state.blockNumber + revealTimeout) return;
+    dispatchRequestAndGetResponse(channelSettle, (requestSettle$) =>
+      action$.pipe(
+        filter(withdrawMessage.success.is),
+        groupBy((action) => channelKey(action.meta)),
+        mergeMap((grouped$) =>
+          grouped$.pipe(
+            concatMap((action) =>
+              // observable inside concatMap ensures the body is evaluated at subscription time
+              combineLatest([latest$, config$]).pipe(
+                first(),
+                mergeMap(([{ state }, { revealTimeout }]) => {
+                  const channel = state.channels[channelKey(action.meta)];
+                  if (channel?.state !== ChannelState.open) return EMPTY;
 
-      const channel = state.channels[channelKey(action.meta)];
-      if (channel?.state !== ChannelState.open) return;
+                  const {
+                    ownCapacity,
+                    partnerCapacity,
+                    ownTotalWithdrawable,
+                    partnerTotalWithdrawable,
+                  } = channelAmounts(channel);
+                  if (
+                    channel.own.locks.length ||
+                    channel.partner.locks.length ||
+                    !ownCapacity.isZero() || // when both capacities are zero, both sides should be ready
+                    !partnerCapacity.isZero()
+                  )
+                    return EMPTY;
 
-      const { ownCapacity, partnerCapacity, ownTotalWithdrawable, partnerTotalWithdrawable } =
-        channelAmounts(channel);
-      if (
-        channel.own.locks.length ||
-        channel.partner.locks.length ||
-        !ownCapacity.isZero() || // when both capacities are zero, both sides should be ready
-        !partnerCapacity.isZero()
-      )
-        return;
+                  const ownReq = channel.own.pendingWithdraws.find(
+                    (msg): msg is Signed<WithdrawRequest> =>
+                      msg.type === MessageType.WITHDRAW_REQUEST &&
+                      msg.expiration.gte(state.blockNumber + revealTimeout) &&
+                      msg.total_withdraw.eq(ownTotalWithdrawable) &&
+                      !!msg.coop_settle, // only requests where coop_settle is true
+                  );
+                  if (!ownReq || ownReq.expiration.lt(state.blockNumber + revealTimeout))
+                    return EMPTY; // not our request or expires too soon
 
-      const ownReq = channel.own.pendingWithdraws.find(
-        (msg): msg is Signed<WithdrawRequest> =>
-          msg.type === MessageType.WITHDRAW_REQUEST &&
-          msg.expiration.gte(state.blockNumber + revealTimeout) &&
-          msg.total_withdraw.eq(ownTotalWithdrawable) &&
-          !!msg.coop_settle, // only requests where coop_settle is true
-      );
-      if (!ownReq) return; // not our request
+                  const ownConfirmation = channel.own.pendingWithdraws.find(
+                    matchWithdraw(MessageType.WITHDRAW_CONFIRMATION, ownReq),
+                  );
+                  const partnerReq = channel.partner.pendingWithdraws.find(
+                    (msg): msg is Signed<WithdrawRequest> =>
+                      msg.type === MessageType.WITHDRAW_REQUEST &&
+                      msg.expiration.gte(state.blockNumber + revealTimeout) &&
+                      msg.total_withdraw.eq(partnerTotalWithdrawable),
+                  );
+                  if (!partnerReq) return EMPTY; // shouldn't happen
+                  const partnerConfirmation = channel.partner.pendingWithdraws.find(
+                    matchWithdraw(MessageType.WITHDRAW_CONFIRMATION, partnerReq),
+                  );
+                  if (!ownConfirmation || !partnerConfirmation) {
+                    log.info('no matching WithdrawConfirmations found', {
+                      ownConfirmation,
+                      partnerConfirmation,
+                    });
+                    return EMPTY;
+                  }
 
-      const ownConfirmation = channel.own.pendingWithdraws.find(
-        matchWithdraw(MessageType.WITHDRAW_CONFIRMATION, ownReq),
-      );
-      const partnerReq = channel.partner.pendingWithdraws.find(
-        (msg): msg is Signed<WithdrawRequest> =>
-          msg.type === MessageType.WITHDRAW_REQUEST &&
-          msg.expiration.gte(state.blockNumber + revealTimeout) &&
-          msg.total_withdraw.eq(partnerTotalWithdrawable),
-      );
-      if (!partnerReq) return; // shouldn't happen
-      const partnerConfirmation = channel.partner.pendingWithdraws.find(
-        matchWithdraw(MessageType.WITHDRAW_CONFIRMATION, partnerReq),
-      );
-      if (!ownConfirmation || !partnerConfirmation) {
-        log.info('no matching WithdrawConfirmations found', {
-          ownConfirmation,
-          partnerConfirmation,
-        });
-        return;
-      }
-
-      return channelSettle.request(
-        {
-          coopSettle: [
-            [ownReq, ownConfirmation],
-            [partnerReq, partnerConfirmation],
-          ],
-        },
-        { tokenNetwork: action.meta.tokenNetwork, partner: action.meta.partner },
-      );
-    }),
-    filter(isntNil),
+                  const withdrawMeta = withdrawMetaFromRequest(ownReq, channel);
+                  return requestSettle$(
+                    channelSettle.request(
+                      {
+                        coopSettle: [
+                          [ownReq, ownConfirmation],
+                          [partnerReq, partnerConfirmation],
+                        ],
+                      },
+                      { tokenNetwork: withdrawMeta.tokenNetwork, partner: withdrawMeta.partner },
+                    ),
+                  ).pipe(
+                    map((success) =>
+                      withdraw.success(
+                        pick(success.payload, ['txBlock', 'txHash', 'confirmed'] as const),
+                        withdrawMeta,
+                      ),
+                    ),
+                    catchError((err) => of(withdraw.failure(err, withdrawMeta))),
+                    // prevents this withdraw from expire-failing while we're trying to settle
+                    startWith(withdrawBusy(undefined, withdrawMeta)),
+                  );
+                }),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
   );
 }

--- a/raiden-ts/tests/integration/channels.spec.ts
+++ b/raiden-ts/tests/integration/channels.spec.ts
@@ -34,7 +34,7 @@ import {
 import { defaultAbiCoder, Interface } from '@ethersproject/abi';
 import { BigNumber } from '@ethersproject/bignumber';
 import { hexlify } from '@ethersproject/bytes';
-import { HashZero, Zero } from '@ethersproject/constants';
+import { AddressZero, HashZero, Zero } from '@ethersproject/constants';
 import { firstValueFrom } from 'rxjs';
 import { first, pluck } from 'rxjs/operators';
 
@@ -366,8 +366,8 @@ describe('channelEventsEpic', () => {
   test('new$ ChannelSettled event', async () => {
     expect.assertions(5);
     const settleDataEncoded = defaultAbiCoder.encode(
-      ['uint256', 'bytes32', 'uint256', 'bytes32'],
-      [Zero, HashZero, Zero, HashZero],
+      ['address', 'uint256', 'bytes32', 'address', 'uint256', 'bytes32'],
+      [AddressZero, Zero, HashZero, AddressZero, Zero, HashZero],
     );
 
     const [raiden, partner] = await makeRaidens(2);
@@ -381,7 +381,7 @@ describe('channelEventsEpic', () => {
       makeLog({
         blockNumber: settleBlock,
         transactionHash: settleHash,
-        filter: tokenNetworkContract.filters.ChannelSettled(id, null, null, null, null),
+        filter: tokenNetworkContract.filters.ChannelSettled(id),
         data: settleDataEncoded, // participants amounts aren't indexed, so they go in data
       }),
     );

--- a/raiden-ts/tests/integration/withdraw.spec.ts
+++ b/raiden-ts/tests/integration/withdraw.spec.ts
@@ -3,31 +3,149 @@ import {
   deposit,
   ensureChannelIsClosed,
   ensureChannelIsDeposited,
+  ensureChannelIsOpen,
+  ensureTransferPending,
   ensureTransferUnlocked,
   getChannel,
   id,
+  presenceFromClient,
   tokenNetwork,
 } from './fixtures';
-import { makeRaidens, makeTransaction, waitBlock } from './mocks';
+import { makeLog, makeRaidens, makeTransaction, providersEmit, waitBlock } from './mocks';
 
+import { defaultAbiCoder } from '@ethersproject/abi';
 import { BigNumber } from '@ethersproject/bignumber';
-import { Zero } from '@ethersproject/constants';
+import { HashZero, Zero } from '@ethersproject/constants';
 
 import { raidenConfigUpdate } from '@/actions';
+import { channelSettle } from '@/channels/actions';
 import { channelAmounts } from '@/channels/utils';
 import { Capabilities } from '@/constants';
 import { messageReceived, messageSend } from '@/messages/actions';
 import type { WithdrawConfirmation, WithdrawRequest } from '@/messages/types';
 import { MessageType } from '@/messages/types';
 import { signMessage } from '@/messages/utils';
-import { withdraw, withdrawExpire, withdrawMessage } from '@/transfers/actions';
+import { withdraw, withdrawExpire, withdrawMessage, withdrawResolve } from '@/transfers/actions';
 import { Direction } from '@/transfers/state';
 import { makeMessageId } from '@/transfers/utils';
 import { ErrorCodes } from '@/utils/error';
 import type { Hash, UInt } from '@/utils/types';
 
-import { sleep } from '../utils';
+import { makeAddress, makeHash, sleep } from '../utils';
 import type { MockedRaiden } from './mocks';
+
+describe('withdraw resolve', () => {
+  test('success', async () => {
+    const [raiden, partner] = await makeRaidens(2);
+
+    await ensureChannelIsOpen([raiden, partner]);
+
+    const expiration =
+      raiden.deps.provider.blockNumber +
+      raiden.config.revealTimeout +
+      raiden.config.confirmationBlocks;
+    const meta = {
+      direction: Direction.SENT,
+      tokenNetwork,
+      partner: partner.address,
+      totalWithdraw: Zero as UInt<32>,
+      expiration,
+    };
+    raiden.store.dispatch(withdrawResolve(undefined, meta));
+    await sleep();
+
+    expect(raiden.output).toContainEqual(withdraw.request(undefined, meta));
+  });
+
+  test('success coop-settle', async () => {
+    const [raiden, partner] = await makeRaidens(2);
+
+    await ensureChannelIsOpen([raiden, partner]);
+
+    const expiration =
+      raiden.deps.provider.blockNumber +
+      raiden.config.revealTimeout +
+      raiden.config.confirmationBlocks;
+    const meta = {
+      direction: Direction.SENT,
+      tokenNetwork,
+      partner: partner.address,
+      totalWithdraw: Zero as UInt<32>,
+      expiration,
+    };
+    raiden.store.dispatch(withdrawResolve({ coopSettle: true }, meta));
+    await sleep();
+
+    expect(raiden.output).toContainEqual(withdraw.request({ coopSettle: true }, meta));
+  });
+
+  test('fail partner offline', async () => {
+    const [raiden, partner] = await makeRaidens(2);
+
+    await ensureChannelIsOpen([raiden, partner]);
+    partner.stop();
+    raiden.store.dispatch(presenceFromClient(partner, false));
+
+    const expiration =
+      raiden.deps.provider.blockNumber +
+      raiden.config.revealTimeout +
+      raiden.config.confirmationBlocks;
+    const meta = {
+      direction: Direction.SENT,
+      tokenNetwork,
+      partner: partner.address,
+      totalWithdraw: Zero as UInt<32>,
+      expiration,
+    };
+    raiden.store.dispatch(withdrawResolve(undefined, meta));
+    await sleep();
+
+    expect(raiden.output).not.toContainEqual(
+      withdraw.request(expect.anything(), expect.anything()),
+    );
+    expect(raiden.output).toContainEqual(
+      withdraw.failure(
+        expect.objectContaining({ message: expect.stringContaining('offline') }),
+        meta,
+      ),
+    );
+  });
+
+  test('fail coop-settle if unsupported contract', async () => {
+    const [raiden, partner] = await makeRaidens(2);
+    raiden.deps.provider.getCode.mockResolvedValue('0x1337');
+
+    const token = makeAddress();
+    const tokenNetwork = makeAddress();
+    await ensureChannelIsOpen([raiden, partner], { tokens: [token, tokenNetwork] });
+
+    const expiration =
+      raiden.deps.provider.blockNumber +
+      raiden.config.revealTimeout +
+      raiden.config.confirmationBlocks;
+    const meta = {
+      direction: Direction.SENT,
+      tokenNetwork,
+      partner: partner.address,
+      totalWithdraw: Zero as UInt<32>,
+      expiration,
+    };
+    raiden.store.dispatch(withdrawResolve({ coopSettle: true }, meta));
+    await sleep();
+
+    expect(raiden.output).not.toContainEqual(
+      withdraw.request(expect.anything(), expect.anything()),
+    );
+    expect(raiden.output).toContainEqual(
+      withdraw.failure(
+        expect.objectContaining({
+          message: expect.stringContaining('contract does not have method'),
+        }),
+        meta,
+      ),
+    );
+  });
+});
 
 describe('withdraw receive request', () => {
   const direction = Direction.RECEIVED;
@@ -469,4 +587,269 @@ test('withdraw expire', async () => {
     ),
   );
   expect(getChannel(raiden, partner).own.pendingWithdraws).toEqual([]);
+});
+
+describe('coop-settle', () => {
+  function makeCoopTuple(
+    [raiden, partner]: readonly [MockedRaiden, MockedRaiden],
+    [ourWithdraw, partnerWithdraw]: readonly [BigNumber, BigNumber],
+  ): NonNullable<NonNullable<channelSettle.request['payload']>['coopSettle']> {
+    return [
+      [
+        expect.objectContaining({
+          type: MessageType.WITHDRAW_REQUEST,
+          participant: raiden.address,
+          total_withdraw: ourWithdraw,
+        }),
+        expect.objectContaining({
+          type: MessageType.WITHDRAW_CONFIRMATION,
+          participant: raiden.address,
+          total_withdraw: ourWithdraw,
+        }),
+      ],
+      [
+        expect.objectContaining({
+          type: MessageType.WITHDRAW_REQUEST,
+          participant: partner.address,
+          total_withdraw: partnerWithdraw,
+        }),
+        expect.objectContaining({
+          type: MessageType.WITHDRAW_CONFIRMATION,
+          participant: partner.address,
+          total_withdraw: partnerWithdraw,
+        }),
+      ],
+    ];
+  }
+
+  test('success no deposit', async () => {
+    expect.assertions(3);
+    const [raiden, partner] = await makeRaidens(2);
+
+    await ensureChannelIsOpen([raiden, partner]);
+
+    const expiration =
+      raiden.deps.provider.blockNumber +
+      raiden.config.revealTimeout +
+      raiden.config.confirmationBlocks;
+    const meta = {
+      direction: Direction.SENT,
+      tokenNetwork,
+      partner: partner.address,
+      totalWithdraw: Zero as UInt<32>,
+      expiration,
+    };
+    raiden.store.dispatch(withdraw.request({ coopSettle: true }, meta));
+    await sleep();
+
+    expect(raiden.output).toContainEqual(
+      channelSettle.request(
+        { coopSettle: makeCoopTuple([raiden, partner], [Zero, Zero]) },
+        { tokenNetwork, partner: partner.address },
+      ),
+    );
+
+    // success on settling emits withdraw.success
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+    const settleBlock = raiden.deps.provider.blockNumber;
+    const settleTxHash = makeHash();
+    await providersEmit(
+      {},
+      makeLog({
+        transactionHash: settleTxHash,
+        blockNumber: settleBlock,
+        filter: tokenNetworkContract.filters.ChannelSettled(getChannel(raiden, partner).id),
+        data: defaultAbiCoder.encode(
+          ['address', 'uint256', 'bytes32', 'address', 'uint256', 'bytes32'],
+          [raiden.address, Zero, HashZero, partner.address, Zero, HashZero],
+        ),
+      }),
+    );
+    await waitBlock();
+    await waitBlock(raiden.deps.provider.blockNumber + raiden.config.confirmationBlocks + 1);
+    await waitBlock();
+    expect(raiden.output).not.toContainEqual(
+      withdraw.failure(expect.anything(), expect.anything()),
+    );
+    expect(raiden.output).toContainEqual(
+      withdraw.success(
+        {
+          txHash: settleTxHash,
+          txBlock: settleBlock,
+          confirmed: true,
+        },
+        meta,
+      ),
+    );
+  });
+
+  test('success initiator deposit only', async () => {
+    expect.assertions(3);
+    const [raiden, partner] = await makeRaidens(2);
+
+    const tokenNetworkContract = raiden.deps.getTokenNetworkContract(tokenNetwork);
+    const settleTx = makeTransaction(0);
+    tokenNetworkContract.cooperativeSettle.mockResolvedValue(settleTx);
+
+    await ensureChannelIsDeposited([raiden, partner], deposit);
+
+    const expiration =
+      raiden.deps.provider.blockNumber +
+      raiden.config.revealTimeout +
+      raiden.config.confirmationBlocks;
+    const meta = {
+      direction: Direction.SENT,
+      tokenNetwork,
+      partner: partner.address,
+      totalWithdraw: deposit,
+      expiration,
+    };
+    raiden.store.dispatch(withdraw.request({ coopSettle: true }, meta));
+    await sleep();
+
+    expect(raiden.output).toContainEqual(
+      channelSettle.request(
+        { coopSettle: makeCoopTuple([raiden, partner], [deposit, Zero]) },
+        { tokenNetwork, partner: partner.address },
+      ),
+    );
+
+    // error on settling emits withdraw.failure
+    expect(raiden.output).not.toContainEqual(
+      withdraw.success(expect.anything(), expect.anything()),
+    );
+    expect(raiden.output).toContainEqual(
+      withdraw.failure(
+        expect.objectContaining({ message: ErrorCodes.CNL_COOP_SETTLE_FAILED }),
+        meta,
+      ),
+    );
+  });
+
+  test('success partner deposit only', async () => {
+    expect.assertions(1);
+    const [raiden, partner] = await makeRaidens(2);
+
+    await ensureChannelIsDeposited([partner, raiden], deposit);
+
+    const expiration =
+      raiden.deps.provider.blockNumber +
+      raiden.config.revealTimeout +
+      raiden.config.confirmationBlocks;
+    const meta = {
+      direction: Direction.SENT,
+      tokenNetwork,
+      partner: partner.address,
+      totalWithdraw: Zero as UInt<32>,
+      expiration,
+    };
+    raiden.store.dispatch(withdraw.request({ coopSettle: true }, meta));
+    await sleep();
+
+    expect(raiden.output).toContainEqual(
+      channelSettle.request(
+        { coopSettle: makeCoopTuple([raiden, partner], [Zero, deposit]) },
+        { tokenNetwork, partner: partner.address },
+      ),
+    );
+  });
+
+  test('success deposit both with transfer', async () => {
+    expect.assertions(1);
+    const [raiden, partner] = await makeRaidens(2);
+
+    await ensureChannelIsDeposited([raiden, partner], deposit);
+    await ensureChannelIsDeposited([partner, raiden], amount);
+
+    await ensureTransferUnlocked([raiden, partner], amount);
+
+    const expiration =
+      raiden.deps.provider.blockNumber +
+      raiden.config.revealTimeout +
+      raiden.config.confirmationBlocks;
+    const meta = {
+      direction: Direction.SENT,
+      tokenNetwork,
+      partner: partner.address,
+      totalWithdraw: deposit.sub(amount) as UInt<32>,
+      expiration,
+    };
+    raiden.store.dispatch(withdraw.request({ coopSettle: true }, meta));
+    await sleep();
+
+    expect(raiden.output).toContainEqual(
+      channelSettle.request(
+        {
+          coopSettle: makeCoopTuple([raiden, partner], [deposit.sub(amount), amount.add(amount)]),
+        },
+        { tokenNetwork, partner: partner.address },
+      ),
+    );
+  });
+
+  test('fail if totalWithdraw is not totalWithdrawable', async () => {
+    expect.assertions(2);
+    const [raiden, partner] = await makeRaidens(2);
+
+    await ensureChannelIsDeposited([raiden, partner], deposit);
+    await ensureChannelIsDeposited([partner, raiden], amount);
+
+    const expiration =
+      raiden.deps.provider.blockNumber +
+      raiden.config.revealTimeout +
+      raiden.config.confirmationBlocks;
+    const meta = {
+      direction: Direction.SENT,
+      tokenNetwork,
+      partner: partner.address,
+      totalWithdraw: deposit.sub(1) as UInt<32>,
+      expiration,
+    };
+    raiden.store.dispatch(withdraw.request({ coopSettle: true }, meta));
+    await sleep();
+
+    expect(raiden.output).not.toContainEqual(
+      channelSettle.request(expect.anything(), expect.anything()),
+    );
+    expect(raiden.output).toContainEqual(
+      withdraw.failure(
+        expect.objectContaining({ message: ErrorCodes.CNL_COOP_SETTLE_NOT_POSSIBLE }),
+        meta,
+      ),
+    );
+  });
+
+  test('fail if there is a pending lock', async () => {
+    expect.assertions(2);
+    const [raiden, partner] = await makeRaidens(2);
+
+    await ensureChannelIsDeposited([raiden, partner], deposit);
+    await ensureChannelIsDeposited([partner, raiden], amount);
+
+    await ensureTransferPending([raiden, partner], amount);
+
+    const expiration =
+      raiden.deps.provider.blockNumber +
+      raiden.config.revealTimeout +
+      raiden.config.confirmationBlocks;
+    const meta = {
+      direction: Direction.SENT,
+      tokenNetwork,
+      partner: partner.address,
+      totalWithdraw: deposit.sub(amount) as UInt<32>,
+      expiration,
+    };
+    raiden.store.dispatch(withdraw.request({ coopSettle: true }, meta));
+    await sleep();
+
+    expect(raiden.output).not.toContainEqual(
+      channelSettle.request(expect.anything(), expect.anything()),
+    );
+    expect(raiden.output).toContainEqual(
+      withdraw.failure(
+        expect.objectContaining({ message: ErrorCodes.CNL_COOP_SETTLE_NOT_POSSIBLE }),
+        meta,
+      ),
+    );
+  });
 });

--- a/raiden-ts/tests/unit/reducers.spec.ts
+++ b/raiden-ts/tests/unit/reducers.spec.ts
@@ -714,17 +714,6 @@ describe('raidenReducer', () => {
       expect(newState).toEqual(state);
     });
 
-    test('channel not in "closed|settleable|settling" state', () => {
-      // still in "opened" state
-      const newState = [
-        channelSettle.success(
-          { id: channelId, txHash, txBlock: settleBlock, confirmed: true },
-          { tokenNetwork, partner },
-        ),
-      ].reduce(raidenReducer, state);
-      expect(newState).toEqual(state);
-    });
-
     test('unconfirmed settle => "settling", removed noop', () => {
       const newState = [
         channelClose.success(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3007,6 +3007,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/semver@^7.3.8":
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.8.tgz#508a27995498d7586dcecd77c25e289bfaf90c59"
+  integrity sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==
+
 "@types/serve-static@*":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
@@ -8428,7 +8433,6 @@ ethereum-cryptography@^0.1.3:
 
 "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.8"
-  uid ee3994657fa7a427238e6ba92a84d0b529bbcde0
   resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0"
   dependencies:
     bn.js "^4.11.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3007,11 +3007,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/semver@^7.3.8":
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.8.tgz#508a27995498d7586dcecd77c25e289bfaf90c59"
-  integrity sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now==
-
 "@types/serve-static@*":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"


### PR DESCRIPTION
Fixes #2839 #2850 
Uses contract from https://github.com/raiden-network/raiden-contracts/pull/1474

**Short description**
Cooperative settle. Requires raiden-contracts 0.39, but also works in a backwards compatible manner with current 0.37 (needs more testing).

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Ensure git submodules, dependencies and builds are up to date with this PR
2. Run cli with the compatible PFS: `./raiden --pathfinding-service-address=https://pfs-goerli-with-fee.services-dev.raiden.network`
3. Open a channel between 2 CLIs on these contracts: `http -v PUT http://localhost:5001/api/v1/channels token_address=0xC563388e2e2fdD422166eD5E76971D11eD37A466 partner_address=<addr2> settle_timeout:=60`
4. Check the channels: `http http://localhost:5001/api/v1/channels`
4. Close the channel: `http -v PATCH http://localhost:5001/api/v1/channels/0xC563388e2e2fdD422166eD5E76971D11eD37A466/<addr2> state=closed`
5. Check the channels again and see it was **settled** directly.