### PR TITLE
Check mediators for 'Mediate' capability when initiating transfer

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -7,10 +7,12 @@
 
 ### Fixed
 - [#2831] Force PFS to acknowledge our capabilities updates
+- [#2868] Invalidate routes where some mediator have `capabilities.Mediate=0` and error if this is the only route received from PFS.
 
 [#2730]: https://github.com/raiden-network/light-client/issues/2730
 [#2766]: https://github.com/raiden-network/light-client/pull/2766
 [#2831]: https://github.com/raiden-network/light-client/issues/2831
+[#2868]: https://github.com/raiden-network/light-client/pull/2868
 
 ## [1.0.0] - 2021-06-16
 ### Removed

--- a/raiden-ts/src/services/epics/pathfinding.ts
+++ b/raiden-ts/src/services/epics/pathfinding.ts
@@ -70,7 +70,7 @@ export function pfsRequestEpic(
               getRoute$(action, deps, latest, targetPresence),
             ),
             withLatestFrom(deps.latest$),
-            mergeMap(([route, { state }]) => validateRoute$(state, action, deps, route)),
+            mergeMap(([route, { state }]) => validateRoute$([action, route], state, deps)),
             catchError((err) => of(pathFind.failure(err, action.meta))),
           ),
         ),


### PR DESCRIPTION
Based on top of #2853

**Short description**
PFS doesn't handle capabilities, so it's up to us as initiators to validate that all mediators are able to mediate transfers, by checking they've truthy `Capabilities.Mediate`. Fortunately, PFS sends all hops metadata in `address_metadata`, which allows us to inspect and validate received route's capabilities. This should prevent us from even starting a transfer where some mediator doesn't want to mediate, but the best fix is to have this handled also in the PFS side.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Trying to mediate through a node which doesn't want to (e.g. another dApp) should fail before starting transfer