### PR TITLE
chore: extend CodeClimate ignore rules

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -27,3 +27,4 @@ exclude_patterns:
   - "**/dist/"
   - "**/*.d.ts"
   - "**/coverage/"
+  - ".github/actions/*/dist/"


### PR DESCRIPTION
Unfortunately we need to commit the build directory for the GitHub actions into
the repository. This obviously comes with the issue that CodeClimate has tons of
reports for these files. As there are no actual code we can safely ignore them
and clean up the CodeClimate report.
