### PR TITLE
Serialize withdraw txs per channel

### DIFF
--- a/raiden-ts/src/channels/utils.ts
+++ b/raiden-ts/src/channels/utils.ts
@@ -23,9 +23,13 @@ import type { ChannelKey, ChannelUniqueKey } from './types';
  * @param channel.partner - Partner address
  * @returns A string, for now
  */
-export function channelKey<
-  C extends { tokenNetwork: Address } & ({ partner: { address: Address } } | { partner: Address }),
->({ tokenNetwork, partner }: C): ChannelKey {
+export function channelKey({
+  tokenNetwork,
+  partner,
+}: { tokenNetwork: Address } & (
+  | { partner: { address: Address } }
+  | { partner: Address }
+)): ChannelKey {
   const partnerAddr =
     typeof partner === 'string' ? partner : (partner as { address: Address }).address;
   return `${tokenNetwork}@${partnerAddr}`;


### PR DESCRIPTION
Fix race where multiple txs would be sent if WithdrawConfirmation got
retried, causing one of them to fail and the whole withdraw.request to
be rejected.

Fixes CI flakyness [like this](https://app.circleci.com/pipelines/github/raiden-network/light-client/9710/workflows/94d36d48-2fb4-4194-93ea-e684ec87683d/jobs/60840/tests):
```
Error: expect(received).resolves.toMatch()

Received promise rejected instead of resolved
Rejected to value: [Error: transaction failed (transactionHash="0x67f08bab2d21ac399c9ea0e9c763d03da4f65c6a25d9738fbf7d8289c8ea80fd", transaction={"nonce":16,"gasPrice":{"type":"BigNumber","hex":"0x3b9aca00"},"gasLimit":{"type":"BigNumber","hex":"0x018b31"},"to":"0x49498baBd822Ca4c8150b22c46E35F74a29C8a2D","value":{"type":"BigNumber","hex":"0x00"},"data":"0x9e67ca5f000000000000000000000000000000000000000000000000000000000000000300000000000000000000000014791697260e4c9a71f18484c9f997b308e59325000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000001dc00000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001400000000000000000000000000000000000000000000000000000000000000041764d925ba7cb077f02db39ea0bdaaf6c7e1c18f376dd288c6d75a1bf1ca5ce6a3645af1686c38f733538bf775a8f17bdcc2cc635c5bc12129d8b0afb12af58f91b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000041b72f88eb1f997859eb81e4ba596ba402affcf7f60c1eaadb99eb5c28e391db7b2554ee3356944eda14c31cd95c149eec378b0319cb31ee43cac64c954312f0b81b00000000000000000000000000000000000000000000000000000000000000","chainId":4321,"v":8677,"r":"0x1e0e86f383146ef0b506401074eb8c02359bd12a43d21a7bd17f945858b8589e","s":"0x573355d1b9901287e24460903553c4a3d88e8634abdb065ce5312623d90c0654","from":"0x14791697260E4c9A71f18484C9f997B308e59325","hash":"0x67f08bab2d21ac399c9ea0e9c763d03da4f65c6a25d9738fbf7d8289c8ea80fd","type":null}, receipt={"to":"0x49498baBd822Ca4c8150b22c46E35F74a29C8a2D","from":"0x14791697260E4c9A71f18484C9f997B308e59325","contractAddress":null,"transactionIndex":1,"gasUsed":{"type":"BigNumber","hex":"0xbb5f"},"logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","blockHash":"0x345af5393ea208a000950d96d3c112a23f14cbcfa752dc6ccf962c2f0d8dc3f8","transactionHash":"0x67f08bab2d21ac399c9ea0e9c763d03da4f65c6a25d9738fbf7d8289c8ea80fd","logs":[],"blockNumber":442,"confirmations":1,"cumulativeGasUsed":{"type":"BigNumber","hex":"0x024690"},"status":0,"type":0,"byzantium":true}, code=CALL_EXCEPTION, version=providers/5.4.1)]
    at expect (/home/circleci/src/node_modules/@jest/core/node_modules/expect/build/index.js:134:15)
    at Object.<anonymous> (/home/circleci/src/raiden-ts/tests/e2e/e2e.spec.ts:264:11)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
