### PR TITLE
sdk: refactor: simplify action creators and types

### DIFF
--- a/raiden-ts/src/channels/actions.ts
+++ b/raiden-ts/src/channels/actions.ts
@@ -51,9 +51,7 @@ export interface tokenMonitored extends ActionType<typeof tokenMonitored> {}
  */
 export const channelOpen = createAsyncAction(
   ChannelId,
-  'channel/open/request',
-  'channel/open/success',
-  'channel/open/failed',
+  'channel/open',
   t.partial({ settleTimeout: t.number, subkey: t.boolean, deposit: UInt(32) }),
   t.type({
     id: t.number,
@@ -81,9 +79,7 @@ export interface channelMonitored extends ActionType<typeof channelMonitored> {}
 
 export const channelDeposit = createAsyncAction(
   ChannelId,
-  'channel/deposit/request',
-  'channel/deposit/success',
-  'channel/deposit/failure',
+  'channel/deposit',
   t.intersection([
     t.type({ deposit: UInt(32) }),
     t.partial({ subkey: t.boolean, waitOpen: t.literal(true) }),
@@ -121,9 +117,7 @@ export interface channelWithdrawn extends ActionType<typeof channelWithdrawn> {}
 
 export const channelClose = createAsyncAction(
   ChannelId,
-  'channel/close/request',
-  'channel/close/success',
-  'channel/close/failure',
+  'channel/close',
   t.union([t.partial({ subkey: t.boolean }), t.undefined]),
   t.type({
     id: t.number,
@@ -150,9 +144,7 @@ export interface channelSettleable extends ActionType<typeof channelSettleable> 
 
 export const channelSettle = createAsyncAction(
   ChannelId,
-  'channel/settle/request',
-  'channel/settle/success',
-  'channel/settle/failure',
+  'channel/settle',
   t.union([t.partial({ subkey: t.boolean }), t.undefined]),
   t.intersection([
     t.type({
@@ -164,7 +156,6 @@ export const channelSettle = createAsyncAction(
     t.partial({ locks: t.readonlyArray(Lock) }),
   ]),
 );
-
 export namespace channelSettle {
   export interface request extends ActionType<typeof channelSettle.request> {}
   export interface success extends ActionType<typeof channelSettle.success> {}

--- a/raiden-ts/src/messages/actions.ts
+++ b/raiden-ts/src/messages/actions.ts
@@ -13,9 +13,7 @@ import { Message } from './types';
  */
 export const messageSend = createAsyncAction(
   t.type({ address: Address, msgId: t.string }),
-  'message/send/request',
-  'message/send/success',
-  'message/send/failure',
+  'message/send',
   t.intersection([
     t.type({ message: t.union([t.string, Signed(Message)]) }),
     t.partial({ msgtype: t.string }),
@@ -32,9 +30,7 @@ export namespace messageSend {
 /** One-shot send payload.message to a service room in transport */
 export const messageServiceSend = createAsyncAction(
   t.type({ service: ServiceC, msgId: t.string }),
-  'message/service/send/request',
-  'message/service/send/success',
-  'message/service/send/failure',
+  'message/service/send',
   t.type({ message: Signed(Message) }),
   t.union([t.undefined, t.type({ via: t.unknown, tookMs: t.number, retries: t.number })]),
 );

--- a/raiden-ts/src/services/actions.ts
+++ b/raiden-ts/src/services/actions.ts
@@ -19,9 +19,7 @@ const ServiceId = t.type({
 
 export const pathFind = createAsyncAction(
   PathId,
-  'path/find/request',
-  'path/find/success',
-  'path/find/failure',
+  'path/find',
   t.partial({ paths: Paths, pfs: t.union([PFS, t.null]) }),
   t.type({ paths: Paths }),
 );
@@ -42,9 +40,7 @@ export interface iouClear extends ActionType<typeof iouClear> {}
 
 export const udcDeposit = createAsyncAction(
   t.type({ totalDeposit: UInt(32) }),
-  'udc/deposit/request',
-  'udc/deposit/success',
-  'udc/deposit/failure',
+  'udc/deposit',
   t.intersection([t.type({ deposit: UInt(32) }), t.partial({ subkey: t.boolean })]),
   t.union([
     t.type({ balance: UInt(32) }),
@@ -68,9 +64,7 @@ const UdcWithdrawId = t.type({
 
 export const udcWithdrawPlan = createAsyncAction(
   UdcWithdrawId,
-  'udc/withdraw/plan/request',
-  'udc/withdraw/plan/success',
-  'udc/withdraw/plan/failure',
+  'udc/withdraw/plan',
   t.undefined,
   t.intersection([
     t.type({ block: t.number }),
@@ -85,9 +79,7 @@ export namespace udcWithdrawPlan {
 
 export const udcWithdraw = createAsyncAction(
   UdcWithdrawId,
-  'udc/withdraw/request',
-  'udc/withdraw/success',
-  'udc/withdraw/failure',
+  'udc/withdraw',
   t.undefined,
   t.type({
     withdrawal: UInt(32),

--- a/raiden-ts/src/transfers/actions.ts
+++ b/raiden-ts/src/transfers/actions.ts
@@ -44,9 +44,7 @@ const TransferId = t.type({
  */
 export const transfer = createAsyncAction(
   TransferId,
-  'transfer/request',
-  'transfer/success',
-  'transfer/failure',
+  'transfer',
   t.intersection([
     t.type({
       tokenNetwork: Address,
@@ -111,9 +109,7 @@ export interface transferSecret extends ActionType<typeof transferSecret> {}
 
 export const transferSecretRegister = createAsyncAction(
   TransferId,
-  'transfer/secret/register/request',
-  'transfer/secret/register/success',
-  'transfer/secret/register/failure',
+  'transfer/secret/register',
   t.intersection([t.type({ secret: Secret }), t.partial({ subkey: t.boolean })]),
   t.type({
     secret: Secret,
@@ -148,9 +144,7 @@ export interface transferSecretReveal extends ActionType<typeof transferSecretRe
 
 export const transferUnlock = createAsyncAction(
   TransferId,
-  'transfer/unlock/request',
-  'transfer/unlock/success',
-  'transfer/unlock/failure',
+  'transfer/unlock',
   t.union([t.undefined, Via]),
   t.intersection([t.type({ message: Signed(Unlock), partner: Address }), Via]),
 );
@@ -178,9 +172,7 @@ export interface transferUnlockProcessed extends ActionType<typeof transferUnloc
  */
 export const transferExpire = createAsyncAction(
   TransferId,
-  'transfer/expire/request',
-  'transfer/expire/success',
-  'transfer/expire/failure',
+  'transfer/expire',
   undefined,
   t.type({ message: Signed(LockExpired), partner: Address }),
 );
@@ -223,9 +215,7 @@ const WithdrawId = t.type({
  */
 export const withdraw = createAsyncAction(
   WithdrawId,
-  'withdraw/request',
-  'withdraw/success',
-  'withdraw/failure',
+  'withdraw',
   t.undefined,
   t.type({ txHash: Hash, txBlock: t.number, confirmed: t.union([t.undefined, t.boolean]) }),
 );
@@ -243,9 +233,7 @@ export namespace withdraw {
  */
 export const withdrawMessage = createAsyncAction(
   WithdrawId,
-  'withdraw/message/request',
-  'withdraw/message/success',
-  'withdraw/message/failure',
+  'withdraw/message',
   t.type({ message: Signed(WithdrawRequest) }),
   t.type({ message: Signed(WithdrawConfirmation) }),
 );
@@ -263,9 +251,7 @@ export namespace withdrawMessage {
  */
 export const withdrawExpire = createAsyncAction(
   WithdrawId,
-  'withdraw/expire/request',
-  'withdraw/expire/success',
-  'withdraw/expire/failure',
+  'withdraw/expire',
   t.undefined,
   t.type({ message: Signed(WithdrawExpired) }),
   // ,

--- a/raiden-ts/src/transport/actions.ts
+++ b/raiden-ts/src/transport/actions.ts
@@ -5,6 +5,7 @@ import type { ActionType } from '../utils/actions';
 import { createAction, createAsyncAction } from '../utils/actions';
 import { Address, instanceOf, PublicKey } from '../utils/types';
 import { RaidenMatrixSetup } from './state';
+import { Caps } from './types';
 
 const NodeId = t.type({ address: Address });
 
@@ -20,16 +21,13 @@ export interface matrixSetup extends ActionType<typeof matrixSetup> {}
 
 export const matrixPresence = createAsyncAction(
   NodeId,
-  'matrix/presence/request',
-  'matrix/presence/success',
-  'matrix/presence/failure',
+  'matrix/presence',
   undefined,
   t.intersection([
     t.type({ userId: t.string, available: t.boolean, ts: t.number, pubkey: PublicKey }),
-    t.partial({ caps: t.record(t.string, t.any) }),
+    t.partial({ caps: Caps }),
   ]),
 );
-
 export namespace matrixPresence {
   export interface request extends ActionType<typeof matrixPresence.request> {}
   export interface success extends ActionType<typeof matrixPresence.success> {}

--- a/raiden-ts/tests/unit/actions.spec.ts
+++ b/raiden-ts/tests/unit/actions.spec.ts
@@ -56,14 +56,14 @@ describe('utils/actions', () => {
     const actionTPM = createAction('TEST3', t.type({ a: t.number }), t.type({ m: t.string }));
     const actionTM = createAction('TEST4', undefined, t.type({ m: t.string }));
     const actionTE = createAction('TEST5', undefined, undefined, true);
-    const actionTPE = createAction('TEST6', t.type({ a: t.number }), undefined, false);
+    const actionTPE = createAction('TEST6', t.type({ a: t.number }), undefined, true);
     const actionTPME = createAction(
       'TEST7',
       t.type({ a: t.number }),
       t.type({ m: t.string }),
       true,
     );
-    const actionTME = createAction('TEST8', undefined, t.type({ m: t.string }), false);
+    const actionTME = createAction('TEST8', undefined, t.type({ m: t.string }), true);
     const actionUnd = createAction('TEST_U', t.union([t.type({ a: t.number }), t.undefined]));
 
     const actionFailed = createAction(
@@ -86,7 +86,7 @@ describe('utils/actions', () => {
     });
     expect(actionTM(undefined, { m: 'abc' })).toStrictEqual({ type: 'TEST4', meta: { m: 'abc' } });
     expect(actionTE()).toStrictEqual({ type: 'TEST5', error: true });
-    expect(actionTPE({ a: 1 })).toStrictEqual({ type: 'TEST6', payload: { a: 1 }, error: false });
+    expect(actionTPE({ a: 1 })).toStrictEqual({ type: 'TEST6', payload: { a: 1 }, error: true });
     expect(actionTPME({ a: 1 }, { m: 'abc' })).toStrictEqual({
       type: 'TEST7',
       payload: { a: 1 },
@@ -96,7 +96,7 @@ describe('utils/actions', () => {
     expect(actionTME(undefined, { m: 'abc' })).toStrictEqual({
       type: 'TEST8',
       meta: { m: 'abc' },
-      error: false,
+      error: true,
     });
 
     // test action with payload unioned with undefined
@@ -145,9 +145,7 @@ describe('utils/actions', () => {
   test('createAsyncAction', async () => {
     const asyncAction = createAsyncAction(
       t.type({ id: t.number }),
-      'test/request',
-      'test/success',
-      'test/failure',
+      'test',
       t.partial({ query: t.string }),
       t.boolean,
     );


### PR DESCRIPTION
**Short description**
Main usage difference is that `createAsyncAction` now requires only action prefix, and will add `/request`, `/success` & `/failure` to the respective actions.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
