### PR TITLE
dependencies: upgrade to rxjs@7 and redux-observable@2

### DIFF
--- a/raiden-cli/package.json
+++ b/raiden-cli/package.json
@@ -56,7 +56,7 @@
     "morgan": "^1.10.0",
     "node-localstorage": "^2.2.1",
     "raiden-ts": "*",
-    "rxjs": "^6.6.7",
+    "rxjs": "^7.3.0",
     "wrtc": "^0.4.7",
     "yargs": "^17.1.0"
   }

--- a/raiden-cli/src/routes/tokens.ts
+++ b/raiden-cli/src/routes/tokens.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from 'express';
 import { Router } from 'express';
-import { first } from 'rxjs/operators';
+import { firstValueFrom } from 'rxjs';
 
 import type { Cli } from '../types';
 import {
@@ -32,7 +32,7 @@ async function getTokenNetwork(this: Cli, request: Request, response: Response) 
 
 async function getTokenPartners(this: Cli, request: Request, response: Response) {
   const token: string = request.params.tokenAddress;
-  const channelsDict = await this.raiden.channels$.pipe(first()).toPromise();
+  const channelsDict = await firstValueFrom(this.raiden.channels$);
   const baseUrl = request.baseUrl.replace(/\/\w+$/, '');
   response.json(
     Object.values(channelsDict[token] ?? {}).map(

--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -38,7 +38,7 @@
     "pouchdb": "^7.2.2",
     "pouchdb-adapter-cordova-sqlite": "^2.0.8",
     "raiden-ts": "*",
-    "rxjs": "^6.6.7",
+    "rxjs": "^7.3.0",
     "tiny-async-pool": "^1.2.0",
     "vue": "^2.6.14",
     "vue-class-component": "^7.2.6",

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -188,9 +188,9 @@ export default class RaidenService {
     await this.monitorPreSetTokens(presetTokens);
 
     // update connected tokens data on each newBlock
-    raiden.events$
-      .pipe(filter((value) => value.type === 'block/new'))
-      .subscribe((event) => this.store.commit('updateBlock', event.payload.blockNumber));
+    raiden.events$.subscribe((event) => {
+      if (event.type === 'block/new') this.store.commit('updateBlock', event.payload.blockNumber);
+    });
 
     raiden.events$
       .pipe(
@@ -239,9 +239,9 @@ export default class RaidenService {
         await this.notifyWithdrawal(value.meta.amount, value.payload.withdrawal);
       } else if (value.type === 'udc/withdraw/plan/failure') {
         await this.notifyWithdrawalFailure(
-          value.payload?.code,
+          (value.payload as { code: string }).code,
           value.meta.amount,
-          value.payload.message,
+          (value.payload as { message: string }).message,
         );
       } else if (value.type === 'channel/settle/success') {
         if (value.payload.confirmed) {
@@ -256,8 +256,8 @@ export default class RaidenService {
           value.payload.confirmed,
           value.meta.partner,
         );
-      } else if (value.type === 'channel/open/failed') {
-        await this.notifyChannelOpenFailed(value.payload.message);
+      } else if (value.type === 'channel/open/failure') {
+        await this.notifyChannelOpenFailed((value.payload as Error).message);
       }
     });
 

--- a/raiden-dapp/tests/unit/raiden-service.spec.ts
+++ b/raiden-dapp/tests/unit/raiden-service.spec.ts
@@ -896,7 +896,7 @@ describe('RaidenService', () => {
     (raiden as any).events$ = subject;
     await setupSDK();
     subject.next({
-      type: 'channel/open/failed',
+      type: 'channel/open/failure',
       payload: { message: 'error message' },
       meta: { tokenNetwork: '0xTokenNetwork', partner: '0xPartner' },
     });

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -114,8 +114,8 @@
     "redux": "^4.1.1",
     "redux-devtools-extension": "^2.13.9",
     "redux-logger": "^3.0.6",
-    "redux-observable": "^1.2.0",
-    "rxjs": "^6.6.7"
+    "redux-observable": "^2.0.0",
+    "rxjs": "^7.3.0"
   },
   "optionalDependencies": {
     "pouchdb-adapter-indexeddb": "^7.2.2",

--- a/raiden-ts/src/actions.ts
+++ b/raiden-ts/src/actions.ts
@@ -16,7 +16,7 @@ import * as ServicesActions from './services/actions';
 import * as TransfersActions from './transfers/actions';
 import * as TransportActions from './transport/actions';
 import { Caps } from './transport/types';
-import type { Action, ActionType, ActionTypeOf, AnyAC } from './utils/actions';
+import type { Action, ActionsUnion, ActionType, ActionTypeOf, AnyAC } from './utils/actions';
 import { createAction } from './utils/actions';
 import { ErrorCodec } from './utils/error';
 import { Hash } from './utils/types';
@@ -66,7 +66,7 @@ const RaidenActions = {
 };
 
 /* Tagged union of all action types from the action creators */
-// export type RaidenAction = ActionType<typeof RaidenActions[keyof typeof RaidenActions]>;
+// export type RaidenAction = ActionType<typeof RaidenActions>;
 export type RaidenAction = Action;
 
 /* Mapping { [type: string]: Action } of a subset of RaidenActions exposed as events */
@@ -88,26 +88,12 @@ export const RaidenEvents = [
 /* Tagged union of RaidenEvents actions */
 export type RaidenEvent = ActionType<typeof RaidenEvents>;
 
-type ValueOf<T> = T[keyof T];
 type UnionToActionsMap<T extends AnyAC> = {
-  [K in ActionTypeOf<T>]: Extract<T, { readonly type: K }>;
+  readonly [K in ActionTypeOf<T>]: Extract<T, { readonly type: K }>;
 };
-// receives an actions module/mapping, where values can be either ACs or AACs, and return a mapping
-// type where ACs are flattened from AACs and keys are their type tag literals
-type ActionsMap<T extends Record<string, AnyAC | Record<string, AnyAC>>> = UnionToActionsMap<
-  ValueOf<
-    {
-      [K in keyof T]: T[K] extends AnyAC
-        ? T[K]
-        : T[K] extends Record<string, AnyAC>
-        ? ValueOf<T[K]>
-        : never;
-    }
-  >
->;
 
 // type and object mapping from every action type to its ActionCreator object
-type RaidenActionsMap = Readonly<ActionsMap<typeof RaidenActions>>;
+type RaidenActionsMap = UnionToActionsMap<ActionsUnion<typeof RaidenActions>>;
 const RaidenActionsMap = reduce(
   RaidenActions,
   (acc, v) => ({ ...acc, ...('type' in v ? { [v.type]: v } : mapKeys(v, property('type'))) }),

--- a/raiden-ts/src/channels/epics/settle.ts
+++ b/raiden-ts/src/channels/epics/settle.ts
@@ -1,6 +1,6 @@
 import { concat as concatBytes } from '@ethersproject/bytes';
 import type { Observable } from 'rxjs';
-import { combineLatest, defer, EMPTY, of, throwError } from 'rxjs';
+import { combineLatest, defer, EMPTY, of } from 'rxjs';
 import {
   catchError,
   delayWhen,
@@ -199,14 +199,12 @@ export function channelSettleEpic(
               Direction.SENT,
               ownBH as Hash,
             ).pipe(
-              catchError(() =>
-                throwError(
-                  new RaidenError(ErrorCodes.CNL_SETTLE_INVALID_BALANCEHASH, {
-                    address,
-                    ownBalanceHash: ownBH,
-                  }),
-                ),
-              ),
+              catchError(() => {
+                throw new RaidenError(ErrorCodes.CNL_SETTLE_INVALID_BALANCEHASH, {
+                  address,
+                  ownBalanceHash: ownBH,
+                });
+              }),
             );
           }
 
@@ -221,14 +219,12 @@ export function channelSettleEpic(
               Direction.RECEIVED,
               partnerBH as Hash,
             ).pipe(
-              catchError(() =>
-                throwError(
-                  new RaidenError(ErrorCodes.CNL_SETTLE_INVALID_BALANCEHASH, {
-                    address,
-                    partnerBalanceHash: partnerBH,
-                  }),
-                ),
-              ),
+              catchError(() => {
+                throw new RaidenError(ErrorCodes.CNL_SETTLE_INVALID_BALANCEHASH, {
+                  address,
+                  partnerBalanceHash: partnerBH,
+                });
+              }),
             );
           }
 

--- a/raiden-ts/src/services/epics/helpers.ts
+++ b/raiden-ts/src/services/epics/helpers.ts
@@ -508,7 +508,7 @@ export function validateRoute$(
   let result$: Observable<pathFind.success>;
   if ('error' in route) {
     const { error } = route;
-    result$ = throwError(
+    result$ = throwError(() =>
       isNoRouteFoundError(error)
         ? new RaidenError(ErrorCodes.PFS_NO_ROUTES_BETWEEN_NODES)
         : new RaidenError(ErrorCodes.PFS_ERROR_RESPONSE, {

--- a/raiden-ts/src/transfers/utils.ts
+++ b/raiden-ts/src/transfers/utils.ts
@@ -10,7 +10,7 @@ import { decrypt, encrypt } from 'eciesjs';
 import * as t from 'io-ts';
 import isEmpty from 'lodash/isEmpty';
 import type { Observable } from 'rxjs';
-import { defer, from, of } from 'rxjs';
+import { defer, firstValueFrom, from, of } from 'rxjs';
 import { filter, first, map, mergeMap } from 'rxjs/operators';
 
 import type { Channel } from '../channels';
@@ -258,7 +258,7 @@ export async function getTransfer(
   key: string | { secrethash: Hash; direction: Direction },
 ): Promise<TransferState> {
   if (typeof key !== 'string') key = transferKey(key);
-  if (!('address' in state)) state = await state.pipe(first()).toPromise();
+  if (!('address' in state)) state = await firstValueFrom(state);
   if (key in state.transfers) return state.transfers[key];
   return decode(TransferState, await db.get<TransferStateish>(key));
 }

--- a/raiden-ts/src/transport/epics/init.ts
+++ b/raiden-ts/src/transport/epics/init.ts
@@ -4,7 +4,7 @@ import type { Filter, MatrixClient } from 'matrix-js-sdk';
 import { createClient } from 'matrix-js-sdk';
 import { logger as matrixLogger } from 'matrix-js-sdk/lib/logger';
 import type { Observable } from 'rxjs';
-import { combineLatest, defer, EMPTY, from, merge, of, throwError } from 'rxjs';
+import { combineLatest, defer, EMPTY, from, merge, of } from 'rxjs';
 import { fromFetch } from 'rxjs/fetch';
 import {
   catchError,
@@ -317,7 +317,12 @@ export function initMatrixEpic(
         retryWhen((err$) =>
           // if there're more servers$ observables in queue, emit once to retry from defer;
           // else, errors output with lastError to unsubscribe
-          err$.pipe(mergeMap(() => (servers$Array.length ? of(null) : throwError(lastError)))),
+          err$.pipe(
+            mergeMap(() => {
+              if (servers$Array.length) return of(null);
+              throw lastError;
+            }),
+          ),
         ),
       );
     }),

--- a/raiden-ts/src/utils/actions.ts
+++ b/raiden-ts/src/utils/actions.ts
@@ -2,6 +2,7 @@
 import * as t from 'io-ts';
 import isMatchWith from 'lodash/isMatchWith';
 import type { Observable } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 import { filter, map, take } from 'rxjs/operators';
 
 import { assert } from '../utils';
@@ -378,8 +379,8 @@ export async function asyncActionToPromise<
   action$: Observable<Action>,
   confirmed?: boolean,
 ) {
-  return action$
-    .pipe(
+  return firstValueFrom(
+    action$.pipe(
       filter(
         confirmed
           ? isConfirmationResponseOf<AAC>(asyncAction, meta)
@@ -401,8 +402,9 @@ export async function asyncActionToPromise<
           });
         return action.payload as ActionType<AAC['success']>['payload'];
       }),
-    )
-    .toPromise();
+    ),
+    { defaultValue: undefined },
+  );
 }
 
 // createReducer

--- a/raiden-ts/tests/e2e/e2e.spec.ts
+++ b/raiden-ts/tests/e2e/e2e.spec.ts
@@ -3,7 +3,7 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { Wallet } from '@ethersproject/wallet';
 import type { OpenMode } from 'fs';
 import { promises as fs } from 'fs';
-import { first } from 'rxjs/operators';
+import { firstValueFrom } from 'rxjs';
 
 import { Capabilities } from '@/constants';
 import { Raiden } from '@/raiden';
@@ -78,7 +78,7 @@ function getToken(): string {
 
 async function getChannelCapacity(raiden: Raiden, partner: Address): Promise<BigNumber> {
   const tokenAddress = getToken();
-  const channels = await raiden.channels$.pipe(first()).toPromise();
+  const channels = await firstValueFrom(raiden.channels$);
   const partnerChannel = channels[tokenAddress][partner];
   return partnerChannel.capacity;
 }

--- a/raiden-ts/tests/integration/mediate.spec.ts
+++ b/raiden-ts/tests/integration/mediate.spec.ts
@@ -14,6 +14,7 @@ import { makeRaidens } from './mocks';
 
 import { BigNumber } from '@ethersproject/bignumber';
 import { Zero } from '@ethersproject/constants';
+import { firstValueFrom } from 'rxjs';
 import { first } from 'rxjs/operators';
 
 import { raidenConfigUpdate } from '@/actions';
@@ -40,7 +41,7 @@ describe('mediate transfers', () => {
     partner.store.dispatch(raidenConfigUpdate({ mediationFees: { [token]: { flat } } }));
     await ensurePresence([raiden, target]);
 
-    const promise = target.action$.pipe(first(transfer.success.is)).toPromise();
+    const promise = firstValueFrom(target.action$.pipe(first(transfer.success.is)));
     raiden.store.dispatch(
       transfer.request(
         {
@@ -101,7 +102,7 @@ describe('mediate transfers', () => {
             ],
           },
           partner: target.address,
-          userId: (await target.deps.matrix$.toPromise()).getUserId()!,
+          userId: (await firstValueFrom(target.deps.matrix$)).getUserId()!,
         },
         { secrethash, direction: Direction.SENT },
       ),
@@ -127,7 +128,7 @@ describe('mediate transfers', () => {
     partner.store.dispatch(raidenConfigUpdate({ mediationFees: { [token]: { flat } } }));
     await ensurePresence([raiden, target]);
 
-    const promise = target.action$.pipe(first(transfer.success.is)).toPromise();
+    const promise = firstValueFrom(target.action$.pipe(first(transfer.success.is)));
     raiden.store.dispatch(
       transfer.request(
         {
@@ -189,7 +190,7 @@ describe('mediate transfers', () => {
             ],
           },
           partner: target.address,
-          userId: (await target.deps.matrix$.toPromise()).getUserId()!,
+          userId: (await firstValueFrom(target.deps.matrix$)).getUserId()!,
         },
         { secrethash, direction: Direction.SENT },
       ),

--- a/raiden-ts/tests/integration/monitor.spec.ts
+++ b/raiden-ts/tests/integration/monitor.spec.ts
@@ -22,7 +22,8 @@ import {
 import { defaultAbiCoder } from '@ethersproject/abi';
 import { BigNumber } from '@ethersproject/bignumber';
 import { Two, WeiPerEther } from '@ethersproject/constants';
-import { first, pluck } from 'rxjs/operators';
+import { firstValueFrom } from 'rxjs';
+import { pluck } from 'rxjs/operators';
 
 import { raidenConfigUpdate, raidenShutdown } from '@/actions';
 import { Capabilities } from '@/constants';
@@ -93,7 +94,7 @@ describe('msMonitorRequestEpic', () => {
     const [raiden, partner] = await makeRaidens(2);
     raiden.store.dispatch(raidenConfigUpdate({ rateToSvt: {} }));
     expect(
-      (await raiden.deps.latest$.pipe(pluck('udcDeposit', 'balance'), first()).toPromise()).gte(
+      (await firstValueFrom(raiden.deps.latest$.pipe(pluck('udcDeposit', 'balance')))).gte(
         raiden.config.monitoringReward!,
       ),
     ).toBe(true);

--- a/raiden-ts/tests/integration/path.spec.ts
+++ b/raiden-ts/tests/integration/path.spec.ts
@@ -17,7 +17,7 @@ import { fetch, makeLog, makeRaiden, makeRaidens, providersEmit, waitBlock } fro
 import { defaultAbiCoder } from '@ethersproject/abi';
 import { BigNumber } from '@ethersproject/bignumber';
 import { AddressZero, One, Zero } from '@ethersproject/constants';
-import { first } from 'rxjs/operators';
+import { firstValueFrom } from 'rxjs';
 
 import { raidenConfigUpdate, raidenShutdown } from '@/actions';
 import { Capabilities } from '@/constants';
@@ -130,13 +130,11 @@ describe('PFS: pfsRequestEpic', () => {
           text: jest.fn(async () => ''),
         };
       }
-      const userId = (await client!.deps.matrix$.toPromise()).getUserId()!;
+      const userId = (await firstValueFrom(client!.deps.matrix$)).getUserId()!;
       const result = {
         user_id: userId,
         displayname: await client!.deps.signer.signMessage(userId),
-        capabilities: stringifyCaps(
-          (await client!.deps.latest$.pipe(first()).toPromise()).config.caps!,
-        ),
+        capabilities: stringifyCaps((await firstValueFrom(client!.deps.latest$)).config.caps!),
       };
       return {
         status: 200,

--- a/raiden-ts/tests/integration/receive.spec.ts
+++ b/raiden-ts/tests/integration/receive.spec.ts
@@ -20,6 +20,7 @@ import {
 } from './mocks';
 
 import { One, Zero } from '@ethersproject/constants';
+import { firstValueFrom } from 'rxjs';
 import { first } from 'rxjs/operators';
 
 import { raidenConfigUpdate } from '@/actions';
@@ -150,7 +151,7 @@ describe('receive transfers', () => {
               type: MessageType.SECRET_REQUEST,
               secrethash,
             }),
-            userId: (await partner.deps.matrix$.toPromise()).getUserId()!,
+            userId: (await firstValueFrom(partner.deps.matrix$)).getUserId()!,
           },
           receivedMeta,
         ),
@@ -166,7 +167,7 @@ describe('receive transfers', () => {
       await ensureChannelIsDeposited([partner, raiden]);
 
       // stopping mocked MatrixClient prevents messages from being forwarded
-      (await partner.deps.matrix$.toPromise()).stopClient();
+      (await firstValueFrom(partner.deps.matrix$)).stopClient();
 
       const sentState = getOrWaitTransfer(partner, sentMeta, true);
       partner.store.dispatch(
@@ -260,7 +261,7 @@ describe('receive transfers', () => {
       const [raiden, partner] = await makeRaidens(2);
       await ensureTransferPending([partner, raiden], value);
 
-      (await partner.deps.matrix$.toPromise()).stopClient();
+      (await firstValueFrom(partner.deps.matrix$)).stopClient();
 
       const sentStatePromise = getOrWaitTransfer(partner, sentMeta, (doc) => !!doc.unlock);
       partner.store.dispatch(transferSecret({ secret }, sentMeta));
@@ -271,7 +272,7 @@ describe('receive transfers', () => {
       // "wrong" secret/secrethash
       const secret_ = makeSecret();
       const secrethash_ = getSecrethash(secret_);
-      const promise = raiden.action$.pipe(first(transferUnlock.failure.is)).toPromise();
+      const promise = firstValueFrom(raiden.action$.pipe(first(transferUnlock.failure.is)));
       raiden.store.dispatch(
         messageReceived(
           {
@@ -296,7 +297,7 @@ describe('receive transfers', () => {
       const [raiden, partner] = await makeRaidens(2);
       await ensureTransferPending([partner, raiden], value);
 
-      (await partner.deps.matrix$.toPromise()).stopClient();
+      (await firstValueFrom(partner.deps.matrix$)).stopClient();
 
       const sentStatePromise = getOrWaitTransfer(partner, sentMeta, (doc) => !!doc.unlock);
       partner.store.dispatch(transferSecret({ secret }, sentMeta));
@@ -383,7 +384,7 @@ describe('receive transfers', () => {
       const [raiden, partner] = await makeRaidens(2);
       const pendingSentState = await ensureTransferPending([partner, raiden], value);
 
-      (await partner.deps.matrix$.toPromise()).stopClient();
+      (await firstValueFrom(partner.deps.matrix$)).stopClient();
 
       const sentStatePromise = getOrWaitTransfer(partner, sentMeta, (doc) => !!doc.expired);
       await waitBlock(pendingSentState.expiration + 2 * partner.config.confirmationBlocks + 1);
@@ -393,7 +394,7 @@ describe('receive transfers', () => {
       // "wrong" secret/secrethash
       const secret_ = makeSecret();
       const secrethash_ = getSecrethash(secret_);
-      const promise = raiden.action$.pipe(first(transferExpire.failure.is)).toPromise();
+      const promise = firstValueFrom(raiden.action$.pipe(first(transferExpire.failure.is)));
       raiden.store.dispatch(
         messageReceived(
           {
@@ -419,7 +420,7 @@ describe('receive transfers', () => {
       const [raiden, partner] = await makeRaidens(2);
       const pendingSentState = await ensureTransferPending([partner, raiden], value);
 
-      (await partner.deps.matrix$.toPromise()).stopClient();
+      (await firstValueFrom(partner.deps.matrix$)).stopClient();
 
       const sentStatePromise = getOrWaitTransfer(partner, sentMeta, (doc) => !!doc.expired);
       await waitBlock(pendingSentState.expiration + 2 * partner.config.confirmationBlocks + 1);

--- a/raiden-ts/tests/integration/udc.spec.ts
+++ b/raiden-ts/tests/integration/udc.spec.ts
@@ -4,7 +4,8 @@ import { makeRaiden, makeRaidens, makeStruct, makeTransaction, waitBlock } from 
 import { BigNumber } from '@ethersproject/bignumber';
 import { MaxUint256, Zero } from '@ethersproject/constants';
 import { parseEther } from '@ethersproject/units';
-import { first, pluck } from 'rxjs/operators';
+import { firstValueFrom } from 'rxjs';
+import { pluck } from 'rxjs/operators';
 
 import { raidenConfigUpdate } from '@/actions';
 import { udcDeposit, udcWithdraw, udcWithdrawPlan } from '@/services/actions';
@@ -27,7 +28,7 @@ test('monitorUdcBalanceEpic', async () => {
     udcDeposit.success({ balance: Zero as UInt<32> }, { totalDeposit: Zero as UInt<32> }),
   );
   await expect(
-    raiden.deps.latest$.pipe(pluck('udcDeposit', 'balance'), first()).toPromise(),
+    firstValueFrom(raiden.deps.latest$.pipe(pluck('udcDeposit', 'balance'))),
   ).resolves.toEqual(Zero);
 
   const balance = BigNumber.from(23) as UInt<32>;
@@ -37,7 +38,7 @@ test('monitorUdcBalanceEpic', async () => {
 
   expect(raiden.output).toContainEqual(udcDeposit.success({ balance }, { totalDeposit: balance }));
   await expect(
-    raiden.deps.latest$.pipe(pluck('udcDeposit', 'balance'), first()).toPromise(),
+    firstValueFrom(raiden.deps.latest$.pipe(pluck('udcDeposit', 'balance'))),
   ).resolves.toEqual(balance);
   expect(userDepositContract.effectiveBalance).toHaveBeenCalledTimes(2);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -16353,10 +16353,13 @@ redux-logger@^3.0.6:
   dependencies:
     deep-diff "^0.3.5"
 
-redux-observable@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-1.2.0.tgz#ff51b6c6be2598e9b5e89fc36639186bb0e669c7"
-  integrity sha512-yeR90RP2WzZzCxxnQPlh2uFzyfFLsfXu8ROh53jGDPXVqj71uNDMmvi/YKQkd9ofiVoO4OYb1snbowO49tCEMg==
+redux-observable@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-2.0.0.tgz#4358bef2e924723a8b1ad0e835ccebb1612a6b9a"
+  integrity sha512-FJz4rLXX+VmDDwZS/LpvQsKnSanDOe8UVjiLryx1g3seZiS69iLpMrcvXD5oFO7rtkPyRdo/FmTqldnT3X3m+w==
+  dependencies:
+    rxjs "^7.0.0"
+    tslib "~2.1.0"
 
 redux@^4.0.0:
   version "4.1.0"
@@ -16794,6 +16797,13 @@ rxjs@^6.4.0, rxjs@^6.6.0, rxjs@^6.6.7:
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
+
+rxjs@^7.0.0, rxjs@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.3.0.tgz#39fe4f3461dc1e50be1475b2b85a0a88c1e938c6"
+  integrity sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==
+  dependencies:
+    tslib "~2.1.0"
 
 rxjs@^7.2.0:
   version "7.2.0"


### PR DESCRIPTION
**Short description**
This is a major upgrade of these core dependencies. `redux-observable@2` has minimal interface change, and is mostly a compatibility upgrade.
On rxjs though, there're a handful of important changes. [Here is an article](https://medium.com/volosoft/whats-new-in-rxjs-7-a11cc564c6c0) with a summary of the changes, but the ones which required most adjustments are:
- `toPromise` now correctly reports `| undefined` type and is deprecated, and should be replaced with `firstValueFrom`/`lastValueFrom`; they error like `first` if no item goes through before completion, and this can be prevented by passing the config object `{ defaultValue: v }` as 2nd function param. Erroring if no value goes through is though often the desired behavior.
- `throwError` deprecates the overload which constructs `Observable<never>` directly from an error object, since most of the time (specially inside `*Map` operators) a bare `throw` has the same effect.

An adjustment on top of #2876 is also included, since that revealed our `RaidenEvent` type was being incorrectly broadened to `any`, and fixing this has revealed some small adjustments needed on dApp as well.
Other than those, this is mostly a transparent upgrade, not impacting functionality or UX, therefore no changelog entry is needed.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Tests pass
