### PR TITLE
chore: fix staging CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,7 @@ workflows:
       - deploy_gh_pages:
           public_path: /staging
           requires:
+            - build_dapp
             - test_dapp_unit
             - test_dapp_e2e
 


### PR DESCRIPTION
That must be it...
The only difference to before and because the job failed due to the missing `dist` folder.