### PR TITLE
Fix for caps not getting updated if RTC channels are established

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- [#2889] Ensure capabilities are updated when they change even if RTC channels are established by reconnecting them.
+
+[#2889]: https://github.com/raiden-network/light-client/issues/2889
 
 ## [2.0.0-rc.1] - 2021-08-13
 ### Added

--- a/raiden-ts/src/transport/epics/presence.ts
+++ b/raiden-ts/src/transport/epics/presence.ts
@@ -117,11 +117,11 @@ export function matrixMonitorPresenceEpic(
       grouped$.pipe(
         withLatestFrom(latest$, config$),
         // if we're already fetching presence for this address, no need to fetch again
-        exhaustMap(([action, { rtc }, { httpTimeout }]) => {
+        exhaustMap(([action, { rtc }, { pollingInterval }]) => {
           const { address } = action.meta;
           const cached = cache.get(address);
           // we already fetched this peer's presence recently, or there's an RTC channel with them
-          if (cached && (Date.now() - cached.payload.ts < httpTimeout || address in rtc))
+          if (cached && (Date.now() - cached.payload.ts < pollingInterval || address in rtc))
             return of(cached);
           return searchAddressPresence$(address, deps);
         }),

--- a/raiden-ts/tests/integration/path.spec.ts
+++ b/raiden-ts/tests/integration/path.spec.ts
@@ -203,21 +203,22 @@ describe('PFS: pfsRequestEpic', () => {
   });
 
   test('fail target not available', async () => {
-    expect.assertions(1);
+    expect.assertions(2);
 
     raiden.store.dispatch(presenceFromClient(target, false));
-
-    await waitBlock();
+    // Emitting the pathFind.request action to check pfsRequestEpic runs
+    // and gets the earlier matrix presence error for target
     const pathFindMeta = {
       tokenNetwork,
       target: target.address,
       value: amount,
     };
-    // Emitting the pathFind.request action to check pfsRequestEpic runs
-    // and gets the earlier matrix presence error for target
     raiden.store.dispatch(pathFind.request({}, pathFindMeta));
-    await waitBlock();
-    await sleep(2 * raiden.config.pollingInterval);
+    await sleep();
+    // await sleep(2 * raiden.config.pollingInterval);
+    expect(raiden.output).not.toContainEqual(
+      pathFind.success(expect.anything(), expect.anything()),
+    );
     expect(raiden.output).toContainEqual(
       pathFind.failure(
         expect.objectContaining({


### PR DESCRIPTION
Fixes #2889 

**Short description**
Ensure caps get updated on partners even if RTC channels are established by reconnecting them.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Check bug can't be reproduced
