### PR TITLE
Delay non-closing auto-settle to prevent wasted gas on channelSettle race

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## [Unreleased]
 ### Fixed
+- [#2798] Delay non-closing auto-settle to prevent wasted gas on channelSettle race; closing side is given priority on auto-settling
 - [#2889] Ensure capabilities are updated when they change even if RTC channels are established by reconnecting them.
 
+[#2798]: https://github.com/raiden-network/light-client/issues/2798
 [#2889]: https://github.com/raiden-network/light-client/issues/2889
 
 ## [2.0.0-rc.1] - 2021-08-13

--- a/raiden-ts/src/channels/epics/monitor.ts
+++ b/raiden-ts/src/channels/epics/monitor.ts
@@ -45,7 +45,7 @@ import {
   newBlock,
   tokenMonitored,
 } from '../actions';
-import { channelKey, channelUniqueKey, groupChannel$ } from '../utils';
+import { channelKey, channelUniqueKey, groupChannel } from '../utils';
 
 const tokenNetworkInterface = TokenNetwork__factory.createInterface();
 
@@ -576,7 +576,7 @@ export function channelMonitoredEpic(
   state$: Observable<RaidenState>,
 ): Observable<channelMonitored> {
   return state$.pipe(
-    groupChannel$,
+    groupChannel(),
     mergeMap((grouped$) =>
       grouped$.pipe(
         first(),

--- a/raiden-ts/src/channels/epics/settle.ts
+++ b/raiden-ts/src/channels/epics/settle.ts
@@ -31,7 +31,7 @@ import type { Hash, HexString } from '../../utils/types';
 import { channelSettle, channelSettleable, newBlock } from '../actions';
 import type { Channel } from '../state';
 import { ChannelState } from '../state';
-import { assertTx, channelKey, groupChannel$ } from '../utils';
+import { assertTx, channelKey, groupChannel } from '../utils';
 
 /**
  * Process newBlocks, emits ChannelSettleableAction if any closed channel is now settleable
@@ -81,7 +81,7 @@ export function channelAutoSettleEpic(
   { config$ }: RaidenEpicDeps,
 ): Observable<channelSettle.request> {
   return state$.pipe(
-    groupChannel$,
+    groupChannel(),
     mergeMap((grouped$) =>
       grouped$.pipe(
         filter(

--- a/raiden-ts/src/channels/state.ts
+++ b/raiden-ts/src/channels/state.ts
@@ -4,7 +4,7 @@ import * as t from 'io-ts';
 import { WithdrawConfirmation, WithdrawExpired, WithdrawRequest } from '../messages';
 import type { Int } from '../utils/types';
 import { Address, Signed, UInt } from '../utils/types';
-import { BalanceProof, Lock } from './types';
+import { BalanceProof, ChannelUniqueKey, Lock } from './types';
 
 export enum ChannelState {
   open = 'open',
@@ -40,7 +40,7 @@ export const Channel = t.intersection([
   // readonly needs to be applied to the individual types to allow tagged union narrowing
   t.readonly(
     t.type({
-      _id: t.string,
+      _id: ChannelUniqueKey,
       id: t.number,
       token: Address,
       tokenNetwork: Address,

--- a/raiden-ts/src/channels/types.ts
+++ b/raiden-ts/src/channels/types.ts
@@ -3,13 +3,16 @@ import * as t from 'io-ts';
 
 import { LocksrootZero, SignatureZero } from '../constants';
 import type { Signed } from '../utils/types';
-import { Address, Hash, UInt } from '../utils/types';
+import { Address, Hash, templateLiteral, UInt } from '../utils/types';
 
 // should these become brands?
-export const ChannelKey = t.string;
-export type ChannelKey = string;
-export const ChannelUniqueKey = t.string;
-export type ChannelUniqueKey = string;
+export type ChannelKey = `0x${string}@0x${string}`;
+export const ChannelKey = templateLiteral<ChannelKey>(/^0x[0-9a-fA-F]{40}@0x[0-9a-fA-F]{40}$/);
+
+export type ChannelUniqueKey = `${ChannelKey}#${number}`;
+export const ChannelUniqueKey = templateLiteral<ChannelUniqueKey>(
+  /^0x[0-9a-fA-F]{40}@0x[0-9a-fA-F]{40}#\d+$/,
+);
 
 // Represents a HashTime-Locked amount in a channel
 export const Lock = t.intersection(

--- a/raiden-ts/src/channels/utils.ts
+++ b/raiden-ts/src/channels/utils.ts
@@ -32,7 +32,7 @@ export function channelKey({
 )): ChannelKey {
   const partnerAddr =
     typeof partner === 'string' ? partner : (partner as { address: Address }).address;
-  return `${tokenNetwork}@${partnerAddr}`;
+  return `${tokenNetwork}@${partnerAddr}` as ChannelKey;
 }
 
 /**
@@ -42,13 +42,13 @@ export function channelKey({
  * @returns A string, for now
  */
 export function channelUniqueKey<
-  C extends { _id?: string; id: number; tokenNetwork: Address } & (
+  C extends { _id?: ChannelUniqueKey; id: number; tokenNetwork: Address } & (
     | { partner: { address: Address } }
     | { partner: Address }
   ),
 >(channel: C): ChannelUniqueKey {
   if ('_id' in channel && channel._id) return channel._id;
-  return `${channelKey(channel)}#${channel.id.toString().padStart(9, '0')}`;
+  return `${channelKey(channel)}#${channel.id.toString().padStart(9, '0')}` as ChannelUniqueKey;
 }
 
 /**

--- a/raiden-ts/src/services/epics/monitor.ts
+++ b/raiden-ts/src/services/epics/monitor.ts
@@ -20,7 +20,7 @@ import {
 import type { RaidenAction } from '../../actions';
 import { newBlock } from '../../channels/actions';
 import type { Channel } from '../../channels/state';
-import { channelAmounts, groupChannel$ } from '../../channels/utils';
+import { channelAmounts, groupChannel } from '../../channels/utils';
 import { messageServiceSend } from '../../messages/actions';
 import type { MonitorRequest } from '../../messages/types';
 import { MessageType } from '../../messages/types';
@@ -148,7 +148,7 @@ export function msMonitorRequestEpic(
   deps: RaidenEpicDeps,
 ): Observable<messageServiceSend.request> {
   return state$.pipe(
-    groupChannel$,
+    groupChannel(),
     withLatestFrom(deps.config$),
     mergeMap(([grouped$, { httpTimeout }]) =>
       grouped$.pipe(

--- a/raiden-ts/src/services/epics/pathfinding.ts
+++ b/raiden-ts/src/services/epics/pathfinding.ts
@@ -24,7 +24,7 @@ import {
 import type { RaidenAction } from '../../actions';
 import { newBlock } from '../../channels/actions';
 import { ChannelState } from '../../channels/state';
-import { channelAmounts, groupChannel$ } from '../../channels/utils';
+import { channelAmounts, groupChannel } from '../../channels/utils';
 import { Capabilities } from '../../constants';
 import { messageServiceSend } from '../../messages/actions';
 import type { PFSCapacityUpdate, PFSFeeUpdate } from '../../messages/types';
@@ -98,7 +98,7 @@ export function pfsCapacityUpdateEpic(
   { log, address, network, signer, config$ }: RaidenEpicDeps,
 ): Observable<messageServiceSend.request> {
   return state$.pipe(
-    groupChannel$,
+    groupChannel(),
     mergeMap((grouped$) =>
       grouped$.pipe(
         pairwise(), // skips first emission on startup
@@ -174,7 +174,7 @@ export function pfsFeeUpdateEpic(
   { log, address, network, signer, config$, mediationFeeCalculator }: RaidenEpicDeps,
 ): Observable<messageServiceSend.request> {
   return state$.pipe(
-    groupChannel$,
+    groupChannel(),
     mergeMap((grouped$) =>
       combineLatest([
         grouped$,

--- a/raiden-ts/src/state.ts
+++ b/raiden-ts/src/state.ts
@@ -5,7 +5,6 @@ import * as t from 'io-ts';
 
 import { ConfirmableAction } from './actions';
 import { Channel } from './channels/state';
-import { ChannelKey } from './channels/types';
 import { PartialRaidenConfig } from './config';
 import { IOU, ServicesValidityMap } from './services/types';
 import { TransferState } from './transfers/state';
@@ -21,8 +20,8 @@ const _RaidenState = t.readonly(
     registry: Address,
     blockNumber: t.number,
     config: PartialRaidenConfig,
-    channels: t.readonly(t.record(ChannelKey, Channel)),
-    oldChannels: t.readonly(t.record(t.string, Channel)),
+    channels: t.readonly(t.record(t.string /* ChannelKey */, Channel)),
+    oldChannels: t.readonly(t.record(t.string /* ChannelUniqueKey */, Channel)),
     tokens: t.readonly(t.record(t.string /* token: Address */, Address)),
     transport: t.readonly(t.partial({ server: t.string, setup: RaidenMatrixSetup })),
     transfers: t.readonly(t.record(t.string /*: key: TransferKey */, TransferState)),

--- a/raiden-ts/src/transport/epics/messages.ts
+++ b/raiden-ts/src/transport/epics/messages.ts
@@ -60,7 +60,7 @@ import {
 } from '../../utils/rx';
 import { Address, isntNil, Signed } from '../../utils/types';
 import { matrixPresence } from '../actions';
-import { getAddressFromUserId, getNoDeliveryPeers, getSeenPresences } from '../utils';
+import { getAddressFromUserId, getNoDeliveryPeers, getPresencesByUserId } from '../utils';
 
 function getMessageBody(message: string | Signed<Message>): string {
   return typeof message === 'string' ? message : encodeJsonMessage(message);
@@ -360,7 +360,7 @@ export function matrixMessageReceivedEpic(
             event.getType() === 'm.room.message' && event.getSender() !== matrix.getUserId(),
         ),
         pluck(1),
-        withLatestFrom(config$, action$.pipe(getSeenPresences())),
+        withLatestFrom(config$, action$.pipe(getPresencesByUserId())),
         mergeWith(([event, { httpTimeout }, seenPresences]) => {
           const senderId = event.getSender();
           if (senderId in seenPresences) return of(seenPresences[senderId]);

--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -72,7 +72,7 @@ import {
 import type { Address } from '../../utils/types';
 import { decode, isntNil, last } from '../../utils/types';
 import { matrixPresence, rtcChannel } from '../actions';
-import { getCap, getSeenPresences } from '../utils';
+import { getCap, getPresencesByUserId } from '../utils';
 
 interface CallInfo {
   callId: string;
@@ -613,7 +613,7 @@ function mapRtcMessage(): OperatorFunction<
   return (action$) =>
     action$.pipe(
       filter(messageReceived.is),
-      withLatestFrom(action$.pipe(getSeenPresences())),
+      withLatestFrom(action$.pipe(getPresencesByUserId())),
       filter(
         ([action, seenPresences]) =>
           action.payload.msgtype === rtcMatrixMsgType &&

--- a/raiden-ts/src/transport/utils.ts
+++ b/raiden-ts/src/transport/utils.ts
@@ -102,24 +102,6 @@ export function getSortedAddresses<A extends Address[]>(...addresses: A) {
 }
 
 /**
- * Extracts peer's addresses which don't need Delivered messages as a set
- *
- * @returns custom operator mapping from stream of RaidenActions to address set
- */
-export function getNoDeliveryPeers(): OperatorFunction<RaidenAction, Set<Address>> {
-  const noDelivery = new Set<Address>();
-  return pipe(
-    filter(matrixPresence.success.is),
-    scan((acc, presence) => {
-      if (!getCap(presence.payload.caps, Capabilities.DELIVERY)) acc.add(presence.meta.address);
-      else acc.delete(presence.meta.address);
-      return acc;
-    }, noDelivery),
-    startWith(noDelivery),
-  );
-}
-
-/**
  * Aggregates seen presence updates by userId
  *
  * @returns custom operator mapping from stream of RaidenActions to userId-presences dict
@@ -158,4 +140,15 @@ export function getPresencesByAddress(): OperatorFunction<
     }, emptyDict),
     startWith(emptyDict),
   );
+}
+
+/**
+ * Check if given presence is from an online partner which is another Light Client
+ * For now, this checks peer is online (known presence) and has Capabilities.DELIVERY set to 0
+ *
+ * @param presence - optional presence update
+ * @returns true if partner is online and is another light-client
+ */
+export function peerIsOnlineLC(presence: matrixPresence.success | undefined): boolean {
+  return !!presence && !getCap(presence.payload.caps, Capabilities.DELIVERY);
 }


### PR DESCRIPTION
Fixes #2798 

**Short description**
Optimization: auto-settling peers have shifted timeouts after settleable block; closing side is expected to auto-settle only `confirmationBlocks=5` after channel becomes settleable; if it doesn't, non-closing side auto-settle is delayed to `revealTimeout=50` blocks; unless partner is a PC, which always settle early, so in this case LC always wait longer before attempting auto-settling.
This tries to prevent both clients calling `settleChannel` at the same time and one of them wasting the gas, as only one of the txs will succeed.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
