### PR TITLE
UDC to withdrawToBeneficiary by default with subkey

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -7,10 +7,12 @@
 
 ### Added
 - [#2891] Use `TokenNetwork.openChannelWithDeposit` on new contracts for faster open+deposit in a single transaction.
+- [#2892] Use `UserDeposit.withdrawToBeneficiary` to withdraw from UDC directly to main account
 
 [#2798]: https://github.com/raiden-network/light-client/issues/2798
 [#2889]: https://github.com/raiden-network/light-client/issues/2889
 [#2891]: https://github.com/raiden-network/light-client/issues/2891
+[#2892]: https://github.com/raiden-network/light-client/issues/2892
 
 ## [2.0.0-rc.1] - 2021-08-13
 ### Added

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -1425,9 +1425,16 @@ export class Raiden {
    *
    * @param value - Maximum value which we may try to withdraw. An error will be thrown if this
    *    value is larger than [[getUDCCapacity]]+[[getUDCWithdrawPlan]].amount
+   * @param options - options object
+   * @param options.subkey - if true, force withdrawing to subkey instead of the main account as
+   *       beneficiary
    * @returns Promise to hash of plan transaction, if it succeeds.
    */
-  public async withdrawFromUDC(value?: BigNumberish): Promise<Hash> {
+  public async withdrawFromUDC(
+    value?: BigNumberish,
+    options?: { subkey?: boolean },
+  ): Promise<Hash> {
+    assert(!options?.subkey || this.deps.main, ErrorCodes.RDN_SUBKEY_NOT_SET, this.log.info);
     assert(!this.config.autoUDCWithdraw, ErrorCodes.UDC_WITHDRAW_AUTO_ENABLED, this.log.warn);
     const plan = await this.getUDCWithdrawPlan();
     assert(plan, ErrorCodes.UDC_WITHDRAW_NO_PLAN, this.log.warn);
@@ -1450,7 +1457,7 @@ export class Raiden {
     const promise = asyncActionToPromise(udcWithdraw, meta, this.action$, true).then(
       ({ txHash }) => txHash,
     );
-    this.store.dispatch(udcWithdraw.request(undefined, meta));
+    this.store.dispatch(udcWithdraw.request(options, meta));
     return promise;
   }
 

--- a/raiden-ts/src/services/actions.ts
+++ b/raiden-ts/src/services/actions.ts
@@ -80,9 +80,10 @@ export namespace udcWithdrawPlan {
 export const udcWithdraw = createAsyncAction(
   UdcWithdrawId,
   'udc/withdraw',
-  t.undefined,
+  t.union([t.undefined, t.partial({ subkey: t.boolean })]),
   t.type({
     withdrawal: UInt(32),
+    beneficiary: Address,
     txHash: Hash,
     txBlock: t.number,
     confirmed: t.union([t.undefined, t.boolean]),

--- a/raiden-ts/tests/integration/mocks.ts
+++ b/raiden-ts/tests/integration/mocks.ts
@@ -158,14 +158,20 @@ export function makeSignature(): Signature {
   return '0x5770d597b270ad9d1225c901b1ef6bfd8782b15d7541379619c5dae02c5c03c1196291b042a4fea9dbddcb1c6bcd2a5ee19180e8dc881c2e9298757e84ad190b1c' as Signature;
 }
 
-// not all random 32bytes values are valid secp256k1 private keys, retry
-function makeWallet() {
+/**
+ * Creates and returns a valid Wallet instance
+ *
+ * @returns some wallet instance
+ */
+export function makeWallet() {
   let wallet: Wallet | undefined;
   do {
     try {
-      wallet = new Wallet(makeSecret());
-      assert(Address.is(wallet.address));
+      const wallet_ = new Wallet(makeSecret());
+      assert(Address.is(wallet_.address));
+      wallet = wallet_;
     } catch (err) {}
+    // not all random 32bytes values are valid secp256k1 private keys, retry
   } while (!wallet);
   return wallet;
 }

--- a/raiden-ts/tests/unit/raiden.spec.ts
+++ b/raiden-ts/tests/unit/raiden.spec.ts
@@ -637,6 +637,7 @@ describe('Raiden', () => {
           udcWithdraw.success(
             {
               withdrawal: BigNumber.from(withdrawAmount) as UInt<32>,
+              beneficiary: address,
               txHash: txHash,
               txBlock: txBlock,
               confirmed: true,


### PR DESCRIPTION
Closes #2892 

**Short description**
raiden-contracts@0.39 added to UDC the ability to `withdrawToBeneficiary`, removing the need to a later tx to transfer SVT from subkey back to main account. This PR uses this by default when the subkey is used and
the contracts support it. An `options` param is added to `Raiden.withdrawFwithdrawFromUDC` to allow passing an object containing an explicit `subkey` boolean to force to withdraw to subkey if true (or force to withdraw to main account if false and config.subkey is true).

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. plan and wait for a UDC withdraw to be performed on dApp using a subkey
2. notice the funds lands directly in main account once the plan is completed
