### PR TITLE
sdk: fix channel lookup on waitForPFSCapacityUpdate

### DIFF
--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -645,7 +645,8 @@ export async function waitForPFSCapacityUpdate(
         // ensure it's a PFSCapacityUpdate for this specific channel
         if (
           message.canonical_identifier.token_network_address !== meta.tokenNetwork ||
-          !message.canonical_identifier.channel_identifier.eq(state.channels[channelKey(meta)]?.id)
+          !(channelKey(meta) in state.channels) ||
+          !message.canonical_identifier.channel_identifier.eq(state.channels[channelKey(meta)].id)
         )
           return;
         // on the first messageServiceSend.request for a PFSCapacityUpdate for this channel


### PR DESCRIPTION
**Short description**
Fixes a small issue on waiting for the `PFSCapacityUpdate` after open + deposit. Since the deposit happens at the same time as the channel open, if a concurrent channel on the same token network was being opened, it'd cause the failure on the promise waiting for that other channel's PFSCapacityUpdate,  which would reject while it should wait for the corresponding message.+

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
