### PR TITLE
Enable stricter TS rules for indexed properties access

### DIFF
--- a/raiden-ts/src/channels/epics/close.ts
+++ b/raiden-ts/src/channels/epics/close.ts
@@ -205,7 +205,7 @@ export function channelUpdateEpic(
         getTokenNetworkContract(tokenNetwork),
         onchainSigner,
       );
-      const channel = state.channels[channelKey(action.meta)];
+      const channel = state.channels[channelKey(action.meta)]!; // checked in filter
 
       const balanceHash = createBalanceHash(channel.partner.balanceProof);
       const nonce = channel.partner.balanceProof.nonce;

--- a/raiden-ts/src/channels/epics/deposit.ts
+++ b/raiden-ts/src/channels/epics/deposit.ts
@@ -1,6 +1,6 @@
 import findKey from 'lodash/findKey';
 import type { Observable } from 'rxjs';
-import { AsyncSubject, combineLatest, merge, of } from 'rxjs';
+import { combineLatest, merge, of, ReplaySubject } from 'rxjs';
 import {
   catchError,
   concatMap,
@@ -13,6 +13,7 @@ import {
   mergeMap,
   mergeMapTo,
   pluck,
+  take,
   withLatestFrom,
 } from 'rxjs/operators';
 
@@ -154,11 +155,11 @@ export function channelDepositEpic(
                     // already start 'approve' even while waiting for 'channel$'
                     makeDeposit$(
                       [tokenContract, tokenNetworkContract],
-                      [partner, channelId$],
+                      [partner, channelId$.pipe(take(1))],
                       action.payload.deposit,
                       deps,
                     ),
-                  { connector: () => new AsyncSubject() },
+                  { connector: () => new ReplaySubject(1) },
                 ),
                 // ignore success tx so it's picked by channelEventsEpic
                 ignoreElements(),

--- a/raiden-ts/src/channels/epics/monitor.ts
+++ b/raiden-ts/src/channels/epics/monitor.ts
@@ -79,7 +79,7 @@ function scanRegistryTokenNetworks({
 
       let monitorsIfHasChannels$: Observable<tokenMonitored> = EMPTY;
       if (logs.length) {
-        const firstBlock = logs[0][2].blockNumber;
+        const firstBlock = logs[0]![2].blockNumber;
         const tokenNetworks = new Map<string, [token: Address, event: Event]>(
           logs.map(([token, tokenNetwork, event]) => [tokenNetwork, [token as Address, event]]),
         );
@@ -415,10 +415,11 @@ function fetchPastChannelEvents$(
         const partner = (address === p1 ? p2 : p1) as Address;
         const id = _id.toNumber();
         const key = channelKey({ tokenNetwork, partner });
+        const channel = state.channels[key];
         // filter out settled or old channels, no new event could come from it
         return !(
           channelUniqueKey({ id, tokenNetwork, partner }) in state.oldChannels ||
-          (key in state.channels && id < state.channels[key].id)
+          (channel && id < channel.id)
         );
       });
       const channelIds = [

--- a/raiden-ts/src/channels/reducer.ts
+++ b/raiden-ts/src/channels/reducer.ts
@@ -251,9 +251,7 @@ function channelLockRegisteredReducer(
 
   const end = action.meta.direction === Direction.SENT ? 'own' : 'partner';
   // iterate over channels and update any matching lock
-  const keys = [...Object.keys(state.channels)];
-  for (const key of keys) {
-    const channel = state.channels[key];
+  for (const [key, channel] of Object.entries(state.channels)) {
     const newLocks = markLocksAsRegistered(
       channel[end].locks,
       action.meta.secrethash,

--- a/raiden-ts/src/channels/utils.ts
+++ b/raiden-ts/src/channels/utils.ts
@@ -206,7 +206,7 @@ export function groupChannel(): OperatorFunction<RaidenState, Observable<Channel
       // immediately if resubscribed or withLatestFrom'd
       groupBy(channelUniqueKey, { connector: () => new ReplaySubject<Channel>(1) }),
       map((grouped$) => {
-        const [key, _id] = grouped$.key.split('#');
+        const [key, _id] = grouped$.key.split('#') as [ChannelKey, `${number}`];
         const id = +_id;
         return grouped$.pipe(
           takeUntil(

--- a/raiden-ts/src/db/utils.ts
+++ b/raiden-ts/src/db/utils.ts
@@ -233,7 +233,7 @@ export function latestVersion(migrations: Migrations = defaultMigrations): numbe
  * @returns Version of db passed as param
  */
 export function databaseVersion(db: RaidenDatabase): number {
-  return +db.name.match(/_(\d+)$/)![1];
+  return +db.name.match(/_(\d+)$/)![1]!;
 }
 
 /**
@@ -275,7 +275,7 @@ export async function migrateDatabase(
   let db: RaidenDatabase | undefined;
   // try to load some version present on migrations
   for (let i = sortedMigrations.length - 1; i >= 0; --i) {
-    const _version = sortedMigrations[i];
+    const _version = sortedMigrations[i]!;
     const _db = await databaseExists.call(this, `${name}_${_version}`);
     if (_db) {
       version = _version;
@@ -304,7 +304,7 @@ export async function migrateDatabase(
           filter: ({ _id }) => keyRe.test(_id),
         }).pipe(
           concatMap((change) =>
-            defer(() => migrations[newVersion](change.doc!, db!)).pipe(
+            defer(() => migrations[newVersion]!(change.doc!, db!)).pipe(
               mergeMap((results) => from(results)),
               concatMap(async (result) => {
                 const { _rev: _, ...doc } = result;

--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -634,7 +634,11 @@ export async function waitForPFSCapacityUpdate(
     action$.pipe(
       withLatestFrom(state$),
       tap(([action, state]) => {
-        if (channelDeposit.success.is(action) && action.payload.confirmed) {
+        if (
+          channelDeposit.success.is(action) &&
+          action.payload.confirmed &&
+          action.payload.participant === state.address // only act after our own deposit
+        ) {
           deposited = true;
           return;
         }

--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -643,10 +643,11 @@ export async function waitForPFSCapacityUpdate(
         const message = action.payload.message;
         if (message.type !== 'PFSCapacityUpdate') return;
         // ensure it's a PFSCapacityUpdate for this specific channel
+        const channel = state.channels[channelKey(meta)];
         if (
           message.canonical_identifier.token_network_address !== meta.tokenNetwork ||
-          !(channelKey(meta) in state.channels) ||
-          !message.canonical_identifier.channel_identifier.eq(state.channels[channelKey(meta)].id)
+          !channel ||
+          !message.canonical_identifier.channel_identifier.eq(channel.id)
         )
           return;
         // on the first messageServiceSend.request for a PFSCapacityUpdate for this channel

--- a/raiden-ts/src/persister.ts
+++ b/raiden-ts/src/persister.ts
@@ -76,7 +76,7 @@ export function createPersisterMiddleware(
         // iterate over channels separately
         for (const id in state[key]) {
           if (state[key][id] === prevState[key][id]) continue;
-          const _id = `channels.${state[key][id]._id}`;
+          const _id = `channels.${state[key][id]!._id}`;
           db.storageKeys.add(_id);
           dirtyDocs[_id] = state[key][id];
         }

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -558,8 +558,8 @@ export class Raiden {
         toBlock: await this.getBlockNumber(),
       }).pipe(
         map((log) => this.deps.registryContract.interface.parseLog(log)),
-        filter((parsed) => !!parsed.args.token_address),
-        map((parsed) => parsed.args.token_address as Address),
+        filter((parsed) => !!parsed.args['token_address']),
+        map((parsed) => parsed.args['token_address'] as Address),
         toArray(),
       ),
     );
@@ -771,6 +771,7 @@ export class Raiden {
     // try coop-settle first
     try {
       const channel = this.state.channels[channelKey({ tokenNetwork, partner })];
+      assert(channel, 'channel not found');
       const { ownTotalWithdrawable: totalWithdraw } = channelAmounts(channel);
       const expiration =
         this.state.blockNumber + this.config.revealTimeout + this.config.confirmationBlocks;

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -651,7 +651,19 @@ export class Raiden {
     let depositPromise: Promise<Hash> | undefined;
     let postPromise: Promise<unknown> | undefined;
     if (deposit?.gt(0)) {
-      depositPromise = asyncActionToPromise(channelDeposit, meta, this.action$, true).then(
+      depositPromise = asyncActionToPromise(
+        channelDeposit,
+        meta,
+        this.action$.pipe(
+          filter(isActionOf([channelDeposit.success, channelDeposit.failure])),
+          // ensure we only react on own deposit's responses
+          filter(
+            (action) =>
+              channelDeposit.failure.is(action) || action.payload.participant === this.address,
+          ),
+        ),
+        true,
+      ).then(
         ({ txHash }) => txHash, // pluck txHash
       );
       postPromise = waitForPFSCapacityUpdate(this.action$, this.state$, {

--- a/raiden-ts/src/services/epics/helpers.ts
+++ b/raiden-ts/src/services/epics/helpers.ts
@@ -258,7 +258,7 @@ function filterPaths$(
           path.path.length >= 2 && path.path[0] === address,
           'we are not the first address in path',
         );
-        recipient = path.path[1];
+        recipient = path.path[1]!;
         assert(!invalidatedRecipients.has(recipient), 'already invalidated recipient');
         if (firstPath) {
           assert(firstPath.path[1] === recipient, 'already selected another recipient');
@@ -274,12 +274,11 @@ function filterPaths$(
           );
           if (partnerCanRoutePossible !== true)
             throw new RaidenError(partnerCanRoutePossible, { partnerPresence, channel });
-          for (let idx = 2; idx < path.path.length - 1; ++idx) {
-            const hop = path.path[idx];
+          for (const [idx, hop] of Object.entries(path.path.slice(2, -1))) {
             const presence = searchValidMetadata(path.address_metadata, hop);
             assert(getCap(presence?.payload.caps, Capabilities.MEDIATE), [
               "path: hop doesn't mediate transfers",
-              { hopIndex: idx, hop, hopPresence: presence },
+              { hopIndex: idx + 2, hop, hopPresence: presence },
             ]);
           }
         }
@@ -336,7 +335,7 @@ function getPfsInfo$(
                 additionalServices: config.additionalServices.join(','),
               },
             ]);
-            return pfsInfos[0]; // pop best ranked
+            return pfsInfos[0]!; // pop best ranked
           }),
         ),
       ),

--- a/raiden-ts/src/services/utils.ts
+++ b/raiden-ts/src/services/utils.ts
@@ -49,7 +49,7 @@ const pfsAddressUrl = memoize(async function pfsAddressUrl_(
 });
 
 const urlRegex =
-  process.env.NODE_ENV === 'production'
+  process.env['NODE_ENV'] === 'production'
     ? /^(?:https:\/\/)?[^\s\/$.?#&"']+\.[^\s\/$?#&"']+$/
     : /^(?:(http|https):\/\/)?([^\s\/$.?#&"']+\.)*[^\s\/$?#&"']+(?:(\d+))*$/;
 

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -315,9 +315,10 @@ function makeAndSignUnlock$(
       const transferState = state.transfers[transferKey(action.meta)];
       const channel = getOpenChannel(state, { tokenNetwork, partner });
       assert(
-        transferState.expiration > state.blockNumber ||
-          transferState.secretRegistered ||
-          channel.own.locks.find((lock) => lock.secrethash === secrethash && lock.registered),
+        transferState &&
+          (transferState.expiration > state.blockNumber ||
+            transferState.secretRegistered ||
+            channel.own.locks.find((lock) => lock.secrethash === secrethash && lock.registered)),
         'lock expired',
       );
       return transferUnlock.success(

--- a/raiden-ts/src/transfers/mediate/epics.ts
+++ b/raiden-ts/src/transfers/mediate/epics.ts
@@ -68,8 +68,8 @@ function findValidPartner(
     const outPartner = route[route.indexOf(address) + 1];
     if (!outPartner || !partnersWithOpenChannels.has(outPartner)) continue;
 
-    const channelIn = state.channels[channelKey({ tokenNetwork, partner: inPartner })];
-    const channelOut = state.channels[channelKey({ tokenNetwork, partner: outPartner })];
+    const channelIn = state.channels[channelKey({ tokenNetwork, partner: inPartner })]!;
+    const channelOut = state.channels[channelKey({ tokenNetwork, partner: outPartner })]!;
 
     let fee: Int<32>;
     try {

--- a/raiden-ts/src/transport/epics/messages.ts
+++ b/raiden-ts/src/transport/epics/messages.ts
@@ -94,7 +94,7 @@ function popMessagesOfSameType<T extends requestWithUserId>(
   // per userId message queues with at least one message (which defines chosen msgtype)
   const selected = new Map<string, [T, ...T[]]>();
   for (let i = 0; i < queue.length && selectedCount < maxBatchSize; i++) {
-    const request = queue[i];
+    const request = queue[i]!;
     // guaranteed to be defined from request$
     const peerId = request.payload.userId;
     const peerQueue = selected.get(peerId);
@@ -367,7 +367,8 @@ export function matrixMessageReceivedEpic(
         withLatestFrom(config$, action$.pipe(getPresencesByUserId())),
         mergeWith(([event, { httpTimeout }, seenPresences]) => {
           const senderId = event.getSender();
-          if (senderId in seenPresences) return of(seenPresences[senderId]);
+          const presence = seenPresences[senderId];
+          if (presence) return of(presence);
           return latest$.pipe(
             pluckDistinct('whitelisted'),
             map((whitelisted) => {

--- a/raiden-ts/src/transport/epics/webrtc.ts
+++ b/raiden-ts/src/transport/epics/webrtc.ts
@@ -629,7 +629,7 @@ function mapRtcMessage(): OperatorFunction<
           const json = jsonParse(action.payload.text);
           if (json['type'] === RtcEventType.offer)
             yield [
-              seenPresences[action.payload.userId!],
+              seenPresences[action.payload.userId!]!,
               decode(rtcCodecs[RtcEventType.offer], json),
             ] as const;
         } catch (error) {}

--- a/raiden-ts/src/transport/utils.ts
+++ b/raiden-ts/src/transport/utils.ts
@@ -24,7 +24,7 @@ export function getAddressFromUserId(userId: string): Address | undefined {
   let address: Address | undefined;
   try {
     const match = userRe.exec(userId);
-    if (match) address = getAddress(match[1]) as Address;
+    if (match) address = getAddress(match[1]!) as Address;
   } catch (e) {}
   return address;
 }
@@ -70,12 +70,12 @@ export function parseCaps(caps?: string | null): Caps | undefined {
         else if (lowValue === 'false') resValue = false;
         else if (lowValue === 'true') resValue = true;
       }
-      if (!(key in result)) {
+      let val = result[key];
+      if (val === undefined) {
         result[key] = resValue;
       } else {
-        let prevValues = result[key];
-        if (!Array.isArray(prevValues)) result[key] = prevValues = [prevValues];
-        prevValues.push(resValue);
+        if (!Array.isArray(val)) result[key] = val = [val];
+        val.push(resValue);
       }
     });
     return result;

--- a/raiden-ts/src/utils/actions.ts
+++ b/raiden-ts/src/utils/actions.ts
@@ -80,7 +80,7 @@ export function createAction<
   type A = t.TypeOf<typeof codec>;
 
   const is =
-    process.env.NODE_ENV === 'development'
+    process.env['NODE_ENV'] === 'development'
       ? (action: unknown): action is A => codec.is(action)
       : (action: unknown): action is A =>
           (action as { type: string } | undefined)?.['type'] === type;
@@ -467,8 +467,8 @@ export function createReducer<S, A extends Action = Action>(initialState: S) {
    */
   function makeReducer<ACs>(handlers: Handlers): ExtReducer<ACs> {
     const reducer: Reducer<S, A> = (state: S = initialState, action: A) => {
-      if (action.type in handlers && handlers[action.type][0].is(action))
-        return handlers[action.type][1](state, action); // calls registered handler
+      const handler = handlers[action.type];
+      if (handler && handler[0].is(action)) return handler[1](state, action); // calls registered handler
       return state; // fallback returns unchanged state
     };
 

--- a/raiden-ts/src/utils/ethers.ts
+++ b/raiden-ts/src/utils/ethers.ts
@@ -213,7 +213,8 @@ export function fromEthersEvent<T>(
     : typeof confirmations === 'number'
     ? of(confirmations)
     : confirmations;
-  const blockQueue: number[] = []; // sorted 'fromBlock' queue, at most of [confirmations * 2] size
+  // sorted 'fromBlock' queue, at most of [confirmations * 2] size
+  const blockQueue: [number, ...number[]] = [0];
   let start = Date.now();
   return confirmations$.pipe(
     distinctUntilChanged(),

--- a/raiden-ts/src/utils/matrix.ts
+++ b/raiden-ts/src/utils/matrix.ts
@@ -9,7 +9,7 @@ import { encodeUri } from 'matrix-js-sdk/lib/utils';
  */
 export function getServerName(server: string): string | null {
   const match = /^(?:\w*:?\/\/)?([^/#?&]+)/.exec(server);
-  return match && match[1];
+  return match && match[1]!;
 }
 
 /**

--- a/raiden-ts/src/utils/rx.ts
+++ b/raiden-ts/src/utils/rx.ts
@@ -65,7 +65,7 @@ export const pluckDistinct: typeof pluck = (...properties: string[]) =>
  * @returns Operator to map from a record to changed values (all on first)
  */
 export function distinctRecordValues<R>(
-  compareFn: (x: R, y: R) => boolean = (x, y) => x === y,
+  compareFn: (prev: R | undefined, new_: R) => boolean = (prev, new_) => prev === new_,
 ): OperatorFunction<{ [k: string]: R }, [string, R]> {
   return pipe(
     distinctUntilChanged(),

--- a/raiden-ts/tests/e2e/e2e.spec.ts
+++ b/raiden-ts/tests/e2e/e2e.spec.ts
@@ -22,8 +22,8 @@ const partner1 = '0x517aAD51D0e9BbeF3c64803F86b3B9136641D9ec' as Address;
 const partner2 = '0xCBC49ec22c93DB69c78348C90cd03A323267db86' as Address;
 
 async function createRaiden(account: number | string | Signer): Promise<Raiden> {
-  const deploymentInfoFile = process.env.DEPLOYMENT_INFO;
-  const deploymentServiceInfoFile = process.env.DEPLOYMENT_SERVICES_INFO;
+  const deploymentInfoFile = process.env['DEPLOYMENT_INFO'];
+  const deploymentServiceInfoFile = process.env['DEPLOYMENT_SERVICES_INFO'];
 
   assert(deploymentInfoFile !== undefined);
   assert(deploymentServiceInfoFile !== undefined);
@@ -72,7 +72,7 @@ const wait = async (timeInMs: number): Promise<void> =>
   new Promise((resolve) => setTimeout(() => resolve(), timeInMs));
 
 function getToken(): string {
-  const token = process.env.TTT_TOKEN_ADDRESS;
+  const token = process.env['TTT_TOKEN_ADDRESS'];
   assert(token !== undefined, 'TTT Token address is undefined');
   return token;
 }
@@ -85,18 +85,18 @@ async function getChannelCapacity(raiden: Raiden, partner: Address): Promise<Big
 }
 
 async function depositToUDC(raiden: Raiden) {
-  await expect(raiden.mint(process.env.SVT_TOKEN_ADDRESS as string, svtBalance)).resolves.toMatch(
-    '0x',
-  );
   await expect(
-    raiden.getTokenBalance(process.env.SVT_TOKEN_ADDRESS as string),
+    raiden.mint(process.env['SVT_TOKEN_ADDRESS'] as string, svtBalance),
+  ).resolves.toMatch('0x');
+  await expect(
+    raiden.getTokenBalance(process.env['SVT_TOKEN_ADDRESS'] as string),
   ).resolves.toBeBigNumber(svtBalance);
 
   await expect(raiden.depositToUDC(svtBalance)).resolves.toMatch('0x');
   await expect(raiden.getUDCCapacity()).resolves.toBeBigNumber(svtBalance);
 
   await expect(
-    raiden.getTokenBalance(process.env.SVT_TOKEN_ADDRESS as string),
+    raiden.getTokenBalance(process.env['SVT_TOKEN_ADDRESS'] as string),
   ).resolves.toBeBigNumber(0);
 
   // Give PFS some time
@@ -283,14 +283,14 @@ describe('e2e', () => {
      */
     const udcWithdrawAmount = 10;
     await expect(
-      raiden.getTokenBalance(process.env.SVT_TOKEN_ADDRESS as string),
+      raiden.getTokenBalance(process.env['SVT_TOKEN_ADDRESS'] as string),
     ).resolves.toBeBigNumber(0);
 
     await expect(raiden.planUDCWithdraw(udcWithdrawAmount)).resolves.toMatch('0x');
     await expect(raiden.withdrawFromUDC(udcWithdrawAmount)).resolves.toMatch('0x');
 
     await expect(
-      raiden.getTokenBalance(process.env.SVT_TOKEN_ADDRESS as string),
+      raiden.getTokenBalance(process.env['SVT_TOKEN_ADDRESS'] as string),
     ).resolves.toBeBigNumber(udcWithdrawAmount);
   });
 });

--- a/raiden-ts/tests/integration/patches.ts
+++ b/raiden-ts/tests/integration/patches.ts
@@ -37,7 +37,7 @@ jest.mock('@ethersproject/signing-key', () => {
   class MockedSigningKey extends SigningKey {
     private _address?: string;
     signDigest({}: BytesLike): Signature {
-      if (!this._address) this._address = mockOrigComputeAddress(this.publicKey);
+      if (!this._address) this._address = mockOrigComputeAddress(this['publicKey']);
       const s = HashZero.substr(0, 24) + this._address!.substr(2).toLowerCase() + '00';
       return {
         r: HashZero,

--- a/raiden-ts/tests/integration/path.spec.ts
+++ b/raiden-ts/tests/integration/path.spec.ts
@@ -205,6 +205,7 @@ describe('PFS: pfsRequestEpic', () => {
   test('fail target not available', async () => {
     expect.assertions(2);
 
+    raiden.store.dispatch(raidenConfigUpdate({ pollingInterval: 100 }));
     raiden.store.dispatch(presenceFromClient(target, false));
     // Emitting the pathFind.request action to check pfsRequestEpic runs
     // and gets the earlier matrix presence error for target

--- a/raiden-ts/tests/integration/send.spec.ts
+++ b/raiden-ts/tests/integration/send.spec.ts
@@ -99,6 +99,7 @@ describe('resolve transfer', () => {
   test('failure target presence offline passes through', async () => {
     const [raiden, partner] = await makeRaidens(2);
     await ensureChannelIsDeposited([raiden, partner]);
+    raiden.store.dispatch(raidenConfigUpdate({ pollingInterval: 100 }));
     raiden.store.dispatch(presenceFromClient(partner, false));
 
     raiden.store.dispatch(

--- a/raiden-ts/tests/tsconfig.json
+++ b/raiden-ts/tests/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "noUncheckedIndexedAccess": false,
     "paths": {
       "@/*": ["../src/*"]
     }

--- a/raiden-ts/tsconfig.json
+++ b/raiden-ts/tsconfig.json
@@ -7,6 +7,8 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": true,
     "sourceMap": true,
     "declaration": true,
     "pretty": true,


### PR DESCRIPTION
This would have prevented the issue fixed by #2925 

**Short description**
This enables TS@4.1's `--noUncheckedIndexedAccess` and TS@4.2's `--noPropertyAccessFromIndexSignature` on src only, which should allow us to more strictly type undefined property access on indexed type, requiring us either to type-guard it or to consciously mark it as defined.
There should be no logic change on this PR, just type-strictness fixes.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
