### PR TITLE
Improvements to parallel channelOpen and deposit handling

### DIFF
--- a/raiden-ts/src/channels/actions.ts
+++ b/raiden-ts/src/channels/actions.ts
@@ -82,7 +82,7 @@ export const channelDeposit = createAsyncAction(
   ChannelId,
   'channel/deposit',
   t.intersection([
-    t.type({ deposit: UInt(32) }),
+    t.union([t.type({ deposit: UInt(32) }), t.type({ totalDeposit: UInt(32) })]),
     t.partial({ subkey: t.boolean, waitOpen: t.literal(true) }),
   ]),
   t.type({

--- a/raiden-ts/tests/integration/path.spec.ts
+++ b/raiden-ts/tests/integration/path.spec.ts
@@ -216,7 +216,7 @@ describe('PFS: pfsRequestEpic', () => {
     };
     raiden.store.dispatch(pathFind.request({}, pathFindMeta));
     await sleep();
-    // await sleep(2 * raiden.config.pollingInterval);
+    await sleep(raiden.config.pollingInterval);
     expect(raiden.output).not.toContainEqual(
       pathFind.success(expect.anything(), expect.anything()),
     );
@@ -261,11 +261,12 @@ describe('PFS: pfsRequestEpic', () => {
       target: target.address,
       value: amount,
     };
+    raiden.store.dispatch(raidenConfigUpdate({ pollingInterval: 100 }));
     raiden.store.dispatch(presenceFromClient(target, false));
     raiden.store.dispatch(pathFind.request({}, pathFindMeta));
 
     await waitBlock();
-    await sleep(2 * raiden.config.pollingInterval);
+    await sleep(raiden.config.pollingInterval);
     expect(raiden.output).toContainEqual(
       pathFind.failure(
         expect.objectContaining({


### PR DESCRIPTION
Follow up of #2931 

**Short description**
Fixes a couple of small races when multiple open and/or deposits are requested in parallel (e.g. BF7). This allows `channelOpen.request` with `deposit` to specify explicity a `totalDeposit` for the `channelDeposit.request` emitted in case the race of parallel cross-`openChannelWithDeposit` makes one of the transactions fail. This will allow this explicit edge case to be properly handled and the final result to be resolved in the promised output of `Raiden.openChannel`.
As a bonus, the improved algorithm allows us to perform parallel deposit in different channels when the default config of `maximumAllowance=MaxUint256` is used, since this doesn't have issues with the allowance being reduced enough to make the deposit fail by a parallel deposit on the same token[Network]. Parallel deposits can speed up open+deposit requests in scenarios like BF7 amd MFEE4 (which I've tested manually with this PR and are currently green).

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Scenarios pass
2.
