### PR TITLE
Change the filter tag regex so that publish_production workflow also works for pre-releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ anchor_1: &attach_options
 anchor_2: &filter_release_tag
   filters:
     tags:
-      only: /^v\d+\.\d+\.\d+$/
+      only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
 
 anchor_3: &executor_shared_options
   working_directory: << pipeline.parameters.working_directory >>


### PR DESCRIPTION
Change the filter tag regex so that publish_production workflow also works for pre-releases

**Thank you for submitting this pull request :)**

Fixes #2899 

**Short description**


**Definition of Done**

- [ ] Steps to manually test the change have been documented
- [ ] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
