### PR TITLE
Allow CLI to receive `paths` on `/payments` endpoint

### DIFF
--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- [#2949] Passthrough `/payments` parameters, including `paths`, which should receive pre-fetched route in the format `{ route: Address[]; estimated_fee: NumericString; address_metadata?: MetadataMap }[]`.
+
+[#2949]: https://github.com/raiden-network/light-client/issues/2949
 
 ## [2.0.0-rc.2] - 2021-09-14
 

--- a/raiden-cli/src/routes/payments.ts
+++ b/raiden-cli/src/routes/payments.ts
@@ -86,7 +86,11 @@ async function doTransfer(this: Cli, request: Request, response: Response, next:
       request.params.tokenAddress,
       request.params.targetAddress,
       request.body.amount.toString(),
-      { paymentId: request.body.identifier?.toString(), lockTimeout: request.body.lock_timeout },
+      {
+        ...request.body,
+        paymentId: request.body.identifier?.toString(),
+        lockTimeout: request.body.lock_timeout,
+      },
     );
     const transfer = await this.raiden.waitTransfer(transferKey);
     response.send(transformSdkTransferToApiPayment(transfer));

--- a/raiden-dapp/src/model/types.ts
+++ b/raiden-dapp/src/model/types.ts
@@ -54,12 +54,11 @@ export interface ActionProgressStep {
   failed: boolean;
 }
 
-type RaidenPath = RaidenPaths[number];
-export interface Route extends RaidenPath {
+export type Route = RaidenPaths[number] & {
   readonly key: number;
   readonly hops: number;
   readonly displayFee?: string;
-}
+};
 
 export interface Transfer {
   pfsAddress?: string;

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -601,11 +601,7 @@ export default class RaidenService {
   }
 
   /* istanbul ignore next */
-  async directRoute(
-    token: string,
-    target: string,
-    value: BigNumberish,
-  ): Promise<RaidenPaths | undefined> {
+  async directRoute(token: string, target: string, value: BigNumberish) {
     return await this.raiden.directRoute(token, target, value);
   }
 

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- [#2949] Allows `Raiden.transfer`'s `options.paths` to receive a broader schema, including `{ route: Address[]; estimated_fee: Int<32>; address_metadata?: ... }[]`, needed to support CLI's `paths` parameter of `/payments` endpoint
+
+[#2949]: https://github.com/raiden-network/light-client/issues/2949
 
 ## [2.0.0-rc.2] - 2021-09-14
 

--- a/raiden-ts/src/helpers.ts
+++ b/raiden-ts/src/helpers.ts
@@ -661,7 +661,7 @@ export async function waitForPFSCapacityUpdate(
       pluck(0),
       takeWhile((action) => !(channelDeposit.failure.is(action) && isEqual(action.meta, meta))),
     ),
-  );
+  ).catch(() => undefined);
 }
 
 const settleableStates = [ChannelState.settleable, ChannelState.settling] as const;

--- a/raiden-ts/src/messages/types.ts
+++ b/raiden-ts/src/messages/types.ts
@@ -6,8 +6,8 @@
 import * as t from 'io-ts';
 
 import { Lock } from '../channels/types';
-import { Path, RoutesExtra } from '../services/types';
-import { Address, Hash, Int, Secret, Signature, UInt } from '../utils/types';
+import { Fee, Path, RoutesExtra } from '../services/types';
+import { Address, Hash, Secret, Signature, UInt } from '../utils/types';
 
 // types
 export enum MessageType {
@@ -274,8 +274,8 @@ const _PFSFeeUpdate = t.readonly(
         t.null,
         t.readonlyArray(t.readonly(t.tuple([UInt(32), UInt(32)]))),
       ]),
-      proportional: Int(32),
-      flat: Int(32),
+      proportional: Fee,
+      flat: Fee,
     }),
   }),
 );

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -72,8 +72,8 @@ import {
 import { createPersisterMiddleware } from './persister';
 import { raidenReducer } from './reducer';
 import { pathFind, udcDeposit, udcWithdraw, udcWithdrawPlan } from './services/actions';
-import type { IOU, RaidenPaths, RaidenPFS, SuggestedPartner } from './services/types';
-import { Paths, PFS, PfsMode, SuggestedPartners } from './services/types';
+import type { IOU, Paths, RaidenPFS, SuggestedPartner } from './services/types';
+import { InputPaths, PFS, PfsMode, SuggestedPartners } from './services/types';
 import { pfsListInfo } from './services/utils';
 import type { RaidenState } from './state';
 import { transfer, transferSigned, withdraw, withdrawResolve } from './transfers/actions';
@@ -896,6 +896,7 @@ export class Raiden {
    * @param options.secrethash - Must match secret, if both provided, or else, secret must be
    *     informed to target by other means, and reveal can't be performed
    * @param options.paths - Used to specify possible routes & fees instead of querying PFS.
+   *     Should receive a decodable super-set of the public RaidenPaths interface
    * @param options.pfs - Use this PFS instead of configured or automatically choosen ones.
    *     Is ignored if paths were already provided. If neither are set and config.pfs is not
    *     disabled (null), use it if set or if undefined (auto mode), fetches the best
@@ -913,7 +914,7 @@ export class Raiden {
       paymentId?: BigNumberish;
       secret?: string;
       secrethash?: string;
-      paths?: RaidenPaths;
+      paths?: Decodable<InputPaths>;
       pfs?: RaidenPFS;
       lockTimeout?: number;
       encryptSecret?: boolean;
@@ -930,7 +931,8 @@ export class Raiden {
         ? decode(UInt(8), options.paymentId, ErrorCodes.DTA_INVALID_PAYMENT_ID, this.log.info)
         : makePaymentId();
     const paths =
-      options.paths && decode(Paths, options.paths, ErrorCodes.DTA_INVALID_PATH, this.log.info);
+      options.paths &&
+      decode(InputPaths, options.paths, ErrorCodes.DTA_INVALID_PATH, this.log.info);
     const pfs = options.pfs && decode(PFS, options.pfs, ErrorCodes.DTA_INVALID_PFS, this.log.info);
 
     assert(

--- a/raiden-ts/src/services/actions.ts
+++ b/raiden-ts/src/services/actions.ts
@@ -4,7 +4,7 @@ import * as t from 'io-ts';
 import type { ActionType } from '../utils/actions';
 import { createAction, createAsyncAction } from '../utils/actions';
 import { Address, Hash, Signed, UInt } from '../utils/types';
-import { IOU, Paths, PFS, ServicesValidityMap } from './types';
+import { InputPaths, IOU, Paths, PFS, ServicesValidityMap } from './types';
 
 const PathId = t.type({
   tokenNetwork: Address,
@@ -20,7 +20,7 @@ const ServiceId = t.type({
 export const pathFind = createAsyncAction(
   PathId,
   'path/find',
-  t.partial({ paths: Paths, pfs: t.union([PFS, t.null]) }),
+  t.partial({ paths: InputPaths, pfs: t.union([PFS, t.null]) }),
   t.type({ paths: Paths }),
 );
 export namespace pathFind {

--- a/raiden-ts/src/services/epics/helpers.ts
+++ b/raiden-ts/src/services/epics/helpers.ts
@@ -36,10 +36,10 @@ import { jsonParse, jsonStringify } from '../../utils/data';
 import { assert, ErrorCodes, networkErrors, RaidenError } from '../../utils/error';
 import { lastMap, mergeWith, retryWhile } from '../../utils/rx';
 import type { Address, Signature, Signed } from '../../utils/types';
-import { decode, Int, UInt } from '../../utils/types';
+import { decode, UInt } from '../../utils/types';
 import { iouClear, iouPersist, pathFind } from '../actions';
 import type { AddressMetadataMap, IOU, Paths, PFS } from '../types';
-import { LastIOUResults, PfsError, PfsMode, PfsResult } from '../types';
+import { Fee, LastIOUResults, PfsError, PfsMode, PfsResult } from '../types';
 import { packIOU, pfsInfo, pfsListInfo, signIOU } from '../utils';
 
 type Route = { iou: Signed<IOU> | undefined } & ({ paths: Paths } | { error: PfsError });
@@ -361,10 +361,10 @@ function requestPfs$(
 }
 
 function addFeeSafetyMargin(
-  fee: Int<32>,
+  fee: Fee,
   amount: UInt<32>,
   { pfsSafetyMargin }: Pick<RaidenConfig, 'pfsSafetyMargin'>,
-): Int<32> {
+): Fee {
   let feeMarginMultiplier = 0.0;
   let amountMultiplier = 0.0;
   if (typeof pfsSafetyMargin === 'number') {
@@ -379,7 +379,7 @@ function addFeeSafetyMargin(
     .mul(feeMarginMultiplier)
     .add(new Decimal(amount.toHexString()).mul(amountMultiplier));
   return decode(
-    Int(32),
+    Fee,
     // fee += abs(estimatedFee) * feeMarginMultiplier + amount * amountMultiplier
     fee.add(feeMargin.toFixed(0, Decimal.ROUND_CEIL)),
   );
@@ -446,7 +446,7 @@ export function getRoute$(
       paths: [
         {
           path: [deps.address, target],
-          fee: Zero as Int<32>,
+          fee: Zero as Fee,
           ...(!isEmpty(addressMetadata) ? { address_metadata: addressMetadata } : {}),
         },
       ],

--- a/raiden-ts/src/services/types.ts
+++ b/raiden-ts/src/services/types.ts
@@ -69,17 +69,20 @@ export const AddressMetadataMap = new t.RefinementType(
 
 export const RoutesExtra = t.partial({ address_metadata: AddressMetadataMap });
 
+export const Fee = Int(32);
+export type Fee = t.TypeOf<typeof Fee>;
+
 /**
  * Codec for raiden-ts internal representation of a PFS result/routes
  */
 export const Paths = t.readonlyArray(
-  t.readonly(t.intersection([t.type({ path: Path, fee: Int(32) }), RoutesExtra])),
+  t.readonly(t.intersection([t.type({ path: Path, fee: Fee }), RoutesExtra])),
 );
 export type Paths = t.TypeOf<typeof Paths>;
 
 /** Codec for result from PFS path request */
 export const PfsResult = t.type({
-  result: t.array(t.intersection([t.type({ path: Path, estimated_fee: Int(32) }), RoutesExtra])),
+  result: t.array(t.intersection([t.type({ path: Path, estimated_fee: Fee }), RoutesExtra])),
 });
 
 /** Codec for PFS API returned error */

--- a/raiden-ts/src/services/types.ts
+++ b/raiden-ts/src/services/types.ts
@@ -72,18 +72,33 @@ export const RoutesExtra = t.partial({ address_metadata: AddressMetadataMap });
 export const Fee = Int(32);
 export type Fee = t.TypeOf<typeof Fee>;
 
-/**
- * Codec for raiden-ts internal representation of a PFS result/routes
- */
+/** Codec for raiden-ts internal representation of a PFS result/routes */
 export const Paths = t.readonlyArray(
   t.readonly(t.intersection([t.type({ path: Path, fee: Fee }), RoutesExtra])),
 );
 export type Paths = t.TypeOf<typeof Paths>;
 
+/**
+ * A broader codec representing paths received as input:
+ * - paths array can come on a `route` or `path` member
+ * - `fee` represents the final fee to be used, `estimated_fee` is what comes from PFS and can be
+ *   increased of fee margins
+ * - rest is kept (currently, `address_metadata` map)
+ * Paths is a specific subset of InputPaths
+ */
+export const InputPaths = t.readonlyArray(
+  t.readonly(
+    t.intersection([
+      t.union([t.type({ route: Path }), t.type({ path: Path })]),
+      t.union([t.type({ fee: Fee }), t.type({ estimated_fee: Fee })]),
+      RoutesExtra,
+    ]),
+  ),
+);
+export type InputPaths = t.TypeOf<typeof InputPaths>;
+
 /** Codec for result from PFS path request */
-export const PfsResult = t.type({
-  result: t.array(t.intersection([t.type({ path: Path, estimated_fee: Fee }), RoutesExtra])),
-});
+export const PfsResult = t.readonly(t.type({ result: InputPaths }));
 
 /** Codec for PFS API returned error */
 export const PfsError = t.readonly(
@@ -97,9 +112,7 @@ export const PfsError = t.readonly(
 );
 export type PfsError = t.TypeOf<typeof PfsError>;
 
-/**
- * Public Raiden interface for routes data
- */
+/** Public Raiden interface for routes data */
 export type RaidenPaths = Decodable<Paths>;
 
 /**

--- a/raiden-ts/src/transfers/actions.ts
+++ b/raiden-ts/src/transfers/actions.ts
@@ -13,11 +13,11 @@ import {
   WithdrawExpired,
   WithdrawRequest,
 } from '../messages/types';
-import { Paths, PFS } from '../services/types';
+import { Fee, Paths, PFS } from '../services/types';
 import { Via } from '../transport/types';
 import type { ActionType } from '../utils/actions';
 import { createAction, createAsyncAction } from '../utils/actions';
-import { Address, Hash, Int, Secret, Signed, UInt } from '../utils/types';
+import { Address, Hash, Secret, Signed, UInt } from '../utils/types';
 import { DirectionC, TransferState } from './state';
 
 const TransferId = t.type({
@@ -61,7 +61,7 @@ export const transfer = createAsyncAction(
         t.type({
           resolved: t.literal(true),
           metadata: t.unknown,
-          fee: Int(32),
+          fee: Fee,
           partner: Address,
         }),
         Via,
@@ -83,10 +83,7 @@ export namespace transfer {
 /** A LockedTransfer was signed and should be sent to partner */
 export const transferSigned = createAction(
   'transfer/signed',
-  t.intersection([
-    t.type({ message: Signed(LockedTransfer), fee: Int(32), partner: Address }),
-    Via,
-  ]),
+  t.intersection([t.type({ message: Signed(LockedTransfer), fee: Fee, partner: Address }), Via]),
   TransferId,
 );
 export interface transferSigned extends ActionType<typeof transferSigned> {}

--- a/raiden-ts/src/transfers/actions.ts
+++ b/raiden-ts/src/transfers/actions.ts
@@ -13,7 +13,7 @@ import {
   WithdrawExpired,
   WithdrawRequest,
 } from '../messages/types';
-import { Fee, Paths, PFS } from '../services/types';
+import { Fee, InputPaths, PFS } from '../services/types';
 import { Via } from '../transport/types';
 import type { ActionType } from '../utils/actions';
 import { createAction, createAsyncAction } from '../utils/actions';
@@ -55,7 +55,7 @@ export const transfer = createAsyncAction(
     t.union([
       t.intersection([
         t.type({ resolved: t.literal(false) }),
-        t.partial({ paths: Paths, pfs: t.union([PFS, t.null]), encryptSecret: t.boolean }),
+        t.partial({ paths: InputPaths, pfs: t.union([PFS, t.null]), encryptSecret: t.boolean }),
       ]),
       t.intersection([
         t.type({

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -37,6 +37,7 @@ import {
   isMessageReceivedOfType,
   signMessage,
 } from '../../messages/utils';
+import type { Fee } from '../../services/types';
 import type { RaidenState } from '../../state';
 import { matrixPresence } from '../../transport/actions';
 import { getCap } from '../../transport/utils';
@@ -46,7 +47,7 @@ import { isActionOf } from '../../utils/actions';
 import { ErrorCodes, RaidenError } from '../../utils/error';
 import { LruCache } from '../../utils/lru';
 import { completeWith, pluckDistinct } from '../../utils/rx';
-import type { Address, Hash, Int } from '../../utils/types';
+import type { Address, Hash } from '../../utils/types';
 import { decode, Secret, Signed, UInt, untime } from '../../utils/types';
 import {
   transfer,
@@ -585,7 +586,7 @@ function receiveTransferSigned(
       // if any of these signature prompts fail, none of these actions will be emitted
       return combineLatest([processed$, request$]).pipe(
         mergeMap(function* ([processed, requestOrSecret]) {
-          yield transferSigned({ message: locked, fee: Zero as Int<32>, partner }, meta);
+          yield transferSigned({ message: locked, fee: Zero as Fee, partner }, meta);
           // sets TransferState.transferProcessed
           yield transferProcessed({ message: processed, userId: action.payload.userId }, meta);
           if (Secret.is(requestOrSecret)) {

--- a/raiden-ts/src/transfers/mediate/epics.ts
+++ b/raiden-ts/src/transfers/mediate/epics.ts
@@ -7,10 +7,11 @@ import { channelKey } from '../../channels/utils';
 import type { RaidenConfig } from '../../config';
 import { Capabilities } from '../../constants';
 import { Metadata } from '../../messages/types';
+import type { Fee } from '../../services/types';
 import type { RaidenState } from '../../state';
 import { getCap } from '../../transport/utils';
 import type { RaidenEpicDeps } from '../../types';
-import type { Address, Int } from '../../utils/types';
+import type { Address } from '../../utils/types';
 import { decode, isntNil } from '../../utils/types';
 import { transfer, transferSigned } from '../actions';
 import { Direction } from '../state';
@@ -71,7 +72,7 @@ function findValidPartner(
     const channelIn = state.channels[channelKey({ tokenNetwork, partner: inPartner })]!;
     const channelOut = state.channels[channelKey({ tokenNetwork, partner: outPartner })]!;
 
-    let fee: Int<32>;
+    let fee: Fee;
     try {
       fee = mediationFeeCalculator.fee(
         config.mediationFees,
@@ -94,7 +95,7 @@ function findValidPartner(
       partner: outPartner,
       // on a transfer.request, fee is *added* to the value to get final sent amount,
       // therefore here it needs to contain a negative fee, which we will "earn" instead of pay
-      fee: fee.mul(-1) as Int<32>,
+      fee: fee.mul(-1) as Fee,
       userId: outPartnerPresence?.payload.userId,
       metadata,
     };

--- a/raiden-ts/src/transfers/state.ts
+++ b/raiden-ts/src/transfers/state.ts
@@ -10,7 +10,8 @@ import {
   SecretReveal,
   Unlock,
 } from '../messages/types';
-import { Address, Hash, Int, Secret, Signed, Timed, UInt } from '../utils/types';
+import { Fee } from '../services/types';
+import { Address, Hash, Secret, Signed, Timed, UInt } from '../utils/types';
 
 // it's like an enum, but with literals
 export const Direction = {
@@ -35,7 +36,7 @@ const _TransferState = t.readonly(
         expiration: t.number, // [number] version of [transfer.lock.expiration]
         /** -> outgoing locked transfer */
         transfer: Timed(Signed(LockedTransfer)),
-        fee: Int(32),
+        fee: Fee,
         partner: Address,
         /* timestamp of when transfer completed and may be cleared from state (non-cleared=0) */
         cleared: t.number,

--- a/raiden-ts/src/transfers/utils.ts
+++ b/raiden-ts/src/transfers/utils.ts
@@ -21,12 +21,9 @@ import { Capabilities } from '../constants';
 import type { RaidenDatabase, TransferStateish } from '../db/types';
 import type { RouteMetadata } from '../messages/types';
 import { Metadata } from '../messages/types';
-import {
-  createBalanceHash,
-  getBalanceProofFromEnvelopeMessage,
-  validateAddressMetadata,
-} from '../messages/utils';
+import { createBalanceHash, getBalanceProofFromEnvelopeMessage } from '../messages/utils';
 import type { Paths } from '../services/types';
+import { validateAddressMetadata } from '../services/utils';
 import type { RaidenState } from '../state';
 import type { matrixPresence } from '../transport/actions';
 import type { Caps, Via } from '../transport/types';

--- a/raiden-ts/src/transfers/utils.ts
+++ b/raiden-ts/src/transfers/utils.ts
@@ -22,7 +22,7 @@ import type { RaidenDatabase, TransferStateish } from '../db/types';
 import type { RouteMetadata } from '../messages/types';
 import { Metadata } from '../messages/types';
 import { createBalanceHash, getBalanceProofFromEnvelopeMessage } from '../messages/utils';
-import type { Paths } from '../services/types';
+import type { Fee, Paths } from '../services/types';
 import { validateAddressMetadata } from '../services/utils';
 import type { RaidenState } from '../state';
 import type { matrixPresence } from '../transport/actions';
@@ -30,7 +30,7 @@ import type { Caps, Via } from '../transport/types';
 import { getCap } from '../transport/utils';
 import { assert } from '../utils';
 import { encode, jsonParse, jsonStringify } from '../utils/data';
-import type { Address, Hash, Int, PrivateKey, Secret, UInt } from '../utils/types';
+import type { Address, Hash, PrivateKey, Secret, UInt } from '../utils/types';
 import { decode, HexString, isntNil } from '../utils/types';
 import type { RaidenTransfer } from './state';
 import { Direction, RaidenTransferStatus, RevealedSecret, TransferState } from './state';
@@ -310,7 +310,7 @@ export function metadataFromPaths(
   paths: Paths,
   target: matrixPresence.success,
   encryptSecret?: RevealedSecret,
-): Readonly<{ resolved: true; fee: Int<32>; partner: Address; metadata: unknown } & Via> {
+): Readonly<{ resolved: true; fee: Fee; partner: Address; metadata: unknown } & Via> {
   // paths may come with undesired parameters, so map&filter here before passing to metadata
   const routes = paths.map(({ path: route, fee: _, address_metadata }) => ({
     route,


### PR DESCRIPTION
Fixes #2949 

**Short description**
This is needed in order to expose to the user the ability to pick their own route however they want, and get it used by the CLI, instead of requiring the user to have RDN and pay the PFS to get a route automatically (in the SDK). If the `paths` parameter is provided to the `/payments` endpoint of the CLI, it'll be validated and used.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
