### PR TITLE
dapp: disable service worker for staging

### DIFF
--- a/raiden-dapp/.env.staging
+++ b/raiden-dapp/.env.staging
@@ -1,5 +1,6 @@
 VUE_APP_PUBLIC_PATH=/staging/
 VUE_APP_HUB=hub.raiden.eth
 VUE_APP_ALLOW_MAINNET=false
+VUE_APP_SERVICE_WORKER_DISABLED=true
 VUE_APP_IMPRINT=https://raiden.network/privacy.html
 VUE_APP_TERMS=https://github.com/raiden-network/light-client/blob/master/TERMS.md


### PR DESCRIPTION
The staging version that gets deployed publicly should be be always the
most recent build. There is no version file for it. So if running the
service worker, this will prevent the user from getting the most recent
version as it will have its cache and never updates, as the version file
on the server remains the same until the next actual release.
