### PR TITLE
Fix unhandled rejections shutting down CLI on Node v15+

### DIFF
--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -313,6 +313,7 @@ function registerShutdownHooks(this: Cli): void {
     this.log.info('Exiting', code);
     process.exit(code);
   });
+  process.on('unhandledRejection', (reason) => this.log.warn('Unhandled rejection:', reason));
 }
 
 type Await<T> = T extends Promise<infer U> ? U : T;


### PR DESCRIPTION
Fixes #2998

**Short description**
Handles the rejection in SDK in case of failure, and also adapts CLI to not exit in case of a rejection is not handled, since those come only from public API methods, and therefore are just ways to notify users of some failure, and should never be fatal.
No need for changelog entry, since this doesn't change perceived behavior besides things just working.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
