### PR TITLE
Log invalid PFS

### DIFF
--- a/raiden-dapp/tests/unit/components/transfer/pathfinding-services.spec.ts
+++ b/raiden-dapp/tests/unit/components/transfer/pathfinding-services.spec.ts
@@ -27,6 +27,7 @@ describe('PathfindingService.vue', () => {
     rtt: 62,
     token: '0x3a989D97388a39A0B5796306C615d10B7416bE77',
     url: 'https://pfs-goerli-with-fee.services-test.raiden.network',
+    validTill: Date.now() + 86.4e6,
   };
 
   const raidenPFS2: RaidenPFS = {
@@ -35,6 +36,7 @@ describe('PathfindingService.vue', () => {
     rtt: 171,
     token: '0x3a989D97388a39A0B5796306C615d10B7416bE77',
     url: 'https://pfs-goerli.services-test.raiden.network',
+    validTill: Date.now() + 86.4e6,
   };
 
   function createWrapper() {

--- a/raiden-ts/src/services/types.ts
+++ b/raiden-ts/src/services/types.ts
@@ -125,6 +125,7 @@ export const PFS = t.readonly(
     rtt: t.number,
     price: UInt(32),
     token: Address,
+    validTill: t.number,
   }),
 );
 export interface PFS extends t.TypeOf<typeof PFS> {}

--- a/raiden-ts/tests/integration/mocks.ts
+++ b/raiden-ts/tests/integration/mocks.ts
@@ -349,7 +349,7 @@ function mockedMatrixCreateClient({
       userId: providedUserId,
       presence: 'offline',
     };
-    address = getAddress(providedUserId.substr(1, 42));
+    address = getAddress(providedUserId.substring(1, 43));
   }
 
   let stopped: typeof mockedMatrixUsers[string] | undefined;
@@ -438,7 +438,7 @@ function mockedMatrixCreateClient({
     createRoom: jest.fn(async ({ invite }) => {
       let pair = [address, '0x'];
       try {
-        const peerAddr = getAddress((invite[0] as string).substr(1, 42));
+        const peerAddr = getAddress((invite[0] as string).substring(1, 43));
         pair = getSortedAddresses(...([address, peerAddr] as Address[]));
       } catch (e) {}
       const roomId = `!roomId_${pair[0]}_${pair[1]}:${server}`;
@@ -687,7 +687,7 @@ export async function makeRaiden(
   const seenSighashes = new Set<string>();
   jest
     .spyOn(provider, 'getCode')
-    .mockImplementation(async () => '0x00' + [...seenSighashes].map((s) => `63${s.substr(2)}`));
+    .mockImplementation(async () => '0x00' + [...seenSighashes].map((s) => `63${s.substring(2)}`));
   jest.spyOn(provider, 'getBlock').mockImplementation(
     async (n: string | number | Promise<string | number>) =>
       ({
@@ -801,6 +801,9 @@ export async function makeRaiden(
   spyContract(serviceRegistryContract, 'ServiceRegistry', seenSighashes);
   serviceRegistryContract.token.mockResolvedValue(svtAddress);
   serviceRegistryContract.urls.mockImplementation(async () => 'https://pfs.raiden.test');
+  serviceRegistryContract.callStatic.service_valid_till.mockImplementation(async () =>
+    BigNumber.from(Math.round(Date.now() / 1e3) + 86400),
+  );
 
   const userDepositContract = UserDeposit__factory.connect(
     udcAddress,

--- a/raiden-ts/tests/integration/path.spec.ts
+++ b/raiden-ts/tests/integration/path.spec.ts
@@ -397,6 +397,7 @@ describe('PFS: pfsRequestEpic', () => {
             rtt: 3,
             price: One as UInt<32>,
             token: (await raiden.deps.serviceRegistryContract.token()) as Address,
+            validTill: Date.now() + 86.4e6,
           },
         },
         pathFindMeta,


### PR DESCRIPTION
Fixes #3001

**Short description**
We add PFS's validity timestamp to `PFS`/`RaidenPFS` schema, test it and log a big warning in case the user tries to use an invalid one (either by specifying in config or one-shot in methods `options.pfs`). Since these are advanced options only, we only log and try to use them anyway (as we did before), trusting the user knows what they're doing. For the normal case, `auto` services list already take care of only having/showing valid services.
No changelog needed since this doesn't change user-facing behavior, just add a logging for an advanced edge case.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
