### PR TITLE
Prepare release v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "light-client",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0",
   "description": "Raiden Light Client monorepo",
   "author": "brainbot labs est.",
   "private": true,

--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [2.0.0] - 2021-12-23
 ### Added
 - [#2949] Passthrough `/payments` parameters, including `paths`, which should receive pre-fetched route in the format `{ route: Address[]; estimated_fee: NumericString; address_metadata?: MetadataMap }[]`.
 - [#2971] Allow appending `:<block>` to `--user-deposit-contract-address=` option, to start scanning since this block instead of genesis
@@ -86,7 +88,8 @@
 [#2054]: https://github.com/raiden-network/light-client/pulls/2054
 
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.2...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.2...v2.0.0
 [2.0.0-rc.2]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.1...v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/raiden-network/light-client/compare/v1.1.0...v2.0.0-rc.1
 [1.1.0]: https://github.com/raiden-network/light-client/compare/v1.0.0...v1.1.0

--- a/raiden-cli/package.json
+++ b/raiden-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raiden_network/raiden-cli",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0",
   "author": "brainbot labs est.",
   "license": "MIT",
   "description": "Raiden Light Client standalone app with a REST API via HTTP",

--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.0.0] - 2021-12-23
+
 ## [2.0.0-rc.2] - 2021-09-14
 
 ### Added
@@ -617,7 +619,8 @@
 - Add link to privacy policy.
 - Add basic transfer screen.
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.2...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.2...v2.0.0
 [2.0.0-rc.2]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.1...v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/raiden-network/light-client/compare/v1.1.0...v2.0.0-rc.1
 [1.1.0]: https://github.com/raiden-network/light-client/compare/v1.0.0...v1.1.0

--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-dapp",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0",
   "private": true,
   "description": "A dApp that showcases the Raiden Light Client sdk functionality",
   "author": "brainbot labs est.",

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
 ## [Unreleased]
+
+## [2.0.0] - 2021-12-23
 ### Changed
 - [#2949] Allows `Raiden.transfer`'s `options.paths` to receive a broader schema, including `{ route: Address[]; estimated_fee: Int<32>; address_metadata?: ... }[]`, needed to support CLI's `paths` parameter of `/payments` endpoint
 - [#2953] `config.gasPriceFactor` applies over `maxPriorityFeePerGas`, using the new fee parameters from London when possible; now, by default, no fee parameters are specified, leaving `ethers` and provider (e.g. Metamask) to figure out best gas fees, fixing [#2952];
 - [#2965] Add +5% `gasLimit` margin on transactions which are successfuly estimated, to avoid running out of gas on narrow calls.
+- [#3012] Updated raiden-contracts to [v0.40](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.40.0)
+
+### Removed
 - [#2965] Remove `options.subkey` on certain `Raiden` public methods; if you need to force subkey or main account usage for single txs, set `config.subkey` then reset after tx is sent; default behavior is kept
 
 ### Fixed
@@ -17,6 +22,7 @@
 [#2953]: https://github.com/raiden-network/light-client/pull/2953
 [#2963]: https://github.com/raiden-network/light-client/issues/2963
 [#2965]: https://github.com/raiden-network/light-client/pull/2965
+[#3012]: https://github.com/raiden-network/light-client/pull/3012
 
 ## [2.0.0-rc.2] - 2021-09-14
 
@@ -522,7 +528,8 @@
 - Add protocol message implementation.
 
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.2...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.2...v2.0.0
 [2.0.0-rc.2]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.1...v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/raiden-network/light-client/compare/v1.1.0...v2.0.0-rc.1
 [1.1.0]: https://github.com/raiden-network/light-client/compare/v1.0.0...v1.1.0

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-ts",
-  "version": "2.0.0-rc.2",
+  "version": "2.0.0",
   "description": "Raiden Light Client Typescript/Javascript SDK",
   "main": "dist:cjs/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
Fixes # 

**Short description**
Upgrade raiden-contracts to v0.40.1 (no contracts changes), bump version and adjust changelogs.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
