### PR TITLE
dapp: fix version validation and comparison

### DIFF
--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- [#3021] Fix version handling to detect client updates
+
+[#3021]: https://github.com/raiden-network/light-client/issues/3021
+
 ## [2.0.0] - 2021-12-23
 
 ## [2.0.0-rc.2] - 2021-09-14

--- a/raiden-dapp/src/service-worker/assistant.ts
+++ b/raiden-dapp/src/service-worker/assistant.ts
@@ -1,5 +1,5 @@
 /* istanbul ignore file */
-import compareVersions from 'compare-versions';
+import { validate as validateVersion } from 'compare-versions';
 import type { Store } from 'vuex';
 
 import type { CombinedStoreState } from '@/store/index';
@@ -52,7 +52,7 @@ export default class ServiceWorkerAssistant {
       const data = await response.json();
       const version = data.version.version;
 
-      if (compareVersions.validate(version)) {
+      if (validateVersion(version)) {
         this.store.commit('setAvailableVersion', version);
       } else {
         throw new Error(`Maleformed version string: ${version}`);

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -1,4 +1,4 @@
-import compareVersions from 'compare-versions';
+import { compare as compareVersions, validate as validateVersion } from 'compare-versions';
 import type { BigNumber, providers } from 'ethers';
 import clone from 'lodash/clone';
 import filter from 'lodash/filter';
@@ -154,7 +154,7 @@ const store: StoreOptions<CombinedStoreState> = {
       state.stateBackupReminderDateMs = newReminderDate;
     },
     setAvailableVersion(state: RootState, version: string) {
-      if (compareVersions.validate(version)) {
+      if (validateVersion(version)) {
         state.versionInfo = { ...state.versionInfo, availableVersion: version };
       }
     },
@@ -258,7 +258,7 @@ const store: StoreOptions<CombinedStoreState> = {
       return (
         !!activeVersion &&
         !!availableVersion &&
-        compareVersions.compare(availableVersion, activeVersion, '>')
+        compareVersions(availableVersion, activeVersion, '>')
       );
     },
   },


### PR DESCRIPTION
Fixes #3021

**Short description**
See the issue and the commit message for details.
I'm a little worried. This issue here should have been caught by the type-system **and** our unit tests. In both cases I really don't know how it could have slipped through. I need to check this.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Build a production version of the dApp (`yarn build`)
2. Host the build locally (e.g. `npx serve ./dist`)
3. Open the dApp in the browser (ensure to first clean your cache etc.)
4. Verify that the version been cached (browser dev-tools)
5. Manually adapt the version number in `dist/version.json`
6. Force-reload the dApp tab in the browser
7. Verify that the dApp shows an update is available
