### PR TITLE
Mainnet Release v2.0.1 Kṛttikā

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "light-client",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Raiden Light Client monorepo",
   "author": "brainbot labs est.",
   "private": true,

--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.0.1] - 2021-12-24
+
 ## [2.0.0] - 2021-12-23
 ### Added
 - [#2949] Passthrough `/payments` parameters, including `paths`, which should receive pre-fetched route in the format `{ route: Address[]; estimated_fee: NumericString; address_metadata?: MetadataMap }[]`.
@@ -88,7 +90,8 @@
 [#2054]: https://github.com/raiden-network/light-client/pulls/2054
 
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/raiden-network/light-client/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.2...v2.0.0
 [2.0.0-rc.2]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.1...v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/raiden-network/light-client/compare/v1.1.0...v2.0.0-rc.1

--- a/raiden-cli/package.json
+++ b/raiden-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raiden_network/raiden-cli",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "brainbot labs est.",
   "license": "MIT",
   "description": "Raiden Light Client standalone app with a REST API via HTTP",

--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.0.1] - 2021-12-24
+
 ### Fixed
 
 - [#3021] Fix version handling to detect client updates
@@ -625,7 +627,8 @@
 - Add link to privacy policy.
 - Add basic transfer screen.
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/raiden-network/light-client/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.2...v2.0.0
 [2.0.0-rc.2]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.1...v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/raiden-network/light-client/compare/v1.1.0...v2.0.0-rc.1

--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-dapp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "A dApp that showcases the Raiden Light Client sdk functionality",
   "author": "brainbot labs est.",

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.0.1] - 2021-12-24
+
 ## [2.0.0] - 2021-12-23
 ### Changed
 - [#2949] Allows `Raiden.transfer`'s `options.paths` to receive a broader schema, including `{ route: Address[]; estimated_fee: Int<32>; address_metadata?: ... }[]`, needed to support CLI's `paths` parameter of `/payments` endpoint
@@ -528,7 +530,8 @@
 - Add protocol message implementation.
 
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/raiden-network/light-client/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.2...v2.0.0
 [2.0.0-rc.2]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.1...v2.0.0-rc.2
 [2.0.0-rc.1]: https://github.com/raiden-network/light-client/compare/v1.1.0...v2.0.0-rc.1

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-ts",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Raiden Light Client Typescript/Javascript SDK",
   "main": "dist:cjs/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
# 💉 New Raiden Light Client SDK, dApp and CLI

> **INFO:** The Light Client SDK, CLI and dApp are all **work in progress** projects. All three projects have been released for **mainnet** and all code is available in the Light Client repository. As this release still has its limitations and is a **beta** release, it is crucial to read this readme including the security notes carefully before using the software.

This is a patch release to fix the update feature of the dApp. Users  of the officially hosted https://lightclient.raiden.network client should ensure to update from `v1.1.0` directly to `v2.0.1`. Please remember that this is still a major release jump and implies a switch to the new contracts. For more information, refer to the notes from the [v2.0.0 release](https://github.com/raiden-network/light-client/releases/tag/v2.0.0).

Raiden dApp
-------------------------------
### Fixed

- [#3021] Fix version handling to detect client updates

