### PR TITLE
Mainnet Release v2.1.0 Kṛttikā

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "light-client",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Raiden Light Client monorepo",
   "author": "brainbot labs est.",
   "private": true,

--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.1.0] - 2021-12-29
+
 ## [2.0.1] - 2021-12-24
 
 ## [2.0.0] - 2021-12-23
@@ -90,7 +92,8 @@
 [#2054]: https://github.com/raiden-network/light-client/pulls/2054
 
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/raiden-network/light-client/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/raiden-network/light-client/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.2...v2.0.0
 [2.0.0-rc.2]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.1...v2.0.0-rc.2

--- a/raiden-cli/package.json
+++ b/raiden-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raiden_network/raiden-cli",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "author": "brainbot labs est.",
   "license": "MIT",
   "description": "Raiden Light Client standalone app with a REST API via HTTP",

--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.1.0] - 2021-12-29
+
 ### Added
 
 - [#3024] Prevent the usage of uninstalled versions
@@ -633,7 +635,8 @@
 - Add link to privacy policy.
 - Add basic transfer screen.
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/raiden-network/light-client/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/raiden-network/light-client/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.2...v2.0.0
 [2.0.0-rc.2]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.1...v2.0.0-rc.2

--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-dapp",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "private": true,
   "description": "A dApp that showcases the Raiden Light Client sdk functionality",
   "author": "brainbot labs est.",

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.1.0] - 2021-12-29
+
 ## [2.0.1] - 2021-12-24
 
 ## [2.0.0] - 2021-12-23
@@ -530,7 +532,8 @@
 - Add protocol message implementation.
 
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/raiden-network/light-client/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/raiden-network/light-client/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.2...v2.0.0
 [2.0.0-rc.2]: https://github.com/raiden-network/light-client/compare/v2.0.0-rc.1...v2.0.0-rc.2

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-ts",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Raiden Light Client Typescript/Javascript SDK",
   "main": "dist:cjs/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
# 🧱  New Raiden Light Client SDK, dApp and CLI

> **INFO:** The Light Client SDK, CLI and dApp are all **work in progress** projects. All three projects have been released for **mainnet** and all code is available in the Light Client repository. As this release still has its limitations and is a **beta** release, it is crucial to read this readme including the security notes carefully before using the software.

This new version adds a feature to the dApp that protects the user from loading temporary updates unintentionally. Besides the side effect of loading a different version temporary it is important that users always confirm updates and manually trigger the installation of a new version. Unintended updates can for example happen on a force-reload of of the web-browser. For more information, refer to the notes from the [v2.0.0 release](https://github.com/raiden-network/light-client/releases/tag/v2.0.0).

Raiden dApp
-------------------------------
### Added

- [#3024] Prevent the usage of uninstalled versions