### PR TITLE
dapp: fix loading for the first time with new version

### DIFF
--- a/raiden-dapp/src/App.vue
+++ b/raiden-dapp/src/App.vue
@@ -60,7 +60,7 @@ export default class App extends Mixins(NavigationMixin) {
     return process.env.VUE_APP_TERMS;
   }
 
-  created() {
+  beforeCreate() {
     this.$serviceWorkerAssistant.verifyIfCorrectVersionGotLoaded();
   }
 

--- a/raiden-dapp/src/store/constants.ts
+++ b/raiden-dapp/src/store/constants.ts
@@ -1,0 +1,3 @@
+// Constants must be defined outside of the `@/store/index` module to prevent
+// circular imports when used by modules of the store itself.
+export const DISCLAIMER_STORAGE_KEY = 'disclaimer';

--- a/raiden-dapp/src/store/index.ts
+++ b/raiden-dapp/src/store/index.ts
@@ -29,6 +29,8 @@ import {
 } from '@/store/version-information';
 import type { RootState, Tokens, Transfers } from '@/types';
 
+import { DISCLAIMER_STORAGE_KEY } from './constants';
+
 Vue.use(Vuex);
 
 const _defaultState: RootState = {
@@ -70,7 +72,7 @@ const disclaimerLocalStorage = new VuexPersistence<RootState>({
     disclaimerAccepted: state.persistDisclaimerAcceptance ? state.disclaimerAccepted : false,
   }),
   filter: (mutation) => mutation.type === 'acceptDisclaimer',
-  key: 'disclaimer',
+  key: DISCLAIMER_STORAGE_KEY,
 });
 
 const backupReminderLocalStorage = new VuexPersistence<RootState>({

--- a/raiden-dapp/src/store/version-information/getters.ts
+++ b/raiden-dapp/src/store/version-information/getters.ts
@@ -1,6 +1,8 @@
 import { compare as compareVersions, validate as validateVersion } from 'compare-versions';
 import type { GetterTree } from 'vuex';
 
+import { DISCLAIMER_STORAGE_KEY } from '@/store/constants';
+
 import type {
   RootStateWithVersionInformation,
   VersionInformationGetters,
@@ -26,11 +28,23 @@ function compareSemanticVersions(
   );
 }
 
+// This detection mechanism here isn't very nice. It is not possible to access
+// the data from the root store as it does not allow to distinguish the state.
+// Only when the user has accepted the disclaimer in the past, this data
+// exists. This also means this check here only works when evaluated before the
+// user accepts the disclaimer for the first time. In general it would be better
+// to have any other mechanism to detect the same information. Unfortunately
+// this must work with old versions of the client. This is the only and final
+// idea we came up with.
+function userLoadedApplicationForTheFirstTime(): boolean {
+  return localStorage.getItem(DISCLAIMER_STORAGE_KEY) === null;
+}
+
 export const getters: GetterTree<VersionInformationState, RootStateWithVersionInformation> &
   VersionInformationGetters = {
   correctVersionIsLoaded(state) {
-    if (state.updateInProgress) {
-      return true; // During an update it can never be a wrong version.
+    if (userLoadedApplicationForTheFirstTime() || state.updateInProgress) {
+      return true;
     }
 
     const { installedVersion, activeVersion } = state;
@@ -38,9 +52,9 @@ export const getters: GetterTree<VersionInformationState, RootStateWithVersionIn
     if (installedVersion === undefined) {
       // Only versions up to this number do not persist this information.
       return compareSemanticVersions(activeVersion, '2.0.1', '<=');
+    } else {
+      return compareSemanticVersions(installedVersion, activeVersion, '=');
     }
-
-    return compareSemanticVersions(installedVersion, activeVersion, '=');
   },
   updateIsAvailable(state) {
     return compareSemanticVersions(state.availableVersion, state.installedVersion, '>');


### PR DESCRIPTION
Solves the issues detected in the end-to-end test of #3027 where the version got bumped over the critical threshold. See the commit messages for details of this bug.