### PR TITLE
Arbitrum: read deployment file for arbitrum-rinkeby

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "jest": "^27.5.1",
     "**/redux-observable/rxjs": "^7.5.4",
     "@ethersproject/bignumber": "^5.5.0",
+    "@ethersproject/networks": "^5.5.2",
     "loglevel": "^1.8.0"
   }
 }

--- a/raiden-ts/scripts/versions.js
+++ b/raiden-ts/scripts/versions.js
@@ -5,7 +5,7 @@ const cwd = path.dirname(fs.realpathSync(__filename));
 
 // Get the smart contract version from the `raiden-contracts`
 // sub module.
-const contracts_version = '0.40.0';
+const contracts_version = '1.0.0';
 // TODO: Enable when https://github.com/raiden-network/raiden-contracts/issues/1287 done
 /*
 const { contracts_version } = require(path.join(

--- a/raiden-ts/src/utils/ethers.ts
+++ b/raiden-ts/src/utils/ethers.ts
@@ -313,11 +313,19 @@ export function logToContractEvent<C extends Contract>(contract: C) {
  * @returns name or chainId as string
  */
 export function getNetworkName(network: Network) {
-  return network.name === 'unknown'
-    ? network.chainId.toString()
-    : network.name === 'homestead'
-    ? 'mainnet'
-    : network.name;
+  let name = network.name;
+  switch (network.name) {
+    case 'homestead':
+      name = 'mainnet';
+      break;
+    case 'arbitrum-rinkeby':
+      name = 'rinkeby-arbitrum';
+      break;
+    case 'unknown':
+      name = network.chainId.toString();
+      break;
+  }
+  return name;
 }
 
 // memoized get contract's code as hex string

--- a/yarn.lock
+++ b/yarn.lock
@@ -2614,17 +2614,10 @@
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
   integrity sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==
 
-"@ethersproject/networks@5.5.2", "@ethersproject/networks@^5.5.2":
+"@ethersproject/networks@5.5.2", "@ethersproject/networks@^5.5.0", "@ethersproject/networks@^5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.5.2.tgz#784c8b1283cd2a931114ab428dae1bd00c07630b"
   integrity sha512-NEqPxbGBfy6O3x4ZTISb90SjEDkWYDUbEeIFhJly0F7sZjoQMnj5KYzMSkMkLKZ+1fGpx00EDpHQCy6PrDupkQ==
-  dependencies:
-    "@ethersproject/logger" "^5.5.0"
-
-"@ethersproject/networks@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.5.0.tgz#babec47cab892c51f8dd652ce7f2e3e14283981a"
-  integrity sha512-KWfP3xOnJeF89Uf/FCJdV1a2aDJe5XTN2N52p4fcQ34QhDqQFkgQKZ39VGtiqUgHcLI8DfT0l9azC3KFTunqtA==
   dependencies:
     "@ethersproject/logger" "^5.5.0"
 


### PR DESCRIPTION
Fixes #2976 

**Short description**
Read deployment file for arbitrum-rinkeby. Includes improvements to try to read JSON directly if not deployment not built-in.
Also, fix arbitrum-rinkeby network name, and bump `@ethersproject/networks` to a version which recognizes arbitrum.


**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
