### PR TITLE
Arbitrum: chose matrix server from PFS

### DIFF
--- a/raiden-ts/src/services/epics/helpers.ts
+++ b/raiden-ts/src/services/epics/helpers.ts
@@ -15,7 +15,6 @@ import {
   first,
   map,
   mergeMap,
-  pluck,
   tap,
   timeout,
   toArray,
@@ -35,13 +34,13 @@ import { getCap, stringifyCaps } from '../../transport/utils';
 import type { Latest, RaidenEpicDeps } from '../../types';
 import { jsonParse, jsonStringify } from '../../utils/data';
 import { assert, ErrorCodes, networkErrors, RaidenError } from '../../utils/error';
-import { lastMap, retryWhile, withMergeFrom } from '../../utils/rx';
+import { retryWhile, withMergeFrom } from '../../utils/rx';
 import type { Address, Signature } from '../../utils/types';
 import { decode, Signed, UInt } from '../../utils/types';
 import { iouClear, iouPersist, pathFind } from '../actions';
 import type { AddressMetadataMap, InputPaths, Paths, PFS } from '../types';
 import { Fee, IOU, LastIOUResults, PfsError, PfsMode, PfsResult } from '../types';
-import { packIOU, pfsInfo, pfsListInfo, signIOU } from '../utils';
+import { choosePfs$, packIOU, signIOU } from '../utils';
 
 type RouteResult = { iou: Signed<IOU> | undefined } & ({ paths: Paths } | { error: PfsError });
 
@@ -208,14 +207,14 @@ function getRouteFromPfs$(
   action: pathFind.request,
   deps: RaidenEpicDeps,
 ): Observable<RouteResult> {
-  return deps.config$.pipe(
-    first(),
-    withMergeFrom((config) => getPfsInfo$(action.payload.pfs, config, deps)),
-    withMergeFrom(([, pfs]) => prepareNextIOU$(pfs, action.meta.tokenNetwork, deps)),
-    withMergeFrom(([[config, pfs], iou]) =>
+  return choosePfs$(action.payload.pfs, deps).pipe(
+    first(), // pop first/best PFS
+    withMergeFrom((pfs) => prepareNextIOU$(pfs, action.meta.tokenNetwork, deps)),
+    withLatestFrom(deps.config$),
+    withMergeFrom(([[pfs, iou], config]) =>
       requestPfs$(pfs, iou, action.meta, { address: deps.address, config }),
     ),
-    map(([[[config], iou], { response, text }]) => {
+    map(([[[, iou], config], { response, text }]) => {
       // any decode error here will throw early and end up in catchError
       const data = jsonParse(text);
 
@@ -285,59 +284,6 @@ function filterPaths$(
     map((paths) => {
       if (!paths.length) throw firstError ?? new RaidenError(ErrorCodes.PFS_NO_ROUTES_FOUND);
       return paths;
-    }),
-  );
-}
-
-function getPfsInfo$(
-  pfsByAction: pathFind.request['payload']['pfs'],
-  config: Pick<RaidenConfig, 'pfsMode' | 'additionalServices'>,
-  deps: RaidenEpicDeps,
-): Observable<PFS> {
-  const { log, latest$, init$ } = deps;
-  let pfs$: Observable<PFS> = EMPTY;
-  if (pfsByAction) pfs$ = of(pfsByAction);
-  else if (config.pfsMode === PfsMode.onlyAdditional)
-    pfs$ = defer(async () => {
-      let firstErr;
-      for (const pfsUrlOrAddr of config.additionalServices) {
-        try {
-          return await pfsInfo(pfsUrlOrAddr, deps);
-        } catch (e) {
-          firstErr ??= e;
-        }
-      }
-      throw firstErr;
-    });
-  else {
-    pfs$ = init$.pipe(
-      lastMap(() => latest$.pipe(first(), pluck('state', 'services'))),
-      // fetch pfsInfo from whole list & sort it
-      mergeMap((services) =>
-        pfsListInfo(config.additionalServices.concat(Object.keys(services)), deps).pipe(
-          map((pfsInfos) => {
-            log.info('Auto-selecting best PFS from:', pfsInfos);
-            assert(pfsInfos.length, [
-              ErrorCodes.PFS_INVALID_INFO,
-              {
-                services: Object.keys(services).join(','),
-                additionalServices: config.additionalServices.join(','),
-              },
-            ]);
-            return pfsInfos[0]!; // pop best ranked
-          }),
-        ),
-      ),
-    );
-  }
-  return pfs$.pipe(
-    tap((pfs) => {
-      if (pfs.validTill < Date.now()) {
-        log.warn(
-          'WARNING: PFS registration not valid! This service deposit may have expired and it may not receive network updates anymore.',
-          pfs,
-        );
-      }
     }),
   );
 }

--- a/raiden-ts/src/services/types.ts
+++ b/raiden-ts/src/services/types.ts
@@ -122,6 +122,7 @@ export const PFS = t.readonly(
   t.type({
     address: Address,
     url: t.string,
+    matrixServer: t.string,
     rtt: t.number,
     price: UInt(32),
     token: Address,

--- a/raiden-ts/src/services/utils.ts
+++ b/raiden-ts/src/services/utils.ts
@@ -7,9 +7,22 @@ import * as t from 'io-ts';
 import memoize from 'lodash/memoize';
 import uniqBy from 'lodash/uniqBy';
 import type { Observable } from 'rxjs';
-import { defer, EMPTY, firstValueFrom, from } from 'rxjs';
+import { defer, EMPTY, firstValueFrom, from, of } from 'rxjs';
 import { fromFetch } from 'rxjs/fetch';
-import { catchError, map, mergeMap, toArray } from 'rxjs/operators';
+import {
+  catchError,
+  concatMap,
+  delay,
+  first,
+  last,
+  map,
+  mergeAll,
+  mergeMap,
+  takeUntil,
+  tap,
+  throwIfEmpty,
+  toArray,
+} from 'rxjs/operators';
 
 import type { ServiceRegistry } from '../contracts';
 import { MessageTypeId } from '../messages/utils';
@@ -19,11 +32,12 @@ import type { RaidenEpicDeps } from '../types';
 import { encode, jsonParse } from '../utils/data';
 import { assert, ErrorCodes, networkErrors, RaidenError } from '../utils/error';
 import { LruCache } from '../utils/lru';
-import { retryAsync$ } from '../utils/rx';
+import { pluckDistinct, retryAsync$ } from '../utils/rx';
 import type { PublicKey, Signature, Signed } from '../utils/types';
 import { Address, decode, UInt } from '../utils/types';
+import type { pathFind } from './actions';
 import type { IOU, PFS } from './types';
-import { AddressMetadata, PfsError } from './types';
+import { AddressMetadata, PfsError, PfsMode } from './types';
 
 const serviceRegistryToken = memoize(
   async (serviceRegistryContract: ServiceRegistry, pollingInterval: number) =>
@@ -68,7 +82,7 @@ function validatePfsUrl(url: string) {
 const pfsAddressCache_ = new LruCache<string, Promise<Address>>(32);
 
 /**
- * Returns a cold observable which fetch PFS info & validate for a given server address or URL
+ * Fetch PFS info & validate for a given server address or URL
  *
  * This is a memoized function which caches by url or address, network and registry used.
  *
@@ -350,4 +364,55 @@ export async function signIOU(signer: Signer, iou: IOU): Promise<Signed<IOU>> {
   return signer
     .signMessage(packIOU(iou))
     .then((signature) => ({ ...iou, signature: signature as Signature }));
+}
+
+/**
+ * Choose best PFS and fetch info from it
+ *
+ * @param pfsByAction - Override config for this call: explicit PFS, disabled or undefined
+ * @param deps - Epics dependencies
+ * @returns Observable to choosen PFS
+ */
+export function choosePfs$(
+  pfsByAction: pathFind.request['payload']['pfs'],
+  deps: RaidenEpicDeps,
+): Observable<PFS> {
+  const { log, config$, latest$, init$ } = deps;
+  return config$.pipe(
+    first(),
+    mergeMap(({ pfsMode, additionalServices }) => {
+      if (pfsByAction) return of(pfsByAction);
+      else if (pfsMode === PfsMode.onlyAdditional) {
+        let firstError: Error;
+        return from(additionalServices).pipe(
+          concatMap((service) =>
+            defer(async () => pfsInfo(service, deps)).pipe(
+              catchError((e) => ((firstError ??= e), EMPTY)),
+            ),
+          ),
+          throwIfEmpty(() => firstError),
+        );
+      } else {
+        return latest$.pipe(
+          pluckDistinct('state', 'services'),
+          map((services) => [...additionalServices, ...Object.keys(services)]),
+          // takeUntil above first will error if, after init$ and concatenating additionalServices,
+          // we still could not find a valid service
+          takeUntil(init$.pipe(last(), delay(10))),
+          first((services) => services.length > 0),
+          // fetch pfsInfo from whole list & sort it
+          mergeMap((services) => pfsListInfo(services, deps)),
+          mergeAll(),
+        );
+      }
+    }),
+    tap((pfs) => {
+      if (pfs.validTill < Date.now()) {
+        log.warn(
+          'WARNING: PFS registration not valid! This service deposit may have expired and it may not receive network updates anymore.',
+          pfs,
+        );
+      }
+    }),
+  );
 }

--- a/raiden-ts/src/services/utils.ts
+++ b/raiden-ts/src/services/utils.ts
@@ -126,6 +126,7 @@ export async function pfsInfo(
    */
   const PathInfo = t.type({
     message: t.string,
+    matrix_server: t.string,
     network_info: t.type({
       // literals will fail if trying to decode anything different from these constants
       chain_id: t.literal(network.chainId),
@@ -158,6 +159,7 @@ export async function pfsInfo(
     return {
       address,
       url,
+      matrixServer: info.matrix_server,
       rtt,
       price,
       token: await serviceRegistryToken(serviceRegistryContract, provider.pollingInterval),
@@ -382,7 +384,8 @@ export function choosePfs$(
     first(),
     mergeMap(({ pfsMode, additionalServices }) => {
       if (pfsByAction) return of(pfsByAction);
-      else if (pfsMode === PfsMode.onlyAdditional) {
+      assert(pfsByAction !== null && pfsMode !== PfsMode.disabled, ErrorCodes.PFS_DISABLED);
+      if (pfsMode === PfsMode.onlyAdditional) {
         let firstError: Error;
         return from(additionalServices).pipe(
           concatMap((service) =>

--- a/raiden-ts/src/transport/epics/init.ts
+++ b/raiden-ts/src/transport/epics/init.ts
@@ -29,6 +29,7 @@ import {
 import type { RaidenAction } from '../../actions';
 import { intervalFromConfig } from '../../config';
 import { RAIDEN_DEVICE_ID } from '../../constants';
+import { choosePfs$ } from '../../services/utils';
 import type { RaidenState } from '../../state';
 import type { RaidenEpicDeps } from '../../types';
 import { assert } from '../../utils';
@@ -290,6 +291,11 @@ export function initMatrixEpic(
       } else {
         // previously used server
         if (server) servers$Array.push(of({ server, setup }));
+
+        // server from PFSs, will prefer/pick matrixServer compatible with explicit PFS
+        servers$Array.push(
+          choosePfs$(undefined, deps).pipe(map(({ matrixServer: server }) => ({ server }))),
+        );
 
         // fetched servers list
         // notice it may include stored server again, but no stored setup, which could be the

--- a/raiden-ts/tests/integration/path.spec.ts
+++ b/raiden-ts/tests/integration/path.spec.ts
@@ -70,6 +70,7 @@ describe('PFS: pfsRequestEpic', () => {
   function makePfsInfoResponse() {
     return {
       message: 'pfs message',
+      matrix_server: 'http://transport.pfs.raiden.test',
       network_info: {
         chain_id: raiden.deps.network.chainId,
         token_network_registry_address: raiden.deps.contractsInfo.TokenNetworkRegistry.address,
@@ -393,6 +394,7 @@ describe('PFS: pfsRequestEpic', () => {
           pfs: {
             address: pfsAddress,
             url: pfsUrl,
+            matrixServer: makePfsInfoResponse().matrix_server,
             rtt: 3,
             price: One as UInt<32>,
             token: (await raiden.deps.serviceRegistryContract.token()) as Address,


### PR DESCRIPTION
Fixes #

**Short description**
This is an enhancement to some situations seen while testing with Arbitrum. When not explicitly specified (e.g. through cli's `--matrix-server` command line parameter), transport on `auto` mode will download the list of servers from RSB's github ([this list for testnets](https://raw.githubusercontent.com/raiden-network/raiden-service-bundle/master/known_servers/known_servers-development-v1.2.0.json)), and there's a high probability of those servers being incompatible with the current network (this is the case with arbitrum-rinkeby test PFS, which runs with its own matrix server).

The motivation of this change is that PFSs are either passed explicitly or picked from the chosen contracts (through `ServicesRegistry`), and therefore should always have a compatible matrix server, exposed in `/api/v1/info` endpoint. Therefore, preferring the server from the PFS will mostly ensure it's compatible with the current network and PFS, and only as a fallback we download the list from the `matrixServerLookup` URL.

Tests included.
This doesn't work only for Arbitrum, could work also for `master`, but since this touches test code which was already changed on `arbitrum` (#3034), it was easier to target that base, and most new features are already going to it anyway.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
