### PR TITLE
fix too quick channel interactions for quick-pay

### DIFF
--- a/raiden-dapp/src/components/channels/ChannelDepositAndTransferAction.vue
+++ b/raiden-dapp/src/components/channels/ChannelDepositAndTransferAction.vue
@@ -56,6 +56,9 @@ export default class ChannelDepositAndTransferAction extends Mixins(ActionMixin)
 
     await this.$raiden.deposit(tokenAddress, partnerAddress, depositTokenAmount);
 
+    // Sleep for short while to let the partner node see the channel deposit event.
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
     this.depositStep.completed = true;
     this.depositStep.active = false;
     this.transferStep.active = true;

--- a/raiden-dapp/src/components/channels/ChannelOpenAndTransferAction.vue
+++ b/raiden-dapp/src/components/channels/ChannelOpenAndTransferAction.vue
@@ -87,6 +87,9 @@ export default class ChannelOpenAndTransferAction extends Mixins(ActionMixin) {
       this.handleOpenEvents,
     );
 
+    // Sleep for short while to let the partner node see the open channel event.
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
     this.depositStep.completed = true;
     this.depositStep.active = false;
     this.transferStep.active = true;

--- a/raiden-dapp/tests/unit/components/channels/channel-deposit-and-transfer-action.spec.ts
+++ b/raiden-dapp/tests/unit/components/channels/channel-deposit-and-transfer-action.spec.ts
@@ -88,13 +88,14 @@ describe('ChannelDepositAndTransferAction', () => {
     expect(wrapper.vm.$data.depositStep.active).toBeTruthy();
   });
 
-  test('completes deposit step and activates transfer step when deposit finishes', async () => {
+  test('completes deposit step and activates transfer step after a timeout when deposit finishes', async () => {
     const deposit = jest.fn().mockResolvedValue(undefined);
     const transfer = jest.fn().mockReturnValue(new Promise(() => undefined));
     const wrapper = createWrapper({ deposit, transfer });
 
     (wrapper.vm as any).runAction(defaultDepositOptions);
     await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 3000));
 
     expect(wrapper.vm.$data.depositStep.completed).toBeTruthy();
     expect(wrapper.vm.$data.depositStep.active).toBeFalsy();
@@ -108,6 +109,7 @@ describe('ChannelDepositAndTransferAction', () => {
 
     (wrapper.vm as any).runAction(defaultDepositOptions);
     await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 3000));
 
     expect(wrapper.vm.$data.depositStep.completed).toBeTruthy();
     expect(wrapper.vm.$data.transferStep.completed).toBeTruthy();

--- a/raiden-dapp/tests/unit/components/channels/channel-open-and-transfer-action.spec.ts
+++ b/raiden-dapp/tests/unit/components/channels/channel-open-and-transfer-action.spec.ts
@@ -125,13 +125,14 @@ describe('ChannelOpenAndTransferAction', () => {
     expect(wrapper.vm.$data.depositStep.active).toBeTruthy();
   });
 
-  test('completes deposit step and activates transfer step when channel open finishes', async () => {
+  test('completes deposit step and activates transfer step after a timeout when channel open finishes', async () => {
     const openChannel = mockedOpenChannel.bind({ events: [EventTypes.OPENED], resolve: true });
     const transfer = jest.fn().mockReturnValue(new Promise(() => undefined));
     const wrapper = createWrapper({ openChannel, transfer });
 
     (wrapper.vm as any).runAction(defaultOpenChannelOptions);
     await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 3000));
 
     expect(wrapper.vm.$data.openStep.completed).toBeTruthy();
     expect(wrapper.vm.$data.depositStep.completed).toBeTruthy();
@@ -146,10 +147,11 @@ describe('ChannelOpenAndTransferAction', () => {
 
     await (wrapper.vm as any).runAction(defaultOpenChannelOptions);
     await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 3000));
 
     expect(wrapper.vm.$data.openStep.completed).toBeTruthy();
     expect(wrapper.vm.$data.depositStep.completed).toBeTruthy();
     expect(wrapper.vm.$data.transferStep.completed).toBeTruthy();
     expect(wrapper.vm.$data.transferStep.active).toBeFalsy();
-  });
+  }, 7000);
 });


### PR DESCRIPTION
Fixes #3078

**Short description**
Please checkout the issue and commit message for details.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

(note that this targets a "flaky" issue)
 
1. In theory: do a couple of quick-pays which require to open a new channel and/or make a channel deposit
2. Verify that even after many of them it never failed...
