### PR TITLE
dapp: adapt update message to express the risk

### DIFF
--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -248,7 +248,7 @@
     "transfer-from-raiden-account": "Transfer ETH from Raiden Account to Main Account"
   },
   "update": {
-    "updateAvailable": "A new version is available.",
+    "updateAvailable": "A new version is available. Please make sure to withdraw your funds before updating!",
     "updateMandatory": "Something happened to the local cached version. Perhaps the browser storage got cleared. You must update to get the app working again. You will not lose your current state.",
     "update": "Update",
     "updateInProgress": "Please wait for the update to finish."


### PR DESCRIPTION
This is just a "hot fix". That means that the next update will include a breaking change in terms of new contracts. Users should not simply update without withdrawing their funds first. In future this will be replaced with a proper feature that is able to determine of which kind an update is to alternate the update message.