### PR TITLE
v2: fix transferOnchainTokens when subkey=true

### DIFF
--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- [#3106] Fix bug where `Raiden.transferOnchainTokens` with `subkey=true` could be ignored and main account used instead
+
+[#3106]: https://github.com/raiden-network/light-client/issues/3106
 
 ## [2.2.0] - 2022-04-22
 ### Added

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -1345,15 +1345,15 @@ export class Raiden {
     assert(Address.is(token), [ErrorCodes.DTA_INVALID_ADDRESS, { token }], this.log.info);
     assert(Address.is(to), [ErrorCodes.DTA_INVALID_ADDRESS, { to }], this.log.info);
 
-    const { signer, address } = chooseOnchainAccount(this.deps, subkey ?? this.config.subkey);
-    const tokenContract = getContractWithSigner(this.deps.getTokenContract(token), signer);
+    const { address } = chooseOnchainAccount(this.deps, subkey ?? this.config.subkey);
 
     const curBalance = await this.getTokenBalance(token, address);
     // caps value to balance, so if it's too big, transfer all
     const amount = curBalance.lte(value) ? curBalance : BigNumber.from(value);
 
     const [, receipt] = await lastValueFrom(
-      transact(tokenContract, 'transfer', [to, amount], this.deps, {
+      transact(this.deps.getTokenContract(token), 'transfer', [to, amount], this.deps, {
+        subkey,
         error: ErrorCodes.RDN_TRANSFER_ONCHAIN_TOKENS_FAILED,
       }).pipe(
         retryWhile(intervalFromConfig(this.deps.config$), {

--- a/raiden-ts/src/services/utils.ts
+++ b/raiden-ts/src/services/utils.ts
@@ -407,6 +407,7 @@ export function choosePfs$(
         );
       }
     }),
+    throwIfEmpty(constant(new RaidenError(ErrorCodes.PFS_INVALID_INFO))),
     tap((pfs) => {
       if (pfs.validTill < Date.now()) {
         log.warn(


### PR DESCRIPTION
Fixes #3106

**Short description**
See issue and commit's body.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Serve dApp with subkey
2. Get some tokens in subkey (e.g. by performing a small channel withdraw)
3. Try to withdraw these tokens back to main account
