### PR TITLE
Fix subpaths version loading and deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
       mode:
         description: Mode to configure the environment of the dApp build
         type: enum
-        enum: [production, staging, development, e2e, raiden-package]
+        enum: [production, staging, development, e2e, raiden-package, v2]
     executor: base-executor
     working_directory: << pipeline.parameters.working_directory >>/raiden-dapp
     steps:
@@ -333,6 +333,41 @@ workflows:
             - build_sdk
       - deploy_gh_pages:
           public_path: /staging
+          requires:
+            - build_dapp
+            - test_dapp_unit
+            - test_dapp_e2e
+
+  publish_v2:
+    when:
+      equal: [v2, << pipeline.git.branch >>]
+
+    jobs:
+      - install
+      - build_sdk:
+          requires:
+            - install
+      - test_sdk_unit:
+          requires:
+            - install
+      - test_sdk_integration:
+          requires:
+            - install
+      - test_sdk_e2e:
+          requires:
+            - install
+      - build_dapp:
+          mode: v2
+          requires:
+            - build_sdk
+      - test_dapp_unit:
+          requires:
+            - build_sdk
+      - test_dapp_e2e:
+          requires:
+            - build_sdk
+      - deploy_gh_pages:
+          public_path: /v2
           requires:
             - build_dapp
             - test_dapp_unit

--- a/raiden-dapp/.env.v2
+++ b/raiden-dapp/.env.v2
@@ -1,0 +1,6 @@
+VUE_APP_PUBLIC_PATH=/v2/
+VUE_APP_ALLOW_MAINNET=true
+VUE_APP_SERVICE_WORKER_DISABLED=true
+VUE_APP_IMPRINT=https://raiden.network/privacy.html
+VUE_APP_TERMS=https://github.com/raiden-network/light-client/blob/master/TERMS.md
+VUE_APP_CONFIGURATION_URL=${VUE_APP_PUBLIC_PATH}config.production.json

--- a/raiden-dapp/deploy.sh
+++ b/raiden-dapp/deploy.sh
@@ -40,7 +40,9 @@ git remote add --fetch origin "$remote"
 if git rev-parse --verify origin/gh-pages >/dev/null 2>&1; then
   git checkout gh-pages
   # delete any old site as we are going to replace it
-  git rm -rf ./${PUBLIC_PATH} --ignore-unmatch
+  rm -f ./${PUBLIC_PATH}/* # first, delete all first-level files
+  # then only these folders, possibly preserving other paths
+  rm -rf ./${PUBLIC_PATH}/{css,docs,fonts,img,js}/
 else
   git checkout --orphan gh-pages
 fi
@@ -58,8 +60,8 @@ fi
 
 # stage any changes and new files
 git add -A
-# now commit, ignoring branch gh-pages doesn't seem to work, so trying skip
 
+# now commit, ignoring branch gh-pages doesn't seem to work, so trying skip
 git commit -m "Automated deployment to GitHub Pages: ${CIRCLE_SHA1} [skip ci]" --allow-empty
 
 # and push, but send any output to /dev/null to hide anything sensitive

--- a/raiden-dapp/src/service-worker/assistant.ts
+++ b/raiden-dapp/src/service-worker/assistant.ts
@@ -43,7 +43,7 @@ export default class ServiceWorkerAssistant {
       [ServiceWorkerMessageType.RELOAD_WINDOW]: this.handleReloadWindowMessage,
     };
 
-    if (this.serviceWorkerContainer) {
+    if (this.serviceWorkerContainer && process.env.VUE_APP_SERVICE_WORKER_DISABLED !== 'true') {
       this.serviceWorkerContainer.addEventListener('message', this.onMessage.bind(this));
       this.updateAvailableVersion();
 

--- a/raiden-dapp/src/store/version-information/getters.ts
+++ b/raiden-dapp/src/store/version-information/getters.ts
@@ -43,7 +43,11 @@ function userLoadedApplicationForTheFirstTime(): boolean {
 export const getters: GetterTree<VersionInformationState, RootStateWithVersionInformation> &
   VersionInformationGetters = {
   correctVersionIsLoaded(state) {
-    if (userLoadedApplicationForTheFirstTime() || state.updateInProgress) {
+    if (
+      userLoadedApplicationForTheFirstTime() ||
+      state.updateInProgress ||
+      process.env.VUE_APP_SERVICE_WORKER_DISABLED === 'true'
+    ) {
       return true;
     }
 

--- a/raiden-dapp/vue.config.js
+++ b/raiden-dapp/vue.config.js
@@ -13,6 +13,11 @@ function getPackageVersion() {
   return packageInfo.version ?? '0.0.0';
 }
 
+// if service worker not explicitly enabled, disable if not root BASE_URL
+if (!process.env.VUE_APP_SERVICE_WORKER_DISABLED && (process.env.BASE_URL ?? '/') !== '/') {
+  process.env.VUE_APP_SERVICE_WORKER_DISABLED = 'true';
+}
+
 /*
  * Note that it is not necessary to exclude the version file from the to
  * cache assets. The version file gets generated during the build and is


### PR DESCRIPTION
**Short description**
Ensure dApp instances deployed to subpaths (e.g. `/v2` and `/staging`) don't get deleted when a root instance is deployed (on tag), and also ensure those subpaths instances have service-worker assistant disabled so it doesn't affect the main cached version.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1.
2.
