### PR TITLE
2.2.0 -> 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "light-client",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Raiden Light Client monorepo",
   "author": "brainbot labs est.",
   "private": true,

--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+## [3.0.0] - 2022-05-02
 ### Removed
 - [#3034] Remove `--default-settle-timeout` CLI option, since this value isn't customizable anymore and instead constant per contract's deployment
 
@@ -107,7 +108,8 @@
 [#2054]: https://github.com/raiden-network/light-client/pulls/2054
 
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/raiden-network/light-client/compare/v2.2.0...v3.0.0
 [2.2.0]: https://github.com/raiden-network/light-client/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/raiden-network/light-client/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/raiden-network/light-client/compare/v2.0.0...v2.0.1

--- a/raiden-cli/package.json
+++ b/raiden-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raiden_network/raiden-cli",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "author": "brainbot labs est.",
   "license": "MIT",
   "description": "Raiden Light Client standalone app with a REST API via HTTP",

--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+## [3.0.0] - 2022-05-02
 ### Fixed
 - [#3078] Fix quick pay feature for Arbitrum and zero confirmation blocks
 
@@ -649,7 +650,8 @@
 - Add link to privacy policy.
 - Add basic transfer screen.
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/raiden-network/light-client/compare/v2.2.0...v3.0.0
 [2.2.0]: https://github.com/raiden-network/light-client/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/raiden-network/light-client/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/raiden-network/light-client/compare/v2.0.0...v2.0.1

--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-dapp",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "private": true,
   "description": "A dApp that showcases the Raiden Light Client sdk functionality",
   "author": "brainbot labs est.",

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+## [3.0.0] - 2022-05-02
 ### Fixed
 - [#3106] Fix bug where `Raiden.transferOnchainTokens` with `subkey=true` could be ignored and main account used instead
 
@@ -561,7 +562,8 @@
 - Add protocol message implementation.
 
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/raiden-network/light-client/compare/v2.2.0...v3.0.0
 [2.2.0]: https://github.com/raiden-network/light-client/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/raiden-network/light-client/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/raiden-network/light-client/compare/v2.0.0...v2.0.1

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-ts",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Raiden Light Client Typescript/Javascript SDK",
   "main": "dist:cjs/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
Please **DO NOT** merge this PR before the RSB got updated and tested.


---

Prepared release notes (look slightly different when copying to the release):


# Mainnet Release v3.0.0 Rohinī

## ⚡ New Raiden Light Client SDK, dApp and CLI

> **INFO:** The Light Client SDK, CLI and dApp are all **work in progress** projects. All three projects have been released for **mainnet** and all code is available in the Light Client repository. As this release still has its limitations and is a **beta** release, it is crucial to read this readme including the security notes carefully before using the software.

With this release the Light Client becomes compatible to the contracts version `0.50.0` which do function and are available on Arbitrum based roll-up networks. In result the whole on-boarding process and blockchain interactions in general are much faster and cheaper thanks to the roll-up technology. This required major refactoring also by the Light Client, resulting in breaking changes to all interfaces.

Raiden SDK
-------------------------------
### Fixed
- #3106 Fix bug where `Raiden.transferOnchainTokens` with `subkey=true` could be ignored and main account used instead

### Changed
- #2916 **BREAKING** Switched timeouts to use timestamps (seconds) instead of blocks; previous Raiden stable releases and contracts used block numbers to count the passage of time (e.g. transfers, withdraws and channel settlement timeouts); the new refactored contracts use timestamps (in seconds) instead, which is more predictable on networks with random or on-demand block generation cadence, like rollups; while this change is motivated by the Arbitrum compatiblity effort, it's not restricted to rollups, and may eventually also be deployed to other networks
- #2976 **BREAKING** Switched to `arbitrum` branch of [raiden-contracts](https://github.com/raiden-network/raiden-contracts/tree/arbitrum); this contracts branch uses `block.timestamp`s to count timeouts, instead of block numbers; this also creates a new state for clients (new contracts, new state schema and entry)

### Added
- #3034 SDK now accepts `config.confirmationBlocks = 0` (default for Arbitrum), speeding up transactions wait times on rollup environments

### Removed
- #3034 Remove `settleTimeout` option from `config` and `Raiden.openChannel` methods, since this value is now constant per contract deployment (exposed through `Raiden.settleTimeout` getter)

Raiden dApp
-------------------------------
### Fixed
- #3078 Fix quick pay feature for Arbitrum and zero confirmation blocks

### Changed
- #3051 Adapt UDC withdraws to timestamps instead of block numbers

### Removed
- #3053 Remove `settleTimeout` references and settlement block countdown, since these don't apply anymore

Raiden CLI
-------------------------------
### Removed
- #3034 Remove `--default-settle-timeout` CLI option, since this value isn't customizable anymore and instead constant per contract's deployment

### Changed
- #3034 `--default-reveal-timeout` now receives seconds, instead of blocks