### PR TITLE
Fix revealTimeout on testnets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,7 @@ parameters:
 anchor_1: &attach_options
   at: << pipeline.parameters.working_directory >>
 
-anchor_2: &filter_release_tag
-  filters:
-    tags:
-      only: /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-
-anchor_3: &executor_shared_options
+anchor_2: &executor_shared_options
   working_directory: << pipeline.parameters.working_directory >>
   environment:
     JEST_JUNIT_OUTPUT_DIR: << pipeline.parameters.test_report_directory >>
@@ -151,7 +146,8 @@ jobs:
           name: Compress CLI and bundle
           command: |
             mkdir -p ./cli/
-            yarn pack --out ./cli/%s-%v.tgz
+            yarn pack
+            mv --verbose ./*raiden-cli*.tgz ./cli/
             cp --verbose ./raiden ./package.json ./bundle/
             tar --create --gzip --verbose --file ./cli/raiden-cli-bundle.tgz ./bundle --transform='s/^bundle/raiden-cli/'
       - store_artifacts:
@@ -270,11 +266,12 @@ jobs:
           workspace: '@raiden_network/raiden-cli'
 
 workflows:
-  version: 2
   default_workflow:
-    when:
-      not:
-        equal: [master, << pipeline.git.branch >>]
+    unless:
+      or:
+        - equal: [ master, << pipeline.git.branch >> ]
+        - equal: [ v2, << pipeline.git.branch >> ]
+        - equal: [ gh-pages, << pipeline.git.branch >> ]
 
     jobs:
       - install
@@ -309,7 +306,7 @@ workflows:
 
   publish_staging:
     when:
-      equal: [master, << pipeline.git.branch >>]
+      equal: [ master, << pipeline.git.branch >> ]
 
     jobs:
       - install
@@ -344,7 +341,7 @@ workflows:
 
   publish_v2:
     when:
-      equal: [v2, << pipeline.git.branch >>]
+      equal: [ v2, << pipeline.git.branch >> ]
 
     jobs:
       - install
@@ -388,34 +385,31 @@ workflows:
     # by a new tag must use a tag filter. Else the job does not get executed, no
     # matter its dependencies or anything else.
     jobs:
-      - install:
-          <<: *filter_release_tag
+      - install
       - build_sdk:
-          <<: *filter_release_tag
           requires:
             - install
       - build_dapp:
-          <<: *filter_release_tag
           mode: production
           requires:
             - build_sdk
       - build_cli:
-          <<: *filter_release_tag
           requires:
             - build_sdk
       - generate_documentation:
-          <<: *filter_release_tag
           requires:
             - build_dapp
       - deploy_gh_pages:
-          <<: *filter_release_tag
           public_path: /
           requires:
             - build_dapp
             - generate_documentation
-      - publish_on_npm_registry:
-          <<: *filter_release_tag
-          context: 'Raiden Context'
+      - approve_publish:
+          type: approval
           requires:
             - build_sdk
             - build_cli
+      - publish_on_npm_registry:
+          context: 'Raiden Context'
+          requires:
+            - approve_publish

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- [#3118] Dynamically set `config.revealTimeout` to half of `tokenNetworkRegistryContract.settleTimeout`, if it'd be smaller than default of 600s
+
 ## [3.0.0] - 2022-05-02
 ### Fixed
 - [#3106] Fix bug where `Raiden.transferOnchainTokens` with `subkey=true` could be ignored and main account used instead

--- a/raiden-ts/src/transfers/epics/locked.ts
+++ b/raiden-ts/src/transfers/epics/locked.ts
@@ -141,13 +141,13 @@ function makeAndSignTransfer$(
     expiration = now;
     if ('lockTimeout' in action.payload && action.payload.lockTimeout)
       expiration += action.payload.lockTimeout;
-    else expiration += Math.min(revealTimeout * expiryFactor, settleTimeout / 2);
+    else expiration += Math.min(revealTimeout * expiryFactor, settleTimeout - 1);
   }
   expiration = decode(UInt(32), Math.ceil(expiration));
 
-  // revealTimeout <= Δexpiration <= settleTimeout
+  // revealTimeout < Δexpiration < settleTimeout
   // to ensure we'll have enough time to tx in case it expires, but it can't outlive channel
-  assert(expiration.gte(now + revealTimeout), [
+  assert(expiration.gt(now + revealTimeout), [
     'expiration too soon',
     { expiration, blockNumber: state.blockNumber, settleTimeout, revealTimeout },
   ]);

--- a/serve_pr/ci_dapp.sh
+++ b/serve_pr/ci_dapp.sh
@@ -30,8 +30,8 @@ for PIPELINE in $PIPELINES; do
     log "Pull Request: ${PULL}"
     PULLDIR="${PWD}/${PULL}"
     mkdir -p "${PULLDIR}"
-    OLDFILE="$PULLDIR/dapp.prev.tar.gz"
-    OUTFILE="$PULLDIR/dapp.tar.gz"
+    OLDFILE="$PULLDIR/dapp.prev.tgz"
+    OUTFILE="$PULLDIR/dapp.tgz"
     $CURL -L -o "$OUTFILE" -z "$OLDFILE" "$URL" && SUCCESS=1
     [[ "$SUCCESS" == 1 ]] && break
   done


### PR DESCRIPTION
Fixes #

**Short description**
This fixes a small issue identified on Arbitrum release (v3) on testnets (e.g. `arbitrum-rinkeby`), where `settleTimeout` in deployed contracts (180 seconds) is smaller than default `revealTimeout` (600 seconds), making every transfer fail with `expires too soon` error.

It also includes some simplification of conditionals in circleCI config, preparing for next [patch] release.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Transfers work out-of-the-box on contracts with settleTimeout<600
