### PR TITLE
CLI endpoints and parameters to manage database backups

### DIFF
--- a/e2e-environment/run-e2e-tests.sh
+++ b/e2e-environment/run-e2e-tests.sh
@@ -21,7 +21,7 @@ else
     --publish 127.0.0.1:5001:5001 \
     --publish 127.0.0.1:5002:5002 \
     --publish 127.0.0.1:8545:8545 \
-    --volume supervisord.conf:/etc/supervisor/conf.d/supervisord.conf \
+    --volume $(dirname "${BASH_SOURCE[0]}")/supervisord.conf:/etc/supervisor/conf.d/supervisord.conf \
     "$DOCKER_IMAGE_NAME" \
     >/dev/null
 fi

--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- [#3122] `/api/v1/state.json` endpoint to allow downloading/backing up and `--load-state <path.json>` parameter to upload/rehydrate state/database in a fresh instance
+
+[#3122]: https://github.com/raiden-network/light-client/issues/3122
+
 ## [3.0.0] - 2022-05-02
 ### Removed
 - [#3034] Remove `--default-settle-timeout` CLI option, since this value isn't customizable anymore and instead constant per contract's deployment

--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -136,7 +136,10 @@ async function main() {
   const raiden = await Raiden.create(
     argv.ethRpcEndpoint,
     wallet.privateKey,
-    { prefix: argv.datadir.endsWith('/') ? argv.datadir : argv.datadir + '/' },
+    {
+      prefix: argv.datadir.endsWith('/') ? argv.datadir : argv.datadir + '/',
+      state: argv.loadState ? JSON.parse(await fs.readFile(argv.loadState, 'utf-8')) : undefined,
+    },
     argv.userDepositContractAddress,
     config,
   );

--- a/raiden-cli/src/options.ts
+++ b/raiden-cli/src/options.ts
@@ -121,6 +121,11 @@ const yargsOptions = {
     default: './storage',
     desc: 'Dir path where to store state',
   },
+  loadState: {
+    type: 'string',
+    desc: 'Path to JSON file to upload/rehydrate state from',
+    normalize: true,
+  },
   configFile: {
     type: 'string',
     desc: 'JSON file path containing config object',

--- a/raiden-cli/src/routes/api.v1.ts
+++ b/raiden-cli/src/routes/api.v1.ts
@@ -84,5 +84,16 @@ export function makeApiV1Router(this: Cli): Router {
     response.json(RaidenConfig.encode(this.raiden.config));
   });
 
+  router.get('/state.json', async (_request: Request, response: Response) => {
+    response.writeHead(200, { 'Content-Type': 'application/json' });
+    response.write('[');
+    let count = 0;
+    for await (const row of this.raiden.dumpDatabase()) {
+      response.write((count++ ? ',\n' : '\n') + JSON.stringify(row));
+    }
+    response.write('\n]');
+    response.end();
+  });
+
   return router;
 }

--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- [#3122] `Backup State` doesn't require SDK to be shut down anymore
+
+[#3122]: https://github.com/raiden-network/light-client/issues/3122
+
 ## [3.0.0] - 2022-05-02
 ### Fixed
 - [#3078] Fix quick pay feature for Arbitrum and zero confirmation blocks

--- a/raiden-dapp/src/components/ActionButton.vue
+++ b/raiden-dapp/src/components/ActionButton.vue
@@ -3,6 +3,8 @@
     type="submit"
     :disabled="!enabled"
     :loading="loading"
+    :href="href"
+    :download="download"
     data-cy="action_button"
     class="text-capitalize action-button"
     :class="{
@@ -59,6 +61,12 @@ export default class ActionButton extends Vue {
 
   @Prop({ type: Boolean, default: false })
   angular?: boolean;
+
+  @Prop({ type: String })
+  href?: string;
+
+  @Prop({ type: String })
+  download?: string;
 
   @Emit()
   click(): boolean {

--- a/raiden-dapp/src/components/account/backup-state/DownloadStateDialog.vue
+++ b/raiden-dapp/src/components/account/backup-state/DownloadStateDialog.vue
@@ -52,12 +52,17 @@ export default class DownloadStateDialog extends Mixins(NavigationMixin) {
 
     downloadLink.click();
     this.revokeDownloadURL(stateFileURL, downloadLink);
+    this.visible = false;
   }
 
   /* istanbul ignore next */
   async getStateFileURL(filename: string): Promise<string> {
-    const state = await this.$raiden.stopAndGetDatabaseDump();
-    const stateJSON = JSON.stringify(state);
+    let stateJSON = '[';
+    let count = 0;
+    for await (const row of this.$raiden.getDatabaseDump()) {
+      stateJSON += (count++ ? ',\n' : '\n') + JSON.stringify(row);
+    }
+    stateJSON += '\n]';
     const file = new File([stateJSON], filename, { type: 'application/json' });
     return URL.createObjectURL(file);
   }

--- a/raiden-dapp/src/locales/en.json
+++ b/raiden-dapp/src/locales/en.json
@@ -234,7 +234,7 @@
     "disabled-download": "Downloading the state is only possible when connected to the dApp",
     "disabled-upload": "Uploading the state is only possible when the dApp is disconnected",
     "download": "Download State",
-    "download-warning": "Downloading the state will force the dApp to shut down",
+    "download-warning": "Keep your state backup private and safe",
     "download-button": "Download",
     "upload": "Upload State and Connect",
     "upload-drag-and-drop": "Drag and drop state file",

--- a/raiden-dapp/src/services/raiden-service.ts
+++ b/raiden-dapp/src/services/raiden-service.ts
@@ -636,9 +636,8 @@ export default class RaidenService {
   }
 
   /* istanbul ignore next */
-  async stopAndGetDatabaseDump() {
-    this._raiden!.stop();
-    return this._raiden!.dumpDatabase();
+  async *getDatabaseDump() {
+    yield* this._raiden!.dumpDatabase();
   }
 
   /* istanbul ignore next */

--- a/raiden-dapp/tests/e2e/specs/scenario.spec.ts
+++ b/raiden-dapp/tests/e2e/specs/scenario.spec.ts
@@ -59,20 +59,20 @@ describe('dApp e2e tests', () => {
     mintAndDepositUtilityTokenFromSelectHubScreen();
     mintConnectedTokenFromSelectHubScreen();
     enterAndSelectHub(uiTimeout, partnerAddress);
-    enterChannelDepositAmount(uiTimeout);
+    enterChannelDepositAmount();
     openChannel();
     navigateToNotificationPanel();
     deleteTopNotification(); // This must be the sticky backup notification.
     closeNotificationPanel();
     enterTransferAddress(uiTimeout, partnerAddress);
-    enterTransferAmount(uiTimeout);
+    enterTransferAmount();
     makeDirectTransfer(uiTimeout);
     enterTransferAddress(uiTimeout, thirdAddres);
-    enterTransferAmount(uiTimeout);
+    enterTransferAmount();
     makeMediatedTransfer(uiTimeout);
     navigateToAccountMenu();
     navigateToBackupState();
-    downloadState();
+    downloadState(uiTimeout);
     navigateToTokenSelect();
     navigateToConnectNewTokenFromTokenOverlay();
     navigateBackToTransferScreenFromOverlay();

--- a/raiden-dapp/tests/e2e/specs/scenario.spec.ts
+++ b/raiden-dapp/tests/e2e/specs/scenario.spec.ts
@@ -73,7 +73,6 @@ describe('dApp e2e tests', () => {
     navigateToAccountMenu();
     navigateToBackupState();
     downloadState();
-    connectToDApp();
     navigateToTokenSelect();
     navigateToConnectNewTokenFromTokenOverlay();
     navigateBackToTransferScreenFromOverlay();

--- a/raiden-dapp/tests/e2e/utils/navigation.ts
+++ b/raiden-dapp/tests/e2e/utils/navigation.ts
@@ -62,6 +62,8 @@ export function navigateToBackupState() {
  *
  */
 export function navigateToTokenSelect() {
+  navigateBackToAccountMenu();
+  navigateBackToTransferScreenFromOverlay();
   cy.log('navigate to token select');
   // cypress selectors: raiden-dapp/src/components/transfer/TransferInputs.vue
   cy.get('[data-cy=transfer_inputs]').should('exist');

--- a/raiden-dapp/tests/e2e/utils/navigation.ts
+++ b/raiden-dapp/tests/e2e/utils/navigation.ts
@@ -62,9 +62,8 @@ export function navigateToBackupState() {
  *
  */
 export function navigateToTokenSelect() {
-  navigateBackToAccountMenu();
-  navigateBackToTransferScreenFromOverlay();
   cy.log('navigate to token select');
+  cy.visit('/#/home');
   // cypress selectors: raiden-dapp/src/components/transfer/TransferInputs.vue
   cy.get('[data-cy=transfer_inputs]').should('exist');
   // cypress selectors: raiden-dapp/src/components/transfer/TransferHeaders.vue

--- a/raiden-dapp/tests/e2e/utils/user-interaction.ts
+++ b/raiden-dapp/tests/e2e/utils/user-interaction.ts
@@ -53,14 +53,12 @@ export function enterAndSelectHub(uiTimeout: number, partnerAddress: string) {
 }
 
 /**
- * @param uiTimeout - Timeout to wait
  */
-export function enterChannelDepositAmount(uiTimeout: number) {
+export function enterChannelDepositAmount() {
   cy.log('enter channel deposit amount');
   cy.get('[data-cy=channel-action-form]').should('exist');
   cy.contains('Open Channel');
   cy.get('[data-cy=channel-action-form__token-amount__input]').type('0.5');
-  cy.wait(uiTimeout);
 }
 
 /**
@@ -101,15 +99,13 @@ export function enterTransferAddress(uiTimeout: number, partnerAddress: string) 
 }
 
 /**
- * @param uiTimeout - Timeout to wait
  */
-export function enterTransferAmount(uiTimeout: number) {
+export function enterTransferAmount() {
   cy.log('enter transfer amount');
   // cypress selectors: raiden-dapp/src/components/transfer/TransferInputs.vue
   cy.get('[data-cy=transfer_inputs]').should('exist');
   // cypress selectors: raiden-dapp/src/components/AmountInput.vue
   cy.get('[data-cy=amount_input]').type('0.0001');
-  cy.wait(uiTimeout);
 }
 
 /**
@@ -146,17 +142,19 @@ export function makeMediatedTransfer(uiTimeout: number) {
 }
 
 /**
- *
+ * @param uiTimeout - Timeout
  */
-export function downloadState() {
+export function downloadState(uiTimeout: number) {
   cy.log('download state');
   // cypress selectors: raiden-dapp/src/views/account/BackupState.vue
   cy.get('[data-cy=backup_state]').should('exist');
+  cy.wait(uiTimeout);
   cy.get('[data-cy=backup_state_buttons_download_state]').click();
   // cypress selectors: raiden-dapp/src/components/account/backup-state/DownloadStateDialog.vue
   cy.getWithCustomTimeout('[data-cy=download_state_button]').should('exist');
+  cy.getWithCustomTimeout('[data-cy=download_state_button]').should('not.be.disabled');
   cy.get('[data-cy=download_state_button]').click();
-  cy.getWithCustomTimeout('[data-cy=backup_state]').should('not.exist');
+  cy.wait(uiTimeout);
 }
 
 /**

--- a/raiden-dapp/tests/unit/components/account/backup-state/download-state-dialog.spec.ts
+++ b/raiden-dapp/tests/unit/components/account/backup-state/download-state-dialog.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Wrapper } from '@vue/test-utils';
 import { mount } from '@vue/test-utils';
 import Vue from 'vue';
@@ -12,6 +11,11 @@ Vue.use(Vuetify);
 describe('DownloadStateDialog.vue', () => {
   let wrapper: Wrapper<DownloadStateDialog>;
   let vuetify: Vuetify;
+  const $raiden = {
+    getDatabaseDump: jest.fn(async function* () {
+      yield { test: 1 };
+    }),
+  };
 
   beforeEach(() => {
     vuetify = new Vuetify();
@@ -21,6 +25,7 @@ describe('DownloadStateDialog.vue', () => {
       stubs: ['v-dialog'],
       mocks: {
         $t: (msg: string) => msg,
+        $raiden,
       },
       propsData: {
         visible: true,
@@ -41,10 +46,8 @@ describe('DownloadStateDialog.vue', () => {
   });
 
   test('calls method for getting and downloading state', async () => {
-    (wrapper.vm as any).getAndDownloadState = jest.fn();
     wrapper.findComponent(ActionButton).trigger('click');
     await wrapper.vm.$nextTick();
-
-    expect((wrapper.vm as any).getAndDownloadState).toBeCalled();
+    expect($raiden.getDatabaseDump).toBeCalled();
   });
 });

--- a/raiden-dapp/tests/unit/views/account/backup-state.spec.ts
+++ b/raiden-dapp/tests/unit/views/account/backup-state.spec.ts
@@ -22,6 +22,11 @@ describe('BackupState.vue', () => {
       stubs: ['v-dialog'],
       mocks: {
         $t: (msg: string) => msg,
+        $raiden: {
+          async *getDatabaseDump() {
+            yield { test: 1 };
+          },
+        },
       },
       store,
     });

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -4,6 +4,12 @@
 ### Fixed
 - [#3118] Dynamically set `config.revealTimeout` to half of `tokenNetworkRegistryContract.settleTimeout`, if it'd be smaller than default of 600s
 
+### Changed
+- [#3122] `Raiden.dumpDatabase` now returns an `AsyncIterable` of database rows objects, which allow to stream even big state dumps without having to accumulate everything in memory; also, it doesn't require stopping SDK to dump state anymore
+
+[#3118]: https://github.com/raiden-network/light-client/pull/3118
+[#3122]: https://github.com/raiden-network/light-client/issues/3122
+
 ## [3.0.0] - 2022-05-02
 ### Fixed
 - [#3106] Fix bug where `Raiden.transferOnchainTokens` with `subkey=true` could be ignored and main account used instead

--- a/raiden-ts/src/db/utils.ts
+++ b/raiden-ts/src/db/utils.ts
@@ -4,14 +4,22 @@ import logging from 'loglevel';
 import PouchDB from 'pouchdb';
 import PouchDBFind from 'pouchdb-find';
 import type { Observable } from 'rxjs';
-import { BehaviorSubject, defer, from, fromEvent, lastValueFrom, merge } from 'rxjs';
-import { concatMap, finalize, mergeMap, pluck, takeUntil } from 'rxjs/operators';
+import {
+  BehaviorSubject,
+  defer,
+  firstValueFrom,
+  from,
+  fromEvent,
+  lastValueFrom,
+  merge,
+} from 'rxjs';
+import { concatMap, filter, finalize, mergeMap, pluck, takeUntil } from 'rxjs/operators';
 
 import type { Channel } from '../channels';
 import { channelKey } from '../channels/utils';
 import type { RaidenState } from '../state';
 import type { ContractsInfo } from '../types';
-import { assert, ErrorCodec, ErrorCodes } from '../utils/error';
+import { assert, ErrorCodes } from '../utils/error';
 import type { Address } from '../utils/types';
 import { last } from '../utils/types';
 import { getDefaultPouchAdapter } from './adapter';
@@ -451,6 +459,8 @@ export async function* dumpDatabase(db: RaidenDatabase, { batch = 10 }: { batch?
   let changed: string | undefined;
   const feed = db.changes({ since: 'now', live: true });
   feed.on('change', ({ id }) => (changed = id));
+  await firstValueFrom(db.busy$.pipe(filter((v) => !v)));
+  db.busy$.next(true);
   try {
     yield await databaseMeta(db);
     let startkey = 'a';
@@ -470,40 +480,7 @@ export async function* dumpDatabase(db: RaidenDatabase, { batch = 10 }: { batch?
       else break;
     }
   } finally {
+    db.busy$.next(false);
     feed.cancel();
   }
-}
-
-async function reopenDatabase(db: RaidenDatabase): Promise<RaidenDatabase> {
-  return makeDatabase.call(db.constructor, db.name);
-}
-
-/**
- * Creates an array containing all documents in the database; retries database change errors
- *
- * @param db - Database to dump
- * @param opts - Options
- * @param opts.batch - Size of batches to fetch and yield
- * @returns Array of documents
- */
-export async function dumpDatabaseToArray(db: RaidenDatabase, opts?: { batch?: number }) {
-  const { log } = db.constructor.__defaults;
-  let shouldCloseAfter = false;
-  for (let _try = 10; _try > 0; --_try) {
-    try {
-      const result = [];
-      for await (const doc of dumpDatabase(db, opts)) {
-        result.push(doc);
-      }
-      if (shouldCloseAfter) await db.close(); // on success
-      return result;
-    } catch (e) {
-      if (ErrorCodec.is(e) && e.message.includes('database is closed')) {
-        shouldCloseAfter = true;
-        db = await reopenDatabase(db);
-      }
-      log?.warn('Restarting dump because', e);
-    }
-  }
-  throw new Error('Could not dump database');
 }

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -49,7 +49,7 @@ import type { RaidenConfig } from './config';
 import { intervalFromConfig, PartialRaidenConfig } from './config';
 import { ShutdownReason } from './constants';
 import { CustomToken__factory } from './contracts';
-import { dumpDatabaseToArray } from './db/utils';
+import { dumpDatabase } from './db/utils';
 import { combineRaidenEpics, getLatest$ } from './epics';
 import {
   chooseOnchainAccount,
@@ -484,13 +484,10 @@ export class Raiden {
   /**
    * Dumps database content for backup
    *
-   * @returns JSON object or array containing database content
+   * @yields Rows of objects
    */
-  public async dumpDatabase() {
-    // only wait for db to be closed if it was started
-    if (this.started !== undefined)
-      await lastValueFrom(this.deps.db.busy$, { defaultValue: undefined });
-    return dumpDatabaseToArray(this.deps.db);
+  public async *dumpDatabase() {
+    yield* dumpDatabase(this.deps.db);
   }
 
   /**

--- a/raiden-ts/tests/unit/raiden.spec.ts
+++ b/raiden-ts/tests/unit/raiden.spec.ts
@@ -48,7 +48,7 @@ import {
   TokenNetwork__factory,
   TokenNetworkRegistry__factory,
 } from '@/contracts';
-import { changes$, dumpDatabaseToArray } from '@/db/utils';
+import { changes$ } from '@/db/utils';
 import { combineRaidenEpics } from '@/epics';
 import { signMessage } from '@/messages';
 import { messageServiceSend } from '@/messages/actions';
@@ -1429,30 +1429,6 @@ describe('Raiden', () => {
       MaxUint256,
       expect.anything(),
     );
-  });
-
-  test('dumpDatabase', async () => {
-    const mockDump = dumpDatabaseToArray as jest.MockedFunction<typeof dumpDatabaseToArray>;
-    const result = [{ _id: '1', value: 345 }];
-    mockDump.mockResolvedValue(result);
-
-    const deps = makeDummyDependencies();
-    const raiden = new Raiden(
-      dummyState,
-      deps,
-      combineRaidenEpics([dummyEpic, initEpicMock]),
-      dummyReducer,
-    );
-    await raiden.start();
-
-    const promise = raiden.dumpDatabase();
-    // test dump promise waits for raiden to be stopped
-    await expect(
-      Promise.race([promise, new Promise((resolve) => setTimeout(resolve, 10))]),
-    ).resolves.toBeUndefined(); // timeout wins, promise pending
-    raiden.stop(); // stop will cause it to continue
-    await expect(promise).resolves.toBe(result);
-    expect(mockDump).toHaveBeenCalled();
   });
 
   test('create', async () => {

--- a/raiden-ts/tests/unit/state.spec.ts
+++ b/raiden-ts/tests/unit/state.spec.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import defaultMigrations from '@/db/migrations';
 import type { Migrations } from '@/db/types';
 import {
-  dumpDatabaseToArray,
+  dumpDatabase,
   getDatabaseConstructorFromOptions,
   getRaidenState,
   latestVersion,
@@ -63,8 +63,8 @@ test('migrate, decode & dump', async () => {
       expect(TransferState.is(decodedTransfer)).toBe(true);
     }
 
-    await db.close(); // ensure dumpDatabase can reopen it if needed
-    const newDump = await dumpDatabaseToArray(db);
+    const newDump = [];
+    for await (const row of dumpDatabase(db)) newDump.push(row);
     expect(newDump.length).toBeGreaterThanOrEqual(dump.length);
   }
 });


### PR DESCRIPTION
Fixes #3122 

**Short description**
This adds the `/api/v1/state.json` endpoint to allow downloading state dump from a CLI node, and a new `--load-state <path.json>` parameter, to upload it back in a new instance / database path.
Additionally, we improve UX by not requiring SDK to be shut down for `Raiden.dumpDatabase`, and now it's also incremental by returning an `async` generator of rows (more useful on very big databases), instead of forcing collecting everything in an array beforehand.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [ ] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. Lauch cli
2. `curl http://localhost:5001/api/v1/state.json -o cli_state_dump.json`
3. Stop cli
4. `rm -rv ./storage/raiden_*_<your_address>_*` to clear state
5. Launch cli with `--load-state cli_state_dump.json` and see it continue from state before
