### PR TITLE
WebUI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,7 @@ jobs:
           command: |
             yarn build
             yarn build:bundle
+            yarn build:webui
       - run:
           name: Compress CLI and bundle
           command: |

--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## [Unreleased]
 ### Added
 - [#3122] `/api/v1/state.json` endpoint to allow downloading/backing up and `--load-state <path.json>` parameter to upload/rehydrate state/database in a fresh instance
+- [#3123] **Experimental**: `--web-ui` option to serve [Raiden WebUI](https://github.com/raiden-network/webui) from `/ui` route; requires `yarn build:webui`
 
 [#3122]: https://github.com/raiden-network/light-client/issues/3122
+[#3123]: https://github.com/raiden-network/light-client/issues/3123
 
 ## [3.0.0] - 2022-05-02
 ### Removed

--- a/raiden-cli/package.json
+++ b/raiden-cli/package.json
@@ -27,6 +27,7 @@
     "lint": "eslint --max-warnings 0 --ext '.ts' .",
     "build": "tsc --skipLibCheck",
     "build:bundle": "TS_NODE_PROJECT=./ignored ncc build -C ./src/index.ts -o ./bundle",
+    "build:webui": "curl https://files.pythonhosted.org/packages/32/4e/ee2ff9b3a92d41b1eb69d58d43467ee4279d3c55ae8f640c763031540324/raiden-webui-1.2.1.tar.gz | tar -xzvf - -C ./build/ --strip-components=2 raiden-webui-1.2.1/raiden_webui/ui",
     "preinstall": "npx only-allow yarn"
   },
   "files": [

--- a/raiden-cli/src/app.ts
+++ b/raiden-cli/src/app.ts
@@ -1,11 +1,16 @@
+/* eslint-disable import/no-named-as-default-member */
 import cors from 'cors';
+import { utils as ethersUtils } from 'ethers';
 import type { Express, NextFunction, Request, Response } from 'express';
-import express, { json as expressJson } from 'express';
+import express from 'express';
 import createError from 'http-errors';
 import logger from 'morgan';
+import path from 'path';
 
 import { makeApiV1Router } from './routes/api.v1';
 import type { Cli } from './types';
+
+const { fetchJson } = ethersUtils;
 
 function notFoundHandler(_request: Request, _response: Response, next: NextFunction) {
   next(createError(404, 'Undefined resource'));
@@ -21,22 +26,56 @@ function internalErrorHandler(
   next(createError(500, error.message));
 }
 
+const apiEndpoint = '/api/v1';
+const rpcEndpoint = '/rpc';
+const uiEndpoint = '/ui';
+
 /**
  * Create an app from the Cli
  *
  * @param this - Cli object
  * @param corsOrigin - Which corsOrigin to accept, if any
+ * @param webUi - Whether to enable webUI (needs `yarn build:webui` first)
  * @returns Express app
  */
-export function makeApp(this: Cli, corsOrigin?: string): Express {
+export function makeApp(this: Cli, corsOrigin?: string, webUi?: boolean): Express {
   const app = express();
-  app.use(expressJson());
+  app.use(express.json());
+
   if (corsOrigin) app.use(cors({ origin: corsOrigin }));
   const loggerMiddleware = logger(
     ':remote-addr - :remote-user ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"',
   );
   app.use(loggerMiddleware);
-  app.use('/api/v1', makeApiV1Router.call(this));
+  app.use(apiEndpoint, makeApiV1Router.call(this));
+
+  if (webUi) {
+    this.log.info(`Serving Raiden webUI at ${uiEndpoint}`);
+
+    // proxy endpoint to provider, passthrough version of JsonRpcProvider.send
+    app.post(rpcEndpoint, (request, response) =>
+      fetchJson(this.raiden.provider.connection, JSON.stringify(request.body)).then(
+        (...args) => response.send(...args),
+        (err) => response.status(400).send(err),
+      ),
+    );
+    app.get(`${uiEndpoint}/assets/config/config*.json`, (_, response) =>
+      response.json({
+        raiden: apiEndpoint,
+        web3: rpcEndpoint,
+        reveal_timeout: this.raiden.config.revealTimeout,
+        settle_timeout: this.raiden.settleTimeout,
+        environment_type: 'development',
+      }),
+    );
+    app.use(uiEndpoint, express.static(path.join(__dirname, 'ui')));
+    // SPA fallback
+    app.get(`${uiEndpoint}/*`, (_, response) =>
+      response.sendFile(path.join(__dirname, 'ui', 'index.html')),
+    );
+    app.get('/', (_, response) => response.redirect(301, uiEndpoint));
+  }
+
   app.use(notFoundHandler);
   app.use(internalErrorHandler.bind(this));
   return app;

--- a/raiden-cli/src/index.ts
+++ b/raiden-cli/src/index.ts
@@ -148,7 +148,7 @@ async function main() {
   const cli: Cli | (Cli & App) = { log, raiden };
   if (argv.apiAddress) {
     const [host, port] = argv.apiAddress;
-    const app = makeApp.call(cli, argv.rpccorsdomain);
+    const app = makeApp.call(cli, argv.rpccorsdomain, argv.webUi);
     const server = app.listen(port, host, () =>
       cli.log.info(`Server started at: http://${host}:${port}`),
     );

--- a/raiden-cli/src/options.ts
+++ b/raiden-cli/src/options.ts
@@ -275,6 +275,11 @@ const yargsOptions = {
       }
     },
   },
+  webUi: {
+    type: 'boolean',
+    default: false,
+    desc: 'Serves Raiden webUI in /ui path',
+  },
 } as const;
 
 /**

--- a/raiden-cli/src/utils/validation.ts
+++ b/raiden-cli/src/utils/validation.ts
@@ -137,3 +137,17 @@ export function isInsuficientFundsError(error: any): error is RaidenError {
     ].includes(error.message)
   );
 }
+
+const numRe = /^\d+$/;
+
+/**
+ * Convert query parameters from strings to numbers
+ *
+ * @param query - query params mapping
+ * @returns mapping with numeric strings converted to numbers
+ */
+export function queryAsNumbers(query: any) {
+  return Object.fromEntries(
+    Object.entries<string>(query).map(([k, v]) => [k, numRe.test(v) ? +v : v]),
+  );
+}

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -7,8 +7,12 @@
 ### Changed
 - [#3122] `Raiden.dumpDatabase` now returns an `AsyncIterable` of database rows objects, which allow to stream even big state dumps without having to accumulate everything in memory; also, it doesn't require stopping SDK to dump state anymore
 
+### Added
+- [#3123] `Raiden.getTransfers` method, an easier way to get, filter and paginate over past transfers.
+
 [#3118]: https://github.com/raiden-network/light-client/pull/3118
 [#3122]: https://github.com/raiden-network/light-client/issues/3122
+[#3123]: https://github.com/raiden-network/light-client/issues/3123
 
 ## [3.0.0] - 2022-05-02
 ### Fixed

--- a/raiden-ts/src/db/utils.ts
+++ b/raiden-ts/src/db/utils.ts
@@ -18,10 +18,13 @@ import { concatMap, filter, finalize, mergeMap, pluck, takeUntil } from 'rxjs/op
 import type { Channel } from '../channels';
 import { channelKey } from '../channels/utils';
 import type { RaidenState } from '../state';
+import type { RaidenTransfer } from '../transfers/state';
+import { TransferState } from '../transfers/state';
+import { raidenTransfer } from '../transfers/utils';
 import type { ContractsInfo } from '../types';
 import { assert, ErrorCodes } from '../utils/error';
 import type { Address } from '../utils/types';
-import { last } from '../utils/types';
+import { decode, last } from '../utils/types';
 import { getDefaultPouchAdapter } from './adapter';
 import defaultMigrations from './migrations';
 import type {
@@ -51,6 +54,39 @@ function byPrefix(prefix: string, descending = false) {
 }
 
 async function databaseProps(db: RaidenDatabase) {
+  await Promise.all([
+    /* db.createIndex({
+      index: {
+        name: 'byCleared',
+        fields: ['cleared', 'direction'],
+      },
+    }), */
+    db.createIndex({
+      index: {
+        name: 'byPartner',
+        fields: ['direction', 'partner'],
+      },
+    }),
+    db.createIndex({
+      index: {
+        name: 'bySecrethash',
+        fields: ['secrethash'],
+      },
+    }),
+    db.createIndex({
+      index: {
+        name: 'byChannel',
+        fields: ['channel'],
+      },
+    }),
+    db.createIndex({
+      index: {
+        name: 'byTransferTs',
+        fields: ['transfer.ts'],
+      },
+    }),
+  ]);
+
   const storageKeys = new Set<string>();
   const results = await db.allDocs({ startkey: 'a', endkey: 'z\ufff0' });
   results.rows.forEach(({ id }) => storageKeys.add(id));
@@ -88,33 +124,6 @@ async function makeDatabase(
 ): Promise<RaidenDatabase> {
   const db = new this(name);
   db.setMaxListeners(30);
-
-  await Promise.all([
-    /* db.createIndex({
-      index: {
-        name: 'byCleared',
-        fields: ['cleared', 'direction'],
-      },
-    }), */
-    db.createIndex({
-      index: {
-        name: 'byPartner',
-        fields: ['direction', 'partner'],
-      },
-    }),
-    db.createIndex({
-      index: {
-        name: 'bySecrethash',
-        fields: ['secrethash'],
-      },
-    }),
-    db.createIndex({
-      index: {
-        name: 'byChannel',
-        fields: ['channel'],
-      },
-    }),
-  ]);
 
   return databaseProps(db);
 }
@@ -483,4 +492,54 @@ export async function* dumpDatabase(db: RaidenDatabase, { batch = 10 }: { batch?
     db.busy$.next(false);
     feed.cancel();
   }
+}
+
+const pendingFields = [
+  'unlockProcessed',
+  'expiredProcessed',
+  'secretRegistered',
+  'channelSettled',
+];
+/**
+ * Efficently get transfers from database when paging with offset and limit
+ *
+ * @param db - Database instance
+ * @param filter - Filter options
+ * @param filter.pending - true: only pending; false: only completed; undefined: all
+ * @param filter.token - filter by token address
+ * @param filter.partner - filter by partner address
+ * @param filter.end - filter by initiator or target address
+ * @param opts - Changes options
+ * @param opts.offset - Offset to skip entries
+ * @param opts.limit - Limit number of entries
+ * @param opts.desc - Set to true to get new transfers first
+ * @returns Promise to array of results
+ */
+export async function getTransfers(
+  db: RaidenDatabase,
+  filter?: { pending?: boolean; token?: string; partner?: string; end?: string },
+  { offset: skip, desc, ...opts }: { offset?: number; limit?: number; desc?: boolean } = {},
+): Promise<RaidenTransfer[]> {
+  const $and: any[] = [{ 'transfer.ts': { $gt: 0 } }];
+  if (filter) {
+    if (filter.pending) {
+      for (const field of pendingFields) $and.push({ [field]: { $exists: false } });
+    } else if (filter.pending === false) {
+      $and.push({ $or: pendingFields.map((field) => ({ [field]: { $exists: true } })) });
+    }
+    if ('token' in filter) $and.push({ 'transfer.token': filter.token });
+    if ('partner' in filter) $and.push({ partner: filter.partner });
+    if ('end' in filter)
+      $and.push({
+        $or: [{ 'transfer.initiator': filter.end }, { 'transfer.target': filter.end }],
+      });
+  }
+  const { docs, warning } = await db.find({
+    selector: { $and },
+    sort: [{ 'transfer.ts': desc ? 'desc' : 'asc' }],
+    skip,
+    ...opts,
+  });
+  if (warning) db.__opts.log?.warn('db.getTransfers', warning);
+  return docs.map((doc) => raidenTransfer(decode(TransferState, doc)));
 }

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -530,9 +530,11 @@ export class Raiden {
   /**
    * Returns a list of all token addresses registered as token networks in registry
    *
+   * @param rescan - Whether to rescan events from scratch
    * @returns Promise to list of token addresses
    */
-  public async getTokenList(): Promise<Address[]> {
+  public async getTokenList(rescan = false): Promise<Address[]> {
+    if (!rescan) return Object.keys(this.state.tokens) as Address[];
     return await lastValueFrom(
       getLogsByChunk$(this.deps.provider, {
         ...this.deps.registryContract.filters.TokenNetworkCreated(),

--- a/raiden-ts/src/raiden.ts
+++ b/raiden-ts/src/raiden.ts
@@ -398,6 +398,15 @@ export class Raiden {
   }
 
   /**
+   * Current provider getter
+   *
+   * @returns ether's provider instance
+   */
+  public get provider(): JsonRpcProvider {
+    return this.deps.provider;
+  }
+
+  /**
    * Get current account address (subkey's address, if subkey is being used)
    *
    * @returns Instance address

--- a/raiden-ts/src/utils/ethers.ts
+++ b/raiden-ts/src/utils/ethers.ts
@@ -108,7 +108,7 @@ export function getLogsByChunk$(
     let curChunk = Math.min(chunk, toBlock - fromBlock + 1);
     let retry = 5;
     // every time repeatWhen re-subscribes to this defer, yield (current/retried/next) range/chunk
-    return defer(async () =>
+    return defer<Promise<Log[]>>(async () =>
       provider.send('eth_getLogs', [
         {
           ...filter,
@@ -119,7 +119,7 @@ export function getLogsByChunk$(
     ).pipe(
       // mimics the post-request handling on BaseProvider.getLogs
       map((logs) => {
-        logs.forEach((log: { removed?: boolean }) => {
+        logs.forEach((log) => {
           if (log.removed == null) log.removed = false;
         });
         return Formatter.arrayOf(provider.formatter.filterLog.bind(provider.formatter))(


### PR DESCRIPTION
Fixes #3123 

**Short description**
Adds [Raiden WebUI](https://github.com/raiden-network/webui) to CLI :tada: 
For compliance with schemas, features, behavior and endpoints expected by WebUI, some adjusments were needed:
- on SDK, a new method, `getTransfers`, allows efficient filtering and pagination when fetching transfers from database
- `/payments` and `pending_transfers` now use this method to serve properly paginated results to webUI
- `/config.*.json` serves a dynamic JSON to be used by webUI
- `/rpc` proxies ETH JSON RPC calls to SDK's provider 
- webUI can be downloaded and put inside `build` folder by `yarn build:webui` command, to be run after `yarn build`
- a new CLI option `--web-ui` enables serving the webUI from the `/ui` endpoint.

**Definition of Done**

- [x] Steps to manually test the change have been documented
- [x] Acceptance criteria are met
- [x] Change has been manually tested by the reviewer (dApp) 

**Steps to manually test the change (dApp)**

1. After building the CLI, build the webui with `yarn build:webui`
2. Run the CLI with `--web-ui` parameter
3. Visit http://localhost:5001/ to see the webUI
