### PR TITLE
3.0.0 -> 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "light-client",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Raiden Light Client monorepo",
   "author": "brainbot labs est.",
   "private": true,

--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [3.1.0] - 2022-06-30
 ### Added
 - [#3122] `/api/v1/state.json` endpoint to allow downloading/backing up and `--load-state <path.json>` parameter to upload/rehydrate state/database in a fresh instance
 - [#3123] **Experimental**: `--web-ui` option to serve [Raiden WebUI](https://github.com/raiden-network/webui) from `/ui` route; requires `yarn build:webui`
@@ -115,7 +117,8 @@
 [#2054]: https://github.com/raiden-network/light-client/pulls/2054
 
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/raiden-network/light-client/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/raiden-network/light-client/compare/v2.2.0...v3.0.0
 [2.2.0]: https://github.com/raiden-network/light-client/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/raiden-network/light-client/compare/v2.0.1...v2.1.0

--- a/raiden-cli/package.json
+++ b/raiden-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raiden_network/raiden-cli",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "author": "brainbot labs est.",
   "license": "MIT",
   "description": "Raiden Light Client standalone app with a REST API via HTTP",

--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [3.1.0] - 2022-06-30
 ### Changed
 - [#3122] `Backup State` doesn't require SDK to be shut down anymore
 
@@ -655,7 +657,8 @@
 - Add link to privacy policy.
 - Add basic transfer screen.
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/raiden-network/light-client/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/raiden-network/light-client/compare/v2.2.0...v3.0.0
 [2.2.0]: https://github.com/raiden-network/light-client/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/raiden-network/light-client/compare/v2.0.1...v2.1.0

--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-dapp",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "description": "A dApp that showcases the Raiden Light Client sdk functionality",
   "author": "brainbot labs est.",

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [3.1.0] - 2022-06-30
 ### Fixed
 - [#3118] Dynamically set `config.revealTimeout` to half of `tokenNetworkRegistryContract.settleTimeout`, if it'd be smaller than default of 600s
 
@@ -575,7 +577,8 @@
 - Add protocol message implementation.
 
 
-[Unreleased]: https://github.com/raiden-network/light-client/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/raiden-network/light-client/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/raiden-network/light-client/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/raiden-network/light-client/compare/v2.2.0...v3.0.0
 [2.2.0]: https://github.com/raiden-network/light-client/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/raiden-network/light-client/compare/v2.0.1...v2.1.0

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-ts",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Raiden Light Client Typescript/Javascript SDK",
   "main": "dist:cjs/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
# :cat: New Raiden Light Client SDK, dApp and CLI

> **INFO:** The Light Client SDK, CLI and dApp are all **work in progress** projects. All three projects have been released for **mainnet** and all code is available in the Light Client repository. As this release still has its limitations and is a **beta** release, it is crucial to read this readme including the security notes carefully before using the software.

This release brings the WebUI which was formerly only available for the Python Client to the Light Client. The previous UI is still available as usual. Use `--web-ui` with the CLI to bring up the WebUI.

Raiden SDK
-------------------------------
### Fixed
- [#3118] Dynamically set `config.revealTimeout` to half of `tokenNetworkRegistryContract.settleTimeout`, if it'd be smaller than default of 600s

### Changed
- [#3122] `Raiden.dumpDatabase` now returns an `AsyncIterable` of database rows objects, which allow to stream even big state dumps without having to accumulate everything in memory; also, it doesn't require stopping SDK to dump state anymore

### Added
- [#3123] `Raiden.getTransfers` method, an easier way to get, filter and paginate over past transfers.

[#3118]: https://github.com/raiden-network/light-client/pull/3118
[#3122]: https://github.com/raiden-network/light-client/issues/3122
[#3123]: https://github.com/raiden-network/light-client/issues/3123

Raiden dApp
-------------------------------
### Changed
- [#3122] `Backup State` doesn't require SDK to be shut down anymore

[#3122]: https://github.com/raiden-network/light-client/issues/3122

Raiden CLI
-------------------------------
### Added
- [#3122] `/api/v1/state.json` endpoint to allow downloading/backing up and `--load-state <path.json>` parameter to upload/rehydrate state/database in a fresh instance
- [#3123] **Experimental**: `--web-ui` option to serve [Raiden WebUI](https://github.com/raiden-network/webui) from `/ui` route; requires `yarn build:webui`

[#3122]: https://github.com/raiden-network/light-client/issues/3122
[#3123]: https://github.com/raiden-network/light-client/issues/3123