### PR TITLE
Mainnet Release v2.3.0 Kṛttikā

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "light-client",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Raiden Light Client monorepo",
   "author": "brainbot labs est.",
   "private": true,

--- a/raiden-cli/CHANGELOG.md
+++ b/raiden-cli/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+## [2.3.0] - 2022-07-22
+### Fixed
+- [#3135] Fixed some native dependencies to allow installing and running in ARM64 processors (e.g. Apple's M1 computers)
+
+### Changed
+- [#3160] Backport v3.1.0 improvements to `v2` series (supporting [raiden-contracts v0.40 Coruscant](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.40.0) and Ethereum Mainnet). Notably, `--web-ui` option is available on v2 Mainnet series.
+
+[#3135]: https://github.com/raiden-network/light-client/issues/3135
+[#3160]: https://github.com/raiden-network/light-client/pull/3160
+
 ## [3.1.0] - 2022-06-30
 ### Added
 - [#3122] `/api/v1/state.json` endpoint to allow downloading/backing up and `--load-state <path.json>` parameter to upload/rehydrate state/database in a fresh instance
@@ -120,6 +130,7 @@
 
 
 [Unreleased]: https://github.com/raiden-network/light-client/compare/v3.1.0...HEAD
+[2.3.0]: https://github.com/raiden-network/light-client/compare/v2.2.0...v2.3.0
 [3.1.0]: https://github.com/raiden-network/light-client/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/raiden-network/light-client/compare/v2.2.0...v3.0.0
 [2.2.0]: https://github.com/raiden-network/light-client/compare/v2.1.0...v2.2.0

--- a/raiden-cli/package.json
+++ b/raiden-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raiden_network/raiden-cli",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": "brainbot labs est.",
   "license": "MIT",
   "description": "Raiden Light Client standalone app with a REST API via HTTP",
@@ -50,6 +50,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
+    "@koush/wrtc": "^0.5.3",
     "cors": "^2.8.5",
     "ethers": "^5.6.9",
     "express": "^4.18.1",
@@ -60,7 +61,6 @@
     "node-localstorage": "^2.2.1",
     "raiden-ts": "^2.2.0",
     "rxjs": "^7.5.6",
-    "@koush/wrtc": "^0.5.3",
     "yargs": "^17.5.1"
   }
 }

--- a/raiden-dapp/CHANGELOG.md
+++ b/raiden-dapp/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [2.3.0] - 2022-07-22
+- [#3160] Backport v3.1.0 improvements to `v2` series (supporting [raiden-contracts v0.40 Coruscant](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.40.0) and Ethereum Mainnet).
+
+[#3160]: https://github.com/raiden-network/light-client/pull/3160
+
 ## [3.1.0] - 2022-06-30
 ### Changed
 - [#3122] `Backup State` doesn't require SDK to be shut down anymore
@@ -658,6 +663,7 @@
 - Add basic transfer screen.
 
 [Unreleased]: https://github.com/raiden-network/light-client/compare/v3.1.0...HEAD
+[2.3.0]: https://github.com/raiden-network/light-client/compare/v2.2.0...v2.3.0
 [3.1.0]: https://github.com/raiden-network/light-client/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/raiden-network/light-client/compare/v2.2.0...v3.0.0
 [2.2.0]: https://github.com/raiden-network/light-client/compare/v2.1.0...v2.2.0

--- a/raiden-dapp/package.json
+++ b/raiden-dapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-dapp",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "description": "A dApp that showcases the Raiden Light Client sdk functionality",
   "author": "brainbot labs est.",

--- a/raiden-ts/CHANGELOG.md
+++ b/raiden-ts/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+## [2.3.0] - 2022-07-22
+- [#3160] Backport v3.1.0 improvements to `v2` series (supporting [raiden-contracts v0.40 Coruscant](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.40.0) and Ethereum Mainnet)
+
+[#3160]: https://github.com/raiden-network/light-client/pull/3160
 
 ## [3.1.0] - 2022-06-30
 ### Fixed
@@ -578,6 +582,7 @@
 
 
 [Unreleased]: https://github.com/raiden-network/light-client/compare/v3.1.0...HEAD
+[2.3.0]: https://github.com/raiden-network/light-client/compare/v2.2.0...v2.3.0
 [3.1.0]: https://github.com/raiden-network/light-client/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/raiden-network/light-client/compare/v2.2.0...v3.0.0
 [2.2.0]: https://github.com/raiden-network/light-client/compare/v2.1.0...v2.2.0

--- a/raiden-ts/package.json
+++ b/raiden-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raiden-ts",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Raiden Light Client Typescript/Javascript SDK",
   "main": "dist:cjs/index.js",
   "module": "dist/index.js",
@@ -116,9 +116,9 @@
     "rxjs": "^7.5.6"
   },
   "optionalDependencies": {
+    "@koush/wrtc": "^0.5.3",
     "pouchdb-adapter-indexeddb": "^7.3.0",
-    "pouchdb-adapter-leveldb": "^7.3.0",
-    "@koush/wrtc": "^0.5.3"
+    "pouchdb-adapter-leveldb": "^7.3.0"
   },
   "files": [
     "/dist",


### PR DESCRIPTION
# 🧭  New Raiden Light Client SDK, dApp and CLI

> **INFO:** The Light Client SDK, CLI and dApp are all **work in progress** projects. All three projects have been released for **mainnet** and all code is available in the Light Client repository. As this release still has its limitations and is a **beta** release, it is crucial to read this readme including the security notes carefully before using the software.

This is a maintenance release for the **stable mainnet Krttika release (v2)**. While [current `master` branch](https://github.com/raiden-network/light-client/tree/master) contains development progress for the [new `raiden-contracts` v0.50](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.50.0), with changes required to allow Raiden to run properly on [rollups like Arbitrum](https://github.com/raiden-network/light-client/projects/68), these contracts won't be immediately deployed to Ethereum Mainnet (Homestead) or be the default contracts on testnets (like Goerli).

But these networks are still supported on the [`v2` branch](https://github.com/raiden-network/light-client/tree/v2), and this release backports some refactorings, bugfixes and dependency updates from `master` back to `v2` series ([`v0.40` contracts](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.40.0)) in a fully backwards compatible manner, so no user action is needed.

### Highlights
The main feature of this backports release is the coming of the [Raiden webUI](https://github.com/raiden-network/webui) as an optional interface for the CLI. Not to be confused with the [Light-Client dApp](https://github.com/raiden-network/light-client/tree/master/raiden-dapp), which is a standalone web Raiden client running in the browser, the `webUI` requires a Raiden REST API-capable client running in the background, and provides a web management interface to the underlying full node. It was initially designed for the Python Client, but with the CLI's API achieving full compatibility with the reference implementation, it became possible to run the `webUI` as a drop-in addon. Run the CLI with `--web-ui` to enable it, and then go to http://localhost:5001/ui to see it in action.

-------------------------------
### Fixed
- [#3135] Fixed some native dependencies to allow installing and running in ARM64 processors (e.g. Apple's M1 computers)
 
### Changed
- [#3160] Backport v3.1.0 improvements to `v2` series (supporting [raiden-contracts v0.40 Coruscant](https://github.com/raiden-network/raiden-contracts/releases/tag/v0.40.0) and Ethereum Mainnet). Notably, `--web-ui` option is available on v2 Mainnet series.